### PR TITLE
Canvases are not removed from Inspector Graphics tab when they're removed from the DOM

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -1002,6 +1002,16 @@ void HTMLCanvasElement::didMoveToNewDocument(Document& oldDocument, Document& ne
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 
+void HTMLCanvasElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+{
+    if (removalType.disconnectedFromDocument) {
+        if (RefPtr context = renderingContext())
+            InspectorInstrumentation::didRemoveCanvasFromDocument(*context);
+    }
+
+    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+}
+
 bool HTMLCanvasElement::needsPreparationForDisplay()
 {
     return m_context && m_context->needsPreparationForDisplay();

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -185,6 +185,7 @@ private:
     RefPtr<ScriptExecutionContext> protectedCanvasBaseScriptExecutionContext() const { return canvasBaseScriptExecutionContext(); }
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
+    void removedFromAncestor(RemovalType, ContainerNode&) override;
 
     std::optional<FloatRect> computeDirtyRectangleIfNeeded(const std::optional<FloatRect>&) const;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1117,6 +1117,12 @@ void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& in
         canvasAgent->didChangeCanvasMemory(context);
 }
 
+void InspectorInstrumentation::didRemoveCanvasFromDocumentImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
+{
+    if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        canvasAgent->didRemoveCanvasFromDocument(context);
+}
+
 void InspectorInstrumentation::didFinishRecordingCanvasFrameImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context, bool forceDispatch)
 {
     if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -316,6 +316,7 @@ public:
     static void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     static void didChangeCanvasSize(CanvasRenderingContext&);
     static void didChangeCanvasMemory(CanvasRenderingContext&);
+    static void didRemoveCanvasFromDocument(CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtension(WebGLRenderingContextBase&, const String&);
@@ -521,6 +522,7 @@ private:
     static void didCreateCanvasRenderingContextImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didChangeCanvasSizeImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didChangeCanvasMemoryImpl(InstrumentingAgents&, CanvasRenderingContext&);
+    static void didRemoveCanvasFromDocumentImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrameImpl(InstrumentingAgents&, CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtensionImpl(InstrumentingAgents&, WebGLRenderingContextBase&, const String&);
@@ -1448,6 +1450,13 @@ inline void InspectorInstrumentation::didChangeCanvasMemory(CanvasRenderingConte
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didChangeCanvasMemoryImpl(*agents, context);
+}
+
+inline void InspectorInstrumentation::didRemoveCanvasFromDocument(CanvasRenderingContext& context)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+        didRemoveCanvasFromDocumentImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::didFinishRecordingCanvasFrame(CanvasRenderingContext& context, bool forceDispatch)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -380,6 +380,16 @@ void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context
     m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().canvasBase().memoryCost());
 }
 
+void InspectorCanvasAgent::didRemoveCanvasFromDocument(CanvasRenderingContext& context)
+{
+    auto inspectorCanvas = findInspectorCanvas(context);
+    ASSERT(inspectorCanvas);
+    if (!inspectorCanvas)
+        return;
+
+    unbindCanvas(*inspectorCanvas);
+}
+
 void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)
 {
     auto* context = canvasBase.renderingContext();

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -94,6 +94,7 @@ public:
     void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     void didChangeCanvasSize(CanvasRenderingContext&);
     void didChangeCanvasMemory(CanvasRenderingContext&);
+    void didRemoveCanvasFromDocument(CanvasRenderingContext&);
     void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
     void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     void consoleStopRecordingCanvas(CanvasRenderingContext&);


### PR DESCRIPTION
#### 9b56896dc983fa044321a99eeebf14daa9092843
<pre>
Canvases are not removed from Inspector Graphics tab when they&apos;re removed from the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=284281">https://bugs.webkit.org/show_bug.cgi?id=284281</a>
<a href="https://rdar.apple.com/141535067">rdar://141535067</a>

Reviewed by NOBODY (OOPS!).

HTMLCanvasElement was missing the removedFromAncestor() lifecycle override, so
Inspector never got notified when canvases were removed, causing removed canvases to
persist in the Graphics tab indefinitely if JS held references. We&apos;ve implemented
removedFromAncestor() to call InspectorInstrumentation::didRemoveCanvasFromDocument()
on disconnectedFromDocument, which triggers InspectorCanvasAgent::didRemoveCanvasFromDocument()
to call existing unbindCanvas() for immediate cleanup. This follows the pattern used by
HTMLMediaElement/HTMLImageElement and reuses the existing unbind path.

No new tests (OOPS!).

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::removedFromAncestor):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didRemoveCanvasFromDocumentImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didRemoveCanvasFromDocument):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::didRemoveCanvasFromDocument):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b56896dc983fa044321a99eeebf14daa9092843

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85247 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85a4cfd3-e6e9-49b8-8bea-0a774014a459) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101883 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69336 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aaff166e-fa47-445d-92db-438b45cf0c4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f24f8cb-7067-47d5-8b6f-d65ce8bd0c42) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4283 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1864 "Found 1 new API test failure: TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110260 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110443 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4157 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115646 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59113 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5428 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34000 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->