### PR TITLE
Add a basic implementation of ReadableStream async iterable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any-expected.txt
@@ -8,7 +8,7 @@ PASS the result of compressing [Hello,Hello,] with deflate-raw should be 'HelloH
 PASS the result of compressing [,Hello,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,Hello,] with gzip should be 'HelloHello'
-FAIL the result of compressing [,Hello,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,Hello,] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
+PASS the result of compressing [,Hello,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,Hello,] with brotli should be 'HelloHello'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.serviceworker-expected.txt
@@ -8,7 +8,7 @@ PASS the result of compressing [Hello,Hello,] with deflate-raw should be 'HelloH
 PASS the result of compressing [,Hello,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,Hello,] with gzip should be 'HelloHello'
-FAIL the result of compressing [,Hello,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,Hello,] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
+PASS the result of compressing [,Hello,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,Hello,] with brotli should be 'HelloHello'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.sharedworker-expected.txt
@@ -8,7 +8,7 @@ PASS the result of compressing [Hello,Hello,] with deflate-raw should be 'HelloH
 PASS the result of compressing [,Hello,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,Hello,] with gzip should be 'HelloHello'
-FAIL the result of compressing [,Hello,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,Hello,] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
+PASS the result of compressing [,Hello,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,Hello,] with brotli should be 'HelloHello'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-including-empty-chunk.any.worker-expected.txt
@@ -8,7 +8,7 @@ PASS the result of compressing [Hello,Hello,] with deflate-raw should be 'HelloH
 PASS the result of compressing [,Hello,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,,Hello] with gzip should be 'HelloHello'
 PASS the result of compressing [Hello,Hello,] with gzip should be 'HelloHello'
-FAIL the result of compressing [,Hello,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,,Hello] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
-FAIL the result of compressing [Hello,Hello,] with brotli should be 'HelloHello' assert_array_equals: value should match lengths differ, expected array object "" length 0, got object "72,101,108,108,111,72,101,108,108,111" length 10
+PASS the result of compressing [,Hello,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,,Hello] with brotli should be 'HelloHello'
+PASS the result of compressing [Hello,Hello,] with brotli should be 'HelloHello'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
@@ -2,5 +2,5 @@
 PASS deflate compression with large flush output
 PASS deflate-raw compression with large flush output
 PASS gzip compression with large flush output
-FAIL brotli compression with large flush output assert_array_equals: value should match lengths differ, expected array object "51,44,55,51,51,52,44,55,51,51,53,44,55,51,51,54,44,55,51,51" length 35579, got object "" length 0
+PASS brotli compression with large flush output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.serviceworker-expected.txt
@@ -2,5 +2,5 @@
 PASS deflate compression with large flush output
 PASS deflate-raw compression with large flush output
 PASS gzip compression with large flush output
-FAIL brotli compression with large flush output assert_array_equals: value should match lengths differ, expected array object "51,44,55,51,51,52,44,55,51,51,53,44,55,51,51,54,44,55,51,51" length 35579, got object "" length 0
+PASS brotli compression with large flush output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.sharedworker-expected.txt
@@ -2,5 +2,5 @@
 PASS deflate compression with large flush output
 PASS deflate-raw compression with large flush output
 PASS gzip compression with large flush output
-FAIL brotli compression with large flush output assert_array_equals: value should match lengths differ, expected array object "51,44,55,51,51,52,44,55,51,51,53,44,55,51,51,54,44,55,51,51" length 35579, got object "" length 0
+PASS brotli compression with large flush output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.worker-expected.txt
@@ -2,5 +2,5 @@
 PASS deflate compression with large flush output
 PASS deflate-raw compression with large flush output
 PASS gzip compression with large flush output
-FAIL brotli compression with large flush output assert_array_equals: value should match lengths differ, expected array object "51,44,55,51,51,52,44,55,51,51,53,44,55,51,51,54,44,55,51,51" length 35579, got object "" length 0
+PASS brotli compression with large flush output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any-expected.txt
@@ -44,19 +44,19 @@ PASS compressing 13 chunks with gzip should work
 PASS compressing 14 chunks with gzip should work
 PASS compressing 15 chunks with gzip should work
 PASS compressing 16 chunks with gzip should work
-FAIL compressing 2 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111" length 10, got object "" length 0
-FAIL compressing 3 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 15, got object "" length 0
-FAIL compressing 4 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 20, got object "" length 0
-FAIL compressing 5 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 25, got object "" length 0
-FAIL compressing 6 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 30, got object "" length 0
-FAIL compressing 7 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 35, got object "" length 0
-FAIL compressing 8 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 40, got object "" length 0
-FAIL compressing 9 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 45, got object "" length 0
-FAIL compressing 10 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 50, got object "" length 0
-FAIL compressing 11 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 55, got object "" length 0
-FAIL compressing 12 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 60, got object "" length 0
-FAIL compressing 13 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 65, got object "" length 0
-FAIL compressing 14 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 70, got object "" length 0
-FAIL compressing 15 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 75, got object "" length 0
-FAIL compressing 16 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 80, got object "" length 0
+PASS compressing 2 chunks with brotli should work
+PASS compressing 3 chunks with brotli should work
+PASS compressing 4 chunks with brotli should work
+PASS compressing 5 chunks with brotli should work
+PASS compressing 6 chunks with brotli should work
+PASS compressing 7 chunks with brotli should work
+PASS compressing 8 chunks with brotli should work
+PASS compressing 9 chunks with brotli should work
+PASS compressing 10 chunks with brotli should work
+PASS compressing 11 chunks with brotli should work
+PASS compressing 12 chunks with brotli should work
+PASS compressing 13 chunks with brotli should work
+PASS compressing 14 chunks with brotli should work
+PASS compressing 15 chunks with brotli should work
+PASS compressing 16 chunks with brotli should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.serviceworker-expected.txt
@@ -44,19 +44,19 @@ PASS compressing 13 chunks with gzip should work
 PASS compressing 14 chunks with gzip should work
 PASS compressing 15 chunks with gzip should work
 PASS compressing 16 chunks with gzip should work
-FAIL compressing 2 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111" length 10, got object "" length 0
-FAIL compressing 3 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 15, got object "" length 0
-FAIL compressing 4 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 20, got object "" length 0
-FAIL compressing 5 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 25, got object "" length 0
-FAIL compressing 6 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 30, got object "" length 0
-FAIL compressing 7 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 35, got object "" length 0
-FAIL compressing 8 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 40, got object "" length 0
-FAIL compressing 9 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 45, got object "" length 0
-FAIL compressing 10 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 50, got object "" length 0
-FAIL compressing 11 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 55, got object "" length 0
-FAIL compressing 12 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 60, got object "" length 0
-FAIL compressing 13 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 65, got object "" length 0
-FAIL compressing 14 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 70, got object "" length 0
-FAIL compressing 15 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 75, got object "" length 0
-FAIL compressing 16 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 80, got object "" length 0
+PASS compressing 2 chunks with brotli should work
+PASS compressing 3 chunks with brotli should work
+PASS compressing 4 chunks with brotli should work
+PASS compressing 5 chunks with brotli should work
+PASS compressing 6 chunks with brotli should work
+PASS compressing 7 chunks with brotli should work
+PASS compressing 8 chunks with brotli should work
+PASS compressing 9 chunks with brotli should work
+PASS compressing 10 chunks with brotli should work
+PASS compressing 11 chunks with brotli should work
+PASS compressing 12 chunks with brotli should work
+PASS compressing 13 chunks with brotli should work
+PASS compressing 14 chunks with brotli should work
+PASS compressing 15 chunks with brotli should work
+PASS compressing 16 chunks with brotli should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.sharedworker-expected.txt
@@ -44,19 +44,19 @@ PASS compressing 13 chunks with gzip should work
 PASS compressing 14 chunks with gzip should work
 PASS compressing 15 chunks with gzip should work
 PASS compressing 16 chunks with gzip should work
-FAIL compressing 2 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111" length 10, got object "" length 0
-FAIL compressing 3 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 15, got object "" length 0
-FAIL compressing 4 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 20, got object "" length 0
-FAIL compressing 5 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 25, got object "" length 0
-FAIL compressing 6 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 30, got object "" length 0
-FAIL compressing 7 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 35, got object "" length 0
-FAIL compressing 8 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 40, got object "" length 0
-FAIL compressing 9 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 45, got object "" length 0
-FAIL compressing 10 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 50, got object "" length 0
-FAIL compressing 11 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 55, got object "" length 0
-FAIL compressing 12 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 60, got object "" length 0
-FAIL compressing 13 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 65, got object "" length 0
-FAIL compressing 14 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 70, got object "" length 0
-FAIL compressing 15 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 75, got object "" length 0
-FAIL compressing 16 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 80, got object "" length 0
+PASS compressing 2 chunks with brotli should work
+PASS compressing 3 chunks with brotli should work
+PASS compressing 4 chunks with brotli should work
+PASS compressing 5 chunks with brotli should work
+PASS compressing 6 chunks with brotli should work
+PASS compressing 7 chunks with brotli should work
+PASS compressing 8 chunks with brotli should work
+PASS compressing 9 chunks with brotli should work
+PASS compressing 10 chunks with brotli should work
+PASS compressing 11 chunks with brotli should work
+PASS compressing 12 chunks with brotli should work
+PASS compressing 13 chunks with brotli should work
+PASS compressing 14 chunks with brotli should work
+PASS compressing 15 chunks with brotli should work
+PASS compressing 16 chunks with brotli should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-multiple-chunks.any.worker-expected.txt
@@ -44,19 +44,19 @@ PASS compressing 13 chunks with gzip should work
 PASS compressing 14 chunks with gzip should work
 PASS compressing 15 chunks with gzip should work
 PASS compressing 16 chunks with gzip should work
-FAIL compressing 2 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111" length 10, got object "" length 0
-FAIL compressing 3 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 15, got object "" length 0
-FAIL compressing 4 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 20, got object "" length 0
-FAIL compressing 5 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 25, got object "" length 0
-FAIL compressing 6 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 30, got object "" length 0
-FAIL compressing 7 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 35, got object "" length 0
-FAIL compressing 8 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 40, got object "" length 0
-FAIL compressing 9 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 45, got object "" length 0
-FAIL compressing 10 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 50, got object "" length 0
-FAIL compressing 11 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 55, got object "" length 0
-FAIL compressing 12 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 60, got object "" length 0
-FAIL compressing 13 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 65, got object "" length 0
-FAIL compressing 14 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 70, got object "" length 0
-FAIL compressing 15 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 75, got object "" length 0
-FAIL compressing 16 chunks with brotli should work assert_array_equals: value should match lengths differ, expected array object "72,101,108,108,111,72,101,108,108,111,72,101,108,108,111,72,101,108,108,111" length 80, got object "" length 0
+PASS compressing 2 chunks with brotli should work
+PASS compressing 3 chunks with brotli should work
+PASS compressing 4 chunks with brotli should work
+PASS compressing 5 chunks with brotli should work
+PASS compressing 6 chunks with brotli should work
+PASS compressing 7 chunks with brotli should work
+PASS compressing 8 chunks with brotli should work
+PASS compressing 9 chunks with brotli should work
+PASS compressing 10 chunks with brotli should work
+PASS compressing 11 chunks with brotli should work
+PASS compressing 12 chunks with brotli should work
+PASS compressing 13 chunks with brotli should work
+PASS compressing 14 chunks with brotli should work
+PASS compressing 15 chunks with brotli should work
+PASS compressing 16 chunks with brotli should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any-expected.txt
@@ -10,6 +10,6 @@ PASS gzip empty data should be reinflated back to its origin
 PASS gzip small amount data should be reinflated back to its origin
 PASS gzip large amount data should be reinflated back to its origin
 PASS brotli empty data should be reinflated back to its origin
-FAIL brotli small amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "45,62,32,48,48,58,48,48,58,48,53,46,48,48,48,10,70,111,111,10" length 42, got object "" length 0
-FAIL brotli large amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "130,6,132,183,1,0,0,0,0,0,0,8,247,129,2,241,131,1,4,176" length 76501, got object "" length 0
+PASS brotli small amount data should be reinflated back to its origin
+PASS brotli large amount data should be reinflated back to its origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.serviceworker-expected.txt
@@ -10,6 +10,6 @@ PASS gzip empty data should be reinflated back to its origin
 PASS gzip small amount data should be reinflated back to its origin
 PASS gzip large amount data should be reinflated back to its origin
 PASS brotli empty data should be reinflated back to its origin
-FAIL brotli small amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "45,62,32,48,48,58,48,48,58,48,53,46,48,48,48,10,70,111,111,10" length 42, got object "" length 0
-FAIL brotli large amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "130,6,132,183,1,0,0,0,0,0,0,8,247,129,2,241,131,1,4,176" length 76501, got object "" length 0
+PASS brotli small amount data should be reinflated back to its origin
+PASS brotli large amount data should be reinflated back to its origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.sharedworker-expected.txt
@@ -10,6 +10,6 @@ PASS gzip empty data should be reinflated back to its origin
 PASS gzip small amount data should be reinflated back to its origin
 PASS gzip large amount data should be reinflated back to its origin
 PASS brotli empty data should be reinflated back to its origin
-FAIL brotli small amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "45,62,32,48,48,58,48,48,58,48,53,46,48,48,48,10,70,111,111,10" length 42, got object "" length 0
-FAIL brotli large amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "130,6,132,183,1,0,0,0,0,0,0,8,247,129,2,241,131,1,4,176" length 76501, got object "" length 0
+PASS brotli small amount data should be reinflated back to its origin
+PASS brotli large amount data should be reinflated back to its origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-stream.any.worker-expected.txt
@@ -10,6 +10,6 @@ PASS gzip empty data should be reinflated back to its origin
 PASS gzip small amount data should be reinflated back to its origin
 PASS gzip large amount data should be reinflated back to its origin
 PASS brotli empty data should be reinflated back to its origin
-FAIL brotli small amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "45,62,32,48,48,58,48,48,58,48,53,46,48,48,48,10,70,111,111,10" length 42, got object "" length 0
-FAIL brotli large amount data should be reinflated back to its origin assert_array_equals: value should match lengths differ, expected array object "130,6,132,183,1,0,0,0,0,0,0,8,247,129,2,241,131,1,4,176" length 76501, got object "" length 0
+PASS brotli small amount data should be reinflated back to its origin
+PASS brotli large amount data should be reinflated back to its origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
@@ -1,30 +1,32 @@
 
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
 FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
-FAIL Async-iterating a push source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Async-iterating a pull source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
+PASS Async-iterating a push source
+PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
 FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source manually assert_equals: value expected (number) 1 but got (undefined) undefined
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "Error: assert_unreached: Reached unreachable code"
+PASS Async-iterating a pull source manually
+FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
-FAIL Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function assert_unreached: Reached unreachable code
-FAIL Async-iterating a partially consumed stream assert_array_equals: lengths differ, expected array [2, 3] length 2, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
+PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
+PASS Async-iterating a partially consumed stream
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
+FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
 FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL next() rejects if the stream errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; next() that reports an error; next() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); return() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() assert_equals: next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
@@ -32,12 +34,12 @@ FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection wi
 FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
 FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL values() throws if there's already a lock assert_throws_js: values() should throw function "() => s.values()" did not throw
-FAIL Acquiring a reader after exhaustively async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Acquiring a reader after return()ing from a stream that errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL Acquiring a reader after partially async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
+PASS values() throws if there's already a lock
+PASS Acquiring a reader after exhaustively async-iterating a stream
+FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
 FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL close() while next() is pending assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
@@ -1,30 +1,32 @@
 
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
 FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
-FAIL Async-iterating a push source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Async-iterating a pull source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
+PASS Async-iterating a push source
+PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
 FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source manually assert_equals: value expected (number) 1 but got (undefined) undefined
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "Error: assert_unreached: Reached unreachable code"
+PASS Async-iterating a pull source manually
+FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
-FAIL Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function assert_unreached: Reached unreachable code
-FAIL Async-iterating a partially consumed stream assert_array_equals: lengths differ, expected array [2, 3] length 2, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
+PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
+PASS Async-iterating a partially consumed stream
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
+FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
 FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL next() rejects if the stream errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; next() that reports an error; next() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); return() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() assert_equals: next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
@@ -32,12 +34,12 @@ FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection wi
 FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
 FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL values() throws if there's already a lock assert_throws_js: values() should throw function "() => s.values()" did not throw
-FAIL Acquiring a reader after exhaustively async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Acquiring a reader after return()ing from a stream that errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL Acquiring a reader after partially async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
+PASS values() throws if there's already a lock
+PASS Acquiring a reader after exhaustively async-iterating a stream
+FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
 FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL close() while next() is pending assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
@@ -1,30 +1,32 @@
 
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
 FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
-FAIL Async-iterating a push source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Async-iterating a pull source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
+PASS Async-iterating a push source
+PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
 FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source manually assert_equals: value expected (number) 1 but got (undefined) undefined
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "Error: assert_unreached: Reached unreachable code"
+PASS Async-iterating a pull source manually
+FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
-FAIL Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function assert_unreached: Reached unreachable code
-FAIL Async-iterating a partially consumed stream assert_array_equals: lengths differ, expected array [2, 3] length 2, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
+PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
+PASS Async-iterating a partially consumed stream
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
+FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
 FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL next() rejects if the stream errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; next() that reports an error; next() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); return() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() assert_equals: next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
@@ -32,12 +34,12 @@ FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection wi
 FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
 FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL values() throws if there's already a lock assert_throws_js: values() should throw function "() => s.values()" did not throw
-FAIL Acquiring a reader after exhaustively async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Acquiring a reader after return()ing from a stream that errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL Acquiring a reader after partially async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
+PASS values() throws if there's already a lock
+PASS Acquiring a reader after exhaustively async-iterating a stream
+FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
 FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL close() while next() is pending assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
@@ -1,30 +1,32 @@
 
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
 FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
-FAIL Async-iterating a push source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Async-iterating a pull source assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
+PASS Async-iterating a push source
+PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
 FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source manually assert_equals: value expected (number) 1 but got (undefined) undefined
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "Error: assert_unreached: Reached unreachable code"
+PASS Async-iterating a pull source manually
+FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
-FAIL Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function assert_unreached: Reached unreachable code
-FAIL Async-iterating a partially consumed stream assert_array_equals: lengths differ, expected array [2, 3] length 2, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got [] length 0
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got [] length 0
+PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
+PASS Async-iterating a partially consumed stream
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
+FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
 FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL next() rejects if the stream errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; next() that reports an error; next() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL next() that succeeds; next() that reports an error(); return() assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() assert_equals: next() value expected (number) 0 but got (undefined) undefined
+FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
@@ -32,12 +34,12 @@ FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection wi
 FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
 FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
 FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL values() throws if there's already a lock assert_throws_js: values() should throw function "() => s.values()" did not throw
-FAIL Acquiring a reader after exhaustively async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2, 3] length 3, got [] length 0
-FAIL Acquiring a reader after return()ing from a stream that errors assert_equals: 1st next() value expected (number) 0 but got (undefined) undefined
-FAIL Acquiring a reader after partially async-iterating a stream assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_array_equals: lengths differ, expected array [1, 2] length 2, got [] length 0
+PASS values() throws if there's already a lock
+PASS Acquiring a reader after exhaustively async-iterating a stream
+FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
 FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL close() while next() is pending assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-TIMEOUT ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods Test timed out
+FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.serviceworker-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-TIMEOUT ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods Test timed out
+FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.sharedworker-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-TIMEOUT ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods Test timed out
+FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.worker-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-TIMEOUT ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods Test timed out
+FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -151,20 +151,22 @@ public:
 
     JSDOMGlobalObject* globalObject();
 
-    class Iterator : public RefCountedAndCanMakeWeakPtr<Iterator> {
+    class Iterator : public RefCounted<Iterator> {
     public:
-        static Ref<Iterator> create() { return adoptRef(*new Iterator()); }
-        ~Iterator() = default;
+        static Ref<Iterator> create(Ref<ReadableStreamDefaultReader>&&, bool preventCancel);
+        ~Iterator();
 
         using Result = std::optional<JSC::JSValue>;
         using Callback = CompletionHandler<void(ExceptionOr<Result>&&)>;
         void next(Callback&&);
 
     private:
-        Iterator() = default;
+        Iterator(Ref<ReadableStreamDefaultReader>&&, bool preventCancel);
+
+        const Ref<ReadableStreamDefaultReader> m_reader;
     };
 
-    Ref<Iterator> createIterator(ScriptExecutionContext*) { return Iterator::create(); }
+    ExceptionOr<Ref<Iterator>> createIterator(ScriptExecutionContext*, IteratorOptions&&);
 
 protected:
     static ExceptionOr<Ref<ReadableStream>> createFromJSValues(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -39,6 +39,10 @@ dictionary ReadableWritablePair {
     required WritableStream writable;
 };
 
+dictionary ReadableStreamIteratorOptions {
+    boolean preventCancel = false;
+};
+
 typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStreamReader;
 
 [

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -75,6 +75,8 @@ public:
     bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
+    ReadableStream* stream() { return m_stream.get(); }
+
 private:
     ReadableStreamDefaultReader(Ref<ReadableStream>&&, RefPtr<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
 

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -86,6 +86,7 @@ public:
     using Traits = IteratorTraits;
 
     using DOMWrapped = typename Wrapper::DOMWrapped;
+    using InternalIterator = Ref<typename DOMWrapped::Iterator>;
     using Prototype = JSDOMAsyncIteratorPrototype<Wrapper, Traits>;
 
     DECLARE_INFO;
@@ -104,9 +105,9 @@ public:
     JSC::JSPromise* getNextIterationResult(JSC::JSGlobalObject&);
 
 protected:
-    JSDOMAsyncIteratorBase(JSC::Structure* structure, JSWrapper& iteratedObject, IterationKind kind)
+    JSDOMAsyncIteratorBase(JSC::Structure* structure, JSWrapper& iteratedObject, IterationKind kind, InternalIterator&& iterator)
         : Base(structure, *iteratedObject.globalObject())
-        , m_iterator(iteratedObject.wrapped().createIterator(iteratedObject.globalObject()->protectedScriptExecutionContext().get()))
+        , m_iterator(WTFMove(iterator))
         , m_kind(kind)
     {
     }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
@@ -53,8 +53,6 @@ using namespace JSC;
 
 // Functions
 
-static JSC_DECLARE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_entries);
-static JSC_DECLARE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_keys);
 static JSC_DECLARE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_values);
 
 // Attributes
@@ -114,10 +112,8 @@ template<> void JSTestAsyncIterableWithoutFlagsDOMConstructor::initializePropert
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 4> JSTestAsyncIterableWithoutFlagsPrototypeTableValues {
+static const std::array<HashTableValue, 2> JSTestAsyncIterableWithoutFlagsPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestAsyncIterableWithoutFlagsConstructor, 0 } },
-    HashTableValue { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestAsyncIterableWithoutFlagsPrototypeFunction_entries, 0 } },
-    HashTableValue { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestAsyncIterableWithoutFlagsPrototypeFunction_keys, 0 } },
     HashTableValue { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestAsyncIterableWithoutFlagsPrototypeFunction_values, 0 } },
 };
 
@@ -202,9 +198,9 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    static TestAsyncIterableWithoutFlagsIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestAsyncIterableWithoutFlags& iteratedObject, IterationKind kind)
+    static TestAsyncIterableWithoutFlagsIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestAsyncIterableWithoutFlags& iteratedObject, IterationKind kind, InternalIterator&& iterator)
     {
-        auto* instance = new (NotNull, JSC::allocateCell<TestAsyncIterableWithoutFlagsIterator>(vm)) TestAsyncIterableWithoutFlagsIterator(structure, iteratedObject, kind);
+        auto* instance = new (NotNull, JSC::allocateCell<TestAsyncIterableWithoutFlagsIterator>(vm)) TestAsyncIterableWithoutFlagsIterator(structure, iteratedObject, kind, WTFMove(iterator));
         instance->finishCreation(vm);
         return instance;
     }
@@ -213,8 +209,8 @@ public:
     JSC::JSBoundFunction* createOnFulfilledFunction(JSC::JSGlobalObject*);
     JSC::JSBoundFunction* createOnRejectedFunction(JSC::JSGlobalObject*);
 private:
-    TestAsyncIterableWithoutFlagsIterator(JSC::Structure* structure, JSTestAsyncIterableWithoutFlags& iteratedObject, IterationKind kind)
-        : Base(structure, iteratedObject, kind)
+    TestAsyncIterableWithoutFlagsIterator(JSC::Structure* structure, JSTestAsyncIterableWithoutFlags& iteratedObject, IterationKind kind, InternalIterator&& iterator)
+        : Base(structure, iteratedObject, kind, WTFMove(iterator))
     {
     }
 };
@@ -229,29 +225,12 @@ const JSC::ClassInfo TestAsyncIterableWithoutFlagsIterator::s_info = { "TestAsyn
 template<>
 const JSC::ClassInfo TestAsyncIterableWithoutFlagsIteratorPrototype::s_info = { "TestAsyncIterableWithoutFlags Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestAsyncIterableWithoutFlagsIteratorPrototype) };
 
-static inline EncodedJSValue jsTestAsyncIterableWithoutFlagsPrototypeFunction_entriesCaller(JSGlobalObject*, CallFrame*, JSTestAsyncIterableWithoutFlags* thisObject)
+static inline EncodedJSValue jsTestAsyncIterableWithoutFlagsPrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncIterableWithoutFlags* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestAsyncIterableWithoutFlagsIterator>(*thisObject, IterationKind::Values));
-}
-
-JSC_DEFINE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_entries, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
-{
-    return IDLOperation<JSTestAsyncIterableWithoutFlags>::call<jsTestAsyncIterableWithoutFlagsPrototypeFunction_entriesCaller>(*lexicalGlobalObject, *callFrame, "entries");
-}
-
-static inline EncodedJSValue jsTestAsyncIterableWithoutFlagsPrototypeFunction_keysCaller(JSGlobalObject*, CallFrame*, JSTestAsyncIterableWithoutFlags* thisObject)
-{
-    return JSValue::encode(iteratorCreate<TestAsyncIterableWithoutFlagsIterator>(*thisObject, IterationKind::Keys));
-}
-
-JSC_DEFINE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_keys, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
-{
-    return IDLOperation<JSTestAsyncIterableWithoutFlags>::call<jsTestAsyncIterableWithoutFlagsPrototypeFunction_keysCaller>(*lexicalGlobalObject, *callFrame, "keys");
-}
-
-static inline EncodedJSValue jsTestAsyncIterableWithoutFlagsPrototypeFunction_valuesCaller(JSGlobalObject*, CallFrame*, JSTestAsyncIterableWithoutFlags* thisObject)
-{
-    return JSValue::encode(iteratorCreate<TestAsyncIterableWithoutFlagsIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncIterableWithoutFlagsIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestAsyncIterableWithoutFlagsPrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -203,9 +203,9 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    static TestAsyncKeyValueIterableIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestAsyncKeyValueIterable& iteratedObject, IterationKind kind)
+    static TestAsyncKeyValueIterableIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestAsyncKeyValueIterable& iteratedObject, IterationKind kind, InternalIterator&& iterator)
     {
-        auto* instance = new (NotNull, JSC::allocateCell<TestAsyncKeyValueIterableIterator>(vm)) TestAsyncKeyValueIterableIterator(structure, iteratedObject, kind);
+        auto* instance = new (NotNull, JSC::allocateCell<TestAsyncKeyValueIterableIterator>(vm)) TestAsyncKeyValueIterableIterator(structure, iteratedObject, kind, WTFMove(iterator));
         instance->finishCreation(vm);
         return instance;
     }
@@ -214,8 +214,8 @@ public:
     JSC::JSBoundFunction* createOnFulfilledFunction(JSC::JSGlobalObject*);
     JSC::JSBoundFunction* createOnRejectedFunction(JSC::JSGlobalObject*);
 private:
-    TestAsyncKeyValueIterableIterator(JSC::Structure* structure, JSTestAsyncKeyValueIterable& iteratedObject, IterationKind kind)
-        : Base(structure, iteratedObject, kind)
+    TestAsyncKeyValueIterableIterator(JSC::Structure* structure, JSTestAsyncKeyValueIterable& iteratedObject, IterationKind kind, InternalIterator&& iterator)
+        : Base(structure, iteratedObject, kind, WTFMove(iterator))
     {
     }
 };
@@ -230,9 +230,12 @@ const JSC::ClassInfo TestAsyncKeyValueIterableIterator::s_info = { "TestAsyncKey
 template<>
 const JSC::ClassInfo TestAsyncKeyValueIterableIteratorPrototype::s_info = { "TestAsyncKeyValueIterable Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestAsyncKeyValueIterableIteratorPrototype) };
 
-static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_entriesCaller(JSGlobalObject*, CallFrame*, JSTestAsyncKeyValueIterable* thisObject)
+static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, IterationKind::Entries));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Entries)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_entries, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -240,9 +243,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_entries, (
     return IDLOperation<JSTestAsyncKeyValueIterable>::call<jsTestAsyncKeyValueIterablePrototypeFunction_entriesCaller>(*lexicalGlobalObject, *callFrame, "entries");
 }
 
-static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_keysCaller(JSGlobalObject*, CallFrame*, JSTestAsyncKeyValueIterable* thisObject)
+static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, IterationKind::Keys));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_keys, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -250,9 +256,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_keys, (JSC
     return IDLOperation<JSTestAsyncKeyValueIterable>::call<jsTestAsyncKeyValueIterablePrototypeFunction_keysCaller>(*lexicalGlobalObject, *callFrame, "keys");
 }
 
-static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_valuesCaller(JSGlobalObject*, CallFrame*, JSTestAsyncKeyValueIterable* thisObject)
+static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -1131,15 +1131,15 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    static TestInterfaceIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestInterface& iteratedObject, IterationKind kind)
+    static TestInterfaceIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestInterface& iteratedObject, IterationKind kind, InternalIterator&& iterator)
     {
-        auto* instance = new (NotNull, JSC::allocateCell<TestInterfaceIterator>(vm)) TestInterfaceIterator(structure, iteratedObject, kind);
+        auto* instance = new (NotNull, JSC::allocateCell<TestInterfaceIterator>(vm)) TestInterfaceIterator(structure, iteratedObject, kind, WTFMove(iterator));
         instance->finishCreation(vm);
         return instance;
     }
 private:
-    TestInterfaceIterator(JSC::Structure* structure, JSTestInterface& iteratedObject, IterationKind kind)
-        : Base(structure, iteratedObject, kind)
+    TestInterfaceIterator(JSC::Structure* structure, JSTestInterface& iteratedObject, IterationKind kind, InternalIterator&& iterator)
+        : Base(structure, iteratedObject, kind, WTFMove(iterator))
     {
     }
 };
@@ -1154,9 +1154,12 @@ const JSC::ClassInfo TestInterfaceIterator::s_info = { "TestInterface Iterator"_
 template<>
 const JSC::ClassInfo TestInterfaceIteratorPrototype::s_info = { "TestInterface Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestInterfaceIteratorPrototype) };
 
-static inline EncodedJSValue jsTestInterfacePrototypeFunction_entriesCaller(JSGlobalObject*, CallFrame*, JSTestInterface* thisObject)
+static inline EncodedJSValue jsTestInterfacePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, IterationKind::Entries));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Entries)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_entries, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -1164,9 +1167,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_entries, (JSC::JSGloba
     return IDLOperation<JSTestInterface>::call<jsTestInterfacePrototypeFunction_entriesCaller>(*lexicalGlobalObject, *callFrame, "entries");
 }
 
-static inline EncodedJSValue jsTestInterfacePrototypeFunction_keysCaller(JSGlobalObject*, CallFrame*, JSTestInterface* thisObject)
+static inline EncodedJSValue jsTestInterfacePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, IterationKind::Keys));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_keys, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -1174,9 +1180,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_keys, (JSC::JSGlobalOb
     return IDLOperation<JSTestInterface>::call<jsTestInterfacePrototypeFunction_keysCaller>(*lexicalGlobalObject, *callFrame, "keys");
 }
 
-static inline EncodedJSValue jsTestInterfacePrototypeFunction_valuesCaller(JSGlobalObject*, CallFrame*, JSTestInterface* thisObject)
+static inline EncodedJSValue jsTestInterfacePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -204,15 +204,15 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    static TestIterableIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestIterable& iteratedObject, IterationKind kind)
+    static TestIterableIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestIterable& iteratedObject, IterationKind kind, InternalIterator&& iterator)
     {
-        auto* instance = new (NotNull, JSC::allocateCell<TestIterableIterator>(vm)) TestIterableIterator(structure, iteratedObject, kind);
+        auto* instance = new (NotNull, JSC::allocateCell<TestIterableIterator>(vm)) TestIterableIterator(structure, iteratedObject, kind, WTFMove(iterator));
         instance->finishCreation(vm);
         return instance;
     }
 private:
-    TestIterableIterator(JSC::Structure* structure, JSTestIterable& iteratedObject, IterationKind kind)
-        : Base(structure, iteratedObject, kind)
+    TestIterableIterator(JSC::Structure* structure, JSTestIterable& iteratedObject, IterationKind kind, InternalIterator&& iterator)
+        : Base(structure, iteratedObject, kind, WTFMove(iterator))
     {
     }
 };
@@ -227,9 +227,12 @@ const JSC::ClassInfo TestIterableIterator::s_info = { "TestIterable Iterator"_s,
 template<>
 const JSC::ClassInfo TestIterableIteratorPrototype::s_info = { "TestIterable Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestIterableIteratorPrototype) };
 
-static inline EncodedJSValue jsTestIterablePrototypeFunction_entriesCaller(JSGlobalObject*, CallFrame*, JSTestIterable* thisObject)
+static inline EncodedJSValue jsTestIterablePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_entries, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -237,9 +240,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_entries, (JSC::JSGlobal
     return IDLOperation<JSTestIterable>::call<jsTestIterablePrototypeFunction_entriesCaller>(*lexicalGlobalObject, *callFrame, "entries");
 }
 
-static inline EncodedJSValue jsTestIterablePrototypeFunction_keysCaller(JSGlobalObject*, CallFrame*, JSTestIterable* thisObject)
+static inline EncodedJSValue jsTestIterablePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, IterationKind::Keys));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_keys, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -247,9 +253,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_keys, (JSC::JSGlobalObj
     return IDLOperation<JSTestIterable>::call<jsTestIterablePrototypeFunction_keysCaller>(*lexicalGlobalObject, *callFrame, "keys");
 }
 
-static inline EncodedJSValue jsTestIterablePrototypeFunction_valuesCaller(JSGlobalObject*, CallFrame*, JSTestIterable* thisObject)
+static inline EncodedJSValue jsTestIterablePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -417,15 +417,15 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    static TestNodeIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestNode& iteratedObject, IterationKind kind)
+    static TestNodeIterator* create(JSC::VM& vm, JSC::Structure* structure, JSTestNode& iteratedObject, IterationKind kind, InternalIterator&& iterator)
     {
-        auto* instance = new (NotNull, JSC::allocateCell<TestNodeIterator>(vm)) TestNodeIterator(structure, iteratedObject, kind);
+        auto* instance = new (NotNull, JSC::allocateCell<TestNodeIterator>(vm)) TestNodeIterator(structure, iteratedObject, kind, WTFMove(iterator));
         instance->finishCreation(vm);
         return instance;
     }
 private:
-    TestNodeIterator(JSC::Structure* structure, JSTestNode& iteratedObject, IterationKind kind)
-        : Base(structure, iteratedObject, kind)
+    TestNodeIterator(JSC::Structure* structure, JSTestNode& iteratedObject, IterationKind kind, InternalIterator&& iterator)
+        : Base(structure, iteratedObject, kind, WTFMove(iterator))
     {
     }
 };
@@ -440,9 +440,12 @@ const JSC::ClassInfo TestNodeIterator::s_info = { "TestNode Iterator"_s, &Base::
 template<>
 const JSC::ClassInfo TestNodeIteratorPrototype::s_info = { "TestNode Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TestNodeIteratorPrototype) };
 
-static inline EncodedJSValue jsTestNodePrototypeFunction_entriesCaller(JSGlobalObject*, CallFrame*, JSTestNode* thisObject)
+static inline EncodedJSValue jsTestNodePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_entries, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -450,9 +453,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_entries, (JSC::JSGlobalObje
     return IDLOperation<JSTestNode>::call<jsTestNodePrototypeFunction_entriesCaller>(*lexicalGlobalObject, *callFrame, "entries");
 }
 
-static inline EncodedJSValue jsTestNodePrototypeFunction_keysCaller(JSGlobalObject*, CallFrame*, JSTestNode* thisObject)
+static inline EncodedJSValue jsTestNodePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, IterationKind::Keys));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_keys, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -460,9 +466,12 @@ JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_keys, (JSC::JSGlobalObject*
     return IDLOperation<JSTestNode>::call<jsTestNodePrototypeFunction_keysCaller>(*lexicalGlobalObject, *callFrame, "keys");
 }
 
-static inline EncodedJSValue jsTestNodePrototypeFunction_valuesCaller(JSGlobalObject*, CallFrame*, JSTestNode* thisObject)
+static inline EncodedJSValue jsTestNodePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    return JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, IterationKind::Values));
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncIterable {
-    async iterable<TestNode>;
+    async iterable<TestNode>(TestNode option);
 };
 


### PR DESCRIPTION
#### eb724e8b508bfd8d17bd76d33ce5d3992b292274
<pre>
Add a basic implementation of ReadableStream async iterable
<a href="https://rdar.apple.com/165605714">rdar://165605714</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303302">https://bugs.webkit.org/show_bug.cgi?id=303302</a>

Reviewed by Chris Dumez.

We add a basic ReadableStream Iterator implementation.
As per <a href="https://streams.spec.whatwg.org/#rs-asynciterator">https://streams.spec.whatwg.org/#rs-asynciterator</a>, we implement the init steps and the get next iteration result steps.
A follow-up will implement the return steps.

This is implemented in ReadableStream::Iterator class which takes a reader from its stream.
Given it might throw, we add support for throwing in iteratorCreate.

To do so, we create the internal iterator and pass it to JSDOMIteratorBase or JSDOMAsyncIteratorBase.
We add support for passing parameters to the iterator creation steps and make use of it for passing ReadableStreamIteratorOptions.

We do not yet support converting iterator creation parameters, the binding generator only creates default values (in this case preventCancel = false). This will be fixed in a follow-up.

We also update the binding generator to not expose the entries and keys methods for async iterables that are not key value.
We do not do so for sync iterator since that would break FontFaceSet (which should be moved to setlike).

We update the binding generator according the new iteratorCreate function.

Covered by rebased WPT tests and rebased binding tests.

Canonical link: <a href="https://commits.webkit.org/303734@main">https://commits.webkit.org/303734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606e1c3532df6e9e00b39d3f443b2403078b8d92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141041 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/82909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143688 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/5656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/110670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20638 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69163 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->