### PR TITLE
WebXR Test API Hit Test extensions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt
@@ -1,8 +1,16 @@
 
-FAIL Ensures subscription to hit test works with an XRSpace from input source - no move - webgl assert_equals: expected 1 but got 0
-FAIL Ensures subscription to hit test works with an XRSpace from input source - no move - webgl2 assert_equals: expected 1 but got 0
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl assert_equals: expected 1 but got 0
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl2 assert_equals: expected 1 but got 0
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl assert_equals: expected 1 but got 0
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl2 assert_equals: expected 1 but got 0
+PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl2
+FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl assert_equals: expected 0 but got 1
+FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl2 assert_equals: expected 0 but got 1
+FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl assert_approx_equals: after-move-pose: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: -1.443, y: 1, z: -2.5, w: 1}
+ Difference in component x exceeded the given epsilon.
+ expected 0 +/- 0.001 but got -1.443
+FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl2 assert_approx_equals: after-move-pose: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: -1.443, y: 1, z: -2.5, w: 1}
+ Difference in component x exceeded the given epsilon.
+ expected 0 +/- 0.001 but got -1.443
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt
@@ -1,10 +1,26 @@
 
-FAIL Ensures subscription to hit test works with viewer space - straight ahead - plane - webgl assert_equals: Results length should match expected results length expected 1 but got 0
-FAIL Ensures subscription to hit test works with viewer space - straight ahead - plane - webgl2 assert_equals: Results length should match expected results length expected 1 but got 0
+PASS Ensures subscription to hit test works with viewer space - straight ahead - plane - webgl
+PASS Ensures subscription to hit test works with viewer space - straight ahead - plane - webgl2
 PASS Ensures subscription to hit test works with viewer space - straight up - no results - webgl
 PASS Ensures subscription to hit test works with viewer space - straight up - no results - webgl2
-FAIL Ensures subscription to hit test works with local space - webgl assert_equals: Results length should match expected results length expected 1 but got 0
-FAIL Ensures subscription to hit test works with local space - webgl2 assert_equals: Results length should match expected results length expected 1 but got 0
-FAIL Ensures subscription to hit test works with local-floor space - webgl assert_equals: Results length should match expected results length expected 1 but got 0
-FAIL Ensures subscription to hit test works with local-floor space - webgl2 assert_equals: Results length should match expected results length expected 1 but got 0
+FAIL Ensures subscription to hit test works with local space - webgl assert_approx_equals: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: 0, y: 0, z: -2.5, w: 1}
+ Difference in component y exceeded the given epsilon.
+ expected 1 +/- 0.001 but got 0
+FAIL Ensures subscription to hit test works with local space - webgl2 assert_approx_equals: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: 0, y: 0, z: -2.5, w: 1}
+ Difference in component y exceeded the given epsilon.
+ expected 1 +/- 0.001 but got 0
+FAIL Ensures subscription to hit test works with local-floor space - webgl assert_approx_equals: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: 0, y: 0.25, z: -2.5, w: 1}
+ Difference in component y exceeded the given epsilon.
+ expected 1 +/- 0.001 but got 0.25
+FAIL Ensures subscription to hit test works with local-floor space - webgl2 assert_approx_equals: positions must be equal Point comparison failed.
+ p1: {x: 0, y: 1, z: -2.5, w: 1}
+ p2: {x: 0, y: 0.25, z: -2.5, w: 1}
+ Difference in component y exceeded the given epsilon.
+ expected 1 +/- 0.001 but got 0.25
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_transientInputSources.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_transientInputSources.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - no move - webgl assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - no move - webgl2 assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - after move - no results - webgl assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - after move - no results - webgl2 assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - after move - 1 result - webgl assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
-FAIL Ensures subscription to transient hit test works with an XRSpace from input source - after move - 1 result - webgl2 assert_equals: There should be exactly one group of transient hit test results! expected 1 but got 0
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - no move - webgl
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - no move - webgl2
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - after move - no results - webgl
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - after move - no results - webgl2
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - after move - 1 result - webgl
+PASS Ensures subscription to transient hit test works with an XRSpace from input source - after move - 1 result - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_unlocalizable.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_unlocalizable.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Ensures hit test result returns null pose w/unlocalizable space - viewer space - webgl assert_true: Results should not be empty! expected true got false
-FAIL Ensures hit test result returns null pose w/unlocalizable space - viewer space - webgl2 assert_true: Results should not be empty! expected true got false
+FAIL Ensures hit test result returns null pose w/unlocalizable space - viewer space - webgl assert_true: Pose should be null since input source is not localizable expected true got false
+FAIL Ensures hit test result returns null pose w/unlocalizable space - viewer space - webgl2 assert_true: Pose should be null since input source is not localizable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt
@@ -1,4 +1,6 @@
 
 PASS XRViewport attributes are valid - webgl
 PASS XRViewport attributes are valid - webgl2
+FAIL XRViewport attributes are valid with secondary views requested - webgl assert_equals: expected 3 but got 2
+FAIL XRViewport attributes are valid with secondary views requested - webgl2 assert_equals: expected 3 but got 2
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webxr/webxr_availability.http.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webxr/webxr_availability.http.sub-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Test webxr not available in insecure context
-PASS Test webxr not available in secure context in insecure context
-

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2522,6 +2522,7 @@ if (ENABLE_WEBXR)
         testing/FakeXRInputSourceInit.idl
         testing/FakeXRRigidTransformInit.idl
         testing/FakeXRViewInit.idl
+        testing/FakeXRWorldInit.idl
         testing/WebFakeXRDevice.idl
         testing/WebFakeXRInputController.idl
         testing/WebXRTest.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -2136,6 +2136,7 @@ $(PROJECT_DIR)/testing/FakeXRInputSourceInit.idl
 $(PROJECT_DIR)/testing/FakeXRJointStateInit.idl
 $(PROJECT_DIR)/testing/FakeXRRigidTransformInit.idl
 $(PROJECT_DIR)/testing/FakeXRViewInit.idl
+$(PROJECT_DIR)/testing/FakeXRWorldInit.idl
 $(PROJECT_DIR)/testing/GCObservation.idl
 $(PROJECT_DIR)/testing/InternalSettings.idl
 $(PROJECT_DIR)/testing/Internals.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1090,6 +1090,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRRigidTransformInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRRigidTransformInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRViewInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRViewInit.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRWorldInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRWorldInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchBody.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchBody.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1801,6 +1801,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/testing/FakeXRJointStateInit.idl \
     $(WebCore)/testing/FakeXRRigidTransformInit.idl \
     $(WebCore)/testing/FakeXRViewInit.idl \
+    $(WebCore)/testing/FakeXRWorldInit.idl \
     $(WebCore)/testing/WebFakeXRDevice.idl \
     $(WebCore)/testing/WebFakeXRInputController.idl \
     $(WebCore)/testing/WebXRTest.idl \

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -760,6 +760,14 @@ bool WebXRSession::isHandTrackingEnabled() const
 #endif
 
 #if ENABLE(WEBXR_HIT_TEST)
+template <typename OptionsInit>
+Vector<XRHitTestTrackableType> entityTypesFromOptions(const OptionsInit& options)
+{
+    if (options.entityTypes.isEmpty())
+        return { XRHitTestTrackableType::Plane };
+    return options.entityTypes;
+}
+
 // https://immersive-web.github.io/hit-test/#dom-xrsession-requesthittestsource
 void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, RequestHitTestSourcePromise&& promise)
 {
@@ -787,7 +795,7 @@ void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, Reques
     PlatformXR::Ray ray { { 0, 0, 0 }, { 0, 0, -1 } };
     if (init.offsetRay)
         ray = PlatformXR::Ray { toFloatPoint3D(init.offsetRay->origin()), toFloatPoint3D(init.offsetRay->direction()) };
-    PlatformXR::HitTestOptions options = { *WTFMove(maybeNativeOrigin), init.entityTypes, WTFMove(ray) };
+    PlatformXR::HitTestOptions options = { *WTFMove(maybeNativeOrigin), entityTypesFromOptions(init), WTFMove(ray) };
     device->requestHitTestSource(options, [protectedThis = Ref { *this }, promise = WTFMove(promise)](ExceptionOr<PlatformXR::HitTestSource> exceptionOrSource) mutable {
         if (exceptionOrSource.hasException())
             promise.reject(exceptionOrSource.releaseException());
@@ -818,7 +826,7 @@ void WebXRSession::requestHitTestSourceForTransientInput(const XRTransientInputH
     PlatformXR::Ray ray { { 0, 0, 0 }, { 0, 0, -1 } };
     if (init.offsetRay)
         ray = PlatformXR::Ray { toFloatPoint3D(init.offsetRay->origin()), toFloatPoint3D(init.offsetRay->direction()) };
-    PlatformXR::TransientInputHitTestOptions options = { init.profile, init.entityTypes, WTFMove(ray) };
+    PlatformXR::TransientInputHitTestOptions options = { init.profile, entityTypesFromOptions(init), WTFMove(ray) };
     device->requestTransientInputHitTestSource(options, [protectedThis = Ref { *this }, promise = WTFMove(promise)](ExceptionOr<PlatformXR::TransientInputHitTestSource> exceptionOrSource) mutable {
         if (exceptionOrSource.hasException())
             promise.reject(exceptionOrSource.releaseException());

--- a/Source/WebCore/dom/DOMPointInit.idl
+++ b/Source/WebCore/dom/DOMPointInit.idl
@@ -28,7 +28,9 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-dictionary DOMPointInit {
+[
+    ExportMacro=WEBCORE_EXPORT,
+] dictionary DOMPointInit {
     unrestricted double x = 0;
     unrestricted double y = 0;
     unrestricted double z = 0;

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -129,7 +129,7 @@ public:
 
     WEBCORE_EXPORT TransformationMatrix(const AffineTransform&);
 
-    static TransformationMatrix fromQuaternion(const Quaternion&);
+    WEBCORE_EXPORT static TransformationMatrix fromQuaternion(const Quaternion&);
 
     // Field of view in radians
     static TransformationMatrix fromProjection(double fovUp, double fovDown, double fovLeft, double fovRight, double depthNear, double depthFar);
@@ -175,7 +175,7 @@ public:
     void map4ComponentPoint(double& x, double& y, double& z, double& w) const;
 
     // Maps a 3D point through the transform, returning a 3D point.
-    FloatPoint3D mapPoint(const FloatPoint3D&) const;
+    WEBCORE_EXPORT FloatPoint3D mapPoint(const FloatPoint3D&) const;
 
     // Maps a 2D point through the transform, returning a 2D point.
     // Note that this ignores the z component, effectively projecting the point into the z=0 plane.
@@ -339,7 +339,7 @@ public:
     bool decompose2(Decomposed2Type&) const WARN_UNUSED_RETURN;
     void recompose2(const Decomposed2Type&);
 
-    bool decompose4(Decomposed4Type&) const WARN_UNUSED_RETURN;
+    WEBCORE_EXPORT bool decompose4(Decomposed4Type&) const WARN_UNUSED_RETURN;
     void recompose4(const Decomposed4Type&);
 
     WEBCORE_EXPORT void blend(const TransformationMatrix& from, double progress, CompositeOperation = CompositeOperation::Replace);

--- a/Source/WebCore/testing/FakeXRWorldInit.h
+++ b/Source/WebCore/testing/FakeXRWorldInit.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR_HIT_TEST)
+
+#include "DOMPointInit.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct FakeXRWorldInit {
+    enum class RegionType {
+        Point,
+        Plane,
+        Mesh
+    };
+    struct TriangleInit {
+        Vector<DOMPointInit> vertices;
+    };
+    struct RegionInit {
+        Vector<TriangleInit> faces;
+        RegionType type;
+    };
+
+    Vector<RegionInit> hitTestRegions;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_HIT_TEST)

--- a/Source/WebCore/testing/FakeXRWorldInit.idl
+++ b/Source/WebCore/testing/FakeXRWorldInit.idl
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEBXR_HIT_TEST,
+    EnabledBySetting=WebXRHitTestModuleEnabled
+] enum FakeXRRegionType {
+    "point",
+    "plane",
+    "mesh"
+};
+
+[
+    Conditional=WEBXR_HIT_TEST,
+    EnabledBySetting=WebXRHitTestModuleEnabled
+] dictionary FakeXRTriangleInit {
+    required sequence<DOMPointInit> vertices;
+};
+
+[
+    Conditional=WEBXR_HIT_TEST,
+    EnabledBySetting=WebXRHitTestModuleEnabled
+] dictionary FakeXRRegionInit {
+    required sequence<FakeXRTriangleInit> faces;
+    required FakeXRRegionType type;
+};
+
+[
+    Conditional=WEBXR_HIT_TEST,
+    EnabledBySetting=WebXRHitTestModuleEnabled
+] dictionary FakeXRWorldInit {
+    required sequence<FakeXRRegionInit> hitTestRegions;
+};

--- a/Source/WebCore/testing/WebFakeXRDevice.idl
+++ b/Source/WebCore/testing/WebFakeXRDevice.idl
@@ -65,4 +65,8 @@
 
   // Simulate session shutdown triggered by system
   undefined simulateShutdown();
+
+  // Hit test extensions:
+  [EnabledBySetting=WebXRHitTestModuleEnabled, Conditional=WEBXR_HIT_TEST] undefined setWorld(FakeXRWorldInit world);
+  [EnabledBySetting=WebXRHitTestModuleEnabled, Conditional=WEBXR_HIT_TEST] undefined clearWorld();
 };

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -89,6 +89,11 @@ void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const 
         if (init.floorOrigin)
             device->setFloorOrigin(init.floorOrigin.value());
 
+#if ENABLE(WEBXR_HIT_TEST)
+        if (init.world)
+            device->setWorld(init.world.value());
+#endif
+
         Vector<XRSessionMode> supportedModes;
         if (init.supportedModes) {
             supportedModes = init.supportedModes.value();

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBXR)
 
 #include "EventTarget.h"
+#include "FakeXRWorldInit.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebFakeXRDevice.h"
 #include "XRSessionMode.h"
@@ -54,6 +55,10 @@ public:
 
         std::optional<FakeXRRigidTransformInit> floorOrigin;
         std::optional<FakeXRRigidTransformInit> viewerOrigin;
+
+#if ENABLE(WEBXR_HIT_TEST)
+        std::optional<FakeXRWorldInit> world;
+#endif
     };
 
     static Ref<WebXRTest> create(WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData>&& system) { return adoptRef(*new WebXRTest(WTFMove(system))); }

--- a/Source/WebCore/testing/WebXRTest.idl
+++ b/Source/WebCore/testing/WebXRTest.idl
@@ -81,4 +81,7 @@
     // This sets the viewer origin *shortly after* initialization; since the viewer origin at initialization
     // is used to provide a reference origin for all matrices.
     FakeXRRigidTransformInit viewerOrigin;
+
+    // Hit test extensions:
+    [EnabledBySetting=WebXRHitTestModuleEnabled, Conditional=WEBXR_HIT_TEST] FakeXRWorldInit world;
 };


### PR DESCRIPTION
#### 0d8281c39722575779f9b4fcdd97e34afd3df055
<pre>
WebXR Test API Hit Test extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=301463">https://bugs.webkit.org/show_bug.cgi?id=301463</a>

Reviewed by Sergio Villar Senin.

Implemented the Hit Test extensions of WebXR Test API by porting
Chromium webxr-test.js to C++.

Found out and fixed a bug. As per the spec, in requestHitTestSource
and requestHitTestSourceForTransientInput, if the entityTypes was not
provided, the effective entityTypes should be set to an array
containing single element, &quot;plane&quot;.

Tests: imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_transientInputSources.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_transientInputSources.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_unlocalizable.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webxr/webxr_availability.http.sub-expected.txt: Removed a duplicated expectation.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::entityTypesFromOptions):
(WebCore::WebXRSession::requestHitTestSource):
(WebCore::WebXRSession::requestHitTestSourceForTransientInput):
* Source/WebCore/dom/DOMPointInit.idl:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/testing/FakeXRWorldInit.h: Added.
* Source/WebCore/testing/FakeXRWorldInit.idl: Added.
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
(WebCore::SimulatedXRDevice::requestHitTestSource):
(WebCore::SimulatedXRDevice::requestTransientInputHitTestSource):
(WebCore::SimulatedXRDevice::hitTestWorld):
(WebCore::SimulatedXRDevice::setWorld):
(WebCore::SimulatedXRDevice::clearWorld):
(WebCore::WebFakeXRDevice::setWorld):
(WebCore::WebFakeXRDevice::clearWorld):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/testing/WebFakeXRDevice.idl:
* Source/WebCore/testing/WebXRTest.cpp:
(WebCore::WebXRTest::simulateDeviceConnection):
* Source/WebCore/testing/WebXRTest.h:
* Source/WebCore/testing/WebXRTest.idl:

Canonical link: <a href="https://commits.webkit.org/303898@main">https://commits.webkit.org/303898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b75dd1f62ccc5898c4a94ddfcf43a52493e5e88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69630 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2252 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110847 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4499 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59634 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5940 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34422 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69404 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->