### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PreviewConverterClient

### DIFF
--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -204,7 +204,7 @@ protected:
     ResourceResponse m_response;
     ResourceLoadTiming m_loadTiming;
 #if USE(QUICK_LOOK)
-    std::unique_ptr<LegacyPreviewLoader> m_previewLoader;
+    const RefPtr<LegacyPreviewLoader> m_previewLoader;
 #endif
     bool m_canCrossOriginRequestsAskUserForCredentials { true };
 

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -39,11 +39,11 @@ class LegacyPreviewLoaderClient;
 class ResourceLoader;
 class ResourceResponse;
 
-class LegacyPreviewLoader final : private PreviewConverterClient, private PreviewConverterProvider {
+class LegacyPreviewLoader final : public RefCounted<LegacyPreviewLoader>, private PreviewConverterClient, private PreviewConverterProvider {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LegacyPreviewLoader, Loader);
     WTF_MAKE_NONCOPYABLE(LegacyPreviewLoader);
 public:
-    LegacyPreviewLoader(ResourceLoader&, const ResourceResponse&);
+    static Ref<LegacyPreviewLoader> create(ResourceLoader&, const ResourceResponse&);
     ~LegacyPreviewLoader();
 
     bool didReceiveResponse(const ResourceResponse&);
@@ -53,7 +53,13 @@ public:
 
     WEBCORE_EXPORT static void setClientForTesting(RefPtr<LegacyPreviewLoaderClient>&&);
 
+    // PreviewConverterClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    LegacyPreviewLoader(ResourceLoader&, const ResourceResponse&);
+
     // PreviewConverterClient
     void previewConverterDidStartUpdating(PreviewConverter&) final { };
     void previewConverterDidFinishUpdating(PreviewConverter&) final { };

--- a/Source/WebCore/platform/PreviewConverterClient.h
+++ b/Source/WebCore/platform/PreviewConverterClient.h
@@ -25,18 +25,9 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-struct PreviewConverterClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PreviewConverterClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -44,7 +35,7 @@ class PreviewConverter;
 class ResourceError;
 class FragmentedSharedBuffer;
 
-struct PreviewConverterClient : CanMakeWeakPtr<PreviewConverterClient> {
+struct PreviewConverterClient : AbstractRefCountedAndCanMakeWeakPtr<PreviewConverterClient> {
     virtual ~PreviewConverterClient() = default;
 
     virtual void previewConverterDidStartUpdating(PreviewConverter&) = 0;


### PR DESCRIPTION
#### e7738dfb21813c3287ac1b743f5f0f4302db7f1a
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PreviewConverterClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303285">https://bugs.webkit.org/show_bug.cgi?id=303285</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didReceiveBuffer):
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::didFail):
* Source/WebCore/loader/ios/LegacyPreviewLoader.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.mm:
(WebCore::LegacyPreviewLoader::create):
(WebCore::LegacyPreviewLoader::LegacyPreviewLoader):
* Source/WebCore/platform/PreviewConverterClient.h:

Canonical link: <a href="https://commits.webkit.org/303714@main">https://commits.webkit.org/303714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c094cbd78d0dc0ef876fa24114a1eb196f9d2027

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85300 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6eab1bab-63a1-49eb-a77f-be3a3ee4a368) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101929 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69394 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfe2a173-e14f-49f8-9da6-dd4a5039eb65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82724 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a54f21f-2e82-40b6-aa37-35575c02edbd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4335 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1915 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4203 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59175 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34054 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->