### PR TITLE
Fix table column width distribution for colspan with mixed percent and auto columns

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Table column width distribution reference</title>
+<style>
+  table {
+    border-collapse: collapse;
+    width: 400px;
+  }
+  td {
+    border: 1px solid black;
+    padding: 0;
+  }
+  .marker {
+    width: 100%;
+    height: 20px;
+    background: green;
+  }
+</style>
+</head>
+<body>
+  <p>The green bar should occupy approximately 90% of the table width.</p>
+  <table>
+    <tr>
+      <td style="width: 90%;">
+        <div class="marker"></div>
+      </td>
+      <td style="width: 10%;"></td>
+    </tr>
+    <tr>
+      <td colspan="2" style="white-space: nowrap;">
+        Lorem ipsum dolor sit amet consectetuer adipiscing
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Table column width distribution reference</title>
+<style>
+  table {
+    border-collapse: collapse;
+    width: 400px;
+  }
+  td {
+    border: 1px solid black;
+    padding: 0;
+  }
+  .marker {
+    width: 100%;
+    height: 20px;
+    background: green;
+  }
+</style>
+</head>
+<body>
+  <p>The green bar should occupy approximately 90% of the table width.</p>
+  <table>
+    <tr>
+      <td style="width: 90%;">
+        <div class="marker"></div>
+      </td>
+      <td style="width: 10%;"></td>
+    </tr>
+    <tr>
+      <td colspan="2" style="white-space: nowrap;">
+        Lorem ipsum dolor sit amet consectetuer adipiscing
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Table column width distribution with colspan and mixed percent/auto columns</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/">
+<link rel="match" href="table-colspan-percent-auto-ref.html">
+<style>
+  table {
+    border-collapse: collapse;
+    width: 400px;
+  }
+  td {
+    border: 1px solid black;
+    padding: 0;
+  }
+  .marker {
+    width: 100%;
+    height: 20px;
+    background: green;
+  }
+</style>
+</head>
+<body>
+  <p>The green bar should occupy approximately 90% of the table width.</p>
+  <table>
+    <tr>
+      <td style="width: 90%;">
+        <div class="marker"></div>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td colspan="2" style="white-space: nowrap;">
+        Lorem ipsum dolor sit amet consectetuer adipiscing
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/fast/table/003-expected.txt
+++ b/LayoutTests/platform/gtk/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x52
         RenderTableSection {TBODY} at (0,0) size 784x52
           RenderTableRow {TR} at (0,2) size 784x26
-            RenderTableCell {TD} at (2,5) size 43x20 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,5) size 39x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,4) size 37x17
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (46,2) size 737x26 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 734x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (43,2) size 739x26 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 737x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,30) size 784x20
-            RenderTableCell {TD} at (2,30) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,30) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 253x17
                 text run at (1,1) width 253: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,52) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 145: "I should have nowrap. "
                   text run at (145,0) width 98: "I really should. "
                   text run at (243,0) width 119: "Definitely. Should."
-layer at (58,14) size 728x18
-  RenderBlock {DIV} at (3,3) size 728x18
+layer at (55,14) size 731x18
+  RenderBlock {DIV} at (3,3) size 731x18
 layer at (14,238) size 201x42 clip at (15,239) size 199x40
   RenderTextControl {TEXTAREA} at (2,2) size 201x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 195x18

--- a/LayoutTests/platform/mac-sequoia-wk1/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk1/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x47
         RenderTableSection {TBODY} at (0,0) size 784x47
           RenderTableRow {TR} at (0,2) size 784x21
-            RenderTableCell {TD} at (2,2) size 53x21 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 39x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (56,2) size 727x21 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 724x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (42,2) size 740x21 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,25) size 784x20
-            RenderTableCell {TD} at (2,25) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,25) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (68,14) size 718x13
-  RenderBlock {DIV} at (3,3) size 718x13
+layer at (54,14) size 732x13
+  RenderBlock {DIV} at (3,3) size 732x13
 layer at (14,233) size 161x36 clip at (15,234) size 159x34
   RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x47
         RenderTableSection {TBODY} at (0,0) size 784x47
           RenderTableRow {TR} at (0,2) size 784x21
-            RenderTableCell {TD} at (2,2) size 53x21 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 39x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (56,2) size 727x21 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 724x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (42,2) size 740x21 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,25) size 784x20
-            RenderTableCell {TD} at (2,25) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,25) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (68,14) size 718x13
-  RenderBlock {DIV} at (3,3) size 718x13
+layer at (54,14) size 732x13
+  RenderBlock {DIV} at (3,3) size 732x13
 layer at (14,233) size 161x36 clip at (15,234) size 159x34
   RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac-sonoma-wk1/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x47
         RenderTableSection {TBODY} at (0,0) size 784x47
           RenderTableRow {TR} at (0,2) size 784x21
-            RenderTableCell {TD} at (2,2) size 53x21 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,2) size 39x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (56,2) size 727x21 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 724x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (42,2) size 740x21 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,25) size 784x20
-            RenderTableCell {TD} at (2,25) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,25) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (68,14) size 718x13
-  RenderBlock {DIV} at (3,3) size 718x13
+layer at (54,14) size 732x13
+  RenderBlock {DIV} at (3,3) size 732x13
 layer at (14,233) size 161x36 clip at (15,234) size 159x34
   RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac-wk1/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/table/003-expected.txt
@@ -3,47 +3,47 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x49
-        RenderTableSection {TBODY} at (0,0) size 784x49
-          RenderTableRow {TR} at (0,2) size 784x23
-            RenderTableCell {TD} at (2,3) size 51x21 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 37x19
+      RenderTable {TABLE} at (0,0) size 784x47
+        RenderTableSection {TBODY} at (0,0) size 784x47
+          RenderTableRow {TR} at (0,2) size 784x21
+            RenderTableCell {TD} at (2,2) size 39x21 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (54,2) size 729x23 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 726x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-          RenderTableRow {TR} at (0,27) size 784x20
-            RenderTableCell {TD} at (2,27) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (42,2) size 740x21 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderTableRow {TR} at (0,25) size 784x20
+            RenderTableCell {TD} at (2,25) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
-      RenderTable {TABLE} at (0,49) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
+      RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 96x96
           RenderTableRow {TR} at (0,2) size 96x92
             RenderTableCell {TD} at (2,46) size 92x4 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-      RenderTable {TABLE} at (0,149) size 179x120 [border: (2px outset #000000)]
-        RenderTableSection {TBODY} at (2,2) size 175x116
-          RenderTableRow {TR} at (0,2) size 175x22
-            RenderTableCell {TD} at (2,2) size 171x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,147) size 173x120 [border: (2px outset #000000)]
+        RenderTableSection {TBODY} at (2,2) size 169x116
+          RenderTableRow {TR} at (0,2) size 169x22
+            RenderTableCell {TD} at (2,2) size 165x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "hello"
-          RenderTableRow {TR} at (0,26) size 175x22
-            RenderTableCell {TD} at (2,26) size 171x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 169x22
+            RenderTableCell {TD} at (2,26) size 165x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x18
                 text run at (2,2) width 69: "more hello"
-          RenderTableRow {TR} at (0,50) size 175x22
-            RenderTableCell {TD} at (2,50) size 171x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,50) size 169x22
+            RenderTableCell {TD} at (2,50) size 165x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 38x18
                 text run at (2,2) width 38: "world"
-          RenderTableRow {TR} at (0,74) size 175x40
-            RenderTableCell {TD} at (2,74) size 171x40 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,74) size 169x40
+            RenderTableCell {TD} at (2,74) size 165x40 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,269) size 337x24
+      RenderTable {TABLE} at (0,267) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
           RenderTableRow {TR} at (0,2) size 337x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 331x18
                 text run at (1,1) width 234: "I should wrap and not have nowrap. "
                 text run at (234,1) width 98: "I really should."
-      RenderTable {TABLE} at (0,293) size 337x24
+      RenderTable {TABLE} at (0,291) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
           RenderTableRow {TR} at (0,2) size 337x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
@@ -51,7 +51,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 331x18
                   text run at (0,0) width 234: "I should wrap and not have nowrap. "
                   text run at (233,0) width 98: "I really should."
-      RenderTable {TABLE} at (0,317) size 373x24
+      RenderTable {TABLE} at (0,315) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
@@ -59,7 +59,7 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 147: "I should have nowrap. "
                 text run at (147,1) width 101: "I really should. "
                 text run at (247,1) width 121: "Definitely. Should."
-      RenderTable {TABLE} at (0,341) size 373x24
+      RenderTable {TABLE} at (0,339) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (70,15) size 712x13
-  RenderBlock {DIV} at (7,4) size 712x13
-layer at (14,235) size 167x36 clip at (15,236) size 165x34
-  RenderTextControl {TEXTAREA} at (2,2) size 167x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 155x13
+layer at (54,14) size 732x13
+  RenderBlock {DIV} at (3,3) size 732x13
+layer at (14,233) size 161x36 clip at (15,234) size 159x34
+  RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac-wk2/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x49
         RenderTableSection {TBODY} at (0,0) size 784x49
           RenderTableRow {TR} at (0,2) size 784x23
-            RenderTableCell {TD} at (2,3) size 51x21 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,3) size 39x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (54,2) size 729x23 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 726x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (42,2) size 740x23 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,27) size 784x20
-            RenderTableCell {TD} at (2,27) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,27) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,49) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (70,15) size 712x13
-  RenderBlock {DIV} at (7,4) size 712x13
+layer at (58,15) size 724x13
+  RenderBlock {DIV} at (7,4) size 724x13
 layer at (14,235) size 167x36 clip at (15,236) size 165x34
   RenderTextControl {TEXTAREA} at (2,2) size 167x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 155x13

--- a/LayoutTests/platform/mac/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/003-expected.txt
@@ -3,47 +3,47 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x47
-        RenderTableSection {TBODY} at (0,0) size 784x47
-          RenderTableRow {TR} at (0,2) size 784x21
-            RenderTableCell {TD} at (2,2) size 53x21 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 37x19
+      RenderTable {TABLE} at (0,0) size 784x49
+        RenderTableSection {TBODY} at (0,0) size 784x49
+          RenderTableRow {TR} at (0,2) size 784x23
+            RenderTableCell {TD} at (2,3) size 39x21 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,2) size 37x19
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (56,2) size 727x21 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 724x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-          RenderTableRow {TR} at (0,25) size 784x20
-            RenderTableCell {TD} at (2,25) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (42,2) size 740x23 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 738x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderTableRow {TR} at (0,27) size 784x20
+            RenderTableCell {TD} at (2,27) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
-      RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
+      RenderTable {TABLE} at (0,49) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 96x96
           RenderTableRow {TR} at (0,2) size 96x92
             RenderTableCell {TD} at (2,46) size 92x4 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-      RenderTable {TABLE} at (0,147) size 173x120 [border: (2px outset #000000)]
-        RenderTableSection {TBODY} at (2,2) size 169x116
-          RenderTableRow {TR} at (0,2) size 169x22
-            RenderTableCell {TD} at (2,2) size 165x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,149) size 179x120 [border: (2px outset #000000)]
+        RenderTableSection {TBODY} at (2,2) size 175x116
+          RenderTableRow {TR} at (0,2) size 175x22
+            RenderTableCell {TD} at (2,2) size 171x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "hello"
-          RenderTableRow {TR} at (0,26) size 169x22
-            RenderTableCell {TD} at (2,26) size 165x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 175x22
+            RenderTableCell {TD} at (2,26) size 171x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x18
                 text run at (2,2) width 69: "more hello"
-          RenderTableRow {TR} at (0,50) size 169x22
-            RenderTableCell {TD} at (2,50) size 165x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,50) size 175x22
+            RenderTableCell {TD} at (2,50) size 171x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 38x18
                 text run at (2,2) width 38: "world"
-          RenderTableRow {TR} at (0,74) size 169x40
-            RenderTableCell {TD} at (2,74) size 165x40 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,74) size 175x40
+            RenderTableCell {TD} at (2,74) size 171x40 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,267) size 337x24
+      RenderTable {TABLE} at (0,269) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
           RenderTableRow {TR} at (0,2) size 337x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 331x18
                 text run at (1,1) width 234: "I should wrap and not have nowrap. "
                 text run at (234,1) width 98: "I really should."
-      RenderTable {TABLE} at (0,291) size 337x24
+      RenderTable {TABLE} at (0,293) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
           RenderTableRow {TR} at (0,2) size 337x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
@@ -51,7 +51,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 331x18
                   text run at (0,0) width 234: "I should wrap and not have nowrap. "
                   text run at (233,0) width 98: "I really should."
-      RenderTable {TABLE} at (0,315) size 373x24
+      RenderTable {TABLE} at (0,317) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
@@ -59,7 +59,7 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 147: "I should have nowrap. "
                 text run at (147,1) width 101: "I really should. "
                 text run at (247,1) width 121: "Definitely. Should."
-      RenderTable {TABLE} at (0,339) size 373x24
+      RenderTable {TABLE} at (0,341) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 147: "I should have nowrap. "
                   text run at (146,0) width 101: "I really should. "
                   text run at (246,0) width 121: "Definitely. Should."
-layer at (68,14) size 718x13
-  RenderBlock {DIV} at (3,3) size 718x13
-layer at (14,233) size 161x36 clip at (15,234) size 159x34
-  RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 155x13
+layer at (58,15) size 724x13
+  RenderBlock {DIV} at (7,4) size 724x13
+layer at (14,235) size 167x36 clip at (15,236) size 165x34
+  RenderTextControl {TEXTAREA} at (2,2) size 167x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (6,3) size 155x13

--- a/LayoutTests/platform/wpe/fast/table/003-expected.txt
+++ b/LayoutTests/platform/wpe/fast/table/003-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 784x52
         RenderTableSection {TBODY} at (0,0) size 784x52
           RenderTableRow {TR} at (0,2) size 784x26
-            RenderTableCell {TD} at (2,5) size 47x20 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,5) size 39x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,4) size 37x17
                 text run at (1,1) width 37: "URL:"
-            RenderTableCell {TD} at (50,2) size 733x26 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,1) size 730x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderTableCell {TD} at (43,2) size 739x26 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 737x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderTableRow {TR} at (0,30) size 784x20
-            RenderTableCell {TD} at (2,30) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (2,30) size 780x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 253x17
                 text run at (1,1) width 253: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,52) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
@@ -68,8 +68,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 145: "I should have nowrap. "
                   text run at (145,0) width 98: "I really should. "
                   text run at (243,0) width 119: "Definitely. Should."
-layer at (62,14) size 724x18
-  RenderBlock {DIV} at (3,3) size 724x18
+layer at (55,14) size 731x18
+  RenderBlock {DIV} at (3,3) size 731x18
 layer at (14,238) size 181x42 clip at (15,239) size 179x40
   RenderTextControl {TEXTAREA} at (2,2) size 181x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x18


### PR DESCRIPTION
#### 292b717d89788fcfb8e6192d556a0a6ed7fd9e9f
<pre>
Fix table column width distribution for colspan with mixed percent and auto columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=303263">https://bugs.webkit.org/show_bug.cgi?id=303263</a>
<a href="https://rdar.apple.com/165561401">rdar://165561401</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Chromium / Blink and Gecko / Firefox.

When a table has a row with mixed percentage and auto width columns, and
another row with a colspan spanning those columns, the auto column&apos;s width
was incorrectly negating the percentage constraint. This caused the width
distribution to be based solely on content width rather than respecting the
percentage values.

The issue occurred in AutoTableLayout::calcEffectiveLogicalWidth() when
distributing the colspan cell&apos;s min/max widths. The code had separate paths
for all-fixed columns and all-percent columns, but no proper handling for
mixed percent+auto columns.
The fix adds a new branch that detects when we have mixed percentage and
auto columns. By this point in the code, the earlier percentage distribution
logic has already converted auto columns to effective percentage widths. The
new code calculates the total effective percentage and distributes the
colspan&apos;s min/max widths proportionally based on these percentages, similar
to the existing all-percent case.

This ensures that a 90% column and an auto column (converted to ~10%)
receive width in a 90:10 ratio from the spanning cell, properly respecting
the percentage constraint.

Tests: imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-ref.html
       imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-colspan-percent-auto.html: Added.
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):

&gt; Rebaselines:
* LayoutTests/platform/gtk/fast/table/003-expected.txt:
* LayoutTests/platform/mac-sequoia-wk1/fast/table/003-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/table/003-expected.txt:
* LayoutTests/platform/mac-sonoma-wk1/fast/table/003-expected.txt:
* LayoutTests/platform/mac-wk1/fast/table/003-expected.txt:
* LayoutTests/platform/mac-wk2/fast/table/003-expected.txt:
* LayoutTests/platform/mac/fast/table/003-expected.txt:
* LayoutTests/platform/wpe/fast/table/003-expected.txt:

Canonical link: <a href="https://commits.webkit.org/305120@main">https://commits.webkit.org/305120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73cc724d4e696f3be9399618fb3db555e96b36ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9d379af-9c40-4d64-a99c-4d21a34cf906) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104418 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/74995 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f393ec0-2bcf-49ed-8ae4-a01921cd7b78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85253 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/200b539b-7998-4248-a1cf-2a85c674eb26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4327 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4879 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147041 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28916 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6580 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118647 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62617 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8650 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->