### PR TITLE
REGRESSION(303612@main): Links are not preserved as clickable annotations when exporting to PDF in Safari

### DIFF
--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -120,11 +120,10 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
 
 void OutlinePainter::paintOutline(const RenderInline& renderer, const LayoutPoint& paintOffset) const
 {
-    CheckedRef styleToUse = renderer.style();
-
-    if (!styleToUse->hasOutline())
+    if (!renderer.hasOutline())
         return;
 
+    CheckedRef styleToUse = renderer.style();
     if (styleToUse->outlineStyle() == OutlineStyle::Auto) {
         CheckedPtr paintContainer = m_paintInfo.paintContainer;
         auto focusRingRects = collectFocusRingRects(renderer, paintOffset, paintContainer.get());
@@ -133,8 +132,12 @@ void OutlinePainter::paintOutline(const RenderInline& renderer, const LayoutPoin
         return;
     }
 
-    if (renderer.hasOutlineAnnotation())
+    auto hasThemedFocusRing = renderer.theme().supportsFocusRing(renderer, styleToUse.get());
+    if (renderer.hasOutlineAnnotation() && !hasThemedFocusRing)
         addPDFURLAnnotationForLink(renderer, paintOffset);
+
+    if (!styleToUse->hasOutline())
+        return;
 
     if (m_paintInfo.context().paintingDisabled())
         return;


### PR DESCRIPTION
#### 937a601639aaa7c67e56e014a6557a9df2d92573
<pre>
REGRESSION(<a href="https://commits.webkit.org/303612@main">303612@main</a>): Links are not preserved as clickable annotations when exporting to PDF in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=303274">https://bugs.webkit.org/show_bug.cgi?id=303274</a>
<a href="https://rdar.apple.com/165575382">rdar://165575382</a>

Reviewed by NOBODY (OOPS!).

The refactoring in <a href="https://commits.webkit.org/303612@main">303612@main</a> introduced a bug in outline painting of
inline content, resulting in PDF link annotations to be missing for &lt;a&gt;
elements.

Prior to the refactor, RenderInline::paintOutline() called hasOutline()
on RenderElement, rather than on RenderStyle. For links, the former
returns true when hasOutlineAnnotation() is true, even if there&apos;s no
`outline-style` set or there is a zero `outline-width`. This is not true
for the RenderStyle method, which prevented PDF annotations from being
added.

We fix by:
1. Using renderer.hasOutline() in the initial guard to handle links with
   outline annotations but no CSS outline style.
2. Adding hasThemedFocusRing check to match the focus ring logic in
   RenderInline::paintOutline() prior to <a href="https://commits.webkit.org/303612@main">303612@main</a>.
3. Restorng the early return by consulting RenderStyle::hasOutline()
   _after_ adding the annotation.

No new test, but TestWebKitAPI.PDFSnapshot.Links is now progressed.

* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/937a601639aaa7c67e56e014a6557a9df2d92573

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85234 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/adb86bc0-61cf-4987-8bf6-b05e5963b965) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101871 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69316 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1fd9bcde-8a6d-46c1-985e-d2365c76ae5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c492154b-f828-41c5-9699-37c9407965a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1852 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113353 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37492 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vlr-ltr-ltr-in-multicol.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143393 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110248 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110431 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4149 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59094 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33985 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->