### PR TITLE
[threaded-animations] WPT test `scroll-animations/view-timelines/timeline-offset-in-keyframe.html` crashes with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3111,6 +3111,14 @@ void KeyframeEffect::timelineAccelerationAbilityDidChange()
     scheduleAssociatedAcceleratedEffectStackUpdate();
 }
 
+RefPtr<AcceleratedEffect> KeyframeEffect::updatedAcceleratedRepresentation(const TimelineIdentifier& timelineIdentifier, const IntRect& borderBoxRect, const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>& disallowedProperties)
+{
+    updateComputedKeyframeOffsetsIfNeeded();
+    RefPtr acceleratedEffect = AcceleratedEffect::create(*this, timelineIdentifier, borderBoxRect, baseValues, disallowedProperties);
+    m_acceleratedRepresentation = acceleratedEffect.get();
+    return acceleratedEffect;
+}
+
 #endif
 
 const KeyframeInterpolation::Keyframe& KeyframeEffect::keyframeAtIndex(size_t index) const

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -196,7 +196,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     bool canHaveAcceleratedRepresentation() const;
     const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
-    void setAcceleratedRepresentation(const AcceleratedEffect* acceleratedRepresentation) { m_acceleratedRepresentation = acceleratedRepresentation; }
+    RefPtr<AcceleratedEffect> updatedAcceleratedRepresentation(const TimelineIdentifier&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
     void timelineAccelerationAbilityDidChange();
 #endif
 

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -250,6 +250,7 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const Timelin
             return { };
         }();
 
+        ASSERT(!std::isnan(srcKeyframe.offset()));
         m_keyframes.append({ srcKeyframe.offset(), WTFMove(values), srcKeyframe.timingFunction(), srcKeyframe.compositeOperation(), WTFMove(animatedProperties) });
     }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4527,12 +4527,11 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
                 ASSERT(effect->animation());
                 ASSERT(effect->animation()->timeline());
                 Ref acceleratedTimeline = Ref { *effect->animation()->timeline() }->acceleratedRepresentation();
-                auto acceleratedEffect = AcceleratedEffect::create(*effect, acceleratedTimeline->identifier(), borderBoxRect, baseValues, disallowedAcceleratedProperties);
+                RefPtr acceleratedEffect = effect->updatedAcceleratedRepresentation(acceleratedTimeline->identifier(), borderBoxRect, baseValues, disallowedAcceleratedProperties);
                 if (!acceleratedEffect)
                     continue;
                 if (!hasInterpolatingEffect && effect->isRunningAccelerated())
                     hasInterpolatingEffect = true;
-                effect->setAcceleratedRepresentation(acceleratedEffect.get());
                 weakAcceleratedEffects.add(*acceleratedEffect);
                 acceleratedEffects.append(acceleratedEffect.releaseNonNull());
                 timelines.add(WTFMove(acceleratedTimeline));


### PR DESCRIPTION
#### 7bb7290560c847fcc4f3a24eb8c3762c41c467b7
<pre>
[threaded-animations] WPT test `scroll-animations/view-timelines/timeline-offset-in-keyframe.html` crashes with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303220">https://bugs.webkit.org/show_bug.cgi?id=303220</a>
<a href="https://rdar.apple.com/165549480">rdar://165549480</a>

Reviewed by Anne van Kesteren.

We would crash this test with &quot;Threaded Scroll-driven Animations&quot; enabled because the test would
set the effect of a previously-accelerated animation to a new effect with keyframe offsets using
view timeline ranges [0]. Such keyframe offsets need to be resolved to a computed offset, which
typically occurs under `KeyframeEffect::apply()`, called during style resolution. In this case,
style resolution does not occur prior to the updated effect being uploaded to the remote layer
tree, resulting in an NaN computed offset value which led to `AcceleratedEffect::apply()` not
finding a keyframe interval to apply the effect in the remote layer tree.

To address this, in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`, we move the
accelerated effect creation and link to its source keyframe effect to a new method
`KeyframeEffect::updatedAcceleratedRepresentation()` which will ensure any pending keyframe
offset resolution occurs.

We also add a new assertion in the `AcceleratedEffect` constructor that checks that no NaN
value for keyframe offsets show up, which would have caught this issue in a more explicit manner.

Note that this not an ideal fix, I think our accelerated effect creation code is not very well
structured and could do with a cleaner approach where the creation occurs entirely within `KeyframeEffect`,
similar to how accelerated timelines are created, and ideally also with the creation of an associated
accelerated animation to retain the animation / timeline / effect object relationship that exists
both for non-accelerated animation resolution in Web process and for decoded animations in the remote
layer tree. But this is a larger refactor that will have to wait a bit longer to address an issue
that will otherwise block making &quot;Threaded Scroll-driven Animations&quot; a preview flag.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedScrollDrivenAnimationsEnabled=true`.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges">https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges</a>

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updatedAcceleratedRepresentation):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/303651@main">https://commits.webkit.org/303651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e6b2cc86e4a139ad73912c16713aafe4ef919a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44322 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/140752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/140752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136145 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/140752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5369 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/143400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5451 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59108 "Failed to checkout and rebase branch from PR 54572") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20616 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5424 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5513 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->