### PR TITLE
Reduce use of unsafeGet() in WebCore/

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -341,7 +341,7 @@ void DOMCache::addAll(Vector<RequestInfo>&& infos, DOMPromiseDeferred<void>&& pr
                 if (auto* chunk = result.returnValue())
                     data.append(*chunk);
                 else
-                    taskHandler->addResponseBody(recordPosition, response, data.takeAsContiguous());
+                    taskHandler->addResponseBody(recordPosition, response, data.takeBufferAsContiguous());
             });
         }, cachedResourceRequestInitiatorTypes().fetch);
     }
@@ -420,7 +420,7 @@ void DOMCache::put(RequestInfo&& info, Ref<FetchResponse>&& response, DOMPromise
             if (auto* chunk = result.returnValue())
                 data.append(*chunk);
             else
-                pendingActivity->object().putWithResponseData(WTFMove(promise), WTFMove(request), WTFMove(response), RefPtr<SharedBuffer> { data.takeAsContiguous() });
+                pendingActivity->object().putWithResponseData(WTFMove(promise), WTFMove(request), WTFMove(response), RefPtr<SharedBuffer> { data.takeBufferAsContiguous() });
         });
         return;
     }

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
@@ -150,7 +150,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressZlib(std::s
         storage.append(output);
     }
 
-    RefPtr compressedData = storage.takeAsArrayBuffer();
+    RefPtr compressedData = storage.takeBufferAsArrayBuffer();
     if (!compressedData)
         return Exception { ExceptionCode::OutOfMemoryError };
 

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -166,7 +166,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib(st
         storage.append(output);
     }
 
-    RefPtr decompressedData = storage.takeAsArrayBuffer();
+    RefPtr decompressedData = storage.takeBufferAsArrayBuffer();
     if (!decompressedData)
         return Exception { ExceptionCode::OutOfMemoryError };
 

--- a/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
@@ -89,7 +89,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressAppleCompre
         storage.append(output);
     }
 
-    RefPtr decompressedData = storage.takeAsArrayBuffer();
+    RefPtr decompressedData = storage.takeBufferAsArrayBuffer();
     if (!decompressedData)
         return Exception { ExceptionCode::OutOfMemoryError };
 

--- a/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
@@ -91,7 +91,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppleCo
         storage.append(output);
     }
 
-    RefPtr decompressedData = storage.takeAsArrayBuffer();
+    RefPtr decompressedData = storage.takeBufferAsArrayBuffer();
     if (!decompressedData)
         return Exception { ExceptionCode::OutOfMemoryError };
 

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -287,7 +287,7 @@ void FetchBody::convertReadableStreamToArrayBuffer(FetchBodyOwner& owner, Comple
 
     checkedConsumer()->extract(*protectedReadableStream(), [owner = Ref { owner }, data = SharedBufferBuilder(), completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
         WTF::switchOn(WTFMove(result), [&](std::nullptr_t) {
-            if (RefPtr arrayBuffer = data.takeAsArrayBuffer())
+            if (RefPtr arrayBuffer = data.takeBufferAsArrayBuffer())
                 owner->body().m_data = *arrayBuffer;
             completionHandler({ });
         }, [&](std::span<const uint8_t>&& chunk) {

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -61,7 +61,7 @@ public:
     void append(const SharedBuffer&);
 
     bool hasData() const { return !!m_buffer; }
-    const FragmentedSharedBuffer* data() const LIFETIME_BOUND { return m_buffer.get().unsafeGet(); }
+    const FragmentedSharedBuffer* data() const LIFETIME_BOUND { return m_buffer.buffer(); }
     RefPtr<JSC::ArrayBuffer> asArrayBuffer();
     void setData(Ref<FragmentedSharedBuffer>&&);
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -55,7 +55,7 @@ Ref<CredentialRequestCoordinator> CredentialRequestCoordinator::create(Ref<Crede
 }
 
 CredentialRequestCoordinator::CredentialRequestCoordinator(Ref<CredentialRequestCoordinatorClient>&& client, Page& page)
-    : ActiveDOMObject(page.localTopDocument().get())
+    : ActiveDOMObject(page.localTopDocument())
     , m_client(WTFMove(client))
     , m_page(page)
 {
@@ -267,7 +267,7 @@ void CredentialRequestCoordinator::finalizeDigitalCredential(const DigitalCreden
         return;
     }
 
-    auto document = m_page->localTopDocument();
+    RefPtr document = m_page->localTopDocument();
     if (!document) {
         m_currentPromise->reject(ExceptionCode::InvalidStateError, "No Document."_s);
         m_currentPromise.reset();

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -533,7 +533,7 @@ void HTMLModelElement::createModelPlayer()
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
-        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
+        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeBufferAsContiguous().get());
     else if (!m_environmentMapURL.isEmpty())
         environmentMapRequestResource();
 #endif
@@ -612,7 +612,7 @@ void HTMLModelElement::reloadModelPlayer()
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
-        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
+        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeBufferAsContiguous().get());
     else if (!m_environmentMapURL.isEmpty())
         environmentMapRequestResource();
 #endif
@@ -1163,7 +1163,7 @@ void HTMLModelElement::environmentMapResourceFinished()
     }
     if (m_modelPlayer) {
         m_environmentMapDataMemoryCost.store(m_environmentMapData.size(), std::memory_order_relaxed);
-        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
+        m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeBufferAsContiguous().get());
     }
 
     m_environmentMapResource->removeClient(*this);
@@ -1205,7 +1205,7 @@ void HTMLModelElement::modelResourceFinished()
 
     m_dataComplete = true;
     m_dataMemoryCost.store(m_data.size(), std::memory_order_relaxed);
-    m_model = Model::create(m_data.takeAsContiguous().get(), m_resource->mimeType(), m_resource->url());
+    m_model = Model::create(m_data.takeBufferAsContiguous().get(), m_resource->mimeType(), m_resource->url());
 
     ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -166,7 +166,7 @@ void NotificationResourcesLoader::ResourceLoader::didReceiveData(const SharedBuf
 {
     if (RefPtr image = m_image) {
         m_buffer.append(buffer);
-        image->setData(m_buffer.get(), false);
+        image->setData(m_buffer.buffer(), false);
     }
 }
 
@@ -175,7 +175,7 @@ void NotificationResourcesLoader::ResourceLoader::didFinishLoading(ScriptExecuti
     m_finished = true;
 
     if (RefPtr image = m_image)
-        image->setData(m_buffer.take(), true);
+        image->setData(m_buffer.takeBuffer(), true);
 
     if (m_completionHandler)
         m_completionHandler(this, WTFMove(m_image));

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -101,7 +101,6 @@ css/CSSFontFaceSet.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp
-css/CSSKeyframeRule.cpp
 css/CSSLayerBlockRule.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleRule.cpp
@@ -120,7 +119,6 @@ css/SelectorChecker.cpp
 css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
 css/StyleProperties.cpp
-css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleSheetContents.cpp
 css/query/ContainerQueryFeatures.cpp

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -71,15 +71,19 @@ inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
 
 inline AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isPartOfRelation)
 {
-    if (RefPtr object = get(node))
-        return object.unsafeGet();
+    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+    // as we merely return it right away (rdar://165602290).
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* object = get(node))
+        return object;
     return getOrCreateSlow(node, isPartOfRelation);
 }
 
 inline AccessibilityObject* AXObjectCache::getOrCreate(Element& element, IsPartOfRelation isPartOfRelation)
 {
-    if (RefPtr object = get(element))
-        return object.unsafeGet();
+    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+    // as we merely return it right away (rdar://165602290).
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* object = get(element))
+        return object;
     return getOrCreateSlow(element, isPartOfRelation);
 }
 

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -48,15 +48,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-ContainerNode* composedParentIgnoringDocumentFragments(const Node& node)
+RefPtr<ContainerNode> composedParentIgnoringDocumentFragments(const Node& node)
 {
     RefPtr ancestor = node.parentInComposedTree();
     while (is<DocumentFragment>(ancestor.get()))
         ancestor = ancestor->parentInComposedTree();
-    return ancestor.unsafeGet();
+    return ancestor;
 }
 
-ContainerNode* composedParentIgnoringDocumentFragments(const Node* node)
+RefPtr<ContainerNode> composedParentIgnoringDocumentFragments(const Node* node)
 {
     return node ? composedParentIgnoringDocumentFragments(*node) : nullptr;
 }

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -51,8 +51,8 @@ bool hasPresentationRole(Element&);
 bool hasTableRole(Element&);
 bool isRowGroup(Element&);
 bool isRowGroup(Node*);
-ContainerNode* composedParentIgnoringDocumentFragments(const Node&);
-ContainerNode* composedParentIgnoringDocumentFragments(const Node*);
+RefPtr<ContainerNode> composedParentIgnoringDocumentFragments(const Node&);
+RefPtr<ContainerNode> composedParentIgnoringDocumentFragments(const Node*);
 
 // Returns NodeName and not ElementName because it's impossible to forward declare ElementName.
 NodeName elementName(Node*);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2446,13 +2446,13 @@ bool AccessibilityObject::isModalNode() const
 }
 
 
-static RenderObject* nearestRendererFromNode(Node& node)
+static CheckedPtr<RenderObject> nearestRendererFromNode(Node& node)
 {
     CheckedPtr renderer = node.renderer();
     for (RefPtr ancestor = &node; ancestor && !renderer; ancestor = composedParentIgnoringDocumentFragments(*ancestor))
         renderer = ancestor->renderer();
 
-    return renderer.unsafeGet();
+    return renderer;
 }
 
 static int zIndexFromRenderer(RenderObject* renderer)
@@ -2885,7 +2885,7 @@ bool AccessibilityObject::isLoaded() const
     return document && !document->parser();
 }
 
-RenderObject* AccessibilityObject::rendererOrNearestAncestor() const
+CheckedPtr<RenderObject> AccessibilityObject::rendererOrNearestAncestor() const
 {
     RefPtr node = this->node();
     return node ? nearestRendererFromNode(*node) : nullptr;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -273,7 +273,7 @@ public:
     Element* element() const final;
     Node* node() const override { return nullptr; }
     RenderObject* renderer() const override { return nullptr; }
-    RenderObject* rendererOrNearestAncestor() const;
+    CheckedPtr<RenderObject> rendererOrNearestAncestor() const;
     // Resolves the computed style if necessary (and safe to do so).
     const RenderStyle* style() const;
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -530,8 +530,10 @@ RenderObject* AccessibilityRenderObject::renderParentObject() const
 
 AccessibilityObject* AccessibilityRenderObject::parentObject() const
 {
-    if (RefPtr ownerParent = ownerParentObject()) [[unlikely]]
-        return ownerParent.unsafeGet();
+    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+    // as we merely return it right away (rdar://165602290).
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* ownerParent = ownerParentObject()) [[unlikely]]
+        return ownerParent;
 
 #if USE(ATSPI)
     // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -448,8 +448,8 @@ Document* AccessibilityScrollView::document() const
 
 LocalFrameView* AccessibilityScrollView::documentFrameView() const
 {
-    if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_scrollView.get()))
-        return localFrameView.unsafeGet();
+    if (auto* localFrameView = dynamicDowncast<LocalFrameView>(m_scrollView.get()))
+        return localFrameView;
 
     if (m_frameOwnerElement && m_frameOwnerElement->contentDocument())
         return m_frameOwnerElement->contentDocument()->view();

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -85,9 +85,9 @@ Vector<WeakStyleable> StyleOriginatedTimelinesController::relatedTimelineScopeEl
 
 ScrollTimeline& StyleOriginatedTimelinesController::inactiveNamedTimeline(const AtomString& name)
 {
-    auto inactiveTimeline = ScrollTimeline::createInactiveStyleOriginatedTimeline(name);
-    timelinesForName(name).append(inactiveTimeline);
-    return inactiveTimeline.unsafeGet();
+    auto& timelines = timelinesForName(name);
+    timelines.append(ScrollTimeline::createInactiveStyleOriginatedTimeline(name));
+    return timelines.last();
 }
 
 static bool containsElement(const Vector<WeakStyleable>& timelineScopeElements, Element* matchElement)

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -85,12 +85,9 @@ StyleRuleKeyframe::~StyleRuleKeyframe() = default;
 
 MutableStyleProperties& StyleRuleKeyframe::mutableProperties()
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
-        return *mutableProperties;
-    Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
-    m_properties = WTFMove(mutableProperties);
-    return mutablePropertiesRef;
+    if (!is<MutableStyleProperties>(m_properties))
+        m_properties = m_properties->mutableCopy();
+    return uncheckedDowncast<MutableStyleProperties>(m_properties.get());
 }
 
 String StyleRuleKeyframe::keyText() const

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -100,9 +100,9 @@ public:
         return fromCSSValue<TargetType>(m_value);
     }
 
-    operator const CSSPrimitiveValue&() const
+    operator const CSSPrimitiveValue&() const LIFETIME_BOUND
     {
-        return downcast<CSSPrimitiveValue>(m_value).unsafeGet();
+        return downcast<CSSPrimitiveValue>(m_value.get());
     }
 
     operator const CSSValue&() const

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1217,7 +1217,7 @@ String ShorthandSerializer::serializeGridTemplate() const
 
     StringBuilder result;
     unsigned row = 0;
-    for (auto& currentValue : downcast<CSSValueList>(rowTrackSizes).unsafeGet()) {
+    for (auto& currentValue : downcast<CSSValueList>(rowTrackSizes.get())) {
         if (!result.isEmpty())
             result.append(' ');
         if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue))

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -311,12 +311,9 @@ void StyleRule::setProperties(Ref<StyleProperties>&& properties)
 
 MutableStyleProperties& StyleRule::mutableProperties()
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
-        return *mutableProperties;
-    Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
-    m_properties = WTFMove(mutableProperties);
-    return mutablePropertiesRef;
+    if (!is<MutableStyleProperties>(m_properties))
+        m_properties = m_properties->mutableCopy();
+    return uncheckedDowncast<MutableStyleProperties>(m_properties.get());
 }
 
 void StyleRule::wrapperAdoptSelectorList(CSSSelectorList&& selectors)
@@ -464,12 +461,9 @@ Ref<StyleRulePage> StyleRulePage::create(Ref<StyleProperties>&& properties, CSSS
 
 MutableStyleProperties& StyleRulePage::mutableProperties()
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
-        return *mutableProperties;
-    Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
-    m_properties = WTFMove(mutableProperties);
-    return mutablePropertiesRef;
+    if (!is<MutableStyleProperties>(m_properties))
+        m_properties = m_properties->mutableCopy();
+    return uncheckedDowncast<MutableStyleProperties>(m_properties.get());
 }
 
 StyleRuleFontFace::StyleRuleFontFace(Ref<StyleProperties>&& properties)
@@ -488,12 +482,9 @@ StyleRuleFontFace::~StyleRuleFontFace() = default;
 
 MutableStyleProperties& StyleRuleFontFace::mutableProperties()
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
-        return *mutableProperties;
-    Ref mutableProperties = m_properties->mutableCopy();
-    auto& mutablePropertiesRef = mutableProperties.unsafeGet();
-    m_properties = WTFMove(mutableProperties);
-    return mutablePropertiesRef;
+    if (!is<MutableStyleProperties>(m_properties))
+        m_properties = m_properties->mutableCopy();
+    return uncheckedDowncast<MutableStyleProperties>(m_properties.get());
 }
 
 StyleRuleFontFeatureValues::StyleRuleFontFeatureValues(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&& value)

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -87,8 +87,8 @@ static ContainerNode::ChildChange makeChildChange(CharacterData& characterData, 
     return {
         ContainerNode::ChildChange::Type::TextChanged,
         nullptr,
-        RefPtr { ElementTraversal::previousSibling(characterData) }.unsafeGet(),
-        RefPtr { ElementTraversal::nextSibling(characterData) }.unsafeGet(),
+        ElementTraversal::previousSibling(characterData),
+        ElementTraversal::nextSibling(characterData),
         source,
         ContainerNode::ChildChange::AffectsElements::No
     };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9037,13 +9037,7 @@ void Document::removeMediaCanStartListener(MediaCanStartListener& listener)
 
 MediaCanStartListener* Document::takeAnyMediaCanStartListener()
 {
-    if (m_mediaCanStartListeners.isEmptyIgnoringNullReferences())
-        return nullptr;
-
-    RefPtr listener = m_mediaCanStartListeners.begin().get();
-    m_mediaCanStartListeners.remove(*listener);
-
-    return listener.unsafeGet();
+    return m_mediaCanStartListeners.takeAny();
 }
 
 void Document::addDisplayChangedObserver(const DisplayChangedObserver& observer)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3498,8 +3498,8 @@ RefPtr<ShadowRoot> Element::protectedUserAgentShadowRoot() const
 
 ShadowRoot& Element::ensureUserAgentShadowRoot()
 {
-    if (RefPtr shadow = userAgentShadowRoot())
-        return *shadow.unsafeGet();
+    if (auto* shadow = userAgentShadowRoot())
+        return *shadow;
     return createUserAgentShadowRoot();
 }
 

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -79,8 +79,10 @@ inline Node* EventPath::eventTargetRespectingTargetRules(Node& referenceNode)
 
     // Events sent to elements inside an SVG use element's shadow tree go to the use element.
     if (auto* svgElement = dynamicDowncast<SVGElement>(referenceNode)) {
-        if (RefPtr useElement = svgElement->correspondingUseElement())
-            return useElement.unsafeGet();
+        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+        // as we merely return it right away (rdar://165602290).
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* useElement = svgElement->correspondingUseElement())
+            return useElement;
     }
 
     return &referenceNode;

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -453,9 +453,9 @@ RefPtr<DataTransfer> CompositeEditCommand::inputEventDataTransfer() const
 EditCommandComposition* CompositeEditCommand::composition() const
 {
     for (RefPtr command = this; command; command = command->parent()) {
-        if (auto composition = command->m_composition) {
+        if (auto* composition = command->m_composition.get()) {
             ASSERT(!command->parent());
-            return composition.unsafeGet();
+            return composition;
         }
     }
     return nullptr;

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -198,12 +198,12 @@ Element* editableRootForPosition(const Position& position, EditableType editable
 // Finds the enclosing element until which the tree can be split.
 // When a user hits ENTER, he/she won't expect this element to be split into two.
 // You may pass it as the second argument of splitTreeToNode.
-Element* unsplittableElementForPosition(const Position& position)
+RefPtr<Element> unsplittableElementForPosition(const Position& position)
 {
     // Since enclosingNodeOfType won't search beyond the highest root editable node,
     // this code works even if the closest table cell was outside of the root editable node.
-    if (auto enclosingCell = downcast<Element>(enclosingNodeOfType(position, &isTableCell)))
-        return enclosingCell.unsafeGet();
+    if (RefPtr enclosingCell = downcast<Element>(enclosingNodeOfType(position, &isTableCell)))
+        return enclosingCell;
     return editableRootForPosition(position);
 }
 

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -203,7 +203,7 @@ Ref<Element> createTabSpanElement(Document&, String&& tabText);
 Ref<Element> createBlockPlaceholderElement(Document&);
 
 Element* editableRootForPosition(const Position&, EditableType = ContentIsEditable);
-Element* unsplittableElementForPosition(const Position&);
+RefPtr<Element> unsplittableElementForPosition(const Position&);
 
 bool canMergeLists(Element* firstList, Element* secondList);
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2263,8 +2263,8 @@ Node* Editor::nodeBeforeWritingSuggestions() const
     if (!container)
         return nullptr;
 
-    if (RefPtr text = dynamicDowncast<Text>(container))
-        return text.unsafeGet();
+    if (auto* text = dynamicDowncast<Text>(container.get()))
+        return text;
 
     return position.computeNodeBeforePosition();
 }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -357,8 +357,10 @@ static Node* firstNode(const BoundaryPoint& point)
 {
     if (point.container->isCharacterDataNode())
         return point.container.ptr();
-    if (RefPtr child = point.container->traverseToChildAt(point.offset))
-        return child.unsafeGet();
+    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+    // as we merely return it right away (rdar://165602290).
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* child = point.container->traverseToChildAt(point.offset))
+        return child;
     if (!point.offset)
         return point.container.ptr();
     return NodeTraversal::nextSkippingChildren(point.container);

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -103,7 +103,7 @@ void NetworkResourcesData::ResourceData::decodeDataToContent()
 {
     ASSERT(!hasContent());
 
-    auto buffer = m_dataBuffer.takeAsContiguous();
+    auto buffer = m_dataBuffer.takeBufferAsContiguous();
 
     if (m_decoder) {
         m_base64Encoded = false;

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -375,7 +375,7 @@ void ResourceLoader::addBuffer(const FragmentedSharedBuffer& buffer, DataPayload
 
 const FragmentedSharedBuffer* ResourceLoader::resourceData() const
 {
-    return m_resourceData.get().unsafeGet();
+    return m_resourceData.buffer();
 }
 
 RefPtr<const FragmentedSharedBuffer> ResourceLoader::protectedResourceData() const

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -37,12 +37,12 @@ public:
 
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
-    FragmentedSharedBuffer& data() const { return *m_data.get().unsafeGet(); }
+    FragmentedSharedBuffer& data() const LIFETIME_BOUND { return *m_data.buffer(); }
     Ref<FragmentedSharedBuffer> protectedData() const { return data(); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }
 
-    virtual void deliver(ResourceLoader& loader) { loader.deliverResponseAndData(ResourceResponse { m_response }, m_data.copy()); }
+    virtual void deliver(ResourceLoader& loader) { loader.deliverResponseAndData(ResourceResponse { m_response }, m_data.copyBuffer()); }
 
 protected:
     SubstituteResource(URL&& url, ResourceResponse&& response, Ref<FragmentedSharedBuffer>&& data)

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -202,7 +202,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     asciiString = makeString("--"_s, boundary, "--\r\n"_s).utf8();
     mhtmlData.append(asciiString.span());
 
-    return mhtmlData.take();
+    return mhtmlData.takeBuffer();
 }
 
 }

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -194,7 +194,7 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
     }
 
     Vector<uint8_t> data;
-    auto contiguousContent = content.takeAsContiguous();
+    auto contiguousContent = content.takeBufferAsContiguous();
     switch (mimeHeader.contentTransferEncoding()) {
     case MIMEHeader::Base64: {
         auto decodedData = base64Decode(contiguousContent->span());

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.mm
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.mm
@@ -252,7 +252,7 @@ void LegacyPreviewLoader::providePasswordForPreviewConverter(PreviewConverter& c
 void LegacyPreviewLoader::provideMainResourceForPreviewConverter(PreviewConverter& converter, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&& completionHandler)
 {
     ASSERT_UNUSED(converter, &converter == m_converter);
-    completionHandler(m_originalData.copy());
+    completionHandler(m_originalData.copyBuffer());
 }
 
 bool LegacyPreviewLoader::didReceiveResponse(const ResourceResponse&)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -516,8 +516,8 @@ LocalFrame* FocusController::focusedOrMainFrame() const
 {
     if (auto* frame = focusedLocalFrame())
         return frame;
-    if (RefPtr localMainFrame = m_page->localMainFrame())
-        return localMainFrame.unsafeGet();
+    if (auto* localMainFrame = m_page->localMainFrame())
+        return localMainFrame;
     ASSERT(m_page->settings().siteIsolationEnabled());
     return nullptr;
 }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -747,22 +747,24 @@ FloatSize LocalFrame::resizePageRectsKeepingRatio(const FloatSize& originalSize,
 const UserContentProvider* LocalFrame::userContentProvider() const
 {
     RefPtr document = this->document();
-    RefPtr documentLoader = document ? document->loader() : nullptr;
-    if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
-        return userContentProvider.unsafeGet();
+    if (RefPtr documentLoader = document ? document->loader() : nullptr) {
+        if (auto* userContentProvider = documentLoader->preferences().userContentProvider.get())
+            return userContentProvider;
+    }
     if (RefPtr page = this->page())
-        return page->protectedUserContentProviderForFrame().unsafePtr();
+        return &page->userContentProviderForFrame();
     return nullptr;
 }
 
 UserContentProvider* LocalFrame::userContentProvider()
 {
     RefPtr document = this->document();
-    RefPtr documentLoader = document ? document->loader() : nullptr;
-    if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
-        return userContentProvider.unsafeGet();
+    if (RefPtr documentLoader = document ? document->loader() : nullptr) {
+        if (auto* userContentProvider = documentLoader->preferences().userContentProvider.get())
+            return userContentProvider;
+    }
     if (RefPtr page = this->page())
-        return page->protectedUserContentProviderForFrame().unsafePtr();
+        return &page->userContentProviderForFrame();
     return nullptr;
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4491,24 +4491,12 @@ void Page::enableICECandidateFiltering()
 #endif
 }
 
-RefPtr<LocalFrame> Page::localMainFrame()
+LocalFrame* Page::localMainFrame() const
 {
     return dynamicDowncast<LocalFrame>(mainFrame());
 }
 
-RefPtr<const LocalFrame> Page::localMainFrame() const
-{
-    return dynamicDowncast<LocalFrame>(mainFrame());
-}
-
-RefPtr<Document> Page::localTopDocument()
-{
-    if (RefPtr localMainFrame = this->localMainFrame())
-        return localMainFrame->document();
-    return nullptr;
-}
-
-RefPtr<Document> Page::localTopDocument() const
+Document* Page::localTopDocument() const
 {
     if (RefPtr localMainFrame = this->localMainFrame())
         return localMainFrame->document();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -419,13 +419,10 @@ public:
 
     EditorClient& editorClient() { return m_editorClient.get(); }
 
-    WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame();
-    WEBCORE_EXPORT RefPtr<const LocalFrame> localMainFrame() const;
-    WEBCORE_EXPORT RefPtr<Document> localTopDocument();
-    WEBCORE_EXPORT RefPtr<Document> localTopDocument() const;
+    WEBCORE_EXPORT LocalFrame* localMainFrame() const;
+    WEBCORE_EXPORT Document* localTopDocument() const;
 
-    Frame& mainFrame() { return m_mainFrame.get(); }
-    const Frame& mainFrame() const { return m_mainFrame.get(); }
+    Frame& mainFrame() const { return m_mainFrame.get(); }
     WEBCORE_EXPORT Ref<Frame> protectedMainFrame() const;
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& mainFrameURL() const;
@@ -1020,6 +1017,7 @@ public:
     PluginInfoProvider& pluginInfoProvider();
     Ref<PluginInfoProvider> protectedPluginInfoProvider() const;
 
+    UserContentProvider& userContentProviderForFrame() { return m_userContentProvider; }
     WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProviderForFrame();
     WEBCORE_EXPORT void setUserContentProviderForWebKitLegacy(Ref<UserContentProvider>&&);
 

--- a/Source/WebCore/platform/PreviewConverter.cpp
+++ b/Source/WebCore/platform/PreviewConverter.cpp
@@ -67,7 +67,7 @@ const ResourceError& PreviewConverter::previewError() const
 
 const FragmentedSharedBuffer& PreviewConverter::previewData() const
 {
-    return *m_previewData.get().unsafeGet();
+    return *m_previewData.buffer();
 }
 
 void PreviewConverter::updateMainResource()
@@ -221,7 +221,7 @@ void PreviewConverter::replayToClient(PreviewConverterClient& client)
     client.previewConverterDidStartConverting(*this);
 
     if (!m_previewData.isEmpty() && hasClient(client))
-        client.previewConverterDidReceiveData(*this, *m_previewData.get());
+        client.previewConverterDidReceiveData(*this, *m_previewData.buffer());
 
     if (m_state == State::Converting || !hasClient(client))
         return;

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -76,7 +76,7 @@ std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(I
         if (useUnixDomainSockets || size < minimumPageSize) {
             SharedBufferBuilder builder;
             builder.appendSpans(data);
-            return builder.take();
+            return builder.takeBuffer();
         }
         return std::nullopt;
     }, [](std::optional<WebCore::SharedMemoryHandle>&& handle) -> std::optional<Ref<FragmentedSharedBuffer>> {
@@ -601,7 +601,7 @@ RefPtr<ArrayBuffer> SharedBufferBuilder::tryCreateArrayBuffer() const
     return RefPtr { m_buffer }->tryCreateArrayBuffer();
 }
 
-Ref<FragmentedSharedBuffer> SharedBufferBuilder::take()
+Ref<FragmentedSharedBuffer> SharedBufferBuilder::takeBuffer()
 {
     if (isEmpty())
         return SharedBuffer::create();
@@ -611,16 +611,16 @@ Ref<FragmentedSharedBuffer> SharedBufferBuilder::take()
     return buffer;
 }
 
-Ref<SharedBuffer> SharedBufferBuilder::takeAsContiguous()
+Ref<SharedBuffer> SharedBufferBuilder::takeBufferAsContiguous()
 {
-    return take()->makeContiguous();
+    return takeBuffer()->makeContiguous();
 }
 
-RefPtr<ArrayBuffer> SharedBufferBuilder::takeAsArrayBuffer()
+RefPtr<ArrayBuffer> SharedBufferBuilder::takeBufferAsArrayBuffer()
 {
     if (isEmpty())
         return ArrayBuffer::tryCreate();
-    return take()->tryCreateArrayBuffer();
+    return takeBuffer()->tryCreateArrayBuffer();
 }
 
 void SharedBufferBuilder::updateBufferIfNeeded() const

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -383,18 +383,19 @@ public:
         m_buffer = nullptr;
     }
 
-    RefPtr<FragmentedSharedBuffer> get() const
+    FragmentedSharedBuffer* buffer() const LIFETIME_BOUND
     {
         updateBufferIfNeeded();
-        return m_buffer;
+        return m_buffer.get();
     }
-    Ref<FragmentedSharedBuffer> copy() const { return createBuffer(); }
+    RefPtr<FragmentedSharedBuffer> protectedBuffer() const { return buffer(); }
+    Ref<FragmentedSharedBuffer> copyBuffer() const { return createBuffer(); }
 
     WEBCORE_EXPORT RefPtr<ArrayBuffer> tryCreateArrayBuffer() const;
 
-    WEBCORE_EXPORT Ref<FragmentedSharedBuffer> take();
-    WEBCORE_EXPORT Ref<SharedBuffer> takeAsContiguous();
-    WEBCORE_EXPORT RefPtr<ArrayBuffer> takeAsArrayBuffer();
+    WEBCORE_EXPORT Ref<FragmentedSharedBuffer> takeBuffer();
+    WEBCORE_EXPORT Ref<SharedBuffer> takeBufferAsContiguous();
+    WEBCORE_EXPORT RefPtr<ArrayBuffer> takeBufferAsArrayBuffer();
 
     WEBCORE_EXPORT bool operator==(const SharedBufferBuilder&) const;
 

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -85,7 +85,7 @@ void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuff
 {
     m_received += buffer.size();
     m_content.append(buffer);
-    auto contiguousBuffer = m_content.get()->makeContiguous();
+    auto contiguousBuffer = m_content.protectedBuffer()->makeContiguous();
     auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->span());
     if (mimeType.isEmpty() && m_received < m_maxSize)
         return;
@@ -105,7 +105,7 @@ void MediaResourceSniffer::loadFinished(PlatformMediaResource&, const NetworkLoa
 {
     if (m_producer.isSettled())
         return;
-    Ref contiguousBuffer = m_content.takeAsContiguous();
+    Ref contiguousBuffer = m_content.takeBufferAsContiguous();
     auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->span());
     m_producer.resolve(ContentType { WTFMove(mimeType) });
     cancel();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -233,7 +233,7 @@ void PlatformResourceMediaLoader::dataReceived(PlatformMediaResource&, const Sha
     assertIsCurrent(m_targetDispatcher.get());
 
     m_buffer.append(buffer);
-    m_parent.newDataStoredInSharedBuffer(*m_buffer.get());
+    m_parent.newDataStoredInSharedBuffer(*m_buffer.buffer());
 }
 
 class DataURLResourceMediaLoader {

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1047,7 +1047,7 @@ webm::Status WebMParser::TrackData::readFrameData(webm::Reader& reader, const we
     if (m_partialBytesRead < *m_completePacketSize)
         return webm::Status(webm::Status::kOkPartial);
 
-    m_completeBlockBuffer = m_currentBlockBuffer.take();
+    m_completeBlockBuffer = m_currentBlockBuffer.takeBuffer();
     m_completeFrameData = Ref { *m_completeBlockBuffer };
 
     m_completePacketSize = std::nullopt;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4475,7 +4475,7 @@ InitData MediaPlayerPrivateGStreamer::parseInitDataFromProtectionMessage(GstMess
         m_handledProtectionEvents.add(GST_EVENT_SEQNUM(event.get()));
     }
 
-    return { systemId, payloadBuilder.takeAsContiguous() };
+    return { systemId, payloadBuilder.takeBufferAsContiguous() };
 }
 
 bool MediaPlayerPrivateGStreamer::waitForCDMAttachment()

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -253,7 +253,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (buffer.isEmpty())
         return nullptr;
 
-    return buffer.takeAsContiguous();
+    return buffer.takeBufferAsContiguous();
 }
 #endif
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -543,7 +543,7 @@ Ref<FragmentedSharedBuffer> MediaRecorderPrivateEncoder::takeData()
     {
         Locker locker { m_lock };
         flushDataBuffer();
-        return m_data.take();
+        return m_data.takeBuffer();
     }
 }
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -270,7 +270,7 @@ void MediaRecorderPrivateBackend::fetchData(MediaRecorderPrivate::FetchDataCallb
         {
             Locker locker { m_dataLock };
             GST_DEBUG_OBJECT(m_pipeline.get(), "Transfering %zu encoded bytes, mimeType: %s", m_data.size(), mimeType.ascii().data());
-            buffer = m_data.take();
+            buffer = m_data.takeBuffer();
             timeCode = m_timeCode;
         }
         completionHandler(buffer.releaseNonNull(), mimeType, timeCode);

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -133,12 +133,11 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
     if (bufferSize < range.begin)
         return;
 
-    auto buffer = data.buffer.get();
     CheckedPtr taskData = data.taskData.get(task);
     if (!taskData)
         return;
 
-    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
+    auto giveBytesToTask = [task = retainPtr(task), buffer = data.buffer.protectedBuffer(), bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
         assertIsCurrent(targetQueue);
         if ([task state] != NSURLSessionTaskStateRunning)
             return;

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -58,7 +58,7 @@ String ScriptBuffer::toString() const
         return String();
 
     StringBuilder builder;
-    m_buffer.get()->forEachSegment([&](auto segment) {
+    m_buffer.protectedBuffer()->forEachSegment([&](auto segment) {
         builder.append(byteCast<char8_t>(segment));
     });
     return builder.toString();

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -44,10 +44,12 @@ public:
     static ScriptBuffer empty();
 
     String toString() const;
-    RefPtr<const FragmentedSharedBuffer> buffer() const { return m_buffer.get(); }
+    const SharedBufferBuilder& bufferBuilder() const { return m_buffer; }
+    const FragmentedSharedBuffer* buffer() const { return m_buffer.buffer(); }
+    RefPtr<const FragmentedSharedBuffer> protectedBuffer() const { return m_buffer.buffer(); }
     size_t size() const { return m_buffer.size(); }
 
-    ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copy()) : nullptr); }
+    ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copyBuffer()) : nullptr); }
     explicit operator bool() const { return !!m_buffer; }
     bool isEmpty() const { return m_buffer.isEmpty(); }
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -86,7 +86,7 @@ bool WorkerFontLoadRequest::ensureCustomFontData()
     if (!m_fontCustomPlatformData && !m_errorOccurred && !m_isLoading) {
         RefPtr<SharedBuffer> contiguousData;
         if (m_data)
-            contiguousData = m_data.takeAsContiguous();
+            contiguousData = m_data.takeBufferAsContiguous();
         convertWOFFToSfntIfNecessary(contiguousData);
         if (contiguousData) {
             RefPtr fontCustomPlatformData = FontCustomPlatformData::create(*contiguousData, m_url.fragmentIdentifier().toString());

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -91,7 +91,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     size_t size = script.size();
 
     auto iterateOverBufferAndWriteData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& writeData) {
-        script.buffer()->forEachSegment([&](std::span<const uint8_t> span) {
+        script.protectedBuffer()->forEachSegment([&](std::span<const uint8_t> span) {
             writeData(span);
         });
     };

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -213,7 +213,7 @@ Ref<Blob> XMLHttpRequest::createResponseBlob()
     // FIXME: We just received the data from NetworkProcess, and are sending it back. This is inefficient.
     Vector<uint8_t> data;
     if (m_binaryResponseBuilder)
-        data = m_binaryResponseBuilder.take()->extractData();
+        data = m_binaryResponseBuilder.takeBuffer()->extractData();
     return Blob::create(protectedScriptExecutionContext().get(), WTFMove(data), responseMIMEType(FinalMIMEType::Yes)); // responseMIMEType defaults to text/xml which may be incorrect.
 }
 
@@ -222,7 +222,7 @@ RefPtr<ArrayBuffer> XMLHttpRequest::createResponseArrayBuffer()
     ASSERT(responseType() == ResponseType::Arraybuffer);
     ASSERT(doneWithoutErrors());
 
-    return m_binaryResponseBuilder.takeAsArrayBuffer();
+    return m_binaryResponseBuilder.takeBufferAsArrayBuffer();
 }
 
 ExceptionOr<void> XMLHttpRequest::setTimeout(unsigned timeout)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -148,10 +148,10 @@ void SpeculativeLoad::didFinishLoading(const WebCore::NetworkLoadMetrics&)
     if (m_didComplete)
         return;
     if (!m_cacheEntry && m_bufferedDataForCache) {
-        m_cacheEntry = m_cache->store(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.get(), [](auto&& mappedBody) { });
+        m_cacheEntry = m_cache->store(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.buffer(), [](auto&& mappedBody) { });
         // Create a synthetic cache entry if we can't store.
         if (!m_cacheEntry && isStatusCodeCacheableByDefault(m_response.httpStatusCode()))
-            m_cacheEntry = m_cache->makeEntry(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.take());
+            m_cacheEntry = m_cache->makeEntry(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.takeBuffer());
     }
 
     didComplete();

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2129,7 +2129,7 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
         void didCompleteWithError(const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics&) final
         {
             if (error.isNull())
-                m_completionHandler(m_buffer.take());
+                m_completionHandler(m_buffer.takeBuffer());
             else
                 m_completionHandler(makeUnexpected(error));
             m_selfReference = nullptr;

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -247,7 +247,7 @@ void BackgroundFetchStoreManager::retrieveResponseBody(const String& identifier,
             callback(RefPtr<SharedBuffer> { });
             return;
         }
-        callback(iterator->value[index].copy()->makeContiguous());
+        callback(iterator->value[index].copyBuffer()->makeContiguous());
         return;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6089,7 +6089,7 @@ struct WebCore::ServiceWorkerImportedScript {
 };
 
 class WebCore::ScriptBuffer {
-    RefPtr<const WebCore::FragmentedSharedBuffer> buffer();
+    RefPtr<const WebCore::FragmentedSharedBuffer> protectedBuffer();
 };
 
 header: <wtf/RobinHoodHashTable.h>

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -217,7 +217,7 @@ auto WebURLSchemeTask::didComplete(const ResourceError& error) -> ExceptionType
     m_completed = true;
 
     if (isSync()) {
-        Vector<uint8_t> data = m_syncData.takeAsContiguous()->span();
+        Vector<uint8_t> data = m_syncData.takeBufferAsContiguous()->span();
         m_syncCompletionHandler(m_syncResponse, error, WTFMove(data));
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -816,7 +816,7 @@ RefPtr<FragmentedSharedBuffer> PluginView::liveResourceData() const
 {
     if (!m_isInitialized) {
         if (m_manualStreamState == ManualStreamState::Finished)
-            return m_manualStreamData.get();
+            return m_manualStreamData.buffer();
 
         return nullptr;
     }
@@ -989,7 +989,7 @@ void PluginView::redeliverManualStream()
 
     // Deliver the data.
     if (m_manualStreamData) {
-        m_manualStreamData.take()->forEachSegmentAsSharedBuffer([&](auto&& buffer) {
+        m_manualStreamData.takeBuffer()->forEachSegmentAsSharedBuffer([&](auto&& buffer) {
             manualLoadDidReceiveData(buffer);
         });
     }

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -308,7 +308,7 @@ void WebServiceWorkerFetchTaskClient::continueDidReceiveResponse()
             didFinishInternal(m_networkLoadMetrics);
     }, [this](const SharedBufferBuilder& buffer) {
         assertIsHeld(m_connectionLock);
-        didReceiveDataInternal(buffer.copy()->makeContiguous());
+        didReceiveDataInternal(buffer.copyBuffer()->makeContiguous());
         if (m_didFinish)
             didFinishInternal(m_networkLoadMetrics);
     }, [this](Ref<FormData>& formData) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -927,7 +927,7 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     if (!newPage)
         return nullptr;
     
-    return newPage->localMainFrame().unsafeGet();
+    return newPage->localMainFrame();
 }
 
 void WebLocalFrameLoaderClient::dispatchShow()

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp
@@ -67,7 +67,7 @@ void WebPreviewLoaderClient::didFinishLoading()
     if (!webPage)
         return;
 
-    webPage->didFinishLoadForQuickLookDocumentInMainFrame(m_buffer.take().get());
+    webPage->didFinishLoadForQuickLookDocumentInMainFrame(m_buffer.takeBuffer().get());
 }
 
 void WebPreviewLoaderClient::didFail()


### PR DESCRIPTION
#### 0dda3d536adba7453f849e02deb2091ee38a11d0
<pre>
Reduce use of unsafeGet() in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=303291">https://bugs.webkit.org/show_bug.cgi?id=303291</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::addAll):
(WebCore::DOMCache::put):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::compressZlib):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompressZlib):
* Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm:
(WebCore::CompressionStreamEncoder::compressAppleCompressionFramework):
* Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm:
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::convertReadableStreamToArrayBuffer):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::resolve):
(WebCore::FetchBodyConsumer::takeData):
(WebCore::FetchBodyConsumer::takeAsArrayBuffer):
(WebCore::FetchBodyConsumer::takeAsBlob):
(WebCore::FetchBodyConsumer::takeAsText):
(WebCore::FetchBodyConsumer::setSource):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::CredentialRequestCoordinator):
(WebCore::CredentialRequestCoordinator::finalizeDigitalCredential):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::environmentMapResourceFinished):
(WebCore::HTMLModelElement::modelResourceFinished):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::ResourceLoader::didReceiveData):
(WebCore::NotificationResourcesLoader::ResourceLoader::didFinishLoading):
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::composedParentIgnoringDocumentFragments):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::nearestRendererFromNode):
(WebCore::AccessibilityObject::rendererOrNearestAncestor const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::documentFrameView const):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::inactiveNamedTimeline):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::mutableProperties):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::TypeDeducingCSSValueMapper::operator const CSSPrimitiveValue&amp; const): Deleted.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::mutableProperties):
(WebCore::StyleRulePage::mutableProperties):
(WebCore::StyleRuleFontFace::mutableProperties):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::makeChildChange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::takeAnyMediaCanStartListener):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::ensureUserAgentShadowRoot):
* Source/WebCore/dom/EventPath.h:
(WebCore::EventPath::eventTargetRespectingTargetRules):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::composition const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::unsplittableElementForPosition):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::nodeBeforeWritingSuggestions const):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::firstNode):
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::ResourceData::decodeDataToContent):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::resourceData const):
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::deliver):
(WebCore::SubstituteResource::data const): Deleted.
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp:
(WebCore::MHTMLParser::parseNextPart):
* Source/WebCore/loader/ios/LegacyPreviewLoader.mm:
(WebCore::LegacyPreviewLoader::provideMainResourceForPreviewConverter):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::focusedOrMainFrame const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::userContentProvider const):
(WebCore::LocalFrame::userContentProvider):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::localMainFrame const):
(WebCore::Page::localTopDocument const):
(WebCore::Page::localMainFrame):
(WebCore::Page::localTopDocument):
* Source/WebCore/page/Page.h:
(WebCore::Page::mainFrame const):
(WebCore::Page::userContentProviderForFrame):
(WebCore::Page::mainFrame): Deleted.
* Source/WebCore/platform/PreviewConverter.cpp:
(WebCore::PreviewConverter::previewData const):
(WebCore::PreviewConverter::replayToClient):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::fromIPCData):
(WebCore::SharedBufferBuilder::takeBuffer):
(WebCore::SharedBufferBuilder::takeBufferAsContiguous):
(WebCore::SharedBufferBuilder::takeBufferAsArrayBuffer):
(WebCore::SharedBufferBuilder::take): Deleted.
(WebCore::SharedBufferBuilder::takeAsContiguous): Deleted.
(WebCore::SharedBufferBuilder::takeAsArrayBuffer): Deleted.
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBufferBuilder::protectedBuffer const):
(WebCore::SharedBufferBuilder::copyBuffer const):
(WebCore::SharedBufferBuilder::get const): Deleted.
(WebCore::SharedBufferBuilder::copy const): Deleted.
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp:
(WebCore::MediaResourceSniffer::dataReceived):
(WebCore::MediaResourceSniffer::loadFinished):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::PlatformResourceMediaLoader::dataReceived):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::TrackData::readFrameData):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::parseInitDataFromProtectionMessage):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::readICCProfile):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::takeData):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::fetchData):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::toString const):
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::bufferBuilder const):
(WebCore::ScriptBuffer::buffer const):
(WebCore::ScriptBuffer::protectedBuffer const):
(WebCore::ScriptBuffer::isolatedCopy const):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::ensureCustomFontData):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createResponseBlob):
(WebCore::XMLHttpRequest::createResponseArrayBuffer):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::bufferingTimerFired):
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
(WebKit::NetworkCache::SpeculativeLoad::didFinishLoading):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::loadImageForDecoding):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::retrieveResponseBody):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::didComplete):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::liveResourceData const):
(WebKit::PluginView::redeliverManualStream):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::continueDidReceiveResponse):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchCreatePage):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp:
(WebKit::WebPreviewLoaderClient::didFinishLoading):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, appendBufferCreatedWithContentsOfExistingFile)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, tryCreateArrayBuffer)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, contiguousAlwaysStayContiguous)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, getReturnsContiguous)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, tryCreateArrayBufferLargeSegments)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, copy)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, builder)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, builderEmptyFollowedByGet)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, builderInPlace)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, getSomeData)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, getContiguousData)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, isEqualTo)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, toHexString)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, read)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, takeDataIsContiguousWhenPossible)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, getIsContiguousWhenPossible)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, emptySharedBufferBuilderIsContiguous)):
(TestWebKitAPI::TEST_F(SharedBufferChunkReaderTest, includeSeparator)):
(TestWebKitAPI::TEST_F(SharedBufferChunkReaderTest, peekData)):
(TestWebKitAPI::TEST_F(SharedBufferChunkReaderTest, readAllChunksInMultiSegment)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, createNSDataArray)):
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, createNSDataForDataSegment)):

Canonical link: <a href="https://commits.webkit.org/303790@main">https://commits.webkit.org/303790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b8269bb4eab1e67aa00d2b84918aa9f14b1601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133413 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85461 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/31b770f5-92ff-4458-ac87-f34ea2577b84) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102055 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69485 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/99934023-7304-4b9b-a4a3-e4e339e7e3ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82851 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d1e8dcb-1684-4267-8c4b-c1145ca845e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2029 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143615 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4295 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5639 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34174 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->