### PR TITLE
[MiniBrowser] Use -[PDFDocument writeToURL:] instead of NSData analogue for "Save as PDF"

### DIFF
--- a/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
+++ b/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
@@ -29,5 +29,5 @@ INFOPLIST_FILE = mac/Info.plist
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*] = *
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_PLATFORM_NAME))
 EXCLUDED_SOURCE_FILE_NAMES_maccatalyst = *
-OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Cocoa -framework UniformTypeIdentifiers -framework WebKit
+OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Cocoa -framework PDFKit -framework UniformTypeIdentifiers -framework WebKit
 STRIP_STYLE = debugging;

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -27,6 +27,7 @@
 
 #import "AppDelegate.h"
 #import "SettingsController.h"
+#import <PDFKit/PDFDocument.h>
 #import <QuartzCore/CATextLayer.h>
 #import <SecurityInterface/SFCertificateTrustPanel.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
@@ -1036,7 +1037,8 @@ static BOOL isJavaScriptURL(NSURL *url)
         if (result != NSModalResponseOK)
             return;
         [self->_webView createPDFWithConfiguration:nil completionHandler:^(NSData *pdfSnapshotData, NSError *error) {
-            [pdfSnapshotData writeToURL:[panel URL] options:0 error:nil];
+            PDFDocument *pdfDocument = [[PDFDocument alloc] initWithData:pdfSnapshotData];
+            [pdfDocument writeToURL:[panel URL]];
         }];
     }];
 }


### PR DESCRIPTION
#### a636f519037e5b4d54d5477f30114f933a1eb5eb
<pre>
[MiniBrowser] Use -[PDFDocument writeToURL:] instead of NSData analogue for &quot;Save as PDF&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=303275">https://bugs.webkit.org/show_bug.cgi?id=303275</a>
<a href="https://rdar.apple.com/165576176">rdar://165576176</a>

Reviewed by Wenson Hsieh.

MiniBrowser&apos;s &quot;Save as PDF&quot; was using -[NSData writeToURL:options:error:]
to save the PDF data returned by WKWebView&apos;s createPDFWithConfiguration:.
This method writes the raw PDF data to disk without processing it through
PDFKit, which can result in link annotations being lost or not properly
preserved in the output file.

Using -[PDFDocument writeToURL:] instead ensures that PDFKit properly
handles the PDF structure, including all annotations such as clickable
links, when writing to disk.

* Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig:
Add PDFKit framework to MiniBrowser&apos;s linker flags.

* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController saveAsPDF:]):
Create a PDFDocument from the PDF data and use its writeToURL: method
instead of writing the raw NSData directly.

Canonical link: <a href="https://commits.webkit.org/303687@main">https://commits.webkit.org/303687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d6c9ed10427fc588b9a98bc86ca93982730cba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/534357c7-1190-41c7-953f-cf089a0757ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69317 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b805eee4-279d-49e9-ab01-780fa224a9a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82667 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af047c4a-a44b-46b6-a9a4-08e327603a83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4277 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1853 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143394 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5363 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110432 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4150 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59098 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20621 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5418 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33986 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5264 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->