### PR TITLE
Temporal: Implement valueOf for PlainMonthDay objects

### DIFF
--- a/JSTests/stress/temporal-plainmonthday.js
+++ b/JSTests/stress/temporal-plainmonthday.js
@@ -109,3 +109,8 @@ shouldBe(Temporal.PlainMonthDay.prototype.toPlainDate.length, 1);
     shouldBe(leapDay.toPlainDate({ year: 2025 }).toString(), "2025-02-28");
 
 }
+
+shouldBe(Temporal.PlainMonthDay.prototype.valueOf.length, 0);
+{
+    shouldThrow(() => monthDay.valueOf(), TypeError);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -161,9 +161,6 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/name.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/not-a-constructor.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/prop-desc.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/basic.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/branding.js
-    - test/built-ins/Temporal/PlainMonthDay/prototype/valueOf/prop-desc.js
 
     # Depends on Temporal.PlainYearMonth
     - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/basic.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -376,9 +376,6 @@ test/built-ins/Temporal/PlainDateTime/prototype/yearOfWeek/branding.js:
 test/built-ins/Temporal/PlainDateTime/prototype/yearOfWeek/prop-desc.js:
   default: "TypeError: undefined is not an object (evaluating 'descriptor.get')"
   strict mode: "TypeError: undefined is not an object (evaluating 'descriptor.get')"
-test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/order-of-operations.js:
-  default: "TypeError: pmd.toPlainDate is not a function. (In 'pmd.toPlainDate(fields)', 'pmd.toPlainDate' is undefined)"
-  strict mode: "TypeError: pmd.toPlainDate is not a function. (In 'pmd.toPlainDate(fields)', 'pmd.toPlainDate' is undefined)"
 test/built-ins/Temporal/PlainTime/from/observable-get-overflow-argument-string-invalid.js:
   default: 'Test262Error: Actual [get overflow, get overflow.toString, call overflow.toString] and expected [] should have the same contents. options read after ISO string parsing'
   strict mode: 'Test262Error: Actual [get overflow, get overflow.toString, call overflow.toString] and expected [] should have the same contents. options read after ISO string parsing'

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -43,6 +43,7 @@ static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToJSON);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncEquals);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncValueOf);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterCalendarId);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterDay);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterMonthCode);
@@ -63,6 +64,7 @@ const ClassInfo TemporalPlainMonthDayPrototype::s_info = { "Temporal.PlainMonthD
   toLocaleString   temporalPlainMonthDayPrototypeFuncToLocaleString     DontEnum|Function 0
   with             temporalPlainMonthDayPrototypeFuncWith               DontEnum|Function 1
   equals           temporalPlainMonthDayPrototypeFuncEquals             DontEnum|Function 1
+  valueOf          temporalPlainMonthDayPrototypeFuncValueOf            DontEnum|Function 0
   calendarId       temporalPlainMonthDayPrototypeGetterCalendarId       DontEnum|ReadOnly|CustomAccessor
   day              temporalPlainMonthDayPrototypeGetterDay              DontEnum|ReadOnly|CustomAccessor
   monthCode        temporalPlainMonthDayPrototypeGetterMonthCode        DontEnum|ReadOnly|CustomAccessor
@@ -205,6 +207,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTFMove(plainDateOptional.value()))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof
+JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncValueOf, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects."_s);
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendarid


### PR DESCRIPTION
#### 883b821820a9a6dfa6d249584000c0ce9612fd29
<pre>
Temporal: Implement valueOf for PlainMonthDay objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=303243">https://bugs.webkit.org/show_bug.cgi?id=303243</a>

Reviewed by Justin Michaud.

Implement valueOf for PlainMonthDay (which always throws).

Also enable a test for PlainDate that passes, which somehow
wasn&apos;t enabled in the previous Temporal PR.

* JSTests/stress/temporal-plainmonthday.js:
(shouldBe):
* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/303631@main">https://commits.webkit.org/303631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/469f6ea6714b1ecf5f900a9763c9a3a9591c5972

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85136 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136045 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4184 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1769 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125170 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143289 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131607 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5269 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4067 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115537 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/58910 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33891 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164574 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68776 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42888 "Build was cancelled. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->