### PR TITLE
[threaded-animations] WPT test `scroll-animations/scroll-timelines/setting-timeline.tentative.html` crashes with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3075,9 +3075,6 @@ KeyframeEffect::StackMembershipMutationScope::~StackMembershipMutationScope()
 
 bool KeyframeEffect::canHaveAcceleratedRepresentation() const
 {
-    if (m_acceleratedRepresentation)
-        return true;
-
     if (RefPtr document = this->document()) {
         Ref settings = document->settings();
         if (m_isAssociatedWithProgressBasedTimeline && settings->threadedScrollDrivenAnimationsEnabled())


### PR DESCRIPTION
#### d7fdc6d1513b3dcdf42711967bbf53689c0e29c2
<pre>
[threaded-animations] WPT test `scroll-animations/scroll-timelines/setting-timeline.tentative.html` crashes with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303253">https://bugs.webkit.org/show_bug.cgi?id=303253</a>
<a href="https://rdar.apple.com/165550231">rdar://165550231</a>

Reviewed by Tim Nguyen.

The line of code in the test that causes this crash is when we&apos;re switching from a scroll timeline to a document
timeline, causing a query of the animation current time under the `KeyframeEffect::StackMembershipMutationScope`
destructor and we end up with a start time that is yet to be updated to a monotonic time value from a progress-based
value.

This code path should not be hit at all since switching to a document timeline, which do not support acceleration
at the moment, should immediately mark the animation&apos;s associated keyframe effect as not supporting acceleration.

Indeed, we had a quick check in `KeyframeEffect::canHaveAcceleratedRepresentation()` that would return `true` if we
had an existing accelerated representation for this effect, which is not a valid assumption since the effect could
have been accelerated when it was associated with a timeline supporting acceleration, such as a scroll-driven timeline,
but should no longer be accelerated by virtue of switching to a document timeline.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedScrollDrivenAnimationsEnabled=true`.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canHaveAcceleratedRepresentation const):

Canonical link: <a href="https://commits.webkit.org/303645@main">https://commits.webkit.org/303645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c248399b2819828ca4d35bf8a70ef5f8944562c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85170 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69204 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82614 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4215 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1797 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110376 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4095 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58985 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5357 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33922 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5446 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->