### PR TITLE
[blocks-in-inline]  WPT html/rendering/widgets/button-layout/block-in-inline.html is failing

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-button-baseline-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-button-baseline-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/343257603">
+<link rel="match" href="block-in-inline-ref.html">
+<button style="width: 100px; height: 100px;">
+  <span>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+  </span>
+</button>

--- a/LayoutTests/fast/inline/blocks-in-inline-button-baseline.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-button-baseline.html
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/343257603">
+<link rel="match" href="block-in-inline-ref.html">
+<button style="width: 100px; height: 100px;">
+  <span>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+  </span>
+</button>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -884,7 +884,7 @@ LayoutUnit LineLayout::lastLineBaseline() const
         if (auto baseline = baselineForLineOrBlock(line))
             return *baseline;
     }
-    return baselineForLine(m_inlineContent->displayContent().lines.first());
+    return baselineForLine(m_inlineContent->displayContent().lines.last());
 }
 
 LayoutUnit LineLayout::baselineForLine(const InlineDisplay::Line& line) const


### PR DESCRIPTION
#### cb7b958ab8e10c026e0a96cf52b35eeb8c0ba526
<pre>
[blocks-in-inline]  WPT html/rendering/widgets/button-layout/block-in-inline.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303222">https://bugs.webkit.org/show_bug.cgi?id=303222</a>
<a href="https://rdar.apple.com/165514786">rdar://165514786</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-button-baseline.html
* LayoutTests/fast/inline/blocks-in-inline-button-baseline-expected.html: Copied from LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html.
* LayoutTests/fast/inline/blocks-in-inline-button-baseline.html: Copied from LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::lastLineBaseline const):

If we don&apos;t find any usable baseline return the baseline of the last (non-contentful) line instead of the first.

Canonical link: <a href="https://commits.webkit.org/303626@main">https://commits.webkit.org/303626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e63cdfb229e2d387bb9c526b2b4b57b7c63260

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85087 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/010ceb0a-6e9e-453e-a838-efe80cd54533) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101747 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69103 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a3b3074-63c3-4009-8776-fa98a2a7b9b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135998 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0f99565d-18c0-4a0a-8ace-b856b7a9ffed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4135 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83823 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143241 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110126 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27962 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4018 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58823 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5276 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5118 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5366 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->