### PR TITLE
Add possibility to use large strings in WebPage::runJavaScript without copies

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -119,6 +119,7 @@
 
         const fundamentalTypes = [
             "char",
+            "char16_t",
             "char32_t",
             "short",
             "float",

--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -32,6 +32,7 @@
 #include "JSStringRef.h"
 #include "OpaqueJSString.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/cf/VectorCF.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -156,12 +156,27 @@ inline std::span<const char> CFStringGetASCIICStringSpan(CFStringRef string)
     return unsafeMakeSpan(characters, CFStringGetLength(string));
 }
 
-inline std::span<const char> CFStringGetLatin1CStringSpan(CFStringRef string)
+inline std::span<const Latin1Character> CFStringGetLatin1CStringSpan(CFStringRef string)
 {
     auto* characters = CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1);
     if (!characters)
         return { };
-    return unsafeMakeSpan(characters, CFStringGetLength(string));
+    return unsafeMakeSpan(reinterpret_cast<const Latin1Character*>(characters), CFStringGetLength(string));
+}
+
+inline std::span<const char16_t> CFStringGetCharactersSpan(CFStringRef string)
+{
+    auto* characters = CFStringGetCharactersPtr(string);
+    if (!characters)
+        return { };
+    return unsafeMakeSpan(reinterpret_cast<const char16_t*>(characters), CFStringGetLength(string));
+}
+
+inline void CFStringCopyCharactersSpan(CFStringRef string, std::span<char16_t> span)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    CFStringGetCharacters(string, CFRangeMake(0, span.size()), reinterpret_cast<UniChar*>(span.data()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline std::span<const uint8_t> span(CFDataRef data)
@@ -207,6 +222,8 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::CFStringGetASCIICStringSpan;
 using WTF::CFStringGetLatin1CStringSpan;
+using WTF::CFStringGetCharactersSpan;
+using WTF::CFStringCopyCharactersSpan;
 using WTF::createCFArray;
 using WTF::makeVector;
 using WTF::mutableSpan;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -94,6 +94,8 @@ public:
     GraphemeClusters graphemeClusters() const;
 
     bool is8Bit() const;
+    unsigned sizeInBytes() const;
+
     const void* rawCharacters() const LIFETIME_BOUND { return m_characters; }
     std::span<const Latin1Character> span8() const LIFETIME_BOUND;
     std::span<const char16_t> span16() const LIFETIME_BOUND;
@@ -559,6 +561,11 @@ inline StringView::operator bool() const
 inline bool StringView::is8Bit() const
 {
     return m_is8Bit;
+}
+
+inline unsigned StringView::sizeInBytes() const
+{
+    return m_length * (m_is8Bit ? sizeof(Latin1Character) : sizeof(char16_t));
 }
 
 inline StringView StringView::substring(unsigned start, unsigned length) const

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -39,16 +39,15 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
     if (!string)
         return nullptr;
 
-    if (auto span = byteCast<Latin1Character>(CFStringGetLatin1CStringSpan(string)); span.data())
+    if (auto span = CFStringGetLatin1CStringSpan(string); !span.empty())
         return add(span);
 
-    size_t length = CFStringGetLength(string);
-    if (const UniChar* ptr = CFStringGetCharactersPtr(string))
-        return add(unsafeMakeSpan(reinterpret_cast<const char16_t*>(ptr), length));
+    if (auto span = CFStringGetCharactersSpan(string); !span.empty())
+        return add(span);
 
-    Vector<UniChar, 1024> ucharBuffer(length);
-    CFStringGetCharacters(string, CFRangeMake(0, length), ucharBuffer.mutableSpan().data());
-    return add(spanReinterpretCast<const char16_t>(ucharBuffer.span()));
+    Vector<char16_t, 1024> ucharBuffer(CFStringGetLength(string));
+    CFStringCopyCharactersSpan(string, ucharBuffer.mutableSpan());
+    return add(ucharBuffer.span());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -25,6 +25,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/StringBuffer.h>
 
 namespace WTF {
@@ -53,7 +54,7 @@ String::String(CFStringRef str)
     }
 
     StringBuffer<char16_t> ucharBuffer(size);
-    CFStringGetCharacters(str, CFRangeMake(0, size), reinterpret_cast<UniChar *>(ucharBuffer.characters()));
+    CFStringCopyCharactersSpan(str, ucharBuffer.span());
     m_impl = StringImpl::adopt(WTFMove(ucharBuffer));
 }
 

--- a/Source/WTF/wtf/text/cf/StringConcatenateCF.h
+++ b/Source/WTF/wtf/text/cf/StringConcatenateCF.h
@@ -58,7 +58,7 @@ template<> inline void StringTypeAdapter<CFStringRef>::writeTo<Latin1Character>(
 template<> inline void StringTypeAdapter<CFStringRef>::writeTo<char16_t>(std::span<char16_t> destination) const
 {
     if (m_string)
-        CFStringGetCharacters(m_string.get(), CFRangeMake(0, CFStringGetLength(m_string.get())), reinterpret_cast<UniChar*>(destination.data()));
+        CFStringCopyCharactersSpan(m_string.get(), destination.first(CFStringGetLength(m_string.get())));
 }
 
 #ifdef __OBJC__

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -468,6 +468,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Platform/IPC/SharedBufferReference.serialization.in
     Platform/IPC/SharedFileHandle.serialization.in
     Platform/IPC/StreamServerConnection.serialization.in
+    Platform/IPC/TransferString.serialization.in
 
     Shared/AccessibilityPreferences.serialization.in
     Shared/AuxiliaryProcessCreationParameters.serialization.in
@@ -519,6 +520,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/RemoteWorkerType.serialization.in
     Shared/ResourceLoadInfo.serialization.in
     Shared/ResourceLoadStatisticsParameters.serialization.in
+    Shared/RunJavaScriptParameters.serialization.in
     Shared/SameDocumentNavigationType.serialization.in
     Shared/SandboxExtension.serialization.in
     Shared/ScriptTrackingPrivacyFilter.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -175,6 +175,7 @@ $(PROJECT_DIR)/Platform/IPC/ObjectIdentifierReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedBufferReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedFileHandle.serialization.in
 $(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in
+$(PROJECT_DIR)/Platform/IPC/TransferString.serialization.in
 $(PROJECT_DIR)/Platform/LogMessages.in
 $(PROJECT_DIR)/Platform/SharedMemory.serialization.in
 $(PROJECT_DIR)/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
@@ -367,6 +368,7 @@ $(PROJECT_DIR)/Shared/RemoteWorkerInitializationData.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadInfo.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadStatisticsParameters.serialization.in
+$(PROJECT_DIR)/Shared/RunJavaScriptParameters.serialization.in
 $(PROJECT_DIR)/Shared/SameDocumentNavigationType.serialization.in
 $(PROJECT_DIR)/Shared/SandboxExtension.serialization.in
 $(PROJECT_DIR)/Shared/ScriptTrackingPrivacyFilter.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -621,6 +621,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Platform/IPC/SharedBufferReference.serialization.in \
 	Platform/IPC/SharedFileHandle.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \
+	Platform/IPC/TransferString.serialization.in \
 	Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in \
 	Shared/AuxiliaryProcessCreationParameters.serialization.in \
 	Shared/JavaScriptEvaluationResult.serialization.in \
@@ -763,6 +764,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/RemoteWorkerType.serialization.in \
 	Shared/ResourceLoadInfo.serialization.in \
 	Shared/ResourceLoadStatisticsParameters.serialization.in \
+	Shared/RunJavaScriptParameters.serialization.in \
 	Shared/SameDocumentNavigationType.serialization.in \
 	Shared/SandboxExtension.serialization.in \
 	Shared/ScriptTrackingPrivacyFilter.serialization.in \

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TransferString.h"
+
+#include <wtf/text/ExternalStringImpl.h>
+
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
+
+namespace IPC {
+
+#if USE(CF)
+std::optional<TransferString> TransferString::create(CFStringRef string)
+{
+    // The transferAsMappingSize checks are inside the `if`s because we want to make sure
+    // that the getter will return the data. We need that during ::toIPCData.
+    CFIndex size = CFStringGetLength(string);
+    if (!size)
+        return TransferString { };
+    if (auto span8 = CFStringGetLatin1CStringSpan(string); !span8.empty()) {
+        if (span8.size_bytes() < transferAsMappingSize)
+            return TransferString { string };
+        return createCopy(span8);
+    }
+    if (auto span16 = CFStringGetCharactersSpan(string); !span16.empty()) {
+        if (span16.size_bytes() < transferAsMappingSize)
+            return TransferString { string };
+        return createCopy(span16);
+    }
+    RefPtr buffer = WebCore::SharedMemory::allocate(size * sizeof(char16_t));
+    if (!buffer)
+        return std::nullopt;
+    auto bufferSpan = spanReinterpretCast<char16_t>(buffer->mutableSpan());
+    CFStringCopyCharactersSpan(string, bufferSpan);
+    auto handle = buffer->createHandle(WebCore::SharedMemoryProtection::ReadOnly);
+    if (!handle)
+        return std::nullopt;
+    return std::optional<TransferString> { std::in_place, SharedSpan16 { WTFMove(*handle) } };
+}
+
+TransferString::TransferString(CFStringRef string)
+    : m_storage(RetainPtr { string })
+{
+}
+
+#endif
+
+std::optional<TransferString> TransferString::createCopy(std::span<const Latin1Character> span8)
+{
+    auto handle = WebCore::SharedMemoryHandle::createCopy(span8, WebCore::SharedMemoryProtection::ReadOnly);
+    if (!handle)
+        return std::nullopt;
+    return std::optional<TransferString> { std::in_place, SharedSpan8 { WTFMove(*handle) } };
+}
+
+std::optional<TransferString> TransferString::createCopy(std::span<const char16_t> span16)
+{
+    auto handle = WebCore::SharedMemoryHandle::createCopy(asBytes(span16), WebCore::SharedMemoryProtection::ReadOnly);
+    if (!handle)
+        return std::nullopt;
+    return std::optional<TransferString> { std::in_place, SharedSpan16 { WTFMove(*handle) } };
+}
+
+std::optional<String> TransferString::release(size_t maxCopySizeInBytes) && // NOLINT
+{ // NOLINT
+    return WTF::switchOn(WTFMove(m_storage),
+        [](String string) {
+            return std::optional<String> { std::in_place, WTFMove(string) };
+        },
+#if USE(CF)
+        [](RetainPtr<CFStringRef> string) {
+            return std::optional<String> { std::in_place, string.get() };
+        },
+#endif
+        [maxCopySizeInBytes](SharedSpan8 handle) -> std::optional<String> {
+            RefPtr<SharedMemory> memory = WebCore::SharedMemory::map(WTFMove(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
+            if (!memory)
+                return std::nullopt;
+            if (memory->size() > maxCopySizeInBytes) {
+                Ref<StringImpl> impl = ExternalStringImpl::create(byteCast<Latin1Character>(memory->span()), [memory = memory.releaseNonNull()] (auto...) mutable { });
+                return std::optional<String> { std::in_place, String { WTFMove(impl) } };
+            }
+            return std::optional<String> { std::in_place, String { byteCast<Latin1Character>(memory->span()) } };
+        },
+        [maxCopySizeInBytes](SharedSpan16 handle) -> std::optional<String> {
+            RefPtr<SharedMemory> memory = WebCore::SharedMemory::map(WTFMove(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
+            if (!memory || (memory->size() % sizeof(char16_t)))
+                return std::nullopt;
+            if (memory->size() > maxCopySizeInBytes) {
+                Ref<StringImpl> impl = ExternalStringImpl::create(spanReinterpretCast<const char16_t>(memory->span()), [memory = memory.releaseNonNull()] (auto...) mutable { });
+                return std::optional<String> { std::in_place, String { WTFMove(impl) } };
+            }
+            return std::optional<String> { std::in_place, String { spanReinterpretCast<const char16_t>(memory->span()) } };
+
+        });
+}
+
+TransferString::IPCData TransferString::toIPCData() const
+{
+    return WTF::switchOn(m_storage,
+        [](const String& string) {
+            if (auto span8 = string.span8(); !span8.empty())
+                return IPCData { span8 };
+            return IPCData { string.span16() };
+        },
+#if USE(CF)
+        [](const RetainPtr<CFStringRef>& string) {
+            if (auto span8 = CFStringGetLatin1CStringSpan(string.get()); !span8.empty())
+                return IPCData { span8 };
+            return IPCData { CFStringGetCharactersSpan(string.get()) };
+        },
+#endif
+        [](const SharedSpan8& handle) {
+            return IPCData { SharedSpan8 { WebCore::SharedMemoryHandle { handle.dataHandle } } };
+        },
+        [](const SharedSpan16& handle) -> IPCData {
+            return IPCData { SharedSpan16 { WebCore::SharedMemoryHandle { handle.dataHandle } } };
+        });
+}
+
+}

--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/SharedMemory.h>
+#include <limits>
+#include <wtf/text/WTFString.h>
+
+namespace IPC {
+
+// String type for efficient holding of read-only strings that are transfered multiple times,
+// possibly to different processes.
+// Originators are able to optionally create from custom memory mappings.
+// A small string is held without copy and transferred inline.
+// A large string is held as single shared memory object.
+// Receive side, release()d Strings refer to the possible shared memory object.
+class TransferString {
+public:
+    struct SharedSpan8 {
+        WebCore::SharedMemoryHandle dataHandle;
+    };
+    struct SharedSpan16 {
+        WebCore::SharedMemoryHandle dataHandle;
+    };
+    using IPCData = Variant<std::span<const Latin1Character>, std::span<const char16_t>, SharedSpan8, SharedSpan16>;
+
+    static std::optional<TransferString> create(const String&);
+    static std::optional<TransferString> create(StringView);
+#if USE(CF)
+    static std::optional<TransferString> create(CFStringRef);
+#endif
+#if USE(FOUNDATION) && defined(__OBJC__)
+    static std::optional<TransferString> create(NSString *);
+#endif
+
+    TransferString() = default;
+    // Constructor for custom memory mapping of Latin1 (String::span8()) string.
+    TransferString(SharedSpan8&&);
+    // Constructor for custom memory mapping of char16_t (String::span16()) string.
+    TransferString(SharedSpan16&&);
+
+    TransferString(IPCData&&);
+    TransferString(TransferString&&) = default;
+    TransferString& operator=(TransferString&&) = default;
+
+    static constexpr size_t transferAsMappingSize = 16384 * 5;
+
+    // Release the string.
+    // Pass maxCopySizeInBytes = transferAsMappingSize - 1 to release without copy, possibly holding the underlying virtual memory mapping.
+    // Pass maxCopySizeInBytes = std::numeric_limits<size_t>::max() to release with copy always, avoiding potential virtual memory fragmentation.
+    // Fails on out-of-memory (if mapping fails).
+    std::optional<String> release(size_t maxCopySizeInBytes = transferAsMappingSize - 1) &&;
+
+    // Release the string via copy.
+    std::optional<String> releaseToCopy() && { return WTFMove(*this).release(std::numeric_limits<size_t>::max()); };
+
+    IPCData toIPCData() const LIFETIME_BOUND;
+
+private:
+    static std::optional<TransferString> createCopy(std::span<const Latin1Character>);
+    static std::optional<TransferString> createCopy(std::span<const char16_t>);
+    TransferString(String&&);
+#if USE(CF)
+    TransferString(CFStringRef);
+#endif
+
+#if USE(CF)
+    using Storage = Variant<String, RetainPtr<CFStringRef>, SharedSpan8, SharedSpan16>;
+#else
+    using Storage = Variant<String, SharedSpan8, SharedSpan16>;
+#endif
+    Storage m_storage;
+};
+
+inline std::optional<TransferString> TransferString::create(const String& string)
+{
+    if (string.sizeInBytes() < transferAsMappingSize)
+        return TransferString { String { string } };
+    if (auto span8 = string.span8(); !span8.empty())
+        return createCopy(span8);
+    return createCopy(string.span16());
+}
+
+inline std::optional<TransferString> TransferString::create(StringView string)
+{
+    if (string.sizeInBytes() < transferAsMappingSize)
+        return TransferString { string.toString() };
+    if (auto span8 = string.span8(); !span8.empty())
+        return createCopy(span8);
+    return createCopy(string.span16());
+}
+
+inline TransferString::TransferString(String&& string)
+    : m_storage(WTFMove(string))
+{
+}
+
+#if USE(FOUNDATION) && defined(__OBJC__)
+inline std::optional<TransferString> TransferString::create(NSString *string)
+{
+    return create((__bridge CFStringRef)string);
+}
+#endif
+
+inline TransferString::TransferString(SharedSpan8&& handle)
+    : m_storage(WTFMove(handle))
+{
+}
+
+inline TransferString::TransferString(SharedSpan16&& handle)
+    : m_storage(WTFMove(handle))
+{
+}
+
+inline TransferString::TransferString(IPCData&& data)
+{
+    WTF::switchOn(WTFMove(data),
+        [&](std::span<const Latin1Character> characters) {
+            m_storage = String { characters };
+        },
+        [&](std::span<const char16_t> characters) {
+            m_storage = String { characters };
+        },
+        [&](SharedSpan8 handle) {
+            m_storage = WTFMove(handle);
+        },
+        [&](SharedSpan16 handle) {
+            m_storage = WTFMove(handle);
+        });
+}
+
+}

--- a/Source/WebKit/Platform/IPC/TransferString.serialization.in
+++ b/Source/WebKit/Platform/IPC/TransferString.serialization.in
@@ -1,0 +1,37 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+webkit_platform_header: "TransferString.h"
+
+[Nested, RValue] struct IPC::TransferString::SharedSpan8 {
+    WebCore::SharedMemoryHandle dataHandle;
+};
+
+[Nested, RValue] struct IPC::TransferString::SharedSpan16 {
+    WebCore::SharedMemoryHandle dataHandle;
+};
+
+using IPC::TransferString::IPCData = Variant<std::span<const uint8_t>, std::span<const char16_t>, IPC::TransferString::SharedSpan8, IPC::TransferString::SharedSpan16>;
+
+[CustomHeader] class IPC::TransferString {
+    IPC::TransferString::IPCData toIPCData();
+};

--- a/Source/WebKit/Platform/Sources.txt
+++ b/Source/WebKit/Platform/Sources.txt
@@ -21,3 +21,4 @@ Platform/IPC/StreamConnectionBuffer.cpp
 Platform/IPC/StreamConnectionWorkQueue.cpp
 Platform/IPC/SharedFileHandle.cpp
 Platform/IPC/StreamServerConnection.cpp
+Platform/IPC/TransferString.cpp

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -440,6 +440,8 @@
 [UnsafeWrapper] WebCore::SharedMemoryHandle {
     [Legacy] StructureParam WebKit::ConsumerSharedCARingBufferHandle.memory
     [Legacy] StructureParam WebCore::ShareableResourceHandle.m_handle
+    [NotSentFromWebContent] StructureParam IPC::TransferString::SharedSpan8.dataHandle
+    [NotSentFromWebContent] StructureParam IPC::TransferString::SharedSpan16.dataHandle
 }
 
 [UnsafeWrapper] WebCore::SharedMemory::Handle {
@@ -465,6 +467,8 @@
 }
 
 [Legacy] StructureParam WebCore::DDModel::DDUpdateMeshDescriptor.vertexData Vector<Vector<uint8_t>>
+
+[UnsafeWrapper] AliasParam IPC::TransferString::IPCData Variant<std::span<const uint8_t>, std::span<const char16_t>, IPC::TransferString::SharedSpan8, IPC::TransferString::SharedSpan16>
 
 # GTK Specific
 [Legacy] StructureParam sk_sp<SkColorSpace>.dataReference() std::span<const uint8_t>

--- a/Source/WebKit/Shared/RunJavaScriptParameters.h
+++ b/Source/WebKit/Shared/RunJavaScriptParameters.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "TransferString.h"
 #include <wtf/HashMap.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 enum class RunAsAsyncFunction : bool;
@@ -39,7 +39,7 @@ enum class RemoveTransientActivation : bool;
 namespace WebKit {
 
 struct RunJavaScriptParameters {
-    String source;
+    IPC::TransferString source;
     JSC::SourceTaintedOrigin taintedness;
     URL sourceURL;
     WebCore::RunAsAsyncFunction runAsAsyncFunction;

--- a/Source/WebKit/Shared/RunJavaScriptParameters.serialization.in
+++ b/Source/WebKit/Shared/RunJavaScriptParameters.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "RunJavaScriptParameters.h"
+
+struct WebKit::RunJavaScriptParameters {
+    IPC::TransferString source;
+    JSC::SourceTaintedOrigin taintedness;
+    URL sourceURL;
+    WebCore::RunAsAsyncFunction runAsAsyncFunction;
+    std::optional<Vector<std::pair<String, WebKit::JavaScriptEvaluationResult>>> arguments;
+    WebCore::ForceUserGesture forceUserGesture;
+    WebCore::RemoveTransientActivation removeTransientActivation;
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4142,16 +4142,6 @@ enum class WebCore::RunAsAsyncFunction : bool;
 enum class WebCore::ForceUserGesture : bool;
 enum class WebCore::RemoveTransientActivation : bool;
 
-struct WebKit::RunJavaScriptParameters {
-    String source;
-    JSC::SourceTaintedOrigin taintedness;
-    URL sourceURL;
-    WebCore::RunAsAsyncFunction runAsAsyncFunction;
-    std::optional<Vector<std::pair<String, WebKit::JavaScriptEvaluationResult>>> arguments;
-    WebCore::ForceUserGesture forceUserGesture;
-    WebCore::RemoveTransientActivation removeTransientActivation;
-}
-
 header: <WebCore/WritingDirection.h>
 enum class WebCore::WritingDirection : uint8_t {
     Natural,

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -145,8 +145,13 @@ Ref<WebPageProxy> RemoteInspectorProtocolHandler::protectedPage() const
 void RemoteInspectorProtocolHandler::runScript(const String& script)
 {
     constexpr bool wantsResult = true;
+    auto scriptString = IPC::TransferString::create(script);
+    if (!scriptString) {
+        LOG_ERROR("Out of memory running script");
+        return;
+    }
     protectedPage()->runJavaScriptInMainFrame(WebKit::RunJavaScriptParameters {
-        script,
+        WTFMove(*scriptString),
         JSC::SourceTaintedOrigin::Untainted,
         URL { },
         WebCore::RunAsAsyncFunction::No,

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1613,6 +1613,7 @@
 		7B73124125CC8525003B2796 /* StreamServerConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123825CC8524003B2796 /* StreamServerConnection.h */; };
 		7B73124225CC8525003B2796 /* StreamConnectionEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123925CC8525003B2796 /* StreamConnectionEncoder.h */; };
 		7B7C380F2EBABD7F00F71B4A /* TextManipulationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7C380E2EBABD5300F71B4A /* TextManipulationParameters.h */; };
+		7B8486842ED9C1FC00E34DC1 /* TransferString.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8486822ED9C1D500E34DC1 /* TransferString.h */; };
 		7B9FC5A828A38D1E007570E7 /* PlatformUnifiedSource1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B9FC59628A28D13007570E7 /* PlatformUnifiedSource1.cpp */; };
 		7B9FC5BB28A5233B007570E7 /* libWebKitPlatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9FC59D28A28F88007570E7 /* libWebKitPlatform.a */; };
 		7B9FC5D028A5300D007570E7 /* PlatformUnifiedSource2-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B9FC5C628A52702007570E7 /* PlatformUnifiedSource2-nonARC.mm */; };
@@ -6856,6 +6857,8 @@
 		7B73123925CC8525003B2796 /* StreamConnectionEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamConnectionEncoder.h; sourceTree = "<group>"; };
 		7B7C380E2EBABD5300F71B4A /* TextManipulationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextManipulationParameters.h; sourceTree = "<group>"; };
 		7B7C38102EBABF1500F71B4A /* TextManipulationParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextManipulationParameters.serialization.in; sourceTree = "<group>"; };
+		7B8486822ED9C1D500E34DC1 /* TransferString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TransferString.h; sourceTree = "<group>"; };
+		7B8486832ED9C1D500E34DC1 /* TransferString.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TransferString.cpp; sourceTree = "<group>"; };
 		7B8679072C2D3D9D00268208 /* GPUProcessConnectionIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessConnectionIdentifier.h; sourceTree = "<group>"; };
 		7B904165254AFDEA006EEB8C /* RemoteGraphicsContextGLProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxy.cpp; sourceTree = "<group>"; };
 		7B904166254AFDEB006EEB8C /* RemoteGraphicsContextGLProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxy.h; sourceTree = "<group>"; };
@@ -10655,6 +10658,8 @@
 				7B2E73472CA2C611002C1A84 /* SyncRequestID.h */,
 				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
+				7B8486832ED9C1D500E34DC1 /* TransferString.cpp */,
+				7B8486822ED9C1D500E34DC1 /* TransferString.h */,
 				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,
 			);
 			path = IPC;
@@ -18279,6 +18284,7 @@
 				1AAF263914687C39004A1E8A /* TiledCoreAnimationDrawingArea.h in Headers */,
 				1AF05D8714688348008B1E81 /* TiledCoreAnimationDrawingAreaProxy.h in Headers */,
 				F48570A32644BEC500C05F71 /* Timeout.h in Headers */,
+				7B8486842ED9C1FC00E34DC1 /* TransferString.h in Headers */,
 				57EB2E3A21E1983E00B89CDF /* U2fAuthenticator.h in Headers */,
 				1AFE436618B6C081009C7A48 /* UIDelegate.h in Headers */,
 				515BE1B51D5917FF00DD7C68 /* UIGamepad.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4487,6 +4487,11 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         return;
     }
 #endif
+    auto source = WTFMove(parameters.source).release();
+    if (!source) {
+        completionHandler(makeUnexpected(ExceptionDetails { "Unable to execute JavaScript: out of memory"_s }));
+        return;
+    }
 
     bool shouldAllowUserInteraction = [&] {
         if (m_userIsInteracting)
@@ -4531,7 +4536,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     };
 
     WebCore::RunJavaScriptParameters coreParameters {
-        WTFMove(parameters.source),
+        WTFMove(*source),
         WTFMove(parameters.taintedness),
         WTFMove(parameters.sourceURL),
         parameters.runAsAsyncFunction == WebCore::RunAsAsyncFunction::Yes,


### PR DESCRIPTION
#### 51cc3ec2d8f317616c72419425b37e8818625d2b
<pre>
Add possibility to use large strings in WebPage::runJavaScript without copies
<a href="https://bugs.webkit.org/show_bug.cgi?id=303295">https://bugs.webkit.org/show_bug.cgi?id=303295</a>
<a href="https://rdar.apple.com/165603388">rdar://165603388</a>

Reviewed by Ben Nham.

Add IPC::TransferString to support explicit serialization of large
strings. In subsequent patches, this will be used to pass large JS
strings as memory that is shared between multiple WebContent processes.

Avoids extra NSString * -&gt; wtf::String copy that was done only to
send the string via IPC.

To be conservative, the feature is added as explicit TransferString
instead of being built-in to IPC string serialization. If the feature
turns out to be non-problematic and receive-side API issues are solved,
it may be merged as the default String serialization.

* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCreateWithCFString):
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::CFStringGetLatin1CStringSpan):
(WTF::CFStringGetCharactersSpan):
(WTF::CFStringCopyCharactersSpan):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::sizeInBytes const):
* Source/WTF/wtf/text/cf/AtomStringImplCF.cpp:
(WTF::AtomStringImpl::add):
* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::String):
* Source/WTF/wtf/text/cf/StringConcatenateCF.h:
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;char16_t&gt; const):
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/Sources.txt:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/RunJavaScriptParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageEvaluateJavaScriptInFrame):
(callAsyncJavaScript):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(unknownError):
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::runScript):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):

Canonical link: <a href="https://commits.webkit.org/303899@main">https://commits.webkit.org/303899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff125b1134aa6ea8c938f3e51b040648bd42c394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85812 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dba37d23-f2f2-40b7-83a2-e2441d9c5905) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102319 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69665 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/892b7f4a-65c5-45be-ba08-7ac5fe41e852) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4790 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119910 "Found 1 new API test failure: TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83122 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e8a3f61f-37a2-4ebb-85b7-6ef9d29b8d30) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133102 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2283 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125830 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143976 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132267 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110696 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4527 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59679 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5985 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34456 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165230 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69449 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43161 "Found 7 new JSC stress test failures: microbenchmarks/emscripten-cube2hash-resizable.js.dfg-eager, stress/regexp-bm-search-character-non-fixed-size.js.dfg-eager, stress/regexp-named-capture-groups.js.dfg-eager, stress/to-lower-case-intrinsic-on-empty-rope.js.dfg-eager, stress/to-lower-case-intrinsic-on-empty-rope.js.mini-mode, stress/v8-regexp-strict.js.default, v8-v6/v8-regexp.js.mini-mode (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->