### PR TITLE
Cannot rely on auto-positioned absolutely positioned descendants being marked for layout

### DIFF
--- a/LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left-expected.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>The word "FAIL" should not be seen below.</p>
+<div style="margin-left:200px; width:300px; height:25em; background:blue;"></div>

--- a/LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<p>The word "FAIL" should not be seen below.</p>
+<div style="position:relative; width:500px;">
+    <div id="elm" style="background:blue; height:25em;">
+        <div style="position:absolute; top:0; color:blue;">
+            FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL
+        </div>
+    </div>
+</div>
+<script>
+    document.body.offsetTop;
+    document.getElementById("elm").style.marginLeft = "200px";
+</script>

--- a/LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins-expected.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>On this page there should be a blue square above a yellow square.</p>
+<div style="margin-left:150px; width:200px; height:400px; background:yellow;">
+    <div style="width:200px; height:200px; background:blue;"></div>
+</div>

--- a/LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<p>On this page there should be a blue square above a yellow square.</p>
+<div style="position:relative; width:500px;">
+    <div id="elm" style="margin:auto; width:100px; height:400px; background:yellow;">
+        <div></div>
+        <div style="position:absolute; width:200px; height:200px; background:blue;"></div>
+    </div>
+</div>
+<script>
+    document.body.offsetTop;
+    document.getElementById("elm").style.width = "200px";
+</script>

--- a/LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left-expected.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>There should be no red on this page.</p>
+<div style="margin-left:200px; width:200px; height:200px; background:green;"></div>

--- a/LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left.html
+++ b/LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<p>There should be no red on this page.</p>
+<div style="position:relative;">
+    <div id="elm" style="width:200px; height:200px; background:red;">
+        <div style="position:absolute; top:0; width:200px; height:200px; background:green;"></div>
+    </div>
+</div>
+<script>
+    document.body.offsetTop;
+    document.getElementById("elm").style.marginLeft = "200px";
+</script>

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2-expected.txt
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2-expected.txt
@@ -1,0 +1,3 @@
+a
+crbug.com/501353: Tests positioned movement layout when margins change.
+PASS

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2.html
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+}
+#first {
+    height:100px;
+}
+#next {
+    position:absolute;
+}
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<div id="container">
+    <div id="first">a</div>
+    <div id="next" data-total-y=0>crbug.com/501353: Tests positioned movement layout when margins change.</div>
+</div>
+<div id="test-output"></div>
+<script>
+    document.body.offsetTop;
+    container = document.getElementById("container");
+    container.style['margin-top'] = '-100px';
+    window.checkLayout("#next", document.getElementById("test-output"));
+</script>

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3-expected.txt
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3-expected.txt
@@ -1,0 +1,3 @@
+a
+crbug.com/501353: Tests positioned movement layout when margins change.
+PASS

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3.html
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+}
+#first {
+    height:100px;
+}
+#next {
+    position:absolute;
+}
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<div id="container">
+    <div id="first">a</div>
+    <div id="next" data-total-y=200>crbug.com/501353: Tests positioned movement layout when margins change.</div>
+</div>
+<div id="test-output"></div>
+<script>
+    document.body.offsetTop;
+    container = document.getElementById("container");
+    container.style['margin-top'] = '100px';
+    window.checkLayout("#next", document.getElementById("test-output"));
+</script>

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4-expected.txt
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4-expected.txt
@@ -1,0 +1,3 @@
+a
+crbug.com/501353: Tests positioned movement layout when margins change.
+PASS

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4.html
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+}
+#first {
+    height:100px;
+}
+#next {
+    position:absolute;
+}
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<div id="container">
+    <div id="first">a</div>
+    <div id="next" data-total-y=200>crbug.com/501353: Tests positioned movement layout when margins change.</div>
+</div>
+<div id="test-output"></div>
+<script>
+    document.body.offsetTop;
+    first = document.getElementById("first");
+    first.style['margin-top'] = '100px';
+    window.checkLayout("#next", document.getElementById("test-output"));
+</script>

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-expected.txt
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-expected.txt
@@ -1,0 +1,3 @@
+a
+crbug.com/501353: Tests positioned movement layout when margins change.
+PASS

--- a/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes.html
+++ b/LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+}
+#first {
+    height:100px;
+}
+#next {
+    position:absolute;
+}
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<div id="container">
+    <div id="first">a</div>
+    <div id="next" data-total-y=0>crbug.com/501353: Tests positioned movement layout when margins change.</div>
+</div>
+<div id="test-output"></div>
+<script>
+    document.body.offsetTop;
+    first = document.getElementById("first");
+    first.style['margin-top'] = '-100px';
+    window.checkLayout("#next", document.getElementById("test-output"));
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -794,6 +794,32 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     return margin;
 }
 
+static bool needsLayoutDueToStaticPosition(RenderBox& child)
+{
+    // When a non-positioned block element moves, it may have positioned children that are
+    // implicitly positioned relative to the non-positioned block.
+    bool isHorizontal = child.isHorizontalWritingMode();
+
+    if (child.style().hasStaticBlockPosition(isHorizontal)) {
+        LayoutUnit currentLogicalTop = child.logicalTop();
+        LayoutUnit currentLogicalHeight = child.logicalHeight();
+        auto computedValues = child.computeLogicalHeight(currentLogicalHeight, currentLogicalTop);
+        if (computedValues.m_position != currentLogicalTop || computedValues.m_extent != currentLogicalHeight)
+            return true;
+    }
+
+    if (child.style().hasStaticInlinePosition(isHorizontal)) {
+        LayoutUnit currentLogicalLeft = child.logicalLeft();
+        LayoutUnit currentLogicalWidth = child.logicalWidth();
+        RenderBox::LogicalExtentComputedValues computedValues;
+        child.computeLogicalWidth(computedValues);
+        if (computedValues.m_position != currentLogicalLeft || computedValues.m_extent != currentLogicalWidth)
+            return true;
+    }
+
+    return false;
+}
+
 void RenderBlock::layoutOutOfFlowBox(RenderBox& outOfFlowBox, RelayoutChildren relayoutChildren, bool fixedPositionObjectsOnly)
 {
     ASSERT(outOfFlowBox.isOutOfFlowPositioned());
@@ -818,7 +844,7 @@ void RenderBlock::layoutOutOfFlowBox(RenderBox& outOfFlowBox, RelayoutChildren r
     // non-positioned block.  Rather than trying to detect all of these movement cases, we just always lay out positioned
     // objects that are positioned implicitly like this.  Such objects are rare, and so in typical DHTML menu usage (where everything is
     // positioned explicitly) this should not incur a performance penalty.
-    if (relayoutChildren == RelayoutChildren::Yes || (outOfFlowBox.style().hasStaticBlockPosition(isHorizontalWritingMode()) && outOfFlowBox.parent() != this))
+    if (relayoutChildren == RelayoutChildren::Yes || needsLayoutDueToStaticPosition(outOfFlowBox))
         outOfFlowBox.setChildNeedsLayout(MarkOnlyThis);
 
     // If relayoutChildren is set and the child has percentage padding or an embedded content box, we also need to invalidate the childs pref widths.

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1208,9 +1208,6 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
 
 void RenderBlockFlow::adjustOutOfFlowBlock(RenderBox& child, const MarginInfo& marginInfo)
 {
-    bool isHorizontal = isHorizontalWritingMode();
-    bool hasStaticBlockPosition = child.style().hasStaticBlockPosition(isHorizontal);
-    
     LayoutUnit logicalTop = logicalHeight();
     updateStaticInlinePositionForChild(child, logicalTop);
 
@@ -1223,11 +1220,8 @@ void RenderBlockFlow::adjustOutOfFlowBlock(RenderBox& child, const MarginInfo& m
     }
 
     RenderLayer* childLayer = child.layer();
-    if (childLayer->staticBlockPosition() != logicalTop) {
+    if (childLayer->staticBlockPosition() != logicalTop)
         childLayer->setStaticBlockPosition(logicalTop);
-        if (hasStaticBlockPosition)
-            child.setChildNeedsLayout(MarkOnlyThis);
-    }
 }
 
 void RenderBlockFlow::determineLogicalLeftPositionForChild(RenderBox& child, ApplyLayoutDeltaMode applyDelta)


### PR DESCRIPTION
#### 382f98d6c39c57cd9679c7445c5fb5d0f5320c87
<pre>
Cannot rely on auto-positioned absolutely positioned descendants being marked for layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=276350">https://bugs.webkit.org/show_bug.cgi?id=276350</a>
<a href="https://rdar.apple.com/131806062">rdar://131806062</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/f9fc64fcfef3cfbd4552572eb1293769d6ddc535">https://chromium.googlesource.com/chromium/src/+/f9fc64fcfef3cfbd4552572eb1293769d6ddc535</a> and
<a href="https://chromium.googlesource.com/chromium/src/+/f80ec451d0871da501ad200468203f51136ec52a">https://chromium.googlesource.com/chromium/src/+/f80ec451d0871da501ad200468203f51136ec52a</a>

When a parent element changes size or position, absolutely positioned
children with static inline or block positions need to be re-laid out
because their computed positions depend on their parent&apos;s dimensions.

Previously, WebKit only checked hasStaticBlockPosition() and only
verified if the position changed, not the extent (width/height). This
caused failures when a parent&apos;s margin change affected the child&apos;s
computed width or static inline position.

The fix adds needsLayoutDueToStaticPosition() which proactively checks
both static inline and block positions, and verifies both position and
extent changes. This is called during layoutOutOfFlowBox() rather than
relying on earlier marking mechanisms.

Additionally, it do clean-up in &apos;RenderBlockFlow::adjustOutOfFlowBlock&apos;,
which is now redundant after above change.

Tests: fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left.html
       fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins.html
       fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left.html
       fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2.html
       fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3.html
       fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4.html
       fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes.html
* LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left-expected.html: Added.
* LayoutTests/fast/block/positioning/abspos-auto-left-and-width-change-parent-margin-left.html: Added.
* LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins-expected.html: Added.
* LayoutTests/fast/block/positioning/abspos-auto-left-auto-top-inside-auto-margins.html: Added.
* LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left-expected.html: Added.
* LayoutTests/fast/block/positioning/abspos-auto-left-fixed-top-change-parent-margin-left.html: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2-expected.txt: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-2.html: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3-expected.txt: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-3.html: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4-expected.txt: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-4.html: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes-expected.txt: Added.
* LayoutTests/fast/block/positioning/positioned-layout-in-block-flow-when-margin-changes.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::needsLayoutDueToStaticPosition):
(WebCore::RenderBlock::layoutOutOfFlowBox):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustOutOfFlowBlock):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/382f98d6c39c57cd9679c7445c5fb5d0f5320c87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85075 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a48bba3d-a71f-42ad-bdcf-1e062c7e9c78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101739 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69082 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa77b3fc-2c0f-4b63-9c64-12159af56388) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82538 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad7ffbe0-c45d-4813-a0e8-f4ab38da09fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143229 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110118 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110300 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4008 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58803 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5264 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33827 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->