### PR TITLE
Use consteval and std::span for StaticStringImpl creation

### DIFF
--- a/Source/WTF/wtf/text/StringHasher.h
+++ b/Source/WTF/wtf/text/StringHasher.h
@@ -61,8 +61,8 @@ public:
     template<typename T, typename Converter = DefaultConverter>
     static unsigned computeHashAndMaskTop8Bits(std::span<const T> data);
 
-    template<typename T, unsigned characterCount>
-    static constexpr unsigned computeLiteralHashAndMaskTop8Bits(const T (&characters)[characterCount]);
+    template<typename T>
+    static consteval unsigned computeLiteralHashAndMaskTop8Bits(std::span<T>);
 
     void addCharacter(char16_t character);
 

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -39,16 +39,15 @@ unsigned StringHasher::computeHashAndMaskTop8Bits(std::span<const T> data)
 #endif
 }
 
-template<typename T, unsigned characterCount>
-constexpr unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(const T (&characters)[characterCount])
+template<typename T>
+inline consteval unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(std::span<T> data)
 {
-    constexpr unsigned characterCountWithoutNull = characterCount - 1;
 #if ENABLE(WYHASH_STRING_HASHER)
-    if constexpr (characterCountWithoutNull <= smallStringThreshold)
-        return SuperFastHash::computeHashAndMaskTop8Bits<T>(unsafeMakeSpan(characters, characterCountWithoutNull));
-    return WYHash::computeHashAndMaskTop8Bits<T>(unsafeMakeSpan(characters, characterCountWithoutNull));
+    if (data.size() <= smallStringThreshold)
+        return SuperFastHash::computeHashAndMaskTop8Bits<T>(data);
+    return WYHash::computeHashAndMaskTop8Bits<T>(data);
 #else
-    return SuperFastHash::computeHashAndMaskTop8Bits<T>(unsafeMakeSpan(characters, characterCountWithoutNull));
+    return SuperFastHash::computeHashAndMaskTop8Bits<T>(data);
 #endif
 }
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -300,6 +300,12 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
     return create(result.buffer);
 }
 
+Ref<StringImpl> StringImpl::createStaticStringImpl(std::span<const char> characters)
+{
+    ASSERT(charactersAreAllASCII(byteCast<Latin1Character>(characters)));
+    return createStaticStringImpl(byteCast<Latin1Character>(characters));
+}
+
 Ref<StringImpl> StringImpl::createStaticStringImpl(std::span<const Latin1Character> characters)
 {
     if (characters.empty())

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -152,12 +152,9 @@ public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
 
 protected:
-    StringImplShape(unsigned refCount, std::span<const Latin1Character>, unsigned hashAndFlags);
-    StringImplShape(unsigned refCount, std::span<const char16_t>, unsigned hashAndFlags);
-
-    enum ConstructWithConstExprTag { ConstructWithConstExpr };
-    template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
-    template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
+    constexpr StringImplShape(unsigned refCount, std::span<const char>, unsigned hashAndFlags);
+    constexpr StringImplShape(unsigned refCount, std::span<const Latin1Character>, unsigned hashAndFlags);
+    constexpr StringImplShape(unsigned refCount, std::span<const char16_t>, unsigned hashAndFlags);
 
     std::atomic<unsigned> m_refCount;
     unsigned m_length;
@@ -167,7 +164,6 @@ protected:
         // It seems that reinterpret_cast prevents constexpr's compile time initialization in VC++.
         // These are needed to avoid reinterpret_cast.
         const char* m_data8Char;
-        const char16_t* m_data16Char;
     };
     mutable unsigned m_hashAndFlags;
 };
@@ -280,11 +276,7 @@ public:
     static Ref<StringImpl> createByReplacingInCharacters(std::span<const Latin1Character>, char16_t target, char16_t replacement, size_t indexOfFirstTargetCharacter);
     static Ref<StringImpl> createByReplacingInCharacters(std::span<const char16_t>, char16_t target, char16_t replacement, size_t indexOfFirstTargetCharacter);
 
-    static Ref<StringImpl> createStaticStringImpl(std::span<const char> characters)
-    {
-        ASSERT(charactersAreAllASCII(byteCast<Latin1Character>(characters)));
-        return createStaticStringImpl(byteCast<Latin1Character>(characters));
-    }
+    WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(std::span<const char> characters);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(std::span<const Latin1Character>);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(std::span<const char16_t>);
 
@@ -404,8 +396,16 @@ public:
         //       StringImpl::hash() only sets a new hash iff !hasHash().
         //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
 
-        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
-        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
+        consteval StaticStringImpl(std::span<const char>, StringKind);
+        consteval StaticStringImpl(std::span<const char16_t>, StringKind);
+
+        template <typename CharType, size_t characterCountWithNullTerminator>
+        explicit consteval StaticStringImpl(const CharType (&characters)[characterCountWithNullTerminator], StringKind flags = StringNormal)
+            : StaticStringImpl(unsafeMakeSpan<const CharType>(characters, characterCountWithNullTerminator - 1), flags)
+        {
+            RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(m_length == std::char_traits<CharType>::length(characters));
+        }
+
         operator StringImpl&();
         operator const StringImpl&() const;
     };
@@ -874,7 +874,16 @@ inline bool deprecatedIsNotSpaceOrNewline(char16_t character)
     return !deprecatedIsSpaceOrNewline(character);
 }
 
-inline StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin1Character> data, unsigned hashAndFlags)
+inline constexpr StringImplShape::StringImplShape(unsigned refCount, std::span<const char> data, unsigned hashAndFlags)
+    : m_refCount(refCount)
+    , m_length(data.size())
+    , m_data8Char(data.data())
+    , m_hashAndFlags(hashAndFlags)
+{
+    RELEASE_ASSERT(data.size() <= MaxLength);
+}
+
+inline constexpr StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin1Character> data, unsigned hashAndFlags)
     : m_refCount(refCount)
     , m_length(data.size())
     , m_data8(data.data())
@@ -883,31 +892,13 @@ inline StringImplShape::StringImplShape(unsigned refCount, std::span<const Latin
     RELEASE_ASSERT(data.size() <= MaxLength);
 }
 
-inline StringImplShape::StringImplShape(unsigned refCount, std::span<const char16_t> data, unsigned hashAndFlags)
+inline constexpr StringImplShape::StringImplShape(unsigned refCount, std::span<const char16_t> data, unsigned hashAndFlags)
     : m_refCount(refCount)
     , m_length(data.size())
     , m_data16(data.data())
     , m_hashAndFlags(hashAndFlags)
 {
     RELEASE_ASSERT(data.size() <= MaxLength);
-}
-
-template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
-    : m_refCount(refCount)
-    , m_length(length)
-    , m_data8Char(characters)
-    , m_hashAndFlags(hashAndFlags)
-{
-    RELEASE_ASSERT(length <= MaxLength);
-}
-
-template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
-    : m_refCount(refCount)
-    , m_length(length)
-    , m_data16Char(characters)
-    , m_hashAndFlags(hashAndFlags)
-{
-    RELEASE_ASSERT(length <= MaxLength);
 }
 
 inline Ref<StringImpl> StringImpl::isolatedCopy() const
@@ -1292,15 +1283,19 @@ inline void StringImpl::assertHashIsCorrect() const
     ASSERT(existingHash() == StringHasher::computeHashAndMaskTop8Bits(span8()));
 }
 
-template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char (&characters)[characterCount], StringKind stringKind)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlag8BitBuffer | s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+consteval StringImpl::StaticStringImpl::StaticStringImpl(std::span<const char> data, StringKind stringKind)
+    : StringImplShape(
+        s_refCountFlagIsStaticString,
+        data,
+        s_hashFlag8BitBuffer | s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(data) << s_flagCount))
 {
 }
 
-template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char16_t (&characters)[characterCount], StringKind stringKind)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+consteval StringImpl::StaticStringImpl::StaticStringImpl(std::span<const char16_t> data, StringKind stringKind)
+    : StringImplShape(
+        s_refCountFlagIsStaticString,
+        data,
+        s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(data) << s_flagCount))
 {
 }
 

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -58,11 +58,15 @@ public:
     class StaticSymbolImpl final : private StringImplShape {
         WTF_MAKE_NONCOPYABLE(StaticSymbolImpl);
     public:
-        template<unsigned characterCount>
-        inline constexpr StaticSymbolImpl(const char (&characters)[characterCount], Flags = s_flagDefault);
+        template<typename CharType, unsigned characterCount>
+        consteval StaticSymbolImpl(const CharType (&characters)[characterCount], Flags flags = s_flagDefault)
+            : StaticSymbolImpl(unsafeMakeSpan<const CharType>(characters, characterCount - 1), flags)
+        {
+            RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(m_length == std::char_traits<CharType>::length(characters));
+        }
 
-        template<unsigned characterCount>
-        inline constexpr StaticSymbolImpl(const char16_t (&characters)[characterCount], Flags = s_flagDefault);
+        template<typename CharType>
+        consteval StaticSymbolImpl(std::span<CharType>, Flags);
 
         operator SymbolImpl&() { SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<SymbolImpl*>(this); }
 
@@ -115,18 +119,10 @@ inline SymbolImpl::SymbolImpl(Flags flags)
     static_assert(StringImpl::tailOffset<StringImpl*>() == OBJECT_OFFSETOF(SymbolImpl, m_owner));
 }
 
-template<unsigned characterCount>
-inline constexpr SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(const char (&characters)[characterCount], Flags flags)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlag8BitBuffer | s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-    , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
-    , m_flags(flags)
-{
-}
-
-template<unsigned characterCount>
-inline constexpr SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(const char16_t (&characters)[characterCount], Flags flags)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-    , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
+template<typename CharType>
+consteval SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(std::span<CharType> data, Flags flags)
+    : StringImplShape(s_refCountFlagIsStaticString, data, s_hashFlag8BitBuffer | s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(data) << s_flagCount))
+    , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(data) << s_flagCount)
     , m_flags(flags)
 {
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -645,11 +645,11 @@ TEST(WTF, StringImplStaticToAtomString)
 
 TEST(WTF, StringImplConstexprHasher)
 {
-    ASSERT_EQ(stringFromUTF8("")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits(""));
-    ASSERT_EQ(stringFromUTF8("A")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("A"));
-    ASSERT_EQ(stringFromUTF8("AA")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("AA"));
-    ASSERT_EQ(stringFromUTF8("Cocoa")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("Cocoa"));
-    ASSERT_EQ(stringFromUTF8("Cappuccino")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("Cappuccino"));
+    ASSERT_EQ(stringFromUTF8("")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits(""_s.span()));
+    ASSERT_EQ(stringFromUTF8("A")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("A"_s.span()));
+    ASSERT_EQ(stringFromUTF8("AA")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("AA"_s.span()));
+    ASSERT_EQ(stringFromUTF8("Cocoa")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("Cocoa"_s.span()));
+    ASSERT_EQ(stringFromUTF8("Cappuccino")->hash(), StringHasher::computeLiteralHashAndMaskTop8Bits("Cappuccino"_s.span()));
 }
 
 TEST(WTF, StringImplEmpty)


### PR DESCRIPTION
#### c3647515a5b2c6b9afb0c803e9a2de5094bb4e5b
<pre>
Use consteval and std::span for StaticStringImpl creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303286">https://bugs.webkit.org/show_bug.cgi?id=303286</a>
<a href="https://rdar.apple.com/165590670">rdar://165590670</a>

This is a collection of small refactors to streamline
StaticStringImpl / StaticSymbolImpl / StringImplShape creation
and hashing using consteval and std::span:

- The following were made consteval:
    * StaticStringImpl::StaticStringImpl()
    * StaticSymbolImpl::StaticSymbolImpl()
    * StringHasher::computeLiteralHashAndMaskTop8Bits()
- The following now take std::span arguments instead of C arrays:
    * StringHasher::computeLiteralHashAndMaskTop8Bits()
    * StringImplShape::StringImplShape()
- We now enforce a single null character at the end (by testing the
  string length) for the StaticStringImpl and StaticSymbolImpl
  constructors
- Removed a duplicate union entry (m_data16Char) in StringImplShape
- createStaticStringImpl(std::span) moved out of header
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3647515a5b2c6b9afb0c803e9a2de5094bb4e5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82707 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4316 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1893 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/169 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125303 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143433 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131740 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110289 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110473 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4186 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59150 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5457 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34030 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164707 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68909 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43756 "") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->