### PR TITLE
[JSC] Implement `Iterator.zip` and `Iterator.zipKeyed`

### DIFF
--- a/JSTests/stress/iterator-zip-basic.js
+++ b/JSTests/stress/iterator-zip-basic.js
@@ -1,0 +1,188 @@
+//@ requireOptions("--useIteratorZip=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2, 3], ['a', 'b', 'c']])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+    shouldBeArray(result[2], [3, 'c']);
+}
+
+{
+    const result = [...Iterator.zip([])];
+    shouldBe(result.length, 0);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2, 3]])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1]);
+    shouldBeArray(result[1], [2]);
+    shouldBeArray(result[2], [3]);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2], ['a', 'b', 'c', 'd']])];
+    shouldBe(result.length, 2);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2], ['a', 'b', 'c', 'd']], { mode: 'shortest' })];
+    shouldBe(result.length, 2);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2], ['a', 'b', 'c']], { mode: 'longest' })];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+    shouldBe(result[2][0], undefined);
+    shouldBe(result[2][1], 'c');
+}
+
+{
+    const result = [...Iterator.zip([[1, 2], ['a', 'b', 'c']], { mode: 'longest', padding: [0, 'z'] })];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+    shouldBeArray(result[2], [0, 'c']);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2], ['a', 'b']], { mode: 'strict' })];
+    shouldBe(result.length, 2);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+}
+
+{
+    const customIterable = {
+        [Symbol.iterator]() {
+            let i = 0;
+            return {
+                next() {
+                    if (i < 3) return { done: false, value: i++ };
+                    return { done: true };
+                }
+            };
+        }
+    };
+    const result = [...Iterator.zip([customIterable, [10, 20, 30]])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [0, 10]);
+    shouldBeArray(result[1], [1, 20]);
+    shouldBeArray(result[2], [2, 30]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+    }
+    const result = [...Iterator.zip([gen(), ['a', 'b', 'c']])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBeArray(result[1], [2, 'b']);
+    shouldBeArray(result[2], [3, 'c']);
+}
+
+{
+    const iter = Iterator.zip([[1, 2], ['a', 'b']]);
+    const first = iter.next();
+    shouldBe(first.done, false);
+    shouldBeArray(first.value, [1, 'a']);
+    const second = iter.next();
+    shouldBe(second.done, false);
+    shouldBeArray(second.value, [2, 'b']);
+    const third = iter.next();
+    shouldBe(third.done, true);
+}
+
+{
+    const result = [...Iterator.zip([[1, 2, 3], ['a', 'b', 'c'], [true, false, null]])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], [1, 'a', true]);
+    shouldBeArray(result[1], [2, 'b', false]);
+    shouldBeArray(result[2], [3, 'c', null]);
+}
+
+{
+    const result = [...Iterator.zip([[], []])];
+    shouldBe(result.length, 0);
+}
+
+{
+    let closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const iter2 = [1, 2];
+    const zipped = Iterator.zip([iter1, iter2]);
+    const results = [];
+    for (const item of zipped) {
+        results.push(item);
+    }
+    shouldBe(results.length, 2);
+    shouldBe(closed, true);
+}
+
+{
+    let returnCalled = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { returnCalled = true; return { done: true }; }
+    };
+    const zipped = Iterator.zip([[1, 2, 3], iter]);
+    for (const item of zipped) {
+        break;
+    }
+    shouldBe(returnCalled, true);
+}
+
+{
+    const result = [...Iterator.zip([[1], ['a', 'b', 'c', 'd']], { mode: 'longest', padding: [99] })];
+    shouldBe(result.length, 4);
+    shouldBeArray(result[0], [1, 'a']);
+    shouldBe(result[1][0], 99);
+    shouldBe(result[1][1], 'b');
+    shouldBe(result[2][0], 99);
+    shouldBe(result[2][1], 'c');
+    shouldBe(result[3][0], 99);
+    shouldBe(result[3][1], 'd');
+}
+
+{
+    const set = new Set([1, 2, 3]);
+    const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+    const result = [...Iterator.zip([set, map])];
+    shouldBe(result.length, 3);
+    shouldBe(result[0][0], 1);
+    shouldBeArray(result[0][1], ['a', 1]);
+}
+
+{
+    const result = [...Iterator.zip([Array.from('abc'), [1, 2, 3]])];
+    shouldBe(result.length, 3);
+    shouldBeArray(result[0], ['a', 1]);
+    shouldBeArray(result[1], ['b', 2]);
+    shouldBeArray(result[2], ['c', 3]);
+}

--- a/JSTests/stress/iterator-zip-errors.js
+++ b/JSTests/stress/iterator-zip-errors.js
@@ -1,0 +1,444 @@
+//@ requireOptions("--useIteratorZip=1")
+
+function shouldThrow(fn, errorType, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof errorType))
+            throw new Error(`Expected ${errorType.name} but got ${e.name}: ${e.message}`);
+        if (message !== undefined && e.message !== message)
+            throw new Error(`Expected message '${message}' but got '${e.message}'`);
+    }
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+{
+    shouldThrow(() => Iterator.zip(null), TypeError, "Iterator.zip requires iterables to be an object");
+    shouldThrow(() => Iterator.zip(undefined), TypeError, "Iterator.zip requires iterables to be an object");
+    shouldThrow(() => Iterator.zip(42), TypeError, "Iterator.zip requires iterables to be an object");
+    shouldThrow(() => Iterator.zip("string"), TypeError, "Iterator.zip requires iterables to be an object");
+    shouldThrow(() => Iterator.zip(true), TypeError, "Iterator.zip requires iterables to be an object");
+    shouldThrow(() => Iterator.zip(Symbol()), TypeError, "Iterator.zip requires iterables to be an object");
+}
+
+{
+    shouldThrow(() => Iterator.zip([], 42), TypeError, "options should be undefined or object");
+    shouldThrow(() => Iterator.zip([], "string"), TypeError, "options should be undefined or object");
+    shouldThrow(() => Iterator.zip([], true), TypeError, "options should be undefined or object");
+}
+
+{
+    shouldThrow(() => Iterator.zip([], { mode: 'invalid' }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+    shouldThrow(() => Iterator.zip([], { mode: 42 }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+    shouldThrow(() => Iterator.zip([], { mode: null }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+}
+
+{
+    shouldThrow(() => Iterator.zip([], { mode: 'longest', padding: 42 }), TypeError, "padding option should be an object");
+    shouldThrow(() => Iterator.zip([], { mode: 'longest', padding: "string" }), TypeError, "padding option should be an object");
+    shouldThrow(() => Iterator.zip([], { mode: 'longest', padding: true }), TypeError, "padding option should be an object");
+}
+
+{
+    const obj = {};
+    obj[Symbol.iterator] = undefined;
+    shouldThrow(() => Iterator.zip(obj), TypeError, "Iterator.zip requires that iterables[Symbol.iterator] be a function");
+}
+
+{
+    const obj = {
+        [Symbol.iterator]() { return 42; }
+    };
+    shouldThrow(() => Iterator.zip(obj), TypeError, "Iterator.zip requires that iterables[Symbol.iterator]() returns an object");
+}
+
+{
+    shouldThrow(() => {
+        Iterator.zip([[1, 2], 42]);
+    }, TypeError, "GetIteratorFlattenable expects its first argument to be an object");
+}
+
+{
+    shouldThrow(() => {
+        Iterator.zip([[1, 2], "string"]);
+    }, TypeError, "GetIteratorFlattenable expects its first argument to be an object");
+}
+
+{
+    const badIterable = {
+        [Symbol.iterator]() { return 42; }
+    };
+    shouldThrow(() => {
+        Iterator.zip([[1, 2], badIterable]);
+    }, TypeError, "Iterator is not an object");
+}
+
+{
+    const throwingNext = {
+        [Symbol.iterator]() {
+            return {
+                next() { throw new Error("next error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([throwingNext]);
+        iter.next();
+    }, Error, "next error");
+}
+
+{
+    const badResult = {
+        [Symbol.iterator]() {
+            return {
+                next() { return 42; }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([badResult]);
+        iter.next();
+    }, TypeError, "Iterator result interface is not an object");
+}
+
+{
+    let closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingIterable = {
+        [Symbol.iterator]() { throw new Error("iterator error"); }
+    };
+    shouldThrow(() => {
+        Iterator.zip([iter1, throwingIterable]);
+    }, Error, "iterator error");
+    shouldBe(closed, true);
+}
+
+{
+    shouldThrow(() => {
+        const iter = Iterator.zip([[1, 2], [1]], { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    shouldThrow(() => {
+        const iter = Iterator.zip([[1], [1, 2]], { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    let closed = [];
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed.push(1); return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 2 }; },
+        return() { closed.push(2); return { done: true }; }
+    };
+    const throwingIter = {
+        [Symbol.iterator]() { return this; },
+        next() { throw new Error("next throws"); },
+        return() { closed.push(3); return { done: true }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([iter1, iter2, throwingIter]);
+        iter.next();
+    }, Error, "next throws");
+    shouldBe(closed.length, 2);
+    shouldBe(closed[0], 2);
+    shouldBe(closed[1], 1);
+}
+
+{
+    const nonIterablePadding = {};
+    nonIterablePadding[Symbol.iterator] = undefined;
+    shouldThrow(() => {
+        Iterator.zip([[1, 2]], { mode: 'longest', padding: nonIterablePadding });
+    }, TypeError, "padding[Symbol.iterator] is not a function");
+}
+
+{
+    const badPadding = {
+        [Symbol.iterator]() { return 42; }
+    };
+    shouldThrow(() => {
+        Iterator.zip([[1, 2]], { mode: 'longest', padding: badPadding });
+    }, TypeError, "padding[Symbol.iterator]() did not return an object");
+}
+
+{
+    const throwingPaddingNext = {
+        [Symbol.iterator]() {
+            return {
+                next() { throw new Error("padding next error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        Iterator.zip([[1, 2]], { mode: 'longest', padding: throwingPaddingNext });
+    }, Error, "padding next error");
+}
+
+{
+    const badPaddingResult = {
+        [Symbol.iterator]() {
+            return {
+                next() { return "not an object"; }
+            };
+        }
+    };
+    shouldThrow(() => {
+        Iterator.zip([[1, 2]], { mode: 'longest', padding: badPaddingResult });
+    }, TypeError, "Iterator result interface is not an object");
+}
+
+{
+    let closeCalled = false;
+    const throwingClose = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { done: false, value: 1 }; },
+                return() { throw new Error("close error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([throwingClose, [1]]);
+        for (const _ of iter) {}
+    }, Error, "close error");
+}
+
+{
+    let iter1Closed = false;
+    let iter2Closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { iter1Closed = true; return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 2 }; },
+        return() { iter2Closed = true; return { done: true }; }
+    };
+    const iter = Iterator.zip([iter1, iter2]);
+    iter.next();
+    iter.return();
+    shouldBe(iter1Closed, true);
+    shouldBe(iter2Closed, true);
+}
+
+{
+    let iter1Closed = false;
+    let iter2Closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { iter1Closed = true; return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { throw new Error("iter2 next error"); },
+        return() { iter2Closed = true; return { done: true }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([iter1, iter2]);
+        iter.next();
+    }, Error, "iter2 next error");
+    shouldBe(iter1Closed, true);
+    shouldBe(iter2Closed, false);
+}
+
+{
+    let count = 0;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() {
+            count++;
+            if (count <= 2) return { done: false, value: count };
+            return { done: true };
+        }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 'x' }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zip([iter1, iter2], { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const zipped = Iterator.zip([iter, [1, 2]]);
+    try {
+        for (const _ of zipped) {
+            throw new Error("user error");
+        }
+    } catch (e) {
+        if (e.message !== "user error") throw e;
+    }
+    shouldBe(closed, true);
+}
+
+{
+    let inputClosed = false;
+    let innerClosed = false;
+    const inputIter = {
+        [Symbol.iterator]() { return this; },
+        i: 0,
+        next() {
+            this.i++;
+            if (this.i === 1) return { done: false, value: [1, 2] };
+            if (this.i === 2) throw new Error("input iter error");
+            return { done: true };
+        },
+        return() { inputClosed = true; return { done: true }; }
+    };
+    shouldThrow(() => {
+        Iterator.zip(inputIter);
+    }, Error, "input iter error");
+    shouldBe(inputClosed, false);
+    shouldBe(innerClosed, false);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingDone = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return {
+                        get done() { throw new Error("done getter error"); },
+                        value: 1
+                    };
+                }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const zipped = Iterator.zip([iter, throwingDone]);
+        zipped.next();
+    }, Error, "done getter error");
+    shouldBe(closed, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingValue = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return {
+                        done: false,
+                        get value() { throw new Error("value getter error"); }
+                    };
+                }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const zipped = Iterator.zip([iter, throwingValue]);
+        zipped.next();
+    }, Error, "value getter error");
+    shouldBe(closed, true);
+}
+
+{
+    let innerClosed = false;
+    const innerIter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { innerClosed = true; return { done: true }; }
+    };
+    const inputIterWithThrowingDone = {
+        [Symbol.iterator]() { return this; },
+        i: 0,
+        next() {
+            this.i++;
+            if (this.i === 1) return { done: false, value: innerIter };
+            return {
+                get done() { throw new Error("input done getter error"); },
+                value: null
+            };
+        }
+    };
+    shouldThrow(() => {
+        Iterator.zip(inputIterWithThrowingDone);
+    }, Error, "input done getter error");
+    shouldBe(innerClosed, true);
+}
+
+{
+    let innerClosed = false;
+    const innerIter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { innerClosed = true; return { done: true }; }
+    };
+    const inputIterWithThrowingValue = {
+        [Symbol.iterator]() { return this; },
+        i: 0,
+        next() {
+            this.i++;
+            if (this.i === 1) return { done: false, value: innerIter };
+            return {
+                done: false,
+                get value() { throw new Error("input value getter error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        Iterator.zip(inputIterWithThrowingValue);
+    }, Error, "input value getter error");
+    shouldBe(innerClosed, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const paddingWithThrowingNext = {
+        [Symbol.iterator]() {
+            return {
+                get next() { throw new Error("padding next getter error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        Iterator.zip([iter], { mode: "longest", padding: paddingWithThrowingNext });
+    }, Error, "padding next getter error");
+    shouldBe(closed, true);
+}

--- a/JSTests/stress/iterator-zipKeyed-basic.js
+++ b/JSTests/stress/iterator-zipKeyed-basic.js
@@ -1,0 +1,239 @@
+//@ requireOptions("--useIteratorZip=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2, 3], b: ['x', 'y', 'z'] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+    shouldBe(result[2].a, 3);
+    shouldBe(result[2].b, 'z');
+}
+
+{
+    const result = [...Iterator.zipKeyed({})];
+    shouldBe(result.length, 0);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ nums: [1, 2, 3] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].nums, 1);
+    shouldBe(result[1].nums, 2);
+    shouldBe(result[2].nums, 3);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y', 'z', 'w'] })];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y', 'z', 'w'] }, { mode: 'shortest' })];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y', 'z'] }, { mode: 'longest' })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+    shouldBe(result[2].a, undefined);
+    shouldBe(result[2].b, 'z');
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y', 'z'] }, { mode: 'longest', padding: { a: 0, b: 'pad' } })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+    shouldBe(result[2].a, 0);
+    shouldBe(result[2].b, 'z');
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y'] }, { mode: 'strict' })];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+}
+
+{
+    const sym = Symbol('test');
+    const result = [...Iterator.zipKeyed({ a: [1, 2], [sym]: ['x', 'y'] })];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0][sym], 'x');
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1][sym], 'y');
+}
+
+{
+    const customIterable = {
+        [Symbol.iterator]() {
+            let i = 0;
+            return {
+                next() {
+                    if (i < 3) return { done: false, value: i++ };
+                    return { done: true };
+                }
+            };
+        }
+    };
+    const result = [...Iterator.zipKeyed({ custom: customIterable, arr: [10, 20, 30] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].custom, 0);
+    shouldBe(result[0].arr, 10);
+    shouldBe(result[1].custom, 1);
+    shouldBe(result[1].arr, 20);
+    shouldBe(result[2].custom, 2);
+    shouldBe(result[2].arr, 30);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+    }
+    const result = [...Iterator.zipKeyed({ gen: gen(), arr: ['a', 'b', 'c'] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].gen, 1);
+    shouldBe(result[0].arr, 'a');
+    shouldBe(result[1].gen, 2);
+    shouldBe(result[1].arr, 'b');
+    shouldBe(result[2].gen, 3);
+    shouldBe(result[2].arr, 'c');
+}
+
+{
+    const iter = Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y'] });
+    const first = iter.next();
+    shouldBe(first.done, false);
+    shouldBe(first.value.a, 1);
+    shouldBe(first.value.b, 'x');
+    const second = iter.next();
+    shouldBe(second.done, false);
+    shouldBe(second.value.a, 2);
+    shouldBe(second.value.b, 'y');
+    const third = iter.next();
+    shouldBe(third.done, true);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1, 2, 3], b: ['x', 'y', 'z'], c: [true, false, null] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[0].c, true);
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 'y');
+    shouldBe(result[1].c, false);
+    shouldBe(result[2].a, 3);
+    shouldBe(result[2].b, 'z');
+    shouldBe(result[2].c, null);
+}
+
+{
+    let closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const zipped = Iterator.zipKeyed({ iter1, arr: [1, 2] });
+    const results = [];
+    for (const item of zipped) {
+        results.push(item);
+    }
+    shouldBe(results.length, 2);
+    shouldBe(closed, true);
+}
+
+{
+    let returnCalled = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { returnCalled = true; return { done: true }; }
+    };
+    const zipped = Iterator.zipKeyed({ arr: [1, 2, 3], iter });
+    for (const item of zipped) {
+        break;
+    }
+    shouldBe(returnCalled, true);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: [1], b: ['x', 'y', 'z', 'w'] }, { mode: 'longest', padding: { a: 99 } })];
+    shouldBe(result.length, 4);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 'x');
+    shouldBe(result[1].a, 99);
+    shouldBe(result[1].b, 'y');
+    shouldBe(result[2].a, 99);
+    shouldBe(result[2].b, 'z');
+    shouldBe(result[3].a, 99);
+    shouldBe(result[3].b, 'w');
+}
+
+{
+    const obj = { a: [1, 2], b: [3, 4] };
+    Object.defineProperty(obj, 'hidden', {
+        value: [5, 6],
+        enumerable: false
+    });
+    const result = [...Iterator.zipKeyed(obj)];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].a, 1);
+    shouldBe(result[0].b, 3);
+    shouldBe(result[0].hidden, undefined);
+    shouldBe(result[1].a, 2);
+    shouldBe(result[1].b, 4);
+    shouldBe(result[1].hidden, undefined);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ str: Array.from('abc'), arr: [1, 2, 3] })];
+    shouldBe(result.length, 3);
+    shouldBe(result[0].str, 'a');
+    shouldBe(result[0].arr, 1);
+    shouldBe(result[1].str, 'b');
+    shouldBe(result[1].arr, 2);
+    shouldBe(result[2].str, 'c');
+    shouldBe(result[2].arr, 3);
+}
+
+{
+    const result = [...Iterator.zipKeyed({ a: undefined, b: [1, 2] })];
+    shouldBe(result.length, 2);
+    shouldBe(result[0].b, 1);
+    shouldBe(result[0].a, undefined);
+    shouldBe(result[1].b, 2);
+    shouldBe(result[1].a, undefined);
+}
+
+{
+    const result = Iterator.zipKeyed({ a: [1, 2], b: ['x', 'y'] }).next().value;
+    shouldBe(Object.getPrototypeOf(result), null);
+}

--- a/JSTests/stress/iterator-zipKeyed-errors.js
+++ b/JSTests/stress/iterator-zipKeyed-errors.js
@@ -1,0 +1,384 @@
+//@ requireOptions("--useIteratorZip=1")
+
+function shouldThrow(fn, errorType, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof errorType))
+            throw new Error(`Expected ${errorType.name} but got ${e.name}: ${e.message}`);
+        if (message !== undefined && e.message !== message)
+            throw new Error(`Expected message '${message}' but got '${e.message}'`);
+    }
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+{
+    shouldThrow(() => Iterator.zipKeyed(null), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+    shouldThrow(() => Iterator.zipKeyed(undefined), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+    shouldThrow(() => Iterator.zipKeyed(42), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+    shouldThrow(() => Iterator.zipKeyed("string"), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+    shouldThrow(() => Iterator.zipKeyed(true), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+    shouldThrow(() => Iterator.zipKeyed(Symbol()), TypeError, "Iterator.zipKeyed requires iterables to be an object");
+}
+
+{
+    shouldThrow(() => Iterator.zipKeyed({}, 42), TypeError, "options should be undefined or object");
+    shouldThrow(() => Iterator.zipKeyed({}, "string"), TypeError, "options should be undefined or object");
+    shouldThrow(() => Iterator.zipKeyed({}, true), TypeError, "options should be undefined or object");
+}
+
+{
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: 'invalid' }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: 42 }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: null }), TypeError, "mode should be 'shortest' or 'longest' or 'strict'");
+}
+
+{
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: 'longest', padding: 42 }), TypeError, "padding option should be an object");
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: 'longest', padding: "string" }), TypeError, "padding option should be an object");
+    shouldThrow(() => Iterator.zipKeyed({}, { mode: 'longest', padding: true }), TypeError, "padding option should be an object");
+}
+
+{
+    shouldThrow(() => {
+        Iterator.zipKeyed({ a: 42 });
+    }, TypeError, "GetIteratorFlattenable expects its first argument to be an object");
+}
+
+{
+    shouldThrow(() => {
+        Iterator.zipKeyed({ a: "string" });
+    }, TypeError, "GetIteratorFlattenable expects its first argument to be an object");
+}
+
+{
+    const badIterable = {
+        [Symbol.iterator]() { return 42; }
+    };
+    shouldThrow(() => {
+        Iterator.zipKeyed({ a: badIterable });
+    }, TypeError, "Iterator is not an object");
+}
+
+{
+    const throwingNext = {
+        [Symbol.iterator]() {
+            return {
+                next() { throw new Error("next error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: throwingNext });
+        iter.next();
+    }, Error, "next error");
+}
+
+{
+    const badResult = {
+        [Symbol.iterator]() {
+            return {
+                next() { return 42; }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: badResult });
+        iter.next();
+    }, TypeError, "Iterator result interface is not an object");
+}
+
+{
+    let closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingIterable = {
+        [Symbol.iterator]() { throw new Error("iterator error"); }
+    };
+    shouldThrow(() => {
+        Iterator.zipKeyed({ a: iter1, b: throwingIterable });
+    }, Error, "iterator error");
+    shouldBe(closed, true);
+}
+
+{
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: [1, 2], b: [1] }, { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: [1], b: [1, 2] }, { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    let closed = [];
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed.push('a'); return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 2 }; },
+        return() { closed.push('b'); return { done: true }; }
+    };
+    const throwingIter = {
+        [Symbol.iterator]() { return this; },
+        next() { throw new Error("next throws"); },
+        return() { closed.push('c'); return { done: true }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: iter1, b: iter2, c: throwingIter });
+        iter.next();
+    }, Error, "next throws");
+    shouldBe(closed.length, 2);
+    shouldBe(closed[0], 'b');
+    shouldBe(closed[1], 'a');
+}
+
+{
+    let closeCalled = false;
+    const throwingClose = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { done: false, value: 1 }; },
+                return() { throw new Error("close error"); }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: throwingClose, b: [1] });
+        for (const _ of iter) {}
+    }, Error, "close error");
+}
+
+{
+    let iter1Closed = false;
+    let iter2Closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { iter1Closed = true; return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 2 }; },
+        return() { iter2Closed = true; return { done: true }; }
+    };
+    const iter = Iterator.zipKeyed({ a: iter1, b: iter2 });
+    iter.next();
+    iter.return();
+    shouldBe(iter1Closed, true);
+    shouldBe(iter2Closed, true);
+}
+
+{
+    let iter1Closed = false;
+    let iter2Closed = false;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { iter1Closed = true; return { done: true }; }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { throw new Error("iter2 next error"); },
+        return() { iter2Closed = true; return { done: true }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: iter1, b: iter2 });
+        iter.next();
+    }, Error, "iter2 next error");
+    shouldBe(iter1Closed, true);
+    shouldBe(iter2Closed, false);
+}
+
+{
+    let count = 0;
+    const iter1 = {
+        [Symbol.iterator]() { return this; },
+        next() {
+            count++;
+            if (count <= 2) return { done: false, value: count };
+            return { done: true };
+        }
+    };
+    const iter2 = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 'x' }; }
+    };
+    shouldThrow(() => {
+        const iter = Iterator.zipKeyed({ a: iter1, b: iter2 }, { mode: 'strict' });
+        for (const _ of iter) {}
+    }, TypeError, "Iterators in strict mode have different lengths");
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const zipped = Iterator.zipKeyed({ a: iter, b: [1, 2] });
+    try {
+        for (const _ of zipped) {
+            throw new Error("user error");
+        }
+    } catch (e) {
+        if (e.message !== "user error") throw e;
+    }
+    shouldBe(closed, true);
+}
+
+{
+    let closed = false;
+    const obj = {};
+    Object.defineProperty(obj, 'a', {
+        get() { throw new Error("getter error"); },
+        enumerable: true
+    });
+    shouldThrow(() => {
+        Iterator.zipKeyed(obj);
+    }, Error, "getter error");
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const obj = { a: iter };
+    Object.defineProperty(obj, 'b', {
+        get() { throw new Error("getter error"); },
+        enumerable: true
+    });
+    shouldThrow(() => {
+        Iterator.zipKeyed(obj);
+    }, Error, "getter error");
+    shouldBe(closed, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const padding = {};
+    Object.defineProperty(padding, 'a', {
+        get() { throw new Error("padding getter error"); },
+        enumerable: true
+    });
+    shouldThrow(() => {
+        Iterator.zipKeyed({ a: iter }, { mode: 'longest', padding });
+    }, Error, "padding getter error");
+    shouldBe(closed, true);
+}
+
+{
+    let getOwnPropertyDescriptorCalled = false;
+    const proxy = new Proxy({ a: [1, 2] }, {
+        getOwnPropertyDescriptor(target, key) {
+            getOwnPropertyDescriptorCalled = true;
+            throw new Error("getOwnPropertyDescriptor error");
+        },
+        ownKeys() {
+            return ['a'];
+        }
+    });
+    shouldThrow(() => {
+        Iterator.zipKeyed(proxy);
+    }, Error, "getOwnPropertyDescriptor error");
+    shouldBe(getOwnPropertyDescriptorCalled, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const proxy = new Proxy({ a: iter, b: [1, 2] }, {
+        getOwnPropertyDescriptor(target, key) {
+            if (key === 'b') throw new Error("getOwnPropertyDescriptor error");
+            return Object.getOwnPropertyDescriptor(target, key);
+        },
+        ownKeys() {
+            return ['a', 'b'];
+        }
+    });
+    shouldThrow(() => {
+        Iterator.zipKeyed(proxy);
+    }, Error, "getOwnPropertyDescriptor error");
+    shouldBe(closed, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingDone = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return {
+                        get done() { throw new Error("done getter error"); },
+                        value: 1
+                    };
+                }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const zipped = Iterator.zipKeyed({ a: iter, b: throwingDone });
+        zipped.next();
+    }, Error, "done getter error");
+    shouldBe(closed, true);
+}
+
+{
+    let closed = false;
+    const iter = {
+        [Symbol.iterator]() { return this; },
+        next() { return { done: false, value: 1 }; },
+        return() { closed = true; return { done: true }; }
+    };
+    const throwingValue = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return {
+                        done: false,
+                        get value() { throw new Error("value getter error"); }
+                    };
+                }
+            };
+        }
+    };
+    shouldThrow(() => {
+        const zipped = Iterator.zipKeyed({ a: iter, b: throwingValue });
+        zipped.next();
+    }, Error, "value getter error");
+    shouldBe(closed, true);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -10,6 +10,7 @@ flags:
   iterator-sequencing: useIteratorSequencing
   explicit-resource-management: useExplicitResourceManagement
   upsert: useMapGetOrInsert
+  joint-iteration: useIteratorZip
 skip:
   features:
     - callable-boundary-realms
@@ -17,7 +18,6 @@ skip:
     - decorators
     - source-phase-imports
     - import-defer
-    - joint-iteration
   paths:
     - test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO
     - test/built-ins/Temporal/Now/plainDateISO

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -148,6 +148,7 @@ namespace JSC {
     macro(instanceOf) \
     macro(isArraySlow) \
     macro(sameValue) \
+    macro(reflectOwnKeys) \
     macro(regExpCreate) \
     macro(isRegExp) \
     macro(isFinite) \

--- a/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorConstructor.js
@@ -117,3 +117,344 @@ function concat(/* ...items */)
 
     return @iteratorHelperCreate(generator, null);
 }
+
+// https://tc39.es/proposal-joint-iteration/#sec-getoptionsobject
+@linkTimeConstant
+function getOptionsObject(options)
+{
+    if (options === @undefined)
+        return @Object.@create(null);
+    if (@isObject(options))
+        return options;
+    @throwTypeError("options should be undefined or object");
+}
+
+// https://tc39.es/proposal-joint-iteration/#sec-closeall
+@linkTimeConstant
+function iteratorCloseAll(openIters, completion)
+{
+    "use strict";
+
+    for (var i = openIters.length - 1; i >= 0; i--) {
+        var iter = openIters[i];
+        if (iter === null)
+            continue;
+        openIters[i] = null;
+
+        var returnMethod;
+        try {
+            returnMethod = iter.return;
+        } catch (e) {
+            if (completion === @undefined)
+                completion = e;
+            continue;
+        }
+
+        if (returnMethod !== @undefined && returnMethod !== null) {
+            try {
+                returnMethod.@call(iter);
+            } catch (e) {
+                if (completion === @undefined)
+                    completion = e;
+            }
+        }
+    }
+
+    if (completion !== @undefined)
+        throw completion;
+
+    return completion;
+}
+
+// https://tc39.es/proposal-joint-iteration/#sec-IteratorZip
+@linkTimeConstant
+function iteratorZip(iters, iterNextMethods, mode, padding, finishResults)
+{
+    "use strict";
+
+    var iterCount = iters.length;
+    var openIters = [];
+    for (var i = 0; i < iterCount; i++)
+        @arrayPush(openIters, iters[i]);
+    var generator = (function*() {
+        if (iterCount === 0)
+            return;
+        for (;;) {
+            var results = [];
+            for (var i = 0; i < iterCount; i++) {
+                var iter = iters[i];
+                if (iter === null) {
+                    @arrayPush(results, padding[i]);
+                } else {
+                    var result;
+                    var resultValue;
+                    var isDone = false;
+                    try {
+                        result = iterNextMethods[i].@call(iter);
+                        if (!@isObject(result))
+                            @throwTypeError("Iterator result interface is not an object");
+                        isDone = result.done;
+                        if (!isDone)
+                            resultValue = result.value;
+                    } catch (e) {
+                        openIters[i] = null;
+                        throw @iteratorCloseAll(openIters, e);
+                    }
+                    if (isDone) {
+                        openIters[i] = null;
+                        if (mode === "shortest") {
+                            @iteratorCloseAll(openIters, @undefined);
+                            return;
+                        } else if (mode === "strict") {
+                            if (i !== 0)
+                                throw @iteratorCloseAll(openIters, @makeTypeError("Iterators in strict mode have different lengths"));
+
+                            for (var k = 1; k < iterCount; k++) {
+                                var openDone = false;
+                                try {
+                                    var openResult = iterNextMethods[k].@call(iters[k]);
+                                    if (!@isObject(openResult))
+                                        @throwTypeError("Iterator result interface is not an object");
+                                    openDone = openResult.done;
+                                } catch (e) {
+                                    openIters[k] = null;
+                                    throw @iteratorCloseAll(openIters, e);
+                                }
+                                if (openDone)
+                                    openIters[k] = null;
+                                else
+                                    throw @iteratorCloseAll(openIters, @makeTypeError("Iterators in strict mode have different lengths"));
+                            }
+                            return;
+                        } else {
+                            var allClosed = true;
+                            for (var j = 0; j < iterCount; j++) {
+                                if (openIters[j] !== null) {
+                                    allClosed = false;
+                                    break;
+                                }
+                            }
+                            if (allClosed)
+                                return;
+                            iters[i] = null;
+                            resultValue = padding[i];
+                        }
+                    }
+                    @arrayPush(results, resultValue);
+                }
+            }
+            results = finishResults(results);
+            var yieldAbrupt = true;
+            try {
+                yield results;
+                yieldAbrupt = false;
+            } finally {
+                if (yieldAbrupt)
+                    @iteratorCloseAll(openIters, @undefined);
+            }
+        }
+    })();
+    return @iteratorHelperCreate(generator, openIters);
+}
+
+// https://tc39.es/proposal-joint-iteration/#sec-iterator.zip
+function zip(iterables)
+{
+    "use strict";
+
+    if (!@isObject(iterables))
+        @throwTypeError("Iterator.zip requires iterables to be an object");
+
+    var options = @getOptionsObject(@argument(1));
+    var mode = options.mode;
+    if (mode === @undefined)
+        mode = "shortest";
+    if (mode !== "shortest" && mode !== "longest" && mode !== "strict")
+        @throwTypeError("mode should be 'shortest' or 'longest' or 'strict'");
+
+    var paddingOption;
+    if (mode === "longest") {
+        paddingOption = options.padding;
+        if (paddingOption !== @undefined && !@isObject(paddingOption))
+            @throwTypeError("padding option should be an object");
+    }
+
+    var iters = [];
+    var iterNextMethods = [];
+    var padding = [];
+
+    var iteratorMethod = iterables.@@iterator;
+    if (!@isCallable(iteratorMethod))
+        @throwTypeError("Iterator.zip requires that iterables[Symbol.iterator] be a function");
+    var inputIter = iteratorMethod.@call(iterables);
+    if (!@isObject(inputIter))
+        @throwTypeError("Iterator.zip requires that iterables[Symbol.iterator]() returns an object");
+    var inputIterNextMethod = inputIter.next;
+
+    for (;;) {
+        var result;
+        var done;
+        var value;
+        try {
+            result = inputIterNextMethod.@call(inputIter);
+            if (!@isObject(result))
+                @throwTypeError("Iterator result interface is not an object");
+            done = result.done;
+            if (!done)
+                value = result.value;
+        } catch (e) {
+            throw @iteratorCloseAll(iters, e);
+        }
+        if (done)
+            break;
+        var iter;
+        var iterNextMethod;
+        try {
+            iter = @getIteratorFlattenable(value, true);
+            iterNextMethod = iter.next;
+        } catch (e) {
+            var allIters = [inputIter];
+            for (var j = 0; j < iters.length; j++)
+                @arrayPush(allIters, iters[j]);
+            throw @iteratorCloseAll(allIters, e);
+        }
+        @arrayPush(iters, iter);
+        @arrayPush(iterNextMethods, iterNextMethod);
+    }
+
+    var iterCount = iters.length;
+    if (mode === "longest") {
+        if (paddingOption === @undefined) {
+            for (var i = 0; i < iterCount; i++)
+                @arrayPush(padding, @undefined);
+        } else {
+            var paddingIterMethod = paddingOption.@@iterator;
+            if (!@isCallable(paddingIterMethod))
+                throw @iteratorCloseAll(iters, @makeTypeError("padding[Symbol.iterator] is not a function"));
+
+            var paddingIter;
+            var paddingIterNextMethod;
+            try {
+                paddingIter = paddingIterMethod.@call(paddingOption);
+                if (!@isObject(paddingIter))
+                    @throwTypeError("padding[Symbol.iterator]() did not return an object");
+                paddingIterNextMethod = paddingIter.next;
+            } catch (e) {
+                throw @iteratorCloseAll(iters, e);
+            }
+            var usingIterator = true;
+            try {
+                for (var i = 0; i < iterCount; i++) {
+                    if (usingIterator) {
+                        var paddingResult = paddingIterNextMethod.@call(paddingIter);
+                        if (!@isObject(paddingResult))
+                            @throwTypeError("Iterator result interface is not an object");
+
+                        if (paddingResult.done)
+                            usingIterator = false;
+                        else
+                            @arrayPush(padding, paddingResult.value);
+                    }
+                    if (!usingIterator)
+                        @arrayPush(padding, @undefined);
+                }
+            } catch (e) {
+                throw @iteratorCloseAll(iters, e);
+            }
+            if (usingIterator) {
+                try {
+                    @iteratorGenericClose(paddingIter);
+                } catch (e) {
+                    throw @iteratorCloseAll(iters, e);
+                }
+            }
+        }
+    }
+    return @iteratorZip(iters, iterNextMethods, mode, padding, function (results) { return results });
+}
+
+// https://tc39.es/proposal-joint-iteration/#sec-iterator.zipkeyed
+function zipKeyed(iterables)
+{
+    "use strict";
+
+    if (!@isObject(iterables))
+        @throwTypeError("Iterator.zipKeyed requires iterables to be an object");
+
+    var options = @getOptionsObject(@argument(1));
+    var mode = options.mode;
+    if (mode === @undefined)
+        mode = "shortest";
+    if (mode !== "shortest" && mode !== "longest" && mode !== "strict")
+        @throwTypeError("mode should be 'shortest' or 'longest' or 'strict'");
+
+    var paddingOption;
+    if (mode === "longest") {
+        paddingOption = options.padding;
+        if (paddingOption !== @undefined && !@isObject(paddingOption))
+            @throwTypeError("padding option should be an object");
+    }
+
+    var iters = [];
+    var iterNextMethods = [];
+    var padding = [];
+    var keys = [];
+    var allKeys = @reflectOwnKeys(iterables);
+
+    for (var i = 0; i < allKeys.length; i++) {
+        var key = allKeys[i];
+        var desc;
+        try {
+            desc = @Object.@getOwnPropertyDescriptor(iterables, key);
+        } catch (e) {
+            throw @iteratorCloseAll(iters, e);
+        }
+        if (desc !== @undefined && desc.enumerable === true) {
+            var value;
+            try {
+                value = iterables[key];
+            } catch (e) {
+                throw @iteratorCloseAll(iters, e);
+            }
+            if (value !== @undefined) {
+                @arrayPush(keys, key);
+                var iter;
+                var iterNextMethod;
+                try {
+                    iter = @getIteratorFlattenable(value, true);
+                    iterNextMethod = iter.next;
+                } catch (e) {
+                    throw @iteratorCloseAll(iters, e);
+                }
+                @arrayPush(iters, iter);
+                @arrayPush(iterNextMethods, iterNextMethod);
+            }
+        }
+    }
+
+    var iterCount = iters.length;
+    if (mode === "longest") {
+        if (paddingOption === @undefined) {
+            for (var i = 0; i < iterCount; i++)
+                @arrayPush(padding, @undefined);
+        } else {
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                var value;
+                try {
+                    value = paddingOption[key];
+                } catch (e) {
+                    throw @iteratorCloseAll(iters, e);
+                }
+                @arrayPush(padding, value);
+            }
+        }
+    }
+    var finishResults = function(results) {
+        var obj = @Object.@create(null);
+        for (var i = 0; i < iterCount; i++)
+            obj[keys[i]] = results[i];
+        return obj;
+    };
+    return @iteratorZip(iters, iterNextMethods, mode, padding, finishResults);
+}

--- a/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
@@ -53,8 +53,13 @@ function return()
         @putGeneratorInternalField(generator, @generatorFieldState, @GeneratorStateCompleted);
 
         var underlyingIterator = @getIteratorHelperInternalField(this, @iteratorHelperFieldUnderlyingIterator);
-        if (underlyingIterator !== null)
-            @iteratorGenericClose(underlyingIterator);
+        if (underlyingIterator !== null) {
+            // For Iterator.zip, underlyingIterator is an array of iterators (openIters)
+            if (@isArray(underlyingIterator))
+                @iteratorCloseAll(underlyingIterator, @undefined);
+            else
+                @iteratorGenericClose(underlyingIterator);
+        }
 
         return { value: @undefined, done: true };
     }

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -137,6 +137,7 @@ class JSGlobalObject;
     v(webAssemblyInstantiateStreamingInternal, nullptr) \
     v(Object, nullptr) \
     v(Array, nullptr) \
+    v(reflectOwnKeys, nullptr) \
     v(applyFunction, nullptr) \
     v(callFunction, nullptr) \
     v(hasOwnPropertyFunction, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2054,6 +2054,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::toLength)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "toLength"_s, globalFuncToLength, ImplementationVisibility::Private, ToLengthIntrinsic));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::reflectOwnKeys)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "reflectOwnKeys"_s, globalFuncReflectOwnKeys, ImplementationVisibility::Private, ReflectOwnKeysIntrinsic));
+    });
 
     // RegExp.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpCreate)].initLater([] (const Initializer<JSCell>& init) {

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -1134,6 +1134,18 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncSpeciesGetter, (JSGlobalObject* globalObject,
     return JSValue::encode(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(globalFuncReflectOwnKeys, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(callFrame->argumentCount() == 1);
+    ASSERT(callFrame->uncheckedArgument(0).isObject());
+
+    JSValue target = callFrame->uncheckedArgument(0);
+    RELEASE_AND_RETURN(scope, JSValue::encode(ownPropertyKeys(globalObject, asObject(target), PropertyNameMode::StringsAndSymbols, DontEnumPropertiesMode::Include)));
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
@@ -67,6 +67,7 @@ JSC_DECLARE_HOST_FUNCTION(globalFuncIsNaN);
 JSC_DECLARE_HOST_FUNCTION(globalFuncToIntegerOrInfinity);
 JSC_DECLARE_HOST_FUNCTION(globalFuncToLength);
 JSC_DECLARE_HOST_FUNCTION(globalFuncSpeciesGetter);
+JSC_DECLARE_HOST_FUNCTION(globalFuncReflectOwnKeys);
 
 JS_EXPORT_PRIVATE double jsToNumber(StringView);
 

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -59,6 +59,11 @@ void JSIteratorConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject,
 
     if (Options::useIteratorSequencing())
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), jsIteratorConstructorConcatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useIteratorZip()) {
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().zipPublicName(), jsIteratorConstructorZipCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().zipKeyedPublicName(), jsIteratorConstructorZipKeyedCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -645,6 +645,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
+    v(Bool, useIteratorZip, false, Normal, "Expose the Iterator.zip method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useMapGetOrInsert, true, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
     v(Bool, useMathSumPreciseMethod, true, Normal, "Expose the Math.sumPrecise() method."_s) \


### PR DESCRIPTION
#### c52cba27eb16bb89458cf1eb53a6e70ab8de2cf2
<pre>
[JSC] Implement `Iterator.zip` and `Iterator.zipKeyed`
<a href="https://bugs.webkit.org/show_bug.cgi?id=303246">https://bugs.webkit.org/show_bug.cgi?id=303246</a>

Reviewed by NOBODY (OOPS!).

This patch implements `Iterator.zip` and `Iterator.zipKeyed` from
Stage 2.7 Joint Iteration Proposal[1].

It passes all test cases of test262.

[1]: <a href="https://github.com/tc39/proposal-joint-iteration">https://github.com/tc39/proposal-joint-iteration</a>

* JSTests/stress/iterator-zip-basic.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBeArray.gen):
* JSTests/stress/iterator-zip-errors.js: Added.
(shouldThrow):
(shouldBe):
(throw.new.Error):
(Iterator.zip):
(const.throwingNext.Symbol.iterator):
(iter.next):
(const.iter1.Symbol.iterator):
(const.iter1.next):
(const.iter1.return):
(const.throwingIterable.Symbol.iterator):
(const.iter2.Symbol.iterator):
(const.iter2.next):
(const.iter2.return):
(const.throwingIter.Symbol.iterator):
(const.throwingIter.next):
(const.throwingIter.return):
(const.badPadding.Symbol.iterator):
(const.badPaddingResult.Symbol.iterator):
(const.iter.Symbol.iterator):
(const.iter.next):
(const.iter.return):
(catch):
(shouldBe.const.throwingDone.Symbol.iterator.return.next.return.get done):
(shouldBe.const.throwingValue.Symbol.iterator.return.next.return.get value):
(shouldBe.const.inputIterWithThrowingDone.next.return.get done):
(shouldBe.const.inputIterWithThrowingValue.next.return.get value):
(shouldBe.const.paddingWithThrowingNext.Symbol.iterator.return.get next):
* JSTests/stress/iterator-zipKeyed-basic.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.gen):
* JSTests/stress/iterator-zipKeyed-errors.js: Added.
(shouldThrow):
(shouldBe):
(throw.new.Error):
(Iterator.zipKeyed):
(const.throwingNext.Symbol.iterator):
(iter.next):
(const.iter1.Symbol.iterator):
(const.iter1.next):
(const.iter1.return):
(const.throwingIterable.Symbol.iterator):
(const.iter2.Symbol.iterator):
(const.iter2.next):
(const.iter2.return):
(const.throwingIter.Symbol.iterator):
(const.throwingIter.next):
(const.throwingIter.return):
(const.iter.Symbol.iterator):
(const.iter.next):
(const.iter.return):
(catch):
(shouldBe.get shouldThrow):
(get throw):
(getOwnPropertyDescriptor):
(ownKeys):
(shouldBe.const.throwingDone.Symbol.iterator.return.next.return.get done):
(shouldBe.const.throwingValue.Symbol.iterator.return.next.return.get value):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/JSIteratorConstructor.js:
(linkTimeConstant.getOptionsObject):
(linkTimeConstant.iteratorCloseAll):
(generator):
(linkTimeConstant.iteratorZip):
(zip):
(zipKeyed.finishResults):
(zipKeyed):
* Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js:
(return):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h:
* Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp:
(JSC::JSIteratorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c52cba27eb16bb89458cf1eb53a6e70ab8de2cf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85149 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101799 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4193 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1777 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125182 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143301 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131619 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5281 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4075 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58932 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5336 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33900 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164586 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68788 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/42890 "Build was cancelled. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->