### PR TITLE
[RenderStyleGen] Generalize logical property getter/setters

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2661,9 +2661,8 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
-                "render-style-storage-name": "m_color",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.bottom()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.colors()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
@@ -2688,7 +2687,7 @@
                 "style-extractor-converter": "StyleType<BorderRadiusValue>",
                 "disables-native-appearance": true,
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_radii"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::BorderRadiusValue",
                 "parser-grammar": "<length-percentage [0,inf]>{1,2}@(type=CSSValuePair default=previous)"
@@ -2713,7 +2712,7 @@
                 "style-extractor-converter": "StyleType<BorderRadiusValue>",
                 "disables-native-appearance": true,
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_radii"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::BorderRadiusValue",
                 "parser-grammar": "<length-percentage [0,inf]>{1,2}@(type=CSSValuePair default=previous)"
@@ -2745,9 +2744,8 @@
                 },
                 "disables-native-appearance": true,
                 "render-style-initial": "initialBorderStyle",
-                "render-style-storage-name": "m_style",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.bottom()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.styles()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "enum",
                 "render-style-type": "BorderStyle",
                 "parser-grammar": "<line-style>"
@@ -3273,9 +3271,8 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
-                "render-style-storage-name": "m_color",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.left()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.colors()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
@@ -3307,9 +3304,8 @@
                 },
                 "disables-native-appearance": true,
                 "render-style-initial": "initialBorderStyle",
-                "render-style-storage-name": "m_style",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.left()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.styles()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "enum",
                 "render-style-type": "BorderStyle",
                 "parser-grammar": "<line-style>"
@@ -3395,9 +3391,8 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
-                "render-style-storage-name": "m_color",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.right()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.colors()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
@@ -3429,9 +3424,8 @@
                 },
                 "disables-native-appearance": true,
                 "render-style-initial": "initialBorderStyle",
-                "render-style-storage-name": "m_style",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.right()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.styles()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "enum",
                 "render-style-type": "BorderStyle",
                 "parser-grammar": "<line-style>"
@@ -3572,9 +3566,8 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "disables-native-appearance": true,
-                "render-style-storage-name": "m_color",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.top()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.colors()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::Color",
                 "parser-grammar": "<color>"
@@ -3599,7 +3592,7 @@
                 "style-extractor-converter": "StyleType<BorderRadiusValue>",
                 "disables-native-appearance": true,
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_radii"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::BorderRadiusValue",
                 "parser-grammar": "<length-percentage [0,inf]>{1,2}@(type=CSSValuePair default=previous)"
@@ -3624,7 +3617,7 @@
                 "style-extractor-converter": "StyleType<BorderRadiusValue>",
                 "disables-native-appearance": true,
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_radii"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::BorderRadiusValue",
                 "parser-grammar": "<length-percentage [0,inf]>{1,2}@(type=CSSValuePair default=previous)"
@@ -3656,9 +3649,8 @@
                 },
                 "disables-native-appearance": true,
                 "render-style-initial": "initialBorderStyle",
-                "render-style-storage-name": "m_style",
-                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_edges.top()"],
-                "render-style-storage-container": "struct",
+                "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.styles()"],
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "enum",
                 "render-style-type": "BorderStyle",
                 "parser-grammar": "<line-style>"
@@ -3733,7 +3725,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialInset",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "inset"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::InsetEdge",
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
@@ -4126,7 +4118,7 @@
                 "style-converter": "StyleType<CornerShapeValue>",
                 "render-style-initial": "initialCornerShapeValue",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_cornerShapes"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::CornerShapeValue",
                 "parser-grammar": "<corner-shape-value>"
@@ -4149,7 +4141,7 @@
                 "style-converter": "StyleType<CornerShapeValue>",
                 "render-style-initial": "initialCornerShapeValue",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_cornerShapes"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::CornerShapeValue",
                 "parser-grammar": "<corner-shape-value>"
@@ -4172,7 +4164,7 @@
                 "style-converter": "StyleType<CornerShapeValue>",
                 "render-style-initial": "initialCornerShapeValue",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_cornerShapes"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::CornerShapeValue",
                 "parser-grammar": "<corner-shape-value>"
@@ -4195,7 +4187,7 @@
                 "style-converter": "StyleType<CornerShapeValue>",
                 "render-style-initial": "initialCornerShapeValue",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "border.m_cornerShapes"],
-                "render-style-storage-container": "rect-corners",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::CornerShapeValue",
                 "parser-grammar": "<corner-shape-value>"
@@ -5072,7 +5064,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialInset",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "inset"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::InsetEdge",
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
@@ -5436,7 +5428,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "margin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::MarginEdge",
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
@@ -5521,7 +5513,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "margin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::MarginEdge",
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
@@ -5547,7 +5539,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "margin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::MarginEdge",
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
@@ -5573,7 +5565,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "margin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::MarginEdge",
                 "parser-grammar": "<length-percentage anchor-size=allowed> | auto"
@@ -7328,7 +7320,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "padding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::PaddingEdge",
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7405,7 +7397,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "padding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::PaddingEdge",
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7429,7 +7421,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "padding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::PaddingEdge",
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7453,7 +7445,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "padding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::PaddingEdge",
                 "parser-grammar": "<length-percentage [0,inf]>"
@@ -7683,7 +7675,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialInset",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "inset"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::InsetEdge",
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
@@ -8413,7 +8405,7 @@
                 "style-extractor-custom": true,
                 "render-style-initial": "initialInset",
                 "render-style-storage-path": ["m_nonInheritedData", "surroundData", "inset"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::InsetEdge",
                 "parser-grammar": "auto | <length-percentage anchor=allowed anchor-size=allowed>"
@@ -12106,7 +12098,7 @@
                 "style-converter": "StyleType<ScrollMarginEdge>",
                 "render-style-initial": "initialScrollMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollMargin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollMarginEdge",
                 "parser-grammar": "<length>"
@@ -12131,7 +12123,7 @@
                 "style-converter": "StyleType<ScrollMarginEdge>",
                 "render-style-initial": "initialScrollMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollMargin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollMarginEdge",
                 "parser-grammar": "<length>"
@@ -12156,7 +12148,7 @@
                 "style-converter": "StyleType<ScrollMarginEdge>",
                 "render-style-initial": "initialScrollMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollMargin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollMarginEdge",
                 "parser-grammar": "<length>"
@@ -12181,7 +12173,7 @@
                 "style-converter": "StyleType<ScrollMarginEdge>",
                 "render-style-initial": "initialScrollMargin",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollMargin"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollMarginEdge",
                 "parser-grammar": "<length>"
@@ -12321,7 +12313,7 @@
                 "style-converter": "StyleType<ScrollPaddingEdge>",
                 "render-style-initial": "initialScrollPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollPadding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollPaddingEdge",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
@@ -12346,7 +12338,7 @@
                 "style-converter": "StyleType<ScrollPaddingEdge>",
                 "render-style-initial": "initialScrollPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollPadding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollPaddingEdge",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
@@ -12371,7 +12363,7 @@
                 "style-converter": "StyleType<ScrollPaddingEdge>",
                 "render-style-initial": "initialScrollPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollPadding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollPaddingEdge",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
@@ -12396,7 +12388,7 @@
                 "style-converter": "StyleType<ScrollPaddingEdge>",
                 "render-style-initial": "initialScrollPadding",
                 "render-style-storage-path": ["m_nonInheritedData", "rareData", "scrollPadding"],
-                "render-style-storage-container": "rect-edges",
+                "render-style-storage-container": "physical-group",
                 "render-style-storage-kind": "reference",
                 "render-style-type": "Style::ScrollPaddingEdge",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"

--- a/Source/WebCore/rendering/style/BorderValue.h
+++ b/Source/WebCore/rendering/style/BorderValue.h
@@ -31,9 +31,11 @@
 
 namespace WebCore {
 
+class BorderData;
 class RenderStyle;
 
-class BorderValue {
+class BorderValue final {
+    friend class BorderData;
     friend class RenderStyle;
 public:
     BorderValue()
@@ -51,7 +53,7 @@ public:
 
     bool operator==(const BorderValue&) const = default;
 
-protected:
+private:
     Style::Color m_color { Style::Color::currentColor() };
     Style::LineWidth m_width { Style::LineWidth::Length { 3.0f } };
     PREFERRED_TYPE(BorderStyle) unsigned m_style : 4;


### PR DESCRIPTION
#### eb281cc190eaee7b6833e873c4aafcb47c30d00e
<pre>
[RenderStyleGen] Generalize logical property getter/setters
<a href="https://bugs.webkit.org/show_bug.cgi?id=303257">https://bugs.webkit.org/show_bug.cgi?id=303257</a>

Reviewed by Darin Adler.

Replaces &apos;rect-edges&apos; and &apos;rect-corners&apos; container types with a single
&apos;physical-group&apos; container type.

Also adds BorderEdgesView adaptor for accessing the `border-*-style` and
`border-*-color` property sets, allowing use of the &apos;physical-group&apos;
container type for them.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/BorderValue.h:

Canonical link: <a href="https://commits.webkit.org/303653@main">https://commits.webkit.org/303653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb684a7bb1685d0cd9f2c1f109c069d7462fedf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133200 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69333 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4285 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1861 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143402 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110256 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110439 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4159 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5426 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68878 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->