### PR TITLE
Web Inspector uses system highlight color, which becomes misleading when that's grey

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js
@@ -92,6 +92,12 @@ InspectorFrontendAPI = {
             WI.diagnosticController.diagnosticLoggingAvailable = available;
     },
 
+    systemAppearanceDidChange: function()
+    {
+        if (WI.Platform.name === "mac")
+            WI._updateAccentColorClass();
+    },
+
     showConsole: function()
     {
         WI.showConsoleTab({

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -387,6 +387,8 @@ body {
     }
 
     &.mac-platform {
+        --system-accent-color: -apple-system-control-accent;
+
         --text-color: hsl(0, 0%, 15%);
         --text-color-transparent: hsla(0, 0%, 15%, 0.4);
 
@@ -406,11 +408,11 @@ body {
         --selected-background-color: -apple-system-selected-content-background;
         --selected-text-background-color: -apple-system-selected-text-background;
 
-        --breakpoint-color: -apple-system-control-accent;
+        --breakpoint-color: var(--system-accent-color);
         --breakpoint-color-disabled: -apple-system-selected-text-background;
 
-        --glyph-color-active: -apple-system-control-accent;
-        --glyph-color-active-pressed: -apple-system-control-accent;
+        --glyph-color-active: var(--system-accent-color);
+        --glyph-color-active-pressed: var(--system-accent-color);
 
         @media (prefers-color-scheme: dark) {
             --text-color: hsl(0, 0%, 85%);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -824,6 +824,15 @@ void WebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 #endif
 }
 
+void WebInspectorUIProxy::systemAppearanceDidChange()
+{
+    RefPtr inspectorPage = m_inspectorPage.get();
+    if (!inspectorPage)
+        return;
+
+    protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SystemAppearanceDidChange(), inspectorPage->webPageIDInMainFrameProcess());
+}
+
 void WebInspectorUIProxy::save(Vector<InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
     if (!protect(protect(inspectedPage())->preferences())->developerExtrasEnabled())

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -206,6 +206,8 @@ public:
 
     void setDiagnosticLoggingAvailable(bool);
 
+    void systemAppearanceDidChange();
+
     // Provided by platform WebInspectorUIProxy implementations.
     static String inspectorPageURL();
     static String inspectorTestPageURL();

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -152,6 +152,12 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
         proxy->windowFullScreenDidChange();
 }
 
+- (void)_systemColorsDidChange:(NSNotification *)notification
+{
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->systemAppearanceDidChange();
+}
+
 - (void)inspectedViewFrameDidChange:(NSNotification *)notification
 {
     // Resizing the views while inside this notification can lead to bad results when entering
@@ -478,6 +484,7 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
     m_objCAdapter = adoptNS([[WKWebInspectorUIProxyObjCAdapter alloc] initWithWebInspectorUIProxy:this]);
     RetainPtr inspectedView = inspectedPage->inspectorAttachmentView();
     [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:NSViewFrameDidChangeNotification object:inspectedView.get()];
+    [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(_systemColorsDidChange:) name:NSSystemColorsDidChangeNotification object:nil];
 
     Ref configuration = inspectedPage->uiClient().configurationForLocalInspector(*inspectedPage, *this);
     m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protect(WebKit::wrapper(configuration.get())).get() inspectedPage:inspectedPage.get()]);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -356,6 +356,11 @@ void WebInspectorUI::setDiagnosticLoggingAvailable(bool available)
 }
 #endif // ENABLE(INSPECTOR_TELEMETRY)
 
+void WebInspectorUI::systemAppearanceDidChange()
+{
+    m_frontendAPIDispatcher->dispatchCommandWithResultAsync("systemAppearanceDidChange"_s);
+}
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
 bool WebInspectorUI::supportsWebExtensions()
 {

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -107,6 +107,8 @@ public:
     void setDiagnosticLoggingAvailable(bool);
 #endif
 
+    void systemAppearanceDidChange();
+
     // WebCore::InspectorFrontendClient
     void windowObjectCleared() override;
     void frontendLoaded() override;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in
@@ -40,6 +40,8 @@ messages -> WebInspectorUI {
     SetDiagnosticLoggingAvailable(bool available)
 #endif
 
+    SystemAppearanceDidChange()
+
     ShowConsole()
     ShowResources()
 


### PR DESCRIPTION
#### e4ac810c5e5f4855566304c3c00c06dbed215cc9
<pre>
Web Inspector uses system highlight color, which becomes misleading when that&apos;s grey
<a href="https://bugs.webkit.org/show_bug.cgi?id=291237">https://bugs.webkit.org/show_bug.cgi?id=291237</a>
<a href="https://rdar.apple.com/148779029">rdar://148779029</a>

Reviewed by BJ Burg.

When macOS accent color is set to Graphite (gray), enabled toolbar buttons and selected DOM
elements become visually indistinguishable from disabled/unselected states. This patch detects
gray accent colors by checking if RGB channels differ by ≤ 20 (graphite is ~5, all chromatic
colors are &gt; 50) and overrides accent-derived CSS variables with blue. To handle changes while
Web Inspector is open, NSSystemColorsDidChangeNotification is observed in the UIProcess and
forwarded via IPC to WebInspectorUI, which dispatches systemAppearanceDidChange to
InspectorFrontendAPI to re-run the detection live.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js:
(InspectorFrontendAPI.systemAppearanceDidChange):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(&amp;.mac-platform):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::systemAppearanceDidChange):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter _systemColorsDidChange:]):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::systemAppearanceDidChange):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.messages.in:

Canonical link: <a href="https://commits.webkit.org/307943@main">https://commits.webkit.org/307943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f736d4d8c3461553434f9ffa09112a29429d65a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154683 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64cb7e96-40b3-48ad-b2f3-d9bba577a8cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112315 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e30ec7e-6c1f-47a0-8bb9-522638481e07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14691 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93209 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dd2165d-2031-4fba-bd44-788742ca9ae8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2127 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156994 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120328 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30921 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74231 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7444 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18141 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->