### PR TITLE
Remove CSSTextUnderlinePositionLeftRightEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1563,20 +1563,6 @@ CSSTextTransformMathAutoEnabled:
     WebCore:
       default: false
 
-CSSTextUnderlinePositionLeftRightEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS text-underline-position: left right"
-  humanReadableDescription: "Enable the property text-underline-position left and right value support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSTextWrapPrettyEnabled:
    type: bool
    status: stable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11522,7 +11522,7 @@
                 "render-style-storage-path": ["m_rareInheritedData"],
                 "render-style-storage-kind": "raw",
                 "render-style-type": "Style::TextUnderlinePosition",
-                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ]@(settings-flag=cssTextUnderlinePositionLeftRightEnabled) ]@(no-single-item-opt)"
+                "parser-grammar": "auto | [ [ under | from-font ] || [ left | right ] ]@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-text-decor",

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -49,7 +49,6 @@ static void applyUASheetBehaviorsToContext(CSSParserContext& context)
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     context.cssAppearanceBaseEnabled = true;
     context.cssTextTransformMathAutoEnabled = true;
-    context.cssTextUnderlinePositionLeftRightEnabled = true;
     context.popoverAttributeEnabled = true;
     context.propertySettings.cssInputSecurityEnabled = true;
     context.propertySettings.supportHDRDisplayEnabled = true;
@@ -93,7 +92,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssAppearanceBaseEnabled { document.settings().cssAppearanceBaseEnabled() }
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , cssShapeFunctionEnabled { document.settings().cssShapeFunctionEnabled() }
-    , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssTextDecorationLineErrorValues { document.settings().cssTextDecorationLineErrorValues() }
     , cssBackgroundClipBorderAreaEnabled  { document.settings().cssBackgroundClipBorderAreaEnabled() }
     , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
@@ -136,30 +134,29 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssAppearanceBaseEnabled                  << 7
         | context.cssPaintingAPIEnabled                     << 8
         | context.cssShapeFunctionEnabled                   << 9
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 10
-        | context.cssBackgroundClipBorderAreaEnabled        << 11
-        | context.cssWordBreakAutoPhraseEnabled             << 12
-        | context.popoverAttributeEnabled                   << 13
-        | context.sidewaysWritingModesEnabled               << 14
-        | context.cssTextWrapPrettyEnabled                  << 15
-        | context.thumbAndTrackPseudoElementsEnabled        << 16
+        | context.cssBackgroundClipBorderAreaEnabled        << 10
+        | context.cssWordBreakAutoPhraseEnabled             << 11
+        | context.popoverAttributeEnabled                   << 12
+        | context.sidewaysWritingModesEnabled               << 13
+        | context.cssTextWrapPrettyEnabled                  << 14
+        | context.thumbAndTrackPseudoElementsEnabled        << 15
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 17
+        | context.imageControlsEnabled                      << 16
 #endif
-        | context.colorLayersEnabled                        << 18
-        | context.contrastColorEnabled                      << 19
-        | context.targetTextPseudoElementEnabled            << 20
-        | context.viewTransitionTypesEnabled                << 21
-        | context.cssProgressFunctionEnabled                << 22
-        | context.cssRandomFunctionEnabled                  << 23
-        | context.cssTreeCountingFunctionsEnabled           << 24
-        | context.cssURLModifiersEnabled                    << 25
-        | context.cssURLIntegrityModifierEnabled            << 26
-        | context.cssAxisRelativePositionKeywordsEnabled    << 27
-        | context.cssDynamicRangeLimitMixEnabled            << 28
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 29
-        | context.cssTextDecorationLineErrorValues          << 30
-        | context.cssTextTransformMathAutoEnabled           << 31;
+        | context.colorLayersEnabled                        << 17
+        | context.contrastColorEnabled                      << 18
+        | context.targetTextPseudoElementEnabled            << 19
+        | context.viewTransitionTypesEnabled                << 20
+        | context.cssProgressFunctionEnabled                << 21
+        | context.cssRandomFunctionEnabled                  << 22
+        | context.cssTreeCountingFunctionsEnabled           << 23
+        | context.cssURLModifiersEnabled                    << 24
+        | context.cssURLIntegrityModifierEnabled            << 25
+        | context.cssAxisRelativePositionKeywordsEnabled    << 26
+        | context.cssDynamicRangeLimitMixEnabled            << 27
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 28
+        | context.cssTextDecorationLineErrorValues          << 29
+        | context.cssTextTransformMathAutoEnabled           << 30;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -64,7 +64,6 @@ struct CSSParserContext {
     bool cssAppearanceBaseEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssShapeFunctionEnabled : 1 { false };
-    bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };
     bool cssTextDecorationLineErrorValues : 1 { false };
     bool cssBackgroundClipBorderAreaEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };


### PR DESCRIPTION
#### 36807182919dae7fa16589d90ba8c5467133710c
<pre>
Remove CSSTextUnderlinePositionLeftRightEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=303288">https://bugs.webkit.org/show_bug.cgi?id=303288</a>
<a href="https://rdar.apple.com/165592548">rdar://165592548</a>

Reviewed by Alan Baradlay.

Clean up flag to free up bits in CSSParserContext.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:

Canonical link: <a href="https://commits.webkit.org/303662@main">https://commits.webkit.org/303662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c85818cdc0631bb4653c643a02ac098a18ec1801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85281 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b6bab6f-067d-4a38-8bd0-6d1acf66ba55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82708 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/612c9f39-0f65-44ea-ba79-a14dc741d792) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4318 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125307 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143437 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131744 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38118 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4190 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59154 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34034 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164711 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68913 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->