### PR TITLE
JSStringCreateWithCFString duplicates String(CFStringRef)

### DIFF
--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -34,7 +34,9 @@ String::String(CFStringRef str)
     if (!str)
         return;
 
-    CFIndex size = CFStringGetLength(str);
+    // We cannot use CFIndex here since CFStringGetLength can return values larger than
+    // CFIndex can hold.  (<rdar://problem/6806478>)
+    size_t size = CFStringGetLength(str);
     if (!size) {
         m_impl = StringImpl::empty();
         return;
@@ -44,7 +46,7 @@ String::String(CFStringRef str)
         StringBuffer<Latin1Character> buffer(size);
         CFIndex usedBufLen;
         CFIndex convertedSize = CFStringGetBytes(str, CFRangeMake(0, size), kCFStringEncodingISOLatin1, 0, false, byteCast<UInt8>(buffer.characters()), size, &usedBufLen);
-        if (convertedSize == size && usedBufLen == size) {
+        if (static_cast<size_t>(convertedSize) == size && static_cast<size_t>(usedBufLen) == size) {
             m_impl = StringImpl::adopt(WTFMove(buffer));
             return;
         }


### PR DESCRIPTION
#### a50f9211ee1f38e8a21780bda8f879d5a3cfaf12
<pre>
JSStringCreateWithCFString duplicates String(CFStringRef)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303298">https://bugs.webkit.org/show_bug.cgi?id=303298</a>
<a href="https://rdar.apple.com/165604254">rdar://165604254</a>

Reviewed by Alexey Proskuryakov.

Remove the implementation of JSStringCreateWithCFString. Use
the more efficient implementation in String::String(CFStringRef).

* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCreateWithCFString):
* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::String):

Canonical link: <a href="https://commits.webkit.org/303816@main">https://commits.webkit.org/303816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0545ab0253084db8e7cdf3bc288cfa6f4d5044d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140856 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85347 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6016e7fd-02bd-4fd5-b881-297fe244b508) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101969 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69419 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/03b9e649-e58e-48dd-8638-fe810a0e4c3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04d9e1ef-082d-46fb-95ed-71a117f88e83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4370 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1952 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125373 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143503 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131810 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5472 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110340 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4230 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59222 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5527 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34092 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164777 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68979 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43058 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5616 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->