### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for HTMLResourcePreloader

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -73,7 +73,7 @@ HTMLDocumentParser::HTMLDocumentParser(HTMLDocument& document, OptionSet<ParserC
     , m_scriptRunner(makeUnique<HTMLScriptRunner>(document, static_cast<HTMLScriptRunnerHost&>(*this)))
     , m_treeBuilder(makeUniqueRef<HTMLTreeBuilder>(*this, document, parserContentPolicy(), m_options))
     , m_parserScheduler(HTMLParserScheduler::create(*this))
-    , m_preloader(makeUnique<HTMLResourcePreloader>(document))
+    , m_preloader(HTMLResourcePreloader::create(document))
     , m_shouldEmitTracePoints(isMainDocumentLoadingFromHTTP(document))
 {
 }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -150,7 +150,7 @@ private:
     RefPtr<HTMLParserScheduler> m_parserScheduler;
     TextPosition m_textPosition;
 
-    std::unique_ptr<HTMLResourcePreloader> m_preloader;
+    const RefPtr<HTMLResourcePreloader> m_preloader;
 
     bool m_endWasDelayed { false };
     unsigned m_pumpSessionNestingLevel { 0 };

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -581,10 +581,10 @@ bool testPreloadScannerViewportSupport(Document* document)
     ASSERT(document);
     HTMLParserOptions options(*document);
     HTMLPreloadScanner scanner(options, document->url());
-    HTMLResourcePreloader preloader(*document);
+    Ref preloader = HTMLResourcePreloader::create(*document);
     scanner.appendToEnd(String("<meta name=viewport content='width=400'>"_s));
     scanner.scan(preloader, *document);
-    return (document->viewportArguments().width == 400);
+    return document->viewportArguments().width == 400;
 }
 
 }

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -28,17 +28,9 @@
 #include "CachedResource.h"
 #include "CachedResourceRequest.h"
 #include "ScriptType.h"
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
-
-namespace WebCore {
-class HTMLResourcePreloader;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::HTMLResourcePreloader> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -86,20 +78,20 @@ private:
 
 typedef Vector<std::unique_ptr<PreloadRequest>> PreloadRequestStream;
 
-class HTMLResourcePreloader : public CanMakeWeakPtr<HTMLResourcePreloader> {
+class HTMLResourcePreloader : public RefCountedAndCanMakeWeakPtr<HTMLResourcePreloader> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLResourcePreloader);
     WTF_MAKE_NONCOPYABLE(HTMLResourcePreloader);
 public:
-    explicit HTMLResourcePreloader(Document& document)
-        : m_document(document)
-    {
-    }
+    static Ref<HTMLResourcePreloader> create(Document&);
+    ~HTMLResourcePreloader();
 
     void preload(PreloadRequestStream);
     void preload(std::unique_ptr<PreloadRequest>);
 
 private:
-    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+    explicit HTMLResourcePreloader(Document&);
+
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f19ec5dcc6177897bfc06557fdabc6501339b85d
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for HTMLResourcePreloader
<a href="https://bugs.webkit.org/show_bug.cgi?id=303283">https://bugs.webkit.org/show_bug.cgi?id=303283</a>

Reviewed by Darin Adler.

* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::HTMLDocumentParser):
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::testPreloadScannerViewportSupport):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::HTMLResourcePreloader::create):
(WebCore::HTMLResourcePreloader::HTMLResourcePreloader):
(WebCore::HTMLResourcePreloader::preload):
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::HTMLResourcePreloader::HTMLResourcePreloader): Deleted.

Canonical link: <a href="https://commits.webkit.org/303713@main">https://commits.webkit.org/303713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d535506c006b9e9555933d2f1452edf741c92451

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b3272aa-8aac-4572-b5a7-6e8772a30c92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101907 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69367 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1613b65-1776-4ee1-973b-e90a3f31504c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82701 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b608198c-0ae1-43ff-9de8-0e466585292c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1891 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143429 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4182 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59146 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5453 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34025 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5542 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->