### PR TITLE
[GTK] Update list of skipped tests for run-perf-tests on the GTK performance test bot

### DIFF
--- a/PerformanceTests/Skipped
+++ b/PerformanceTests/Skipped
@@ -128,6 +128,24 @@ MediaTime/
 [GTK] IndexedDB/basic/index-cursor-delete.html
 [GTK] IndexedDB/basic/index-cursor-update.html
 
+# Bug 303226 - [GTK] More IndexedDB performance test timeouts
+[GTK] IndexedDB/basic/index-cursor-delete-2.html
+[GTK] IndexedDB/basic/index-multientry.html
+[GTK] IndexedDB/basic/objectstore-add.html
+[GTK] IndexedDB/basic/objectstore-clear.html
+[GTK] IndexedDB/basic/objectstore-cursor-delete.html
+[GTK] IndexedDB/basic/objectstore-cursor-update.html
+[GTK] IndexedDB/basic/objectstore-delete.html
+[GTK] IndexedDB/basic/objectstore-put.html
+[GTK] IndexedDB/stress/large-array-keys.html
+[GTK] IndexedDB/stress/large-number-of-inserts-responsiveness.html
+[GTK] IndexedDB/stress/large-string-keys.html
+
+# Bug 303227 - [GTK] 3 canvas performance tests timeout
+[GTK] Canvas/compositing-fillRect.html
+[GTK] Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html
+[GTK] Canvas/drawImageSourceVideoFrameOffscreenCanvasWebGL.html
+
 # Bug 203229 - [GTK] Perf test SVG/UnderTheSeeBenchmark.html timeouts
 [GTK] SVG/UnderTheSeeBenchmark.html
 


### PR DESCRIPTION
#### baf3c5d1b7aa3930eb3b18904f01db8733b01443
<pre>
[GTK] Update list of skipped tests for run-perf-tests on the GTK performance test bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=303228">https://bugs.webkit.org/show_bug.cgi?id=303228</a>

Unreviewed gardening commit.

Skip the tests that are timing out constantly on the GTK perf bot
to speed up the testing step.
14 tests skipped that time out after 600 sec =&gt; 2h20min less.

* PerformanceTests/Skipped:

Canonical link: <a href="https://commits.webkit.org/303625@main">https://commits.webkit.org/303625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13482a5ab7ac10012c2809cf8c8ed3303d3c800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44169 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/140603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/5430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/140603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136013 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/140603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5237 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/37942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/143256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5319 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/5430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58845 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20608 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5381 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->