### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PreviewPlatformDelegate

### DIFF
--- a/Source/WebCore/platform/PreviewConverter.h
+++ b/Source/WebCore/platform/PreviewConverter.h
@@ -30,7 +30,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
-#include <wtf/RefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -40,22 +40,13 @@ OBJC_CLASS QLPreviewConverter;
 OBJC_CLASS WebPreviewConverterDelegate;
 
 namespace WebCore {
-struct PreviewPlatformDelegate;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PreviewPlatformDelegate> : std::true_type { };
-}
-
-namespace WebCore {
 
 class ResourceError;
 class ResourceRequest;
 struct PreviewConverterClient;
 struct PreviewConverterProvider;
 
-struct PreviewPlatformDelegate : CanMakeWeakPtr<PreviewPlatformDelegate> {
+struct PreviewPlatformDelegate : AbstractRefCountedAndCanMakeWeakPtr<PreviewPlatformDelegate> {
     virtual ~PreviewPlatformDelegate() = default;
 
     virtual void delegateDidReceiveData(const FragmentedSharedBuffer&) = 0;
@@ -75,6 +66,10 @@ public:
     WEBCORE_EXPORT static bool supportsMIMEType(const String& mimeType);
 
     ~PreviewConverter();
+
+    // PreviewPlatformDelegate.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     ResourceRequest safeRequest(const ResourceRequest&) const;
     ResourceResponse previewResponse() const;

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -61,21 +61,21 @@
     ASSERT_UNUSED(connection, !connection);
     ASSERT_UNUSED(lengthReceived, lengthReceived >= 0);
     ASSERT(data.length == static_cast<NSUInteger>(lengthReceived));
-    if (auto delegate = _delegate.get())
+    if (RefPtr delegate = _delegate.get())
         delegate->delegateDidReceiveData(WebCore::SharedBuffer::create(data).get());
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
     ASSERT_UNUSED(connection, !connection);
-    if (auto delegate = _delegate.get())
+    if (RefPtr delegate = _delegate.get())
         delegate->delegateDidFinishLoading();
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
 {
     ASSERT_UNUSED(connection, !connection);
-    if (auto delegate = _delegate.get())
+    if (RefPtr delegate = _delegate.get())
         delegate->delegateDidFailWithError(error);
 }
 


### PR DESCRIPTION
#### fc3205d40efc4b1325e8b2f0105589bde3ca5fc0
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PreviewPlatformDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=303284">https://bugs.webkit.org/show_bug.cgi?id=303284</a>

Reviewed by Rupin Mittal.

* Source/WebCore/platform/PreviewConverter.h:
* Source/WebCore/platform/ios/PreviewConverterIOS.mm:
(-[WebPreviewConverterDelegate connection:didReceiveData:lengthReceived:]):
(-[WebPreviewConverterDelegate connectionDidFinishLoading:]):
(-[WebPreviewConverterDelegate connection:didFailWithError:]):

Canonical link: <a href="https://commits.webkit.org/303723@main">https://commits.webkit.org/303723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01efe9c6d59cb218708b369574bcbfc90a72049c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85275 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf9245b8-1b44-4884-a270-3d9ab53474bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69369 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0942099d-afe6-4b15-ae00-71798203614e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82702 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50e83195-c628-4526-aeb6-c5e53b85e41c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4314 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1892 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5400 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38112 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110284 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4185 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59148 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5455 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34028 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->