### PR TITLE
[visionOS] spatial video don't play when MediaPlayerPrivateMediaSourceAVFObjC runs in the WebContent process

### DIFF
--- a/Source/WebCore/platform/TrackInfo.h
+++ b/Source/WebCore/platform/TrackInfo.h
@@ -142,6 +142,10 @@ struct VideoInfo : public TrackInfo {
     uint8_t bitDepth { 8 };
     PlatformVideoColorSpace colorSpace;
 
+#if PLATFORM(VISION)
+    RetainPtr<CFDictionaryRef> spatialVideoMetadata;
+#endif
+
     Vector<AtomData> extensionAtoms;
 
 private:
@@ -164,6 +168,7 @@ private:
         , extensionAtoms(WTFMove(extensionAtoms))
     {
     }
+
 #if ENABLE(ENCRYPTED_MEDIA)
     static Ref<VideoInfo> create(FourCC codecName, const String& codecString, WebCore::TrackID trackID, std::optional<EncryptionData>&& encryptionData, std::optional<FourCC> encryptionOriginalFormat, Vector<EncryptionInitData>&& encryptionInitDatas, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, Vector<AtomData>&& extensionAtoms)
     {
@@ -179,6 +184,41 @@ private:
         , extensionAtoms(WTFMove(extensionAtoms))
     {
     }
+#endif
+
+#if PLATFORM(VISION)
+    static Ref<VideoInfo> create(FourCC codecName, const String& codecString, WebCore::TrackID trackID, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, RetainPtr<CFDictionaryRef>&& spatialVideoMetadata, Vector<AtomData>&& extensionAtoms)
+    {
+        return adoptRef(*new VideoInfo(codecName, codecString, trackID, size, displaySize, bitDepth, colorSpace, WTFMove(spatialVideoMetadata), WTFMove(extensionAtoms)));
+    }
+
+    VideoInfo(FourCC codecName, const String& codecString, WebCore::TrackID trackID, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, RetainPtr<CFDictionaryRef>&& spatialVideoMetadata, Vector<AtomData>&& extensionAtoms)
+        : TrackInfo(TrackType::Video, codecName, codecString, trackID)
+        , size(size)
+        , displaySize(displaySize)
+        , bitDepth(bitDepth)
+        , colorSpace(colorSpace)
+        , spatialVideoMetadata(WTFMove(spatialVideoMetadata))
+        , extensionAtoms(WTFMove(extensionAtoms))
+    {
+    }
+#if ENABLE(ENCRYPTED_MEDIA)
+    static Ref<VideoInfo> create(FourCC codecName, const String& codecString, WebCore::TrackID trackID, std::optional<EncryptionData>&& encryptionData, std::optional<FourCC> encryptionOriginalFormat, Vector<EncryptionInitData>&& encryptionInitDatas, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, RetainPtr<CFDictionaryRef>&& spatialVideoMetadata, Vector<AtomData>&& extensionAtoms)
+    {
+        return adoptRef(*new VideoInfo(codecName, codecString, trackID, WTFMove(encryptionData), encryptionOriginalFormat, WTFMove(encryptionInitDatas), size, displaySize, bitDepth, colorSpace, WTFMove(spatialVideoMetadata), WTFMove(extensionAtoms)));
+    }
+
+    VideoInfo(FourCC codecName, const String& codecString, WebCore::TrackID trackID, std::optional<EncryptionData>&& encryptionData, std::optional<FourCC> encryptionOriginalFormat, Vector<EncryptionInitData>&& encryptionInitDatas, FloatSize size, FloatSize displaySize, uint8_t bitDepth, PlatformVideoColorSpace colorSpace, RetainPtr<CFDictionaryRef>&& spatialVideoMetadata, Vector<AtomData>&& extensionAtoms)
+        : TrackInfo(TrackType::Video, codecName, codecString, trackID, WTFMove(encryptionData), encryptionOriginalFormat, WTFMove(encryptionInitDatas))
+        , size(size)
+        , displaySize(displaySize)
+        , bitDepth(bitDepth)
+        , colorSpace(colorSpace)
+        , spatialVideoMetadata(WTFMove(spatialVideoMetadata))
+        , extensionAtoms(WTFMove(extensionAtoms))
+    {
+    }
+#endif
 #endif
 
     bool equalTo(const TrackInfo& otherVideoInfo) const final

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -71,6 +71,10 @@ WEBCORE_EXPORT Vector<Ref<SharedBuffer>> getKeyIDs(CMFormatDescriptionRef);
 
 WEBCORE_EXPORT FourCC computeBoxType(FourCC);
 
+#if PLATFORM(VISION)
+WEBCORE_EXPORT RetainPtr<CFDictionaryRef> extractSpatialVideoMetadata(CMFormatDescriptionRef);
+#endif
+
 class PacketDurationParser final {
     WTF_MAKE_TZONE_ALLOCATED(PacketDurationParser);
 public:

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -63,6 +63,57 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PacketDurationParser);
 constexpr uint32_t kAudioFormatVorbis = 'vorb';
 #endif
 
+#if PLATFORM(VISION)
+static bool canCopyFormatDescriptionExtension()
+{
+    static bool canCopyFormatDescriptionExtension =
+        PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProjectionKind()
+            && PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ViewPackingKind()
+            && PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_CameraCalibrationDataLensCollection();
+    return canCopyFormatDescriptionExtension;
+}
+
+RetainPtr<CFDictionaryRef> extractSpatialVideoMetadata(CMFormatDescriptionRef description)
+{
+    if (!canCopyFormatDescriptionExtension())
+        return nullptr;
+
+    static CFStringRef keys[] = {
+        PAL::kCMFormatDescriptionExtension_CameraCalibrationDataLensCollection,
+        PAL::kCMFormatDescriptionExtension_HasLeftStereoEyeView,
+        PAL::kCMFormatDescriptionExtension_HasRightStereoEyeView,
+        PAL::kCMFormatDescriptionExtension_HeroEye,
+        PAL::kCMFormatDescriptionExtension_HorizontalFieldOfView,
+        PAL::kCMFormatDescriptionExtension_HorizontalDisparityAdjustment,
+        PAL::kCMFormatDescriptionExtension_StereoCameraBaseline,
+        PAL::kCMFormatDescriptionExtension_ProjectionKind,
+        PAL::kCMFormatDescriptionExtension_ViewPackingKind
+    };
+
+    static constexpr size_t numberOfKeys = sizeof(keys) / sizeof(keys[0]);
+    auto keysSpan = unsafeMakeSpan(keys, numberOfKeys);
+    size_t keysSet = 0;
+    Vector<RetainPtr<CFPropertyListRef>, numberOfKeys> values(numberOfKeys, [&](size_t index) -> RetainPtr<CFPropertyListRef> {
+        RetainPtr value = PAL::CMFormatDescriptionGetExtension(description, RetainPtr { keysSpan[index] }.get());
+        if (!value)
+            return nullptr;
+        keysSet++;
+        return value;
+    });
+
+    if (!keysSet)
+        return nullptr;
+
+    RetainPtr<CFMutableDictionaryRef> extensions = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, keysSet, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+    for (size_t index = 0; index < numberOfKeys; index++) {
+        if (values[index])
+            CFDictionarySetValue(extensions.get(), keysSpan[index], values[index].get());
+    }
+    return extensions;
+}
+#endif
+
 CAAudioStreamDescription audioStreamDescriptionFromAudioInfo(const AudioInfo& info)
 {
     ASSERT(info.codecName.value != kAudioFormatLinearPCM);
@@ -353,6 +404,15 @@ RetainPtr<CMFormatDescriptionRef> createFormatDescriptionFromTrackInfo(const Tra
     }
 #endif
 
+#if PLATFORM(VISION)
+    if (videoInfo.spatialVideoMetadata) {
+        CFDictionaryApplyFunction(videoInfo.spatialVideoMetadata.get(), [](CFTypeRef key, CFTypeRef value, void* context) {
+            CFMutableDictionaryRef dict = static_cast<CFMutableDictionaryRef>(context);
+            CFDictionarySetValue(dict, key, value);
+        }, extensions.get());
+    }
+#endif
+
     CMVideoFormatDescriptionRef formatDescription = nullptr;
     auto error = PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, videoInfo.codecName.value, videoInfo.size.width(), videoInfo.size.height(), extensions.get(), &formatDescription);
     if (error != noErr) {
@@ -432,6 +492,10 @@ RefPtr<VideoInfo> createVideoInfoFromFormatDescription(CMFormatDescriptionRef de
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     setEncryptionInfo(videoInfo, description);
+#endif
+
+#if PLATFORM(VISION)
+    videoInfo->spatialVideoMetadata = extractSpatialVideoMetadata(description);
 #endif
 
     return videoInfo;

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "WebCoreDecompressionSession.h"
 
+#import "CMUtilities.h"
 #import "FormatDescriptionUtilities.h"
 #import "IOSurface.h"
 #import "Logging.h"
@@ -54,20 +55,6 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 
 namespace WebCore {
-
-static bool canCopyFormatDescriptionExtension()
-{
-    static bool canCopyFormatDescriptionExtension = false;
-#if PLATFORM(VISION)
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        canCopyFormatDescriptionExtension = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProjectionKind()
-            && PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ViewPackingKind()
-            && PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_CameraCalibrationDataLensCollection();
-    });
-#endif
-    return canCopyFormatDescriptionExtension;
-}
 
 Ref<WebCoreDecompressionSession> WebCoreDecompressionSession::createOpenGL(GuaranteedSerialFunctionDispatcher* dispatcher)
 {
@@ -314,46 +301,34 @@ static bool isNonRecoverableError(OSStatus status)
     return status != noErr && status != kVTVideoDecoderReferenceMissingErr;
 }
 
+#if PLATFORM(VISION)
+static RetainPtr<CFDictionaryRef> cfDictionaryCreateCombined(CFDictionaryRef a, CFDictionaryRef b)
+{
+    ASSERT(a && b);
+    RetainPtr result = adoptCF(CFDictionaryCreateMutable(NULL, CFDictionaryGetCount(a) + CFDictionaryGetCount(b), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+    auto copyKeyValue = [](CFTypeRef key, CFTypeRef value, void* context) {
+        CFMutableDictionaryRef dict = static_cast<CFMutableDictionaryRef>(context);
+        CFDictionarySetValue(dict, key, value);
+    };
+    CFDictionaryApplyFunction(a, copyKeyValue, result.get());
+    CFDictionaryApplyFunction(b, copyKeyValue, result.get());
+
+    return result;
+}
+#endif
+
 static RetainPtr<CMFormatDescriptionRef> copyDescriptionExtensionValuesIfNeeded(RetainPtr<CMFormatDescriptionRef>&& description, const CMVideoFormatDescriptionRef originalDescription, const CMTaggedBufferGroupRef group)
 {
-    if (!canCopyFormatDescriptionExtension())
+#if PLATFORM(VISION)
+    RetainPtr metadata = extractSpatialVideoMetadata(originalDescription);
+
+    if (!metadata || !CFDictionaryGetCount(metadata.get()))
         return description;
 
-    static CFStringRef keys[] = {
-        PAL::kCMFormatDescriptionExtension_CameraCalibrationDataLensCollection,
-        PAL::kCMFormatDescriptionExtension_HasLeftStereoEyeView,
-        PAL::kCMFormatDescriptionExtension_HasRightStereoEyeView,
-        PAL::kCMFormatDescriptionExtension_HeroEye,
-        PAL::kCMFormatDescriptionExtension_HorizontalFieldOfView,
-        PAL::kCMFormatDescriptionExtension_HorizontalDisparityAdjustment,
-        PAL::kCMFormatDescriptionExtension_StereoCameraBaseline,
-        PAL::kCMFormatDescriptionExtension_ProjectionKind,
-        PAL::kCMFormatDescriptionExtension_ViewPackingKind
-    };
-    static constexpr size_t numberOfKeys = sizeof(keys) / sizeof(keys[0]);
-    auto keysSpan = unsafeMakeSpan(keys, numberOfKeys);
-    size_t keysSet = 0;
-    Vector<RetainPtr<CFPropertyListRef>, numberOfKeys> values(numberOfKeys, [&](size_t index) -> RetainPtr<CFPropertyListRef> {
-        RetainPtr value = PAL::CMFormatDescriptionGetExtension(originalDescription, RetainPtr { keysSpan[index] }.get());
-        if (!value)
-            return nullptr;
-        keysSet++;
-        return value;
-    });
-
-    if (!keysSet)
-        return description;
-
-    RetainPtr<CFMutableDictionaryRef> copyExtensions;
+    RetainPtr copyExtensions = metadata;
     if (RetainPtr extensions = PAL::CMFormatDescriptionGetExtensions(description.get()))
-        copyExtensions = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, CFDictionaryGetCount(extensions.get()) + keysSet, extensions.get()));
-    else
-        copyExtensions = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, keysSet, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-
-    for (size_t index = 0; index < numberOfKeys; index++) {
-        if (values[index])
-            CFDictionarySetValue(copyExtensions.get(), keysSpan[index], values[index].get());
-    }
+        copyExtensions = cfDictionaryCreateCombined(extensions.get(), metadata.get());
 
     if (group) {
         CMVideoFormatDescriptionRef newTaggedGroupDescription;
@@ -368,6 +343,11 @@ static RetainPtr<CMFormatDescriptionRef> copyDescriptionExtensionValuesIfNeeded(
     if (auto status = PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, codecType, dimensions.width, dimensions.height, copyExtensions.get(), &newImageDescription); status != noErr)
         return description;
     return adoptCF(newImageDescription);
+#else
+    UNUSED_PARAM(originalDescription);
+    UNUSED_PARAM(group);
+    return description;
+#endif
 }
 
 static Expected<RetainPtr<CMSampleBufferRef>, OSStatus> handleDecompressionOutput(WebCoreDecompressionSession::DecodingFlags flags, OSStatus status, VTDecodeInfoFlags, CVImageBufferRef imageBuffer, CMTaggedBufferGroupRef group, CMTime presentationTimeStamp, CMTime presentationDuration, CMFormatDescriptionRef currentImageDescription, CMVideoFormatDescriptionRef description = nullptr)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -355,6 +355,7 @@
     [Legacy] StructureParam WebKit::SecItemRequestData.m_attributesToMatch
     [Legacy] StructureParam WebKit::SecItemRequestData.m_queryDictionary
     [Legacy] StructureParam WebCore::FontPlatformDataAttributes.m_attributes
+    [Legacy] StructureParam WebCore::VideoInfo.spatialVideoMetadata
 }
 
 [UnsafeWrapper] RetainPtr<CFDataRef> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8865,7 +8865,10 @@ header: <WebCore/TrackInfo.h>
     WebCore::FloatSize displaySize;
     uint8_t bitDepth;
     WebCore::PlatformVideoColorSpace colorSpace;
-    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> extensionAtoms
+#if PLATFORM(VISION)
+    RetainPtr<CFDictionaryRef> spatialVideoMetadata;
+#endif
+    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> extensionAtoms;
 };
 
 [RefCounted, CreateUsing=fromVariant] struct WebCore::TrackInfo {


### PR DESCRIPTION
#### 6e1e231abe2fcd54d207b1cfc54085735cc70a09
<pre>
[visionOS] spatial video don&apos;t play when MediaPlayerPrivateMediaSourceAVFObjC runs in the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=303301">https://bugs.webkit.org/show_bug.cgi?id=303301</a>
<a href="https://rdar.apple.com/165605223">rdar://165605223</a>

Reviewed by NOBODY (OOPS!).

Add support for extracting the Spatial Metadata from the AVFormatDescription.

Manually tested.
* Source/WebCore/platform/TrackInfo.h:
(WebCore::VideoInfo::create):
(WebCore::VideoInfo::VideoInfo):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::canCopyFormatDescriptionExtension):
(WebCore::extractSpatialVideoMetadata):
(WebCore::createVideoInfoFromFormatDescription):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm: Use new utility method extractSpatialVideoMetadata
(WebCore::cfDictionaryCreateCombined):
(WebCore::copyDescriptionExtensionValuesIfNeeded):
(WebCore::canCopyFormatDescriptionExtension): Deleted.
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in: The spatial metadata is opaque content and dynamic in nature.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a052b09940ae7800f20b5362c5d2b0e52a23759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85755 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a74e0586-b1df-462a-8d56-e517b9877f52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69625 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/029606d8-8060-44ac-80e8-9a9185fc9418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83068 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78395e47-6a64-44ce-91ac-a4d611cfd459) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133048 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2244 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110836 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4479 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59625 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5931 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34418 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->