### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for ThermalMitigationNotifier

### DIFF
--- a/Source/WebCore/platform/ThermalMitigationNotifier.h
+++ b/Source/WebCore/platform/ThermalMitigationNotifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -35,18 +36,10 @@ OBJC_CLASS WebThermalMitigationObserver;
 #endif
 
 namespace WebCore {
-class ThermalMitigationNotifier;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ThermalMitigationNotifier> : std::true_type { };
-}
-
-namespace WebCore {
-
-class ThermalMitigationNotifier : public CanMakeWeakPtr<ThermalMitigationNotifier> {
+class ThermalMitigationNotifier final : public CanMakeWeakPtr<ThermalMitigationNotifier>, public CanMakeCheckedPtr<ThermalMitigationNotifier> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ThermalMitigationNotifier, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThermalMitigationNotifier);
 public:
     using ThermalMitigationChangeCallback = Function<void(bool thermalMitigationEnabled)>;
     WEBCORE_EXPORT explicit ThermalMitigationNotifier(ThermalMitigationChangeCallback&&);

--- a/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
+++ b/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
@@ -67,8 +67,8 @@ static bool isThermalMitigationEnabled()
 - (void)thermalStateDidChange
 {
     callOnMainThread([self, protectedSelf = RetainPtr<WebThermalMitigationObserver>(self)] {
-        if (_notifier)
-            notifyThermalMitigationChanged(*_notifier, self.thermalMitigationEnabled);
+        if (CheckedPtr notifier = _notifier.get())
+            notifyThermalMitigationChanged(*notifier, self.thermalMitigationEnabled);
     });
 }
 


### PR DESCRIPTION
#### 2e2aa4ea65727f46d0618ce8af0deae3b874f463
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for ThermalMitigationNotifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=303280">https://bugs.webkit.org/show_bug.cgi?id=303280</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/ThermalMitigationNotifier.h:
* Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm:
(-[WebThermalMitigationObserver thermalStateDidChange]):

Canonical link: <a href="https://commits.webkit.org/303704@main">https://commits.webkit.org/303704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a323e179177f18205fee808dc9c454df9e32882a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85274 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c75e57ca-924d-4904-bd7f-edb662d2a684) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101906 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69368 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb9f239b-a56a-4369-b626-fb8213e5d1d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82700 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f3a0b78-9cfa-49cc-9b26-398e60877bad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1890 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110283 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4183 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59147 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5454 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34026 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5543 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5410 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->