### PR TITLE
[GStreamer][Rice] TCP connections handling

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -159,7 +159,7 @@ static gboolean webkitGstWebRTCIceStreamGatherCandidates(GstWebRTCICEStream* ice
 
         riceAddresses.append(WTFMove(addr));
         riceTransports.append(RICE_TRANSPORT_TYPE_UDP);
-        // TODO: TCP
+        riceTransports.append(RICE_TRANSPORT_TYPE_TCP);
     }
     Vector<const RiceAddress*> riceAddressValues;
     for (const auto& addr : riceAddresses)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
@@ -112,6 +112,7 @@ static GstFlowReturn iceTransportHandleSample(WebKitGstIceTransport* self, GstAp
 
     auto from = riceAddressToString(transmit.from);
     auto to = riceAddressToString(transmit.to);
+    auto protocol = riceTransmitTransportToIceProtocol(transmit);
     auto handle = riceTransmitToSharedMemoryHandle(&transmit);
     if (!handle) [[unlikely]] {
         GST_ERROR_OBJECT(self, "Failed to create shared memory handle");
@@ -119,7 +120,7 @@ static GstFlowReturn iceTransportHandleSample(WebKitGstIceTransport* self, GstAp
     }
 
     auto data = WTFMove(*handle);
-    webkitGstWebRTCIceAgentSend(agent.get(), rice_stream_get_id(riceStream.get()), RTCIceProtocol::Udp, WTFMove(from), WTFMove(to), WTFMove(data));
+    webkitGstWebRTCIceAgentSend(agent.get(), rice_stream_get_id(riceStream.get()), protocol, WTFMove(from), WTFMove(to), WTFMove(data));
     return GST_FLOW_OK;
 }
 

--- a/Source/WebCore/platform/rice/RiceGioBackend.cpp
+++ b/Source/WebCore/platform/rice/RiceGioBackend.cpp
@@ -117,9 +117,9 @@ static gboolean agentSourcePrepare(GSource* base, gint* timeout)
         if (transmit.from && transmit.to) {
             auto from = riceAddressToString(transmit.from);
             auto to = riceAddressToString(transmit.to);
+            auto protocol = riceTransmitTransportToIceProtocol(transmit);
             if (auto handle = riceTransmitToSharedMemoryHandle(&transmit)) {
-                auto data = WTFMove(*handle);
-                webkitGstWebRTCIceAgentSend(iceAgent.get(), transmit.stream_id, RTCIceProtocol::Udp, WTFMove(from), WTFMove(to), WTFMove(data));
+                webkitGstWebRTCIceAgentSend(iceAgent.get(), transmit.stream_id, protocol, WTFMove(from), WTFMove(to), WTFMove(*handle));
                 result = TRUE;
             }
         } else

--- a/Source/WebCore/platform/rice/RiceUtilities.h
+++ b/Source/WebCore/platform/rice/RiceUtilities.h
@@ -81,6 +81,19 @@ static inline std::optional<SharedMemory::Handle> riceTransmitToSharedMemoryHand
     return SharedMemoryHandle::createCopy(unsafeMakeSpan(transmit->data.ptr, transmit->data.size), SharedMemoryProtection::ReadOnly);
 }
 
+static inline RTCIceProtocol riceTransmitTransportToIceProtocol(const RiceTransmit& transmit)
+{
+    switch (transmit.transport) {
+    case RICE_TRANSPORT_TYPE_TCP:
+        return RTCIceProtocol::Tcp;
+    case RICE_TRANSPORT_TYPE_UDP:
+        return RTCIceProtocol::Udp;
+    }
+
+    return RTCIceProtocol::Udp;
+}
+
+
 } // namespace WebCore
 
 #endif // USE(LIBRICE)

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
@@ -103,6 +103,7 @@ private:
     HashMap<unsigned, SocketData, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_sockets;
 
     HashMap<unsigned, Vector<GUniquePtr<RiceAddress>>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_udpAddresses;
+    Vector<GRefPtr<RiceTcpListener>> m_tcpListeners;
 
     HashMap<String, GUniquePtr<RiceAddress>> m_addressCache;
     HashMap<unsigned, Vector<String>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_udpSocketAddressesCache;


### PR DESCRIPTION
#### 2aa4cd8bb03e1386bd8078eb1b5253ef9823d4e6
<pre>
[GStreamer][Rice] TCP connections handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=303229">https://bugs.webkit.org/show_bug.cgi?id=303229</a>

Reviewed by Xabier Rodriguez-Calvar.

Create RiceTcp listeners on Network process side and dispatch RiceTransmit TCP requests accordingly
instead of hard-coding UDP.

Canonical link: <a href="https://commits.webkit.org/303674@main">https://commits.webkit.org/303674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/decee8f70d4877072318feca485ca9eabf8af664

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/101942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136218 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82738 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113430 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38150 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110503 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27996 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59192 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68949 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->