### PR TITLE
Web Inspector: backend/frontend don't handle large console log sizes well, create a batched approach

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -887,6 +887,7 @@
     <script src="Views/StackedAreaChart.js"></script>
     <script src="Views/StackedColumnChart.js"></script>
     <script src="Views/StepsTimingFunctionEditor.js"></script>
+    <script src="Views/StringTreeView.js"></script>
     <script src="Views/StorageSidebarPanel.js"></script>
     <script src="Views/SymbolicBreakpointPopover.js"></script>
     <script src="Views/SymbolicBreakpointTreeElement.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -345,3 +345,26 @@
         color: var(--selected-secondary-text-color-active);
     }
 }
+
+.string-tree.formatted-string {
+    display: inline;
+    color: var(--syntax-highlight-string-color);
+}
+
+.string-tree .string-content {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    word-break: break-word;
+}
+
+.string-show-more-link {
+    color: var(--text-color-secondary);
+    text-decoration: underline;
+    cursor: pointer;
+    font-style: italic;
+}
+
+.string-show-more-link:hover {
+    color: var(--text-color);
+    text-decoration: underline;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -753,6 +753,12 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
             }
         }
 
+        if (object.description && object.description.length > WI.StringTreeView.chunkSize) {
+            let stringTreeView = new WI.StringTreeView(object.description);
+            fragment.appendChild(stringTreeView.element);
+            return;
+        }
+
         fragment.appendChild(WI.FormattedValue.createLinkifiedElementString(object.description));
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/StringTreeView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StringTreeView.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.StringTreeView = class StringTreeView extends WI.Object
+{
+    constructor(string)
+    {
+        super();
+        console.assert(typeof string === "string");
+        this._string = string;
+        this._currentIndex = 0;
+        this._element = document.createElement("span");
+        this._element.className = "string-tree formatted-string";
+        this._stringContainer = this._element.appendChild(document.createElement("span"));
+        this._stringContainer.className = "string-content";
+        this._stringContainer.append("\"");
+        this._chunksContainer = this._stringContainer.appendChild(document.createElement("span"));
+        this._addNextChunk();
+    }
+
+    static get chunkSize() { return 15000; }
+
+    get element()
+    {
+        return this._element;
+    }
+
+    _addNextChunk()
+    {
+        if (this._showMoreLink) {
+            this._showMoreLink.remove();
+            this._showMoreLink = null;
+        }
+
+        if (this._closingQuoteElement) {
+            this._closingQuoteElement.remove();
+            this._closingQuoteElement = null;
+        }
+
+        let chunkEnd = this._currentIndex + WI.StringTreeView.chunkSize;
+        let hasMore = chunkEnd < this._string.length;
+
+        if (!hasMore)
+            chunkEnd = this._string.length;
+
+        let chunk = this._string.slice(this._currentIndex, chunkEnd);
+        let escapedChunk = chunk.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\u21B5");
+        let linkifiedChunk = WI.linkifyStringAsFragment(escapedChunk);
+        this._chunksContainer.appendChild(linkifiedChunk);
+        this._currentIndex = chunkEnd;
+
+        if (hasMore) {
+            this._showMoreLink = document.createElement("span");
+            this._showMoreLink.className = "string-show-more-link";
+            this._showMoreLink.textContent = "(show more)";
+            this._showMoreLink.addEventListener("click", (event) => {
+                event.stop();
+                this._addNextChunk();
+            });
+            this._chunksContainer.appendChild(this._showMoreLink);
+        }
+
+        this._closingQuoteElement = this._stringContainer.appendChild(document.createTextNode("\""));
+        this.dispatchEventToListeners(WI.StringTreeView.Event.Updated);
+    }
+};
+
+WI.StringTreeView.Event = {
+    Updated: "string-tree-view-updated"
+};


### PR DESCRIPTION
#### 63311a69494d0176cea4e057c734cd11bdd9d7cf
<pre>
Web Inspector: backend/frontend don&apos;t handle large console log sizes well, create a batched approach
<a href="https://bugs.webkit.org/show_bug.cgi?id=301950">https://bugs.webkit.org/show_bug.cgi?id=301950</a>
<a href="https://rdar.apple.com/164027281">rdar://164027281</a>

Reviewed by NOBODY (OOPS!).

The Web Inspector currently encounters UI creation hangs when attempting to log
text exceeding approximately 20,000 characters. We have implemented a new StringTreeView
class that progressively renders these large DOM text nodes in chunks of 15,000
characters. A “show more” link to allow users to expand the text incrementally.

* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.string-tree.formatted-string):
(.string-tree .string-content):
(.string-show-more-link):
(.string-show-more-link:hover):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype._formatParameterAsString):
* Source/WebInspectorUI/UserInterface/Views/StringTreeView.js: Added.
(WI.StringTreeView):
(WI.StringTreeView.get chunkSize):
(WI.StringTreeView.prototype.get element):
(WI.StringTreeView.prototype._addNextChunk):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63311a69494d0176cea4e057c734cd11bdd9d7cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85291 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/63e57634-dc51-4d6b-8d7e-104adb213db9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69384 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b2704d2-435b-461d-becf-44fa2d02c9e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ca2e5b0-08d4-46d8-9f94-18f9ad1d07b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4328 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1905 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143447 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110298 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4196 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115688 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59164 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5471 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34042 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->