### PR TITLE
[WPE] WebKitImage uses incorrect color type when encoding

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.cpp
@@ -67,7 +67,7 @@ struct _WebKitImagePrivate {
  *
  * Image objects are always created by WebKit, and considered immutable:
  * a copy of the image data needs to be made before modifying the image.
- * Pixel data can be obtained with [id@webkit_image_as_rgba_bytes].
+ * Pixel data can be obtained with [id@webkit_image_as_bytes].
  *
  * Since: 2.52
  */
@@ -247,21 +247,20 @@ guint webkit_image_get_stride(WebKitImage* image)
 }
 
 /**
- * webkit_image_as_rgba_bytes:
+ * webkit_image_as_bytes:
  * @image: a #WebKitImage
  *
  * Get the @image pixel data as an array of bytes.
  *
  * The pixel format for the returned byte buffer is 32-bit per pixel
  * with 8-bit premultiplied alpha, in the preferred byte order for
- * the architecture (typically ABGR8888 on little-endian hosts, and
- * RGBA8888 on big-endian ones).
+ * the architecture.
  *
  * Returns: (transfer none): a #GBytes
  *
  * Since: 2.52
  */
-GBytes* webkit_image_as_rgba_bytes(WebKitImage* image)
+GBytes* webkit_image_as_bytes(WebKitImage* image)
 {
     g_return_val_if_fail(WEBKIT_IS_IMAGE(image), nullptr);
 
@@ -276,7 +275,7 @@ static guint webkitImageHash(GIcon* icon)
 
     Hasher hasher;
 
-    auto* bytes = webkit_image_as_rgba_bytes(image);
+    auto* bytes = webkit_image_as_bytes(image);
     auto dataSpan = span(bytes);
 
     gsize rowBytes = image->priv->width * RGBA8BytesPerPixel;
@@ -306,8 +305,8 @@ static gboolean webkitImageEqual(GIcon* icon1, GIcon* icon2)
         || image1->priv->height != image2->priv->height)
         return false;
 
-    auto* bytes1 = webkit_image_as_rgba_bytes(image1);
-    auto* bytes2 = webkit_image_as_rgba_bytes(image2);
+    auto* bytes1 = webkit_image_as_bytes(image1);
+    auto* bytes2 = webkit_image_as_bytes(image2);
 
     auto dataSpan1 = span(bytes1);
     auto dataSpan2 = span(bytes2);
@@ -333,7 +332,7 @@ static GInputStream* webkitImageLoad(GLoadableIcon* icon, int size, char** type,
     g_return_val_if_fail(WEBKIT_IS_IMAGE(icon), nullptr);
 
     auto* image = WEBKIT_IMAGE(icon);
-    auto* bytes = webkit_image_as_rgba_bytes(image);
+    auto* bytes = webkit_image_as_bytes(image);
     if (!bytes) {
         LOG_ERROR("Failed to retrieve image RGBA bytes");
         g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to encode image as PNG");
@@ -347,7 +346,7 @@ static GInputStream* webkitImageLoad(GLoadableIcon* icon, int size, char** type,
     SkImageInfo info = SkImageInfo::Make(
         image->priv->width,
         image->priv->height,
-        kRGBA_8888_SkColorType,
+        kBGRA_8888_SkColorType,
         kUnpremul_SkAlphaType
     );
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
@@ -34,10 +34,10 @@ G_BEGIN_DECLS
 
 WEBKIT_DECLARE_FINAL_TYPE (WebKitImage, webkit_image, WEBKIT, IMAGE, GObject)
 
-WEBKIT_API int          webkit_image_get_width     (WebKitImage *image);
-WEBKIT_API int          webkit_image_get_height    (WebKitImage *image);
-WEBKIT_API guint        webkit_image_get_stride    (WebKitImage *image);
-WEBKIT_API GBytes      *webkit_image_as_rgba_bytes (WebKitImage *image);
+WEBKIT_API int          webkit_image_get_width  (WebKitImage *image);
+WEBKIT_API int          webkit_image_get_height (WebKitImage *image);
+WEBKIT_API guint        webkit_image_get_stride (WebKitImage *image);
+WEBKIT_API GBytes      *webkit_image_as_bytes   (WebKitImage *image);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5206,7 +5206,8 @@ void webkit_web_view_get_snapshot(WebKitWebView* webView, WebKitSnapshotRegion r
  * @result: a #GAsyncResult
  * @error: return location for error or %NULL to ignore
  *
- * Finishes an asynchronous operation started with webkit_web_view_get_snapshot().
+ * Finishes an asynchronous operation started with webkit_web_view_get_snapshot(), producing
+ * an image of the snapshot using the BGRA8888 pixel format.
  *
  * Returns: (transfer full): an image with the retrieved snapshot, or %NULL in case of error.
  */

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
@@ -87,7 +87,7 @@ static void testWebKitImagePropertiesConstruct(WebKitImageTest*, gconstpointer)
         "stride", &stride,
         nullptr);
 
-    GBytes* retrieved_data = webkit_image_as_rgba_bytes(image.get());
+    GBytes* retrieved_data = webkit_image_as_bytes(image.get());
 
     g_assert_cmpint(width, ==, 1);
     g_assert_cmpint(height, ==, 2);


### PR DESCRIPTION
#### bd53bc0caa62ef3e0ff79cead06684acd77441f8
<pre>
[WPE] WebKitImage uses incorrect color type when encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=303230">https://bugs.webkit.org/show_bug.cgi?id=303230</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

Align WebKitImage with WebKit::WebImage, using BGRA8. This fixes PNG
encoding in WebKitImage load-related functions. Additionally rename
webkit_image_as_rgba_bytes into webkit_image_as_bytes, to stop implying
any pixel format.

Test: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
* Source/WebKit/UIProcess/API/glib/WebKitImage.cpp:
(webkit_image_as_bytes):
(webkitImageHash):
(webkitImageEqual):
(webkitImageLoad):
(webkit_image_as_rgba_bytes): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitImage.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp:
(testWebKitImagePropertiesConstruct):

Canonical link: <a href="https://commits.webkit.org/303675@main">https://commits.webkit.org/303675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76c071abad7fa40b32bc087952c1186509f48835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4154 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1741 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110326 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4040 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58856 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5297 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5138 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68749 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->