### PR TITLE
[CSSOM-View] Include padding for content-box tables in clientWidth/Height

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
@@ -5,7 +5,7 @@ PASS Basic caption
 PASS Table and narrower caption
 PASS Table and wider caption
 PASS Table with padding
-FAIL Table with padding and content-box sizing assert_equals: Table with padding and content-box sizing clientWidth expected 26 but got 20
+PASS Table with padding and content-box sizing
 FAIL Table with separated border assert_equals: Table with separated border clientWidth expected 26 but got 20
 FAIL Table with collapsed border assert_equals: Table with collapsed border clientWidth expected 26 but got 20
 PASS Caption with padding

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1610,8 +1610,11 @@ int Element::clientWidth()
         // Currently, WebKit doesn't have table wrapper box, and we are supposed to
         // retrieve clientWidth/Height from table wrapper box, not table grid box. So
         // when we retrieve clientWidth/Height, it includes table's border size.
-        if (renderer->isRenderTable())
+        if (renderer->isRenderTable()) {
+            if (renderer->style().boxSizing() == BoxSizing::ContentBox)
+                clientWidth += renderer->paddingLeft() + renderer->paddingRight();
             clientWidth += renderer->borderLeft() + renderer->borderRight();
+        }
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientWidth, *renderer).toDouble());
     }
     return 0;
@@ -1644,8 +1647,11 @@ int Element::clientHeight()
         // Currently, WebKit doesn't have table wrapper box, and we are supposed to
         // retrieve clientWidth/Height from table wrapper box, not table grid box. So
         // when we retrieve clientWidth/Height, it includes table's border size.
-        if (renderer->isRenderTable())
+        if (renderer->isRenderTable()) {
+            if (renderer->style().boxSizing() == BoxSizing::ContentBox)
+                clientHeight += renderer->paddingTop() + renderer->paddingBottom();
             clientHeight += renderer->borderTop() + renderer->borderBottom();
+        }
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientHeight, *renderer).toDouble());
     }
     return 0;


### PR DESCRIPTION
#### 9ac5864122deab73a189bdecf30d7ade963e8a0c
<pre>
[CSSOM-View] Include padding for content-box tables in clientWidth/Height
<a href="https://bugs.webkit.org/show_bug.cgi?id=303223">https://bugs.webkit.org/show_bug.cgi?id=303223</a>
<a href="https://rdar.apple.com/165515755">rdar://165515755</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

According to the CSSOM View specification, Element::clientWidth() and
clientHeight() should report the visible content box including padding, but
excluding scrollbars and borders. See spec: [1] and [2].

For tables with box-sizing: content-box, WebKit previously omitted padding,
returning incorrect client geometry. This patch updates clientWidth() and
clientHeight() to add padding for such tables.

References:
[1] <a href="https://drafts.csswg.org/cssom-view/#dom-element-clientwidth">https://drafts.csswg.org/cssom-view/#dom-element-clientwidth</a>
[2] <a href="https://drafts.csswg.org/cssom-view/#dom-element-clientheight">https://drafts.csswg.org/cssom-view/#dom-element-clientheight</a>

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/303641@main">https://commits.webkit.org/303641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65e83622bbbe71ae4dec86e24054472036be20f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85092 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1370585-3e53-4b23-8a4d-2b4ffbfccbb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69113 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ff5e07f-f9c0-4766-8be9-3b9224acb23b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b02b39da-4f17-4759-9b3f-e68f0e0df0ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4169 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1730 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83827 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143245 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110130 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4029 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58828 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5280 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33844 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->