### PR TITLE
[WebDriver] Add force option to run-webdriver-tests to ignore the test expectations

### DIFF
--- a/Tools/Scripts/run-webdriver-tests
+++ b/Tools/Scripts/run-webdriver-tests
@@ -56,6 +56,8 @@ option_parser.add_option('--display-server', choices=['xvfb', 'xorg', 'weston', 
 option_parser.add_option('--disable-webdriver-bidi', action='store_false',
                          dest='enable_webdriver_bidi', default=True,
                          help='Run Selenium tests with BiDi disabled')
+option_parser.add_option('--force', action='store_true',
+                         help='Ignore the expectations file, running all given tests and assuming they should PASS')
 
 options, args = option_parser.parse_args()
 

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
@@ -85,7 +85,11 @@ class WebDriverTestRunner(object):
 
         _log.info('Parsing expectations')
         self._tests_dir = WebKitFinder(self._port.host.filesystem).path_from_webkit_base('WebDriverTests')
-        expectations_file = os.path.join(self._tests_dir, 'TestExpectations.json')
+        if self._port.get_option('force'):
+            _log.info('Force mode enabled: Ignoring test expectations')
+            expectations_file = ''
+        else:
+            expectations_file = os.path.join(self._tests_dir, 'TestExpectations.json')
         build_type = 'Debug' if self._port.get_option('debug') else 'Release'
         self._expectations = TestExpectations(self._port.name(), expectations_file, build_type)
         for test in self._expectations._expectations.keys():


### PR DESCRIPTION
#### 8519d358668dd314f6bec956543838f66d1eeb6f
<pre>
[WebDriver] Add force option to run-webdriver-tests to ignore the test expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=303242">https://bugs.webkit.org/show_bug.cgi?id=303242</a>

Reviewed by Carlos Alberto Lopez Perez.

Add a `--force` option to ensure we assume all found tests are expected
to PASS and should be run.

* Tools/Scripts/run-webdriver-tests:
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py:
(WebDriverTestRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/303659@main">https://commits.webkit.org/303659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a39d365bdad97432c921228d4b6e35b4a433e38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101789 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82587 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132446 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4188 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1766 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143288 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27984 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4065 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33888 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5164 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->