### PR TITLE
[AppKit Gestures] UseAppKitGestures toggle need not require a new UI process for behavior change

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKPanGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKPanGestureController.h
@@ -40,6 +40,7 @@ OBJC_CLASS NSPanGestureRecognizer;
 @interface WKPanGestureController : NSObject <NSGestureRecognizerDelegate>
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
+- (void)enablePanGestureIfNeeded;
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKPanGestureController.mm
@@ -122,11 +122,22 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     _panGestureRecognizer = adoptNS([[NSPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognized:)]);
     [self configureForScrolling:_panGestureRecognizer.get()];
     [_panGestureRecognizer setDelegate:self];
+    [self enablePanGestureIfNeeded];
 
     CheckedPtr checkedViewImpl = _viewImpl.get();
     [checkedViewImpl->protectedView() addGestureRecognizer:_panGestureRecognizer.get()];
 
     return self;
+}
+
+- (void)enablePanGestureIfNeeded
+{
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+    bool panGestureEnabled = page->protectedPreferences()->useAppKitGestures();
+    WK_PAN_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "%@ setEnabled:%d", _panGestureRecognizer.get(), static_cast<int>(panGestureEnabled));
+    [_panGestureRecognizer setEnabled:panGestureEnabled];
 }
 
 #pragma mark - Gesture Recognition

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -480,6 +480,8 @@ public:
 
     void preferencesDidChange();
 
+    void updateNeedsViewFrameInWindowCoordinatesIfNeeded();
+
     void teardownTextIndicatorLayer();
     void startTextIndicatorFadeOut();
     CALayer *textIndicatorInstallationLayer();
@@ -927,8 +929,6 @@ private:
 #endif
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
-
-    void configurePanGestureRecognizerIfNeeded();
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;


### PR DESCRIPTION
#### 0d001d95a9c01896139caafb68eb6914980fec0e
<pre>
[AppKit Gestures] UseAppKitGestures toggle need not require a new UI process for behavior change
<a href="https://bugs.webkit.org/show_bug.cgi?id=303233">https://bugs.webkit.org/show_bug.cgi?id=303233</a>
<a href="https://rdar.apple.com/165522233">rdar://165522233</a>

Reviewed by Wenson Hsieh.

Right now, we gate WKPanGestureController creation behind the value of
UseAppKitGestures at WebViewImpl creation time, meaning the preference
change is only respected at UI process initialization. This makes local
debugging cumbersome.

Instead, in this patch, we start unconditionally creating the pan
gesture controller. Then, we teach WebViewImpl::preferencesDidChange()
to call into -[WKPanGestureController enablePanGestureIfNeeded:], where
we reflect the preference value in the tracked pan gesture&apos;s `enabled`
property.

* Source/WebKit/UIProcess/mac/WKPanGestureController.h:
* Source/WebKit/UIProcess/mac/WKPanGestureController.mm:
(-[WKPanGestureController initWithPage:viewImpl:]):
(-[WKPanGestureController enablePanGestureIfNeeded]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::updateNeedsViewFrameInWindowCoordinatesIfNeeded):
(WebKit::WebViewImpl::preferencesDidChange):
(WebKit::WebViewImpl::configurePanGestureRecognizerIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/303691@main">https://commits.webkit.org/303691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b931854db03ba556a2c8ea62a7ba4e9dab20e9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85217 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba1a3448-7f56-47a6-acb3-2f0176f9cd73) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101858 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69290 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76673871-13ff-4812-a96a-c9eb8f4d64fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82654 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4265 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1842 "Found 1 new API test failure: TestWebKitAPI.FragmentDirectiveGeneration.VerifyFragmentRanges (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113342 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143377 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110236 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110418 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4139 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59073 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20625 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5401 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33975 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->