### PR TITLE
Add a basic implementation of ReadableStream async iterable return method

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
+PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
@@ -11,35 +9,35 @@ FAIL Async-iterating an errored stream throws assert_equals: expected (string) "
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when throwing inside loop body; preventCancel = true
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when breaking inside loop body; preventCancel = true
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when returning inside loop body; preventCancel = true
-FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
+PASS Cancellation behavior when throwing inside loop body; preventCancel = false
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = false
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = false
+FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when manually calling return(); preventCancel = false
+FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
+FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
+FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
+FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() assert_equals: return() done expected true but got false
+FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
+FAIL return(); return() assert_equals: 1st return() done expected true but got false
+FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
+PASS Acquiring a reader after partially async-iterating a stream
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS return() should unlock the stream synchronously when preventCancel = false
+PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
+PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
@@ -11,35 +9,35 @@ FAIL Async-iterating an errored stream throws assert_equals: expected (string) "
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when throwing inside loop body; preventCancel = true
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when breaking inside loop body; preventCancel = true
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when returning inside loop body; preventCancel = true
-FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
+PASS Cancellation behavior when throwing inside loop body; preventCancel = false
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = false
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = false
+FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when manually calling return(); preventCancel = false
+FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
+FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
+FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
+FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() assert_equals: return() done expected true but got false
+FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
+FAIL return(); return() assert_equals: 1st return() done expected true but got false
+FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
+PASS Acquiring a reader after partially async-iterating a stream
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS return() should unlock the stream synchronously when preventCancel = false
+PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
+PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
@@ -11,35 +9,35 @@ FAIL Async-iterating an errored stream throws assert_equals: expected (string) "
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when throwing inside loop body; preventCancel = true
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when breaking inside loop body; preventCancel = true
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when returning inside loop body; preventCancel = true
-FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
+PASS Cancellation behavior when throwing inside loop body; preventCancel = false
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = false
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = false
+FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when manually calling return(); preventCancel = false
+FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
+FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
+FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
+FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() assert_equals: return() done expected true but got false
+FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
+FAIL return(); return() assert_equals: 1st return() done expected true but got false
+FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
+PASS Acquiring a reader after partially async-iterating a stream
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS return() should unlock the stream synchronously when preventCancel = false
+PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-FAIL Async iterator instances should have the correct list of properties assert_array_equals: should have all the correct methods lengths differ, expected array ["next", "return"] length 2, got ["next"] length 1
+PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
 FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
@@ -11,35 +9,35 @@ FAIL Async-iterating an errored stream throws assert_equals: expected (string) "
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when throwing inside loop body; preventCancel = true
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when breaking inside loop body; preventCancel = true
-FAIL Cancellation behavior when returning inside loop body; preventCancel = false assert_array_equals: cancel() should be called lengths differ, expected array ["pull", "cancel", undefined] length 3, got ["pull"] length 1
-PASS Cancellation behavior when returning inside loop body; preventCancel = true
-FAIL Cancellation behavior when manually calling return(); preventCancel = false promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
-FAIL Cancellation behavior when manually calling return(); preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return()', 'it.return' is undefined)"
+PASS Cancellation behavior when throwing inside loop body; preventCancel = false
+FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = false
+FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = false
+FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when manually calling return(); preventCancel = false
+FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return() rejects if the stream has errored promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
+FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL next() that succeeds; return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); next() with delayed cancel() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value')', 'it.return' is undefined)"
-FAIL return(); return() promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
-FAIL return(); return() [no awaiting] promise_test: Unhandled rejection with value: object "TypeError: it.return is not a function. (In 'it.return('return value 1')', 'it.return' is undefined)"
+FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
+FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() assert_equals: return() done expected true but got false
+FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
+FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
+FAIL return(); return() assert_equals: 1st return() done expected true but got false
+FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL Acquiring a reader after partially async-iterating a stream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
-FAIL return() should unlock the stream synchronously when preventCancel = false rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
-FAIL return() should unlock the stream synchronously when preventCancel = true rs.values({ preventCancel }).return is not a function. (In 'rs.values({ preventCancel }).return()', 'rs.values({ preventCancel }).return' is undefined)
+PASS Acquiring a reader after partially async-iterating a stream
+FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS return() should unlock the stream synchronously when preventCancel = false
+PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any-expected.txt
@@ -1,7 +1,7 @@
 
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+PASS ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.serviceworker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+PASS ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.sharedworker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+PASS ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS ReadableStream tee() should not touch Object.prototype properties
 PASS ReadableStream tee() should not call the global ReadableStream
-FAIL ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods promise_test: Unhandled rejection with value: object "TypeError: ReadableStream is locked"
+PASS ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods
 PASS tee() should not call Promise.prototype.then()
 PASS pipeTo() should not call Promise.prototype.then()
 

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -160,10 +160,13 @@ public:
         using Callback = CompletionHandler<void(ExceptionOr<Result>&&)>;
         void next(Callback&&);
 
+        Ref<DOMPromise> returnSteps(JSDOMGlobalObject&, JSC::JSValue);
+
     private:
         Iterator(Ref<ReadableStreamDefaultReader>&&, bool preventCancel);
 
         const Ref<ReadableStreamDefaultReader> m_reader;
+        bool m_preventCancel { false };
     };
 
     ExceptionOr<Ref<Iterator>> createIterator(ScriptExecutionContext*, IteratorOptions&&);


### PR DESCRIPTION
#### 7761dec3dc4d8d6d9450e92079deeb981bafbfe7
<pre>
Add a basic implementation of ReadableStream async iterable return method
<a href="https://rdar.apple.com/165606483">rdar://165606483</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303303">https://bugs.webkit.org/show_bug.cgi?id=303303</a>

Reviewed by Chris Dumez.

As per <a href="https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object">https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object</a>, we add support for the return method,
which allows to do error handling when iterating.

We add a concept to detect whether a native iterator implements returnSteps. If so, we expose the return method.
The returnSteps method returns a Ref&lt;DOMPromise&gt;.

We update JSDOMAsyncIterator to implement <a href="https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object.">https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object.</a>
We reuse the settle method to handle both runNextSteps and runReturnSteps.
To disambiguate between the two, the settle method will be called with a parameter for runReturnSteps and without for runNextSteps.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/303823@main">https://commits.webkit.org/303823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3dfe10ecc47569da1aacdd1525da9ef1d6f1d99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141288 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df04e64d-60e5-4b50-acfc-c61540a15843) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6088 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/810d6329-2fee-42f2-87ca-891bc2f3baea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136662 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/83082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41aae729-37ed-4de3-b96f-502f734ac579) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5894 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/5035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/110851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20667 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5947 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69411 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->