### PR TITLE
Prepare the <model> for an immersive presentation

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Immersive API exists on model and document
 PASS Model immersive request fails without user activation
-FAIL Model enters immersive mode with user activation promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Document.exitImmersive() exits immersive model promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Immersivechange events fire when entering immersive promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Only one model can be immersive at a time promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Removing immersive model from DOM exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
+FAIL Model enters immersive mode with user activation promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Document.exitImmersive() exits immersive model promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Immersivechange events fire when entering immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Only one model can be immersive at a time promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Removing immersive model from DOM exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
 PASS Immersiveerror event fires when request fails
-FAIL CSS :immersive pseudo-class matches correctly promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Model is complete once presented as immersive promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
-FAIL Multiple concurrent requestImmersive calls are handled correctly promise_test: Unhandled rejection with value: object "TypeError: Not implemented"
+FAIL CSS :immersive pseudo-class matches correctly promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Model is complete once presented as immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Multiple concurrent requestImmersive calls are handled correctly promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
 

--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -11,7 +11,7 @@
 <script>
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     assert_true('requestImmersive' in model, 'requestImmersive should exist');
     assert_equals(typeof model.requestImmersive, 'function', 'requestImmersive should be a function');
@@ -24,7 +24,7 @@ promise_test(async t => {
 }, 'Immersive API exists on model and document');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     await promise_rejects_js(t, TypeError, 
         model.requestImmersive(),
@@ -35,17 +35,16 @@ promise_test(async t => {
 }, 'Model immersive request fails without user activation');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
 
     await test_driver.bless("immersive");
-    
     await model.requestImmersive();
     
     assert_equals(document.immersiveElement, model, 'Document should reference immersive model');
 }, 'Model enters immersive mode with user activation');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     await test_driver.bless("immersive");
     await model.requestImmersive();
@@ -58,7 +57,7 @@ promise_test(async t => {
 }, 'Document.exitImmersive() exits immersive model');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     let modelChangeEvents = [];
     let documentChangeEvents = [];
@@ -84,8 +83,8 @@ promise_test(async t => {
 }, 'Immersivechange events fire when entering immersive');
 
 promise_test(async t => {
-    const [model1, source1] = createModelAndSource(t, "resources/cube.usdz");
-    const [model2, source2] = createModelAndSource(t, "resources/sphere.usdz");
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/sphere.usdz");
     
     await test_driver.bless("immersive");
     await model1.requestImmersive();
@@ -99,7 +98,7 @@ promise_test(async t => {
 }, 'Only one model can be immersive at a time');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     await test_driver.bless("immersive");
     await model.requestImmersive();
@@ -112,7 +111,7 @@ promise_test(async t => {
 }, 'Removing immersive model from DOM exits immersive mode');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     let errorFired = false;
     model.addEventListener('immersiveerror', () => {
@@ -127,7 +126,7 @@ promise_test(async t => {
 }, 'Immersiveerror event fires when request fails');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     assert_false(model.matches(':immersive'), 'Should not match :immersive initially');
     
@@ -142,7 +141,7 @@ promise_test(async t => {
 }, 'CSS :immersive pseudo-class matches correctly');
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     await test_driver.bless("immersive");
     await model.requestImmersive();
@@ -151,8 +150,8 @@ promise_test(async t => {
 }, 'Model is complete once presented as immersive');
 
 promise_test(async t => {
-    const [model1, source1] = createModelAndSource(t, "resources/cube.usdz");
-    const [model2, source2] = createModelAndSource(t, "resources/sphere.usdz");
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/sphere.usdz");
     
     await test_driver.bless("immersive");
     const promise1 = model1.requestImmersive();

--- a/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Hidden inline model should successfully enter immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+

--- a/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ModelElementImmersiveEnabled=true shouldAcceptImmersiveEnvironmentRequests=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> immersive</title>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/model-element-test-utils.js"></script>
+<script src="../resources/model-utils.js"></script>
+<body>
+    <model style="display: none;" id='hidden-model'>
+        <source src='../resources/cube.usdz'/>
+    </model>
+
+<script>
+
+promise_test(async t => {
+    const model = document.getElementById("hidden-model");
+
+    await test_driver.bless("immersive");
+    await model.requestImmersive();
+
+    assert_equals(document.immersiveElement, model, 'Hidden model became document\'s immersive element');
+}, 'Hidden inline model should successfully enter immersive');
+
+</script>
+</body>
+
+

--- a/LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html
@@ -11,7 +11,7 @@
 <script>
 
 promise_test(async t => {
-    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
 
     await test_driver.bless("immersive");
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -149,6 +149,8 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool immersive() const;
     void requestImmersive(DOMPromiseDeferred<void>&&);
+    void ensureImmersivePresentation(CompletionHandler<void(ExceptionOr<const LayerHostingContextIdentifier>)>&&);
+    void exitImmersivePresentation(CompletionHandler<void()>&&);
 #endif
 
     bool supportsDragging() const;
@@ -272,6 +274,7 @@ private:
     void setAnimationIsPlaying(bool, DOMPromiseDeferred<void>&&);
 
     LayoutSize contentSize() const;
+    bool modelContainerSizeIsEmpty() const;
 
     void reportExtraMemoryCost();
 
@@ -346,6 +349,16 @@ private:
     CachedResourceHandle<CachedRawResource> m_environmentMapResource;
     UniqueRef<EnvironmentMapPromise> m_environmentMapReadyPromise;
 #endif
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool m_detachedForImmersive { false };
+    void setDetachedForImmersive(bool);
+
+    Vector<CompletionHandler<void(ExceptionOr<RefPtr<ModelPlayer>>)>> m_modelPlayerCreationCallbacks;
+    void ensureModelPlayer(CompletionHandler<void(ExceptionOr<RefPtr<ModelPlayer>>)>&&);
+#endif
+
+    void triggerModelPlayerCreationCallbacksIfNeeded(ExceptionOr<RefPtr<ModelPlayer>>&&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h
@@ -42,6 +42,9 @@ struct ModelPlayerGraphicsLayerConfiguration {
 #if ENABLE(MODEL_ELEMENT_PORTAL)
     bool hasPortal;
 #endif
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool detachedForImmersive;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -59,7 +59,7 @@ public:
     RefPtr<HTMLModelElement> protectedImmersiveElement() const { return immersiveElement(); }
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
-    void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
+    void exitImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitRemovedImmersiveElement(HTMLModelElement*);
 
     enum class EventType : bool { Change, Error };

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -571,6 +571,9 @@ public:
 #if ENABLE(MODEL_CONTEXT)
     virtual void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) { }
 #endif
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    virtual void removeModelContents() { }
+#endif
     virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
     WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1452,6 +1452,18 @@ void GraphicsLayerCA::setContentsToModelContext(Ref<ModelContext> modelContext, 
 }
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+void GraphicsLayerCA::removeModelContents()
+{
+    if (!m_contentsLayer)
+        return;
+
+    m_contentsLayer = nullptr;
+    noteSublayersChanged();
+    noteLayerPropertyChanged(ContentsPlatformLayerChanged);
+}
+#endif
+
 void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, ContentsLayerPurpose purpose)
 {
 #if HAVE(AVKIT)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -176,6 +176,9 @@ public:
 #if ENABLE(MODEL_CONTEXT) && !ENABLE(GPU_PROCESS_MODEL)
     WEBCORE_EXPORT void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) override;
 #endif
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    WEBCORE_EXPORT void removeModelContents() override;
+#endif
     WEBCORE_EXPORT void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT PlatformLayerIdentifier setContentsToAsyncDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>, ContentsLayerPurpose);

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -224,6 +224,11 @@ void ModelProcessModelPlayer::sizeDidChange(WebCore::LayoutSize size)
 
 void ModelProcessModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&& configuration)
 {
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    if (configuration.detachedForImmersive)
+        return graphicsLayer.removeModelContents();
+#endif
+
     auto modelLayerIdentifier = graphicsLayer.primaryLayerID();
     if (!modelLayerIdentifier)
         return;


### PR DESCRIPTION
#### 77b3be1d7a731a6280de28e4637392c8ec4f7fb2
<pre>
Prepare the &lt;model&gt; for an immersive presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303238">https://bugs.webkit.org/show_bug.cgi?id=303238</a>
<a href="https://rdar.apple.com/165527010">rdar://165527010</a>

Reviewed by Etienne Segonzac.

Add logic to ensure that a model player is running before entering the model in immersive
Add logic to allow the creation of the model player for hidden inline models
Remove the inline model from the rendered page

Test: model-element/immersive/model-element-immersive-hidden-inline.html

* LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt: Added.
* LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html: Copied from LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html.
* LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html:
Update test results to reflect the current state.
Add a test for hidden inline models.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::isVisible const):
(WebCore::HTMLModelElement::modelDidChange):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::configureGraphicsLayer):
(WebCore::HTMLModelElement::setEntityTransform):
(WebCore::HTMLModelElement::modelResourceFinished):
(WebCore::HTMLModelElement::ensureImmersivePresentation):
(WebCore::HTMLModelElement::exitImmersivePresentation):
(WebCore::HTMLModelElement::setDetachedForImmersive):
(WebCore::HTMLModelElement::ensureModelPlayer):
(WebCore::HTMLModelElement::triggerModelPlayerCreationCallbacksIfNeeded):
(WebCore::HTMLModelElement::modelContainerSizeIsEmpty const):
(WebCore::HTMLModelElement::sourceRequestResource):
Add a method to ensure the presence of a model player.
This will either directly give the current running model player if it exists,
wake up a suspended model player, or start a new model player creation request.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayerGraphicsLayerConfiguration.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::exitImmersive):
(WebCore::DocumentImmersive::requestImmersive):
* Source/WebCore/dom/DocumentImmersive.h:

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::removeModelContents):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::removeModelContents):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::configureGraphicsLayer):
Remove the model inline presentation if needed.

Canonical link: <a href="https://commits.webkit.org/303751@main">https://commits.webkit.org/303751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c51ac431fda6eac88ecbc7b8b6f1f0ce699f0fc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141061 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102125 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2097 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5676 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4358 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115933 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59426 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5731 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69183 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->