### PR TITLE
[Quirk] straighten the hbomax.com domain in quirks.

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1957,7 +1957,7 @@ bool Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick() const
 
 #endif // ENABLE(TOUCH_EVENTS)
 
-// max.com: rdar://138424489
+// hbomax.com: rdar://138424489
 bool Quirks::needsZeroMaxTouchPointsQuirk() const
 {
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
@@ -2664,21 +2664,6 @@ static void handleGuardianQuirks(QuirksData& quirksData, const URL& /* quirksURL
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-static void handleMaxQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
-{
-    if (quirksDomainString != "max.com"_s) [[unlikely]]
-        return;
-
-    quirksData.enableQuirks({
-        // max.com: rdar://138424489
-        QuirksData::SiteSpecificQuirk::NeedsZeroMaxTouchPointsQuirk,
-        // max.com: rdar://138806698
-        QuirksData::SiteSpecificQuirk::ShouldSupportHoverMediaQueriesQuirk
-    });
-}
-#endif
-
 #if ENABLE(MEDIA_STREAM)
 static void handleBaiduQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL& /* documentURL */)
 {
@@ -2983,17 +2968,26 @@ static void handleHBOMaxQuirks(QuirksData& quirksData, const URL& quirksURL, con
         return;
 
     auto topDocumentHost = quirksURL.host();
-    if (topDocumentHost != "play.hbomax.com"_s)
-        return;
 
-    quirksData.enableQuirks({
-        // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
-        QuirksData::SiteSpecificQuirk::ShouldEnableFontLoadingAPIQuirk,
+    // Needed to be able to login on the site
+    // hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldEnableFontLoadingAPIQuirk);
+
+    // Needed for the HBO player
+    if (topDocumentHost == "play.hbomax.com"_s) {
+        quirksData.enableQuirks({
 #if HAVE(PIP_SKIP_PREROLL)
-        // play.hbomax.com rdar://158430821
-        QuirksData::SiteSpecificQuirk::ShouldDisableAdSkippingInPip,
+            // play.hbomax.com rdar://158430821
+            QuirksData::SiteSpecificQuirk::ShouldDisableAdSkippingInPip,
 #endif
-    });
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+            // hbomax.com: rdar://138424489
+            QuirksData::SiteSpecificQuirk::NeedsZeroMaxTouchPointsQuirk,
+            // hbomax.com: rdar://138806698
+            QuirksData::SiteSpecificQuirk::ShouldSupportHoverMediaQueriesQuirk
+#endif
+        });
+    }
 }
 
 static void handleHotelsQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
@@ -3494,9 +3488,6 @@ void Quirks::determineRelevantQuirks()
         { "mailchimp"_s, &handleMailChimpQuirks },
 #endif
         { "marcus"_s, &handleMarcusQuirks },
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-        { "max"_s, &handleMaxQuirks },
-#endif
         { "medium"_s, &handleMediumQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "cloud"_s, &handleMicrosoftCloudQuirks },


### PR DESCRIPTION
#### 08e2e442d7985f143d86fd411687f774bcfb637e
<pre>
[Quirk] straighten the hbomax.com domain in quirks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303294">https://bugs.webkit.org/show_bug.cgi?id=303294</a>
<a href="https://rdar.apple.com/162988946">rdar://162988946</a>

Reviewed by Brent Fulgham and Brandon Stewart.

HBO Max after having the domain max.com decided a couple of months to
change again to their original domain name which hbomax.com. This is
straightening this. HBO Max has also redirections from max.com to
hbomax.com.

* Source/WebCore/page/Quirks.cpp:
(WebCore::handleHBOMaxQuirks):
(WebCore::Quirks::determineRelevantQuirks):
(WebCore::handleMaxQuirks): Deleted.

Canonical link: <a href="https://commits.webkit.org/303782@main">https://commits.webkit.org/303782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53134ed8249233b44bce37dabb377144bb0317c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85574 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a4a2eea-44f1-46aa-9d4d-cd012323cba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69526 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a570438f-1c1d-4b66-a67d-11931760c0c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5580aa47-0586-4229-8bb2-964c33c1b159) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2112 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5694 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110700 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4370 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59444 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34268 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->