### PR TITLE
Adopt C++20 Concepts in JavaScriptCore/jit

### DIFF
--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -384,7 +384,7 @@ private:
             return;
         }
 
-        constexpr bool regTypeIsGPR = std::is_same<RegType, GPRReg>::value;
+        constexpr bool regTypeIsGPR = std::same_as<RegType, GPRReg>;
 
         if (m_currentSource < 2) {
             m_deferredStoreOffset = storeOffset;
@@ -512,7 +512,7 @@ private:
         RegType regToStore = invalid<RegType>();
         auto& source = m_sources[0];
         auto& srcOffset = source.offset;
-        constexpr bool regTypeIsGPR = std::is_same<RegType, GPRReg>::value;
+        constexpr bool regTypeIsGPR = std::same_as<RegType, GPRReg>;
 
         if (source.type == Source::Type::BufferOffset) {
             regToStore = temp1<RegType>();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1085,11 +1085,11 @@ private:
 #if ENABLE(JUMP_ISLANDS)
         for (RegionAllocator& allocator : m_allocators) {
             using FunctionResultType = decltype(function(allocator));
-            if constexpr (std::is_same<IterationStatus, FunctionResultType>::value) {
+            if constexpr (std::same_as<IterationStatus, FunctionResultType>) {
                 if (function(allocator) == IterationStatus::Done)
                     break;
             } else {
-                static_assert(std::is_same<void, FunctionResultType>::value);
+                static_assert(std::same_as<void, FunctionResultType>);
                 function(allocator);
             }
         }

--- a/Source/JavaScriptCore/jit/JITCompilationKey.h
+++ b/Source/JavaScriptCore/jit/JITCompilationKey.h
@@ -70,7 +70,7 @@ public:
     
     unsigned hash() const
     {
-        return WTF::pairIntHash(WTF::PtrHash<JSCell*>::hash(m_codeBlock), static_cast<std::underlying_type<JITCompilationMode>::type>(m_mode));
+        return WTF::pairIntHash(WTF::PtrHash<JSCell*>::hash(m_codeBlock), static_cast<std::underlying_type_t<JITCompilationMode>>(m_mode));
     }
     
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -886,7 +886,7 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     addSlowCase(branchIfCell(regT2));
 
     done.link(this);
-    if constexpr (std::is_same<Op, OpNstricteq>::value)
+    if constexpr (std::same_as<Op, OpNstricteq>)
         xor64(TrustedImm64(1), regT5);
     boxBoolean(regT5, JSValueRegs { regT5 });
     emitPutVirtualRegister(dst, regT5);
@@ -1045,7 +1045,7 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     addSlowCase(branch64(AboveOrEqual, regT3, regT5));
 
     Jump areEqual = branch64(Equal, regT0, regT1);
-    if constexpr (std::is_same<Op, OpJstricteq>::value)
+    if constexpr (std::same_as<Op, OpJstricteq>)
         addJump(areEqual, target);
 
     move(regT0, regT2);
@@ -1054,7 +1054,7 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     // FIXME: we could do something more precise: unless there is a BigInt32, we only need to do the slow path if both are strings
     addSlowCase(branchIfCell(regT2));
 
-    if constexpr (std::is_same<Op, OpJnstricteq>::value) {
+    if constexpr (std::same_as<Op, OpJnstricteq>) {
         addJump(jump(), target);
         areEqual.link(this);
     }
@@ -1071,7 +1071,7 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     Jump rightOK = branchIfInt32(regT1);
     addSlowCase(branchIfNumber(regT1));
     rightOK.link(this);
-    if constexpr (std::is_same<Op, OpJstricteq>::value)
+    if constexpr (std::same_as<Op, OpJstricteq>)
         addJump(branch64(Equal, regT1, regT0), target);
     else
         addJump(branch64(NotEqual, regT1, regT0), target);

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -535,6 +535,9 @@ template<typename T> concept HasSwitchOn = requires(T t) {
     t.switchOn([](const auto&) {});
 };
 
+template<typename Derived, typename Base>
+concept DerivedFromOrConvertibleTo = std::is_base_of_v<Base, Derived> || std::is_convertible_v<Derived, Base>;
+
 #ifdef _LIBCPP_VERSION
 
 // Single-variant switch-based visit function adapted from https://www.reddit.com/r/cpp/comments/kst2pu/comment/giilcxv/.


### PR DESCRIPTION
#### 6157d21f7a613e8f47ebce0bbeb2b13891cc95ed
<pre>
Adopt C++20 Concepts in JavaScriptCore/jit
<a href="https://bugs.webkit.org/show_bug.cgi?id=303249">https://bugs.webkit.org/show_bug.cgi?id=303249</a>
<a href="https://rdar.apple.com/165542109">rdar://165542109</a>

Reviewed by Justin Michaud and Darin Adler.

* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
(JSC::AssemblyHelpers::CopySpooler::store):
(JSC::AssemblyHelpers::CopySpooler::finalize):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::pokeForArgument):
(JSC::CCallHelpers::setupArgumentsImpl):
(JSC::CCallHelpers::setupArgumentsEntryImpl):
(JSC::CCallHelpers::std::is_integral&lt;CURRENT_ARGUMENT_TYPE&gt;::value): Deleted.
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::PreferredArgumentImpl::sizeOfArg):
(JSC::PreferredArgumentImpl::preferredArgumentJSR):
(JSC::PreferredArgumentImpl::preferredArgumentGPR):
(JSC::preferredArgumentGPR):
(JSC::preferredArgumentJSR):
* Source/JavaScriptCore/jit/JITCompilationKey.h:
(JSC::JITCompilationKey::hash const):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
* Source/WTF/wtf/StdLibExtras.h:

Canonical link: <a href="https://commits.webkit.org/303871@main">https://commits.webkit.org/303871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ca00d625f203d9e2c8833a3b716792b0bb7bc73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85682 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69579 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2198 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125705 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143837 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132142 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4441 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59554 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5857 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34360 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165105 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69315 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43140 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->