### PR TITLE
Ensure margins in table captions contributes to minimum table width

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015-expected.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+
+  <style type="text/css"><![CDATA[
+  div
+  {
+  border-left: blue solid 10px;
+  border-right: orange solid 10px;
+  height: 200px;
+  width: 50px;
+  }
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there is space between the blue and orange lines.</p>
+
+  <div></div>
+
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Margin-right applied to element with display table-caption</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+		<link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-08-19 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-margin-right" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#margin-properties" />
+		<link rel="match" href="margin-left-applies-to-009-ref.xht" />
+
+        <meta name="assert" content="The 'margin-right' property applies to elements with a display of table-caption." />
+        <style type="text/css">
+            #wrapper
+            {
+                border-right: 10px solid orange;
+				float: left;
+            }
+            #test
+            {
+                border-right: 10px solid blue;
+                display: table-caption;
+                height: 200px;
+                margin-right: 50px;
+            }
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is space between the blue and orange lines.</p>
+        <div id="wrapper">
+            <div id="table">
+                <div id="test"></div>
+                <div id="row">
+                    <div id="cell"></div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
@@ -10,6 +10,6 @@ FAIL Table with separated border assert_equals: Table with separated border clie
 FAIL Table with collapsed border assert_equals: Table with collapsed border clientWidth expected 26 but got 20
 PASS Caption with padding
 PASS Caption with border
-FAIL Caption with margin assert_equals: Caption with margin clientWidth expected 46 but got 40
+PASS Caption with margin
 PASS Bottom caption
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt
@@ -10,6 +10,6 @@ FAIL Table with separated border assert_equals: Table with separated border offs
 FAIL Table with collapsed border assert_equals: Table with collapsed border offsetWidth expected 26 but got 20
 PASS Caption with padding
 PASS Caption with border
-FAIL Caption with margin assert_equals: Caption with margin offsetWidth expected 46 but got 40
+PASS Caption with margin
 PASS Bottom caption
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt
@@ -10,6 +10,6 @@ FAIL Table with separated border assert_equals: Table with separated border scro
 FAIL Table with collapsed border assert_equals: Table with collapsed border scrollWidth expected 26 but got 14
 PASS Caption with padding
 PASS Caption with border
-FAIL Caption with margin assert_equals: Caption with margin scrollWidth expected 46 but got 44
+PASS Caption with margin
 PASS Bottom caption
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions1-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 785x1066
       RenderBlock (anonymous) at (0,288) size 769x18
         RenderText {#text} at (0,0) size 384x17
           text run at (0,0) width 384: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,316) size 148x111 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,68) size 138x43 [border: (3px solid #800080)]
-          RenderText {#text} at (37,4) size 47x17
-            text run at (37,4) width 47: "caption"
-          RenderBlock {INPUT} at (85,6) size 13x12
+      RenderTable {TABLE} at (5,316) size 158x111 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,68) size 148x43 [border: (3px solid #800080)]
+          RenderText {#text} at (42,4) size 47x17
+            text run at (42,4) width 47: "caption"
+          RenderBlock {INPUT} at (90,6) size 13x12
           RenderText {#text} at (3,22) size 142x17
             text run at (3,22) width 142: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,10) size 128x46
-          RenderTableRow {TR} at (0,2) size 128x20
-            RenderTableCell {TD} at (2,2) size 61x20 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,10) size 138x46
+          RenderTableRow {TR} at (0,2) size 138x20
+            RenderTableCell {TD} at (2,2) size 66x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-            RenderTableCell {TD} at (64,2) size 62x20 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (69,2) size 67x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-          RenderTableRow {TR} at (0,24) size 128x20
-            RenderTableCell {TD} at (2,24) size 61x20 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,24) size 138x20
+            RenderTableCell {TD} at (2,24) size 66x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-            RenderTableCell {TD} at (64,24) size 62x20 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (69,24) size 67x20 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
       RenderBlock (anonymous) at (0,432) size 769x18

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions2-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions2-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 785x1066
       RenderBlock (anonymous) at (0,288) size 769x18
         RenderText {#text} at (0,0) size 384x17
           text run at (0,0) width 384: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,316) size 148x111 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,2) size 138x43 [border: (3px solid #800080)]
-          RenderText {#text} at (37,4) size 47x17
-            text run at (37,4) width 47: "caption"
-          RenderBlock {INPUT} at (85,6) size 13x12
+      RenderTable {TABLE} at (5,316) size 158x111 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,2) size 148x43 [border: (3px solid #800080)]
+          RenderText {#text} at (42,4) size 47x17
+            text run at (42,4) width 47: "caption"
+          RenderBlock {INPUT} at (90,6) size 13x12
           RenderText {#text} at (3,22) size 142x17
             text run at (3,22) width 142: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,55) size 128x46
-          RenderTableRow {TR} at (0,2) size 128x20
-            RenderTableCell {TD} at (2,2) size 61x20 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,55) size 138x46
+          RenderTableRow {TR} at (0,2) size 138x20
+            RenderTableCell {TD} at (2,2) size 66x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-            RenderTableCell {TD} at (64,2) size 62x20 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (69,2) size 67x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-          RenderTableRow {TR} at (0,24) size 128x20
-            RenderTableCell {TD} at (2,24) size 61x20 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,24) size 138x20
+            RenderTableCell {TD} at (2,24) size 66x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
-            RenderTableCell {TD} at (64,24) size 62x20 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (69,24) size 67x20 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 30x17
                 text run at (1,1) width 30: "Data"
       RenderBlock (anonymous) at (0,432) size 769x18

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions1-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 800x1141
       RenderBlock (anonymous) at (0,310) size 784x20
         RenderText {#text} at (0,0) size 394x19
           text run at (0,0) width 394: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,340) size 151x120 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,72) size 141x48 [border: (3px solid #800080)]
-          RenderText {#text} at (36,5) size 48x19
-            text run at (36,5) width 48: "caption"
-          RenderBlock {INPUT} at (85,6) size 17x16 [bgcolor=#FFFFFF03]
+      RenderTable {TABLE} at (5,340) size 161x120 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,72) size 151x48 [border: (3px solid #800080)]
+          RenderText {#text} at (41,5) size 48x19
+            text run at (41,5) width 48: "caption"
+          RenderBlock {INPUT} at (90,6) size 17x16 [bgcolor=#FFFFFF03]
           RenderText {#text} at (3,25) size 145x19
             text run at (3,25) width 145: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,10) size 131x50
-          RenderTableRow {TR} at (0,2) size 131x22
-            RenderTableCell {TD} at (2,2) size 63x22 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,10) size 141x50
+          RenderTableRow {TR} at (0,2) size 141x22
+            RenderTableCell {TD} at (2,2) size 68x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,2) size 63x22 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,2) size 68x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-          RenderTableRow {TR} at (0,26) size 131x22
-            RenderTableCell {TD} at (2,26) size 63x22 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 141x22
+            RenderTableCell {TD} at (2,26) size 68x22 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,26) size 63x22 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,26) size 68x22 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
       RenderBlock (anonymous) at (0,465) size 784x20

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions2-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 800x1141
       RenderBlock (anonymous) at (0,310) size 784x20
         RenderText {#text} at (0,0) size 394x19
           text run at (0,0) width 394: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,340) size 151x120 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,2) size 141x48 [border: (3px solid #800080)]
-          RenderText {#text} at (36,5) size 48x19
-            text run at (36,5) width 48: "caption"
-          RenderBlock {INPUT} at (85,6) size 17x16 [bgcolor=#FFFFFF03]
+      RenderTable {TABLE} at (5,340) size 161x120 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,2) size 151x48 [border: (3px solid #800080)]
+          RenderText {#text} at (41,5) size 48x19
+            text run at (41,5) width 48: "caption"
+          RenderBlock {INPUT} at (90,6) size 17x16 [bgcolor=#FFFFFF03]
           RenderText {#text} at (3,25) size 145x19
             text run at (3,25) width 145: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,60) size 131x50
-          RenderTableRow {TR} at (0,2) size 131x22
-            RenderTableCell {TD} at (2,2) size 63x22 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,60) size 141x50
+          RenderTableRow {TR} at (0,2) size 141x22
+            RenderTableCell {TD} at (2,2) size 68x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,2) size 63x22 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,2) size 68x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-          RenderTableRow {TR} at (0,26) size 131x22
-            RenderTableCell {TD} at (2,26) size 63x22 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 141x22
+            RenderTableCell {TD} at (2,26) size 68x22 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,26) size 63x22 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,26) size 68x22 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x19
                 text run at (1,1) width 31: "Data"
       RenderBlock (anonymous) at (0,465) size 784x20

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions1-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 785x1066
       RenderBlock (anonymous) at (0,288) size 769x18
         RenderText {#text} at (0,0) size 394x18
           text run at (0,0) width 394: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,316) size 151x111 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,68) size 141x43 [border: (3px solid #800080)]
-          RenderText {#text} at (38,3) size 48x18
-            text run at (38,3) width 48: "caption"
-          RenderBlock {INPUT} at (87,7) size 13x12
+      RenderTable {TABLE} at (5,316) size 161x111 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,68) size 151x43 [border: (3px solid #800080)]
+          RenderText {#text} at (43,3) size 48x18
+            text run at (43,3) width 48: "caption"
+          RenderBlock {INPUT} at (92,7) size 13x12
           RenderText {#text} at (3,22) size 145x18
             text run at (3,22) width 145: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,10) size 131x46
-          RenderTableRow {TR} at (0,2) size 131x20
-            RenderTableCell {TD} at (2,2) size 63x20 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,10) size 141x46
+          RenderTableRow {TR} at (0,2) size 141x20
+            RenderTableCell {TD} at (2,2) size 68x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,2) size 63x20 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,2) size 68x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-          RenderTableRow {TR} at (0,24) size 131x20
-            RenderTableCell {TD} at (2,24) size 63x20 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,24) size 141x20
+            RenderTableCell {TD} at (2,24) size 68x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,24) size 63x20 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,24) size 68x20 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
       RenderBlock (anonymous) at (0,432) size 769x18

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions2-expected.txt
@@ -57,26 +57,26 @@ layer at (0,0) size 785x1066
       RenderBlock (anonymous) at (0,288) size 769x18
         RenderText {#text} at (0,0) size 394x18
           text run at (0,0) width 394: "table 3 - caption gains content extending its max element size"
-      RenderTable {TABLE} at (5,316) size 151x111 [border: (10px solid #008000)]
-        RenderBlock {CAPTION} at (10,2) size 141x43 [border: (3px solid #800080)]
-          RenderText {#text} at (38,3) size 48x18
-            text run at (38,3) width 48: "caption"
-          RenderBlock {INPUT} at (87,7) size 13x12
+      RenderTable {TABLE} at (5,316) size 161x111 [border: (10px solid #008000)]
+        RenderBlock {CAPTION} at (10,2) size 151x43 [border: (3px solid #800080)]
+          RenderText {#text} at (43,3) size 48x18
+            text run at (43,3) width 48: "caption"
+          RenderBlock {INPUT} at (92,7) size 13x12
           RenderText {#text} at (3,22) size 145x18
             text run at (3,22) width 145: "very_large_very_large"
-        RenderTableSection {TBODY} at (10,55) size 131x46
-          RenderTableRow {TR} at (0,2) size 131x20
-            RenderTableCell {TD} at (2,2) size 63x20 [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (10,55) size 141x46
+          RenderTableRow {TR} at (0,2) size 141x20
+            RenderTableCell {TD} at (2,2) size 68x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,2) size 63x20 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,2) size 68x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-          RenderTableRow {TR} at (0,24) size 131x20
-            RenderTableCell {TD} at (2,24) size 63x20 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,24) size 141x20
+            RenderTableCell {TD} at (2,24) size 68x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
-            RenderTableCell {TD} at (66,24) size 63x20 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (71,24) size 68x20 [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18
                 text run at (1,1) width 31: "Data"
       RenderBlock (anonymous) at (0,432) size 769x18

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -958,8 +958,18 @@ void RenderTable::computePreferredLogicalWidths()
 
     m_tableLayout->applyPreferredLogicalWidthQuirks(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
 
-    for (unsigned i = 0; i < m_captions.size(); i++)
-        m_minPreferredLogicalWidth = std::max(m_minPreferredLogicalWidth, m_captions[i]->minPreferredLogicalWidth());
+    for (unsigned i = 0; i < m_captions.size(); i++) {
+        LayoutUnit captionMinWidth = m_captions[i]->minPreferredLogicalWidth();
+
+        // Only add fixed margins during preferred width calculation
+        auto& captionStyle = m_captions[i]->style();
+        if (auto fixedMarginStart = captionStyle.marginStart().tryFixed())
+            captionMinWidth += fixedMarginStart->resolveZoom(captionStyle.usedZoomForLength());
+        if (auto fixedMarginEnd = captionStyle.marginEnd().tryFixed())
+            captionMinWidth += fixedMarginEnd->resolveZoom(captionStyle.usedZoomForLength());
+
+        m_minPreferredLogicalWidth = std::max(m_minPreferredLogicalWidth, captionMinWidth);
+    }
     m_maxPreferredLogicalWidth = std::max(m_maxPreferredLogicalWidth, m_minPreferredLogicalWidth);
 
     auto& styleToUse = style();


### PR DESCRIPTION
#### 0d389e7c6ac10c7549ac12a86c5fed07feea5959
<pre>
Ensure margins in table captions contributes to minimum table width
<a href="https://bugs.webkit.org/show_bug.cgi?id=110063">https://bugs.webkit.org/show_bug.cgi?id=110063</a>
<a href="https://rdar.apple.com/120990942">rdar://120990942</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Captions with fixed horizontal margins (margin-left/margin-right) were not
being considered when computing the table&apos;s preferred logical width. This
caused tables to be narrower than needed to accommodate captions with margins,
resulting in incorrect layout.

The fix adds fixed caption margins to the minimum preferred logical width
calculation. Only fixed margins are included during intrinsic sizing, as
percentage margins depend on the containing block width which hasn&apos;t been
determined yet at this stage.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::computePreferredLogicalWidths):

&gt; Progression:
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt:

&gt; Rebaseline:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/core/captions2-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions1-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/core/captions2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/core/captions2-expected.txt:

Canonical link: <a href="https://commits.webkit.org/303642@main">https://commits.webkit.org/303642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c34e09559b1308f5b0ed4ba38e5c695ef2e90f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140697 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c17dbd3-7702-45f9-9944-e8b24830eb71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5fc2f6e5-5fed-4dfd-ae87-b3adca641841) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4344 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/82627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28be021c-b032-4bf9-b255-65232d2d09ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4228 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113304 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143342 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5316 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4565 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110389 "Failed to checkout and rebase branch from PR 54541") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27971 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59014 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5371 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5460 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->