### PR TITLE
[Swift in WebKit] Work towards modularizing PAL (part 2)

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		07789181273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0778917F273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm */; };
 		077E87B1226A460200A2AFF0 /* AVFoundationSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */; };
 		079D1D9826950DD700883577 /* SystemStatusSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */; };
+		07C9C8DC2EDAAABD007B579A /* CryptoDigestHashFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0CF99CA41F736375007EE793 /* MediaTimeAVFoundation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */; };
 		0CF99CA81F738437007EE793 /* CoreMediaSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CF99CA61F738436007EE793 /* CoreMediaSoftLink.cpp */; };
 		1C09D0561E31C46500725F18 /* CryptoDigestCommonCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C09D0551E31C46500725F18 /* CryptoDigestCommonCrypto.cpp */; };
@@ -88,7 +89,6 @@
 		93B38EC025821CD800198E63 /* SpeechSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93B38EBF25821CD700198E63 /* SpeechSoftLink.mm */; };
 		94A41E732BB1E10D00DA715C /* UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */; };
 		94C759082B990D69000CC511 /* PALSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 94C759072B990D62000CC511 /* PALSwift.h */; };
-		94E867A32BD191FC000EF470 /* PALSwiftUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */; };
 		94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */; };
 		A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D322AB12BF100F57BA4 /* WebAVContentKeyGrouping.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D4D2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -467,6 +467,7 @@
 		077E87B0226A460200A2AFF0 /* AVFoundationSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationSoftLink.h; sourceTree = "<group>"; };
 		079D1D9526950DD700883577 /* SystemStatusSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemStatusSoftLink.h; sourceTree = "<group>"; };
 		079D1D9626950DD700883577 /* SystemStatusSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemStatusSoftLink.mm; sourceTree = "<group>"; };
+		07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoDigestHashFunction.h; sourceTree = "<group>"; };
 		0C00CFD11F68CE4600AAC26D /* MediaTimeAVFoundation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTimeAVFoundation.cpp; sourceTree = "<group>"; };
 		0C00CFD21F68CE4600AAC26D /* MediaTimeAVFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTimeAVFoundation.h; sourceTree = "<group>"; };
 		0C2D9E721EEF5AF600DBC317 /* ExportMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExportMacros.h; sourceTree = "<group>"; };
@@ -678,7 +679,6 @@
 		94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsafeOverlays.swift; path = pal/PALSwift/UnsafeOverlays.swift; sourceTree = SOURCE_ROOT; };
 		94C759022B990D31000CC511 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		94C759072B990D62000CC511 /* PALSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PALSwift.h; sourceTree = "<group>"; };
-		94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PALSwiftUtils.h; sourceTree = "<group>"; };
 		94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoKitShim.swift; path = pal/PALSwift/CryptoKitShim.swift; sourceTree = SOURCE_ROOT; };
 		A10265881F56747A00B4C844 /* HIToolboxSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIToolboxSPI.h; sourceTree = "<group>"; };
 		A102658D1F567E9D00B4C844 /* HIServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HIServicesSPI.h; sourceTree = "<group>"; };
@@ -1067,7 +1067,6 @@
 				1C4876D71F8D7F4E00CCEEBD /* Logging.h */,
 				94C759022B990D31000CC511 /* module.modulemap */,
 				94C759072B990D62000CC511 /* PALSwift.h */,
-				94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */,
 				FE62AC3C2CFE2E0300740A18 /* PALTZoneImpls.cpp */,
 				A3C66CDA1F462D6A009E6EE9 /* SessionID.cpp */,
 				A3C66CDB1F462D6A009E6EE9 /* SessionID.h */,
@@ -1082,6 +1081,7 @@
 			children = (
 				1C09D0541E31C45200725F18 /* commoncrypto */,
 				1C09D0521E31C44100725F18 /* CryptoDigest.h */,
+				07C9C8DB2EDAAABD007B579A /* CryptoDigestHashFunction.h */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -1446,6 +1446,7 @@
 				DD20DE1C27BC90D80093D175 /* CoreUISPI.h in Headers */,
 				DD20DDD127BC90D70093D175 /* CoreVideoSPI.h in Headers */,
 				DD20DD2727BC90D60093D175 /* CryptoDigest.h in Headers */,
+				07C9C8DC2EDAAABD007B579A /* CryptoDigestHashFunction.h in Headers */,
 				DD20DD1D27BC90D60093D175 /* CryptoKitPrivateSoftLink.h in Headers */,
 				DD20DDE327BC90D70093D175 /* CryptoKitPrivateSPI.h in Headers */,
 				DD20DD1E27BC90D60093D175 /* DataDetectorsCoreSoftLink.h in Headers */,
@@ -1547,7 +1548,6 @@
 				DD20DD1327BC90D60093D175 /* OutputContext.h in Headers */,
 				DD20DD1427BC90D60093D175 /* OutputDevice.h in Headers */,
 				94C759082B990D69000CC511 /* PALSwift.h in Headers */,
-				94E867A32BD191FC000EF470 /* PALSwiftUtils.h in Headers */,
 				DD20DE0227BC90D80093D175 /* PassKitInstallmentsSPI.h in Headers */,
 				DD20DD2227BC90D60093D175 /* PassKitSoftLink.h in Headers */,
 				DD20DE0327BC90D80093D175 /* PassKitSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PAL_PUBLIC_HEADERS
     ThreadGlobalData.h
 
     crypto/CryptoDigest.h
+    crypto/CryptoDigestHashFunction.h
 
     system/Clock.h
     system/ClockGeneric.h

--- a/Source/WebCore/PAL/pal/PALSwift.h
+++ b/Source/WebCore/PAL/pal/PALSwift.h
@@ -35,7 +35,6 @@ namespace Cpp {
 
 using VectorUInt8 = WTF::Vector<uint8_t>;
 using SpanConstUInt8 = std::span<const uint8_t>;
-using OptionalVectorUInt8 = std::optional<WTF::Vector<uint8_t>>;
 
 enum class ErrorCodes: int {
     Success = 0,
@@ -64,6 +63,8 @@ struct CryptoOperationReturnValue {
 } // Cpp
 
 #ifndef __swift__
+// FIXME: This is incorrect, but the rest of this file is also incorrect for the time being, so alas.
+#include <pal/crypto/CryptoDigestHashFunction.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include "PALSwift-Generated.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <pal/crypto/CryptoDigestHashFunction.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
@@ -38,13 +39,8 @@ class CryptoDigest {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CryptoDigest, PAL_EXPORT);
     WTF_MAKE_NONCOPYABLE(CryptoDigest);
 public:
-    enum class Algorithm {
-        SHA_1,
-        DEPRECATED_SHA_224,
-        SHA_256,
-        SHA_384,
-        SHA_512,
-    };
+    using Algorithm = CryptoDigestHashFunction;
+
     PAL_EXPORT static std::unique_ptr<CryptoDigest> create(Algorithm);
     PAL_EXPORT ~CryptoDigest();
 

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigestHashFunction.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigestHashFunction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,36 +25,14 @@
 
 #pragma once
 
-#if HAVE(SWIFT_CPP_INTEROP)
-#include "PALSwift.h"
+namespace PAL {
 
-namespace WebCore {
-inline PAL::HashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
-{
-    switch (hash) {
-    case CryptoAlgorithmIdentifier::SHA_256:
-        return PAL::HashFunction::sha256();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_384:
-        return PAL::HashFunction::sha384();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_512:
-        return PAL::HashFunction::sha512();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_1:
-        return PAL::HashFunction::sha1();
-        break;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED();
-    return PAL::HashFunction::sha512();
-}
+enum class CryptoDigestHashFunction : int {
+    SHA_1,
+    DEPRECATED_SHA_224,
+    SHA_256,
+    SHA_384,
+    SHA_512,
+};
 
-inline bool isValidHashParameter(CryptoAlgorithmIdentifier hash)
-{
-    return hash == CryptoAlgorithmIdentifier::SHA_1 || hash == CryptoAlgorithmIdentifier::SHA_256 || hash == CryptoAlgorithmIdentifier::SHA_512 || hash == CryptoAlgorithmIdentifier::SHA_384;
-}
-
-} // WebCore
-#endif
+} // namespace PAL

--- a/Source/WebCore/PAL/pal/module.modulemap
+++ b/Source/WebCore/PAL/pal/module.modulemap
@@ -1,4 +1,11 @@
 module PALSwift {
     header "PALSwift.h"
+
+    // FIXME: This is incorrect, but the rest of the module is also incorrect for the time being, so alas.
+    explicit module CryptoDigestHashFunction {
+        header "crypto/CryptoDigestHashFunction.h"
+        export *
+    }
+
     export *
 }

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h
@@ -29,6 +29,10 @@ DECLARE_SYSTEM_HEADER
 
 #include <CoreMedia/CoreMedia.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <AVFoundation/AVStreamDataParser.h>
+#else
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol AVStreamDataParserOutputHandling;
@@ -73,3 +77,5 @@ typedef NS_ENUM(NSUInteger, AVStreamDataParserOutputMediaDataFlags) {
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSAccessibilitySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSAccessibilitySPI.h
@@ -54,6 +54,8 @@ DECLARE_SYSTEM_HEADER
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
+// FIXME: (rdar://165511706) This file is invalid in a module because AppKit has symbols with incorrect linkage.
+
 WTF_EXTERN_C_BEGIN
 
 extern NSString *const NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification;

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -105,6 +105,7 @@ DECLARE_SYSTEM_HEADER
 
 #if !PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 
+// FIXME: (rdar://165525506) This file is invalid in a module because PassKit has symbols with incorrect linkage.
 // FIXME: PassKit does not declare its NSString constant symbols with C linkage, so we end up with
 // linkage mismatches in the SOFT_LINK_CONSTANT macros used in PassKitSoftLink.mm unless we wrap
 // these includes in an extern "C" block.
@@ -376,6 +377,8 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD) && !USE(APPLE_INTERNAL_SDK)
 
 NS_ASSUME_NONNULL_END
+
+// FIXME: (rdar://165525506) This file is invalid in a module because PassKit has symbols with incorrect linkage.
 
 extern "C"
 void PKDrawApplePayButtonWithCornerRadius(_Nonnull CGContextRef, CGRect drawRect, CGFloat scale, CGFloat cornerRadius, PKPaymentButtonType, PKPaymentButtonStyle, NSString * _Nullable languageCode);

--- a/Source/WebCore/PAL/pal/spi/cocoa/URLFormattingSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/URLFormattingSPI.h
@@ -30,6 +30,7 @@ DECLARE_SYSTEM_HEADER
 #if USE(APPLE_INTERNAL_SDK)
 
 #if HAVE(URL_FORMATTING)
+// FIXME: (rdar://165507825) This file is invalid in a module because URLFormatting has incorrect extern_c attributes in its dependencies.
 #import <URLFormatting/LPNSURLExtras.h>
 #else
 #import <LinkPresentation/LPNSURLExtras.h>

--- a/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
@@ -36,6 +36,8 @@ DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)
 
+// FIXME: (rdar://165540771) This file is invalid in a module because MediaPlayer has incorrect extern_c attributes in its dependencies.
+
 #import <MediaPlayer/MPAVRoutingController.h>
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)

--- a/Source/WebCore/PAL/pal/spi/ios/OpenGLESSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/OpenGLESSPI.h
@@ -28,6 +28,9 @@
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/Foundation.h>
+#import <wtf/Platform.h>
+
+#if PLATFORM(IOS_FAMILY)
 
 #if USE(APPLE_INTERNAL_SDK)
 
@@ -60,3 +63,5 @@ enum {
 - (NSUInteger)getParameter:(EAGLContextParameter)pname to:(int32_t *)params;
 @end
 #endif
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/PAL/pal/spi/ios/QuickLookSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/QuickLookSPI.h
@@ -28,9 +28,15 @@
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/Foundation.h>
+#import <wtf/Platform.h>
+
+#if PLATFORM(IOS_FAMILY)
+
 #import <QuickLook/QuickLook.h>
 
 #if USE(APPLE_INTERNAL_SDK)
+
+// FIXME: (rdar://165510931) This file is invalid in a module because QuickLook has incorrect extern_c attributes in its dependencies.
 
 #import <QuickLook/QuickLookPrivate.h>
 
@@ -95,3 +101,5 @@ NSString *QLTypeCopyBestMimeTypeForURLAndMimeType(NSURL *, NSString *mimeType);
 NSString *QLTypeCopyUTIForURLAndMimeType(NSURL *, NSString *mimeType);
 
 WTF_EXTERN_C_END
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#import <wtf/Platform.h>
+
+#if PLATFORM(IOS_FAMILY)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <SpringBoardServices/SBSStatusBarStyleOverridesAssertion.h>
@@ -73,3 +77,5 @@ typedef void (^SBSStatusBarStyleOverridesAssertionAcquisitionHandler)(BOOL acqui
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if USE(APPKIT)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSCell_Private.h>
@@ -59,3 +63,5 @@ typedef NS_ENUM(NSInteger, NSViewSemanticContext);
 @property (setter=_setFallbackBezelPresentationState:) NSPresentationState _fallbackBezelPresentationState;
 @property (setter=_setFallbackSemanticContext:) NSViewSemanticContext _fallbackSemanticContext;
 @end
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if USE(APPKIT)
+
 #import <AppKit/NSGestureRecognizer.h>
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -67,3 +71,5 @@ DECLARE_SYSTEM_HEADER
 @end
 
 #endif
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if USE(APPKIT)
+
 // FIXME: This should include AppKit/AppKitPrivate.h when using the internal SDK,
 // but that file won't compile as C++.
 
@@ -36,3 +40,5 @@ extern NSString *_NXSmartPaste;
 - (NSData *)_dataWithoutConversionForType:(NSString *)type securityScoped:(BOOL)securityScoped;
 - (BOOL)_setExpirationDate:(NSDate *)date;
 @end
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
@@ -27,9 +27,31 @@
 
 DECLARE_SYSTEM_HEADER
 
+#import <wtf/Platform.h>
+
 #if USE(APPKIT)
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <AppKit/NSColorPopoverController_Private.h>
+#import <AppKit/NSPopoverColorWell.h>
+#else
+
 @interface NSPopoverColorWell : NSColorWell<NSPopoverDelegate>
+@end
+
+@interface NSColorPopoverController : NSViewController
+@end
+
+@class NSColorPickerMatrixView;
+
+@interface NSColorPopoverController ()
+@property (assign) id delegate;
+@property (assign) NSPopover *popover;
+@end
+
+#endif
+
+@interface NSPopoverColorWell ()
 - (void)_showPopover;
 @end
 
@@ -42,12 +64,7 @@ DECLARE_SYSTEM_HEADER
 - (void)setNumberOfColumns:(NSUInteger)columns;
 @end
 
-@interface NSColorPopoverController : NSViewController
-@end
-
 @interface NSColorPopoverController ()
-@property (assign) id delegate;
-@property (assign) NSPopover *popover;
 @property (assign) NSColorPickerMatrixView *topBarMatrixView;
 @end
 

--- a/Source/WebCore/PAL/pal/spi/mac/NSPopoverSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPopoverSPI.h
@@ -27,7 +27,15 @@
 
 DECLARE_SYSTEM_HEADER
 
+#import <wtf/Platform.h>
+
+#if USE(APPKIT)
+
 #import <pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h>
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <AppKit/NSPopover_Private.h>
+#else
 
 // FIXME: This header should include system headers when possible.
 
@@ -49,3 +57,7 @@ typedef NS_OPTIONS(NSUInteger, NSPopoverPositioningOptions) {
 - (void)_setRequiresCorrectContentAppearance:(BOOL)requiresCorrectAppearance;
 @property NSPopoverPositioningOptions positioningOptions;
 @end
+
+#endif
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollingMomentumCalculatorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollingMomentumCalculatorSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if USE(APPKIT)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSScrollingMomentumCalculator_Private.h>
@@ -45,3 +49,5 @@ DECLARE_SYSTEM_HEADER
 @end
 
 #endif /* USE(APPLE_INTERNAL_SDK) */
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
@@ -27,8 +27,12 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if USE(APPKIT)
+
 #import <AppKit/NSSearchFieldCell.h>
 
 @interface NSSearchFieldCell ()
 @property (getter=isCenteredLook) BOOL centeredLook;
 @end
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(MAC)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSSharingService_Private.h>
@@ -52,3 +56,5 @@ typedef NS_ENUM(NSInteger, NSSharingServicePickerStyle) {
 @end
 
 #endif
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSSharingServiceSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSharingServiceSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(MAC)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSSharingService_Private.h>
@@ -57,3 +61,5 @@ typedef NS_OPTIONS(NSUInteger, NSSharingServiceMask) {
 @end
 
 #endif
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
@@ -27,9 +27,13 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if USE(APPKIT)
+
 #import <AppKit/NSTextFieldCell.h>
 
 @interface NSTextFieldCell ()
 - (CFDictionaryRef)_coreUIDrawOptionsWithFrame:(NSRect)cellFrame inView:(NSView *)controlView includeFocus:(BOOL)includeFocus;
 - (CFDictionaryRef)_coreUIDrawOptionsWithFrame:(NSRect)cellFrame inView:(NSView *)controlView includeFocus:(BOOL)includeFocus maskOnly:(BOOL)maskOnly;
 @end
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
@@ -27,6 +27,10 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <wtf/Platform.h>
+
+#if PLATFORM(MAC)
+
 #import <AppKit/NSTextTable.h>
 
 @interface NSTextBlock (Internal)
@@ -36,3 +40,5 @@ DECLARE_SYSTEM_HEADER
 @interface NSTextTab ()
 - (instancetype)initWithTextAlignment:(NSTextAlignment)alignment location:(CGFloat)loc options:(NSDictionary<NSTextTabOptionKey, id> *)options;
 @end
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <pal/crypto/CryptoDigestHashFunction.h>
+
 namespace WebCore {
 
 constexpr auto sha224DeprecationMessage = "SHA224 is not supported";
@@ -51,5 +53,27 @@ enum class CryptoAlgorithmIdentifier : uint8_t {
     Ed25519,
     X25519
 };
+
+inline PAL::CryptoDigestHashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
+{
+    switch (hash) {
+    case CryptoAlgorithmIdentifier::SHA_256:
+        return PAL::CryptoDigestHashFunction::SHA_256;
+    case CryptoAlgorithmIdentifier::SHA_384:
+        return PAL::CryptoDigestHashFunction::SHA_384;
+    case CryptoAlgorithmIdentifier::SHA_512:
+        return PAL::CryptoDigestHashFunction::SHA_512;
+    case CryptoAlgorithmIdentifier::SHA_1:
+        return PAL::CryptoDigestHashFunction::SHA_1;
+    default:
+        ASSERT_NOT_REACHED();
+        return PAL::CryptoDigestHashFunction::SHA_512;
+    }
+}
+
+inline bool isValidHashParameter(CryptoAlgorithmIdentifier hash)
+{
+    return hash == CryptoAlgorithmIdentifier::SHA_1 || hash == CryptoAlgorithmIdentifier::SHA_256 || hash == CryptoAlgorithmIdentifier::SHA_512 || hash == CryptoAlgorithmIdentifier::SHA_384;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -35,7 +35,7 @@
 #include <wtf/StdLibExtras.h>
 
 #if HAVE(SWIFT_CPP_INTEROP)
-#include <pal/PALSwiftUtils.h>
+#include <pal/PALSwift.h>
 #endif
 
 namespace WebCore {
@@ -45,7 +45,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    auto rv = key->sign(data.span(), toCKHashFunction(hash));
+    auto rv = key->sign(data.span(), std::to_underlying(toCKHashFunction(hash)));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTFMove(rv.result);
@@ -55,7 +55,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
 {
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
+    return key->verify(data.span(), signature.span(), std::to_underlying(toCKHashFunction(hash))).errorCode == Cpp::ErrorCodes::Success;
 }
 #else
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
@@ -30,8 +30,9 @@
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
 #include "CryptoUtilitiesCocoa.h"
+
 #if HAVE(SWIFT_CPP_INTEROP)
-#include <pal/PALSwiftUtils.h>
+#include <pal/PALSwift.h>
 #endif
 
 namespace WebCore {
@@ -49,7 +50,7 @@ static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgo
 {
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
-    auto rv = PAL::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, toCKHashFunction(parameters.hashIdentifier));
+    auto rv = PAL::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, std::to_underlying(toCKHashFunction(parameters.hashIdentifier)));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTFMove(rv.result);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
@@ -30,7 +30,7 @@
 #include "CryptoUtilitiesCocoa.h"
 #include <CommonCrypto/CommonHMAC.h>
 #if HAVE(SWIFT_CPP_INTEROP)
-#include <pal/PALSwiftUtils.h>
+#include <pal/PALSwift.h>
 #endif
 #include <wtf/CryptographicUtilities.h>
 
@@ -41,13 +41,13 @@ static ExceptionOr<Vector<uint8_t>> platformSignCryptoKit(const CryptoKeyHMAC& k
 {
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
-    return PAL::HMAC::sign(key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
+    return PAL::HMAC::sign(key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
 }
 static ExceptionOr<bool> platformVerifyCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
         return Exception { ExceptionCode::OperationError };
-    return PAL::HMAC::verify(signature.span(), key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
+    return PAL::HMAC::verify(signature.span(), key.key().span(), data.span(), std::to_underlying(toCKHashFunction(key.hashAlgorithmIdentifier())));
 }
 
 #else

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -160,7 +160,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 - (void)_showPopover
 {
     RetainPtr popover = [[self class] _colorPopoverCreateIfNecessary:YES];
-    popover.get().delegate = self;
+    popover.get().delegate = (id)self;
 
     [self deactivate];
 


### PR DESCRIPTION
#### f6491e12ca0be45502268e4cb24a105e0d274d76
<pre>
[Swift in WebKit] Work towards modularizing PAL (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303250">https://bugs.webkit.org/show_bug.cgi?id=303250</a>
<a href="https://rdar.apple.com/165544156">rdar://165544156</a>

Reviewed by Mike Wyrzykowski.

More fixes made to previously incorrect PAL code.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:

- Remove PALSwiftUtils.h, and add CryptoDigestHashFunction.h (as a private-level header).

* Source/WebCore/PAL/pal/PALSwift.h:

- Remove unused `OptionalVectorUInt8` definition
- Because of the way PAL is currently incorrectly structured for Swift, an include of `CryptoDigestHashFunction.h` is needed before the generated Swift header is included.

* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/PAL/pal/crypto/CryptoDigestHashFunction.h:

Previously, both CryptoKitShim.swift and CryptoDigest.h had more or less the same type to represent a crypto digest hash function. De-duplicate this
logic by creating a separate C++ type shared by both files. This enum is C++ instead of Swift because (a) Swift-Cxx interop is significantly better
supported compared to reverse-interop, and (b) it is easier for this type to be used by a seperate module (aka WebCore) since it is invalid
for C++/Objective C to call Swift code from a different framework/module.

* Source/WebCore/PAL/pal/PALSwiftUtils.h: Removed.

Delete this file entirely, for several reasons:

- It doesn&apos;t really have anything to do with Swift specifically in the first place
- It defines symbols inside the WebCore namespace albeit being in PAL
- It was a project header included from a different framework, which is invalid
- It was dependent on the generated Swift header, which cannot cross module/framework boundaries
- It created a layering violation and dependency cycle since the file uses `CryptoAlgorithmIdentifier`, a type defined in WebCore
- It only &quot;worked&quot; in the first place because the functions inside of it get inlined into WebCore and was always an invalid header file
- The functions inside it are only used in WebCore

* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
(WebCore::toCKHashFunction):
(WebCore::isValidHashParameter):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp:

- Move the functions from PALSwiftUtils to CryptoAlgorithmIdentifier

* Source/WebCore/PAL/pal/module.modulemap:

- Temporarily add a sub-module for Swift to be able to access `CryptoDigestHashFunction`; soon, this module map will be fixed to use an umbrella
header, so this will not be needed then.

* Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/NSAccessibilitySPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/URLFormattingSPI.h:
* Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h:
* Source/WebCore/PAL/pal/spi/ios/OpenGLESSPI.h:
* Source/WebCore/PAL/pal/spi/ios/QuickLookSPI.h:
* Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSPopoverSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSScrollingMomentumCalculatorSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSSharingServiceSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h:
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKPopoverColorWell _showPopover]):

- Add missing compile time guards
- Add FIXMEs for issues that prevent proper modularization of PAL

Canonical link: <a href="https://commits.webkit.org/303648@main">https://commits.webkit.org/303648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38c4111212690315bbb949689f113074fd55c3a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133165 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85205 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/732318e5-a0fa-4cc6-8f9e-a2fbdf2e05cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69276 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f66656a0-0340-47d9-b18f-327b8fef8369) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82646 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/379ecb75-16d1-4894-8fd5-848a7aea1da8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1832 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143367 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110228 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4129 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5391 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33960 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5237 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->