### PR TITLE
Add support for ReadableStream async iterable prevent cancel

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
@@ -2,41 +2,41 @@
 PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
-FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
+PASS Async-iterating a push source with undefined values
+PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
 FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
 PASS Cancellation behavior when throwing inside loop body; preventCancel = false
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
 PASS Cancellation behavior when breaking inside loop body; preventCancel = false
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
 PASS Cancellation behavior when returning inside loop body; preventCancel = false
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
-FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
+PASS Cancellation behavior when manually calling return(); preventCancel = true
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
-FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() assert_equals: return() done expected true but got false
-FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
-FAIL return(); return() assert_equals: 1st return() done expected true but got false
-FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
+PASS next() that succeeds; return()
+PASS next() that succeeds; return() [no awaiting]
+PASS return(); next()
+PASS return(); next() [no awaiting]
+PASS return(); next() with delayed cancel()
+PASS return(); next() with delayed cancel() [no awaiting]
+PASS return(); return()
+PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 PASS Acquiring a reader after partially async-iterating a stream
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false
 PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
@@ -2,41 +2,41 @@
 PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
-FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
+PASS Async-iterating a push source with undefined values
+PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
 FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
 PASS Cancellation behavior when throwing inside loop body; preventCancel = false
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
 PASS Cancellation behavior when breaking inside loop body; preventCancel = false
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
 PASS Cancellation behavior when returning inside loop body; preventCancel = false
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
-FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
+PASS Cancellation behavior when manually calling return(); preventCancel = true
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
-FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() assert_equals: return() done expected true but got false
-FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
-FAIL return(); return() assert_equals: 1st return() done expected true but got false
-FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
+PASS next() that succeeds; return()
+PASS next() that succeeds; return() [no awaiting]
+PASS return(); next()
+PASS return(); next() [no awaiting]
+PASS return(); next() with delayed cancel()
+PASS return(); next() with delayed cancel() [no awaiting]
+PASS return(); return()
+PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 PASS Acquiring a reader after partially async-iterating a stream
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false
 PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
@@ -2,41 +2,41 @@
 PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
-FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
+PASS Async-iterating a push source with undefined values
+PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
 FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
 PASS Cancellation behavior when throwing inside loop body; preventCancel = false
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
 PASS Cancellation behavior when breaking inside loop body; preventCancel = false
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
 PASS Cancellation behavior when returning inside loop body; preventCancel = false
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
-FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
+PASS Cancellation behavior when manually calling return(); preventCancel = true
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
-FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() assert_equals: return() done expected true but got false
-FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
-FAIL return(); return() assert_equals: 1st return() done expected true but got false
-FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
+PASS next() that succeeds; return()
+PASS next() that succeeds; return() [no awaiting]
+PASS return(); next()
+PASS return(); next() [no awaiting]
+PASS return(); next() with delayed cancel()
+PASS return(); next() with delayed cancel() [no awaiting]
+PASS return(); return()
+PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 PASS Acquiring a reader after partially async-iterating a stream
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false
 PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
@@ -2,41 +2,41 @@
 PASS Async iterator instances should have the correct list of properties
 PASS Async-iterating a push source
 PASS Async-iterating a pull source
-FAIL Async-iterating a push source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
-FAIL Async-iterating a pull source with undefined values assert_array_equals: lengths differ, expected array [undefined, undefined, undefined] length 3, got [] length 0
+PASS Async-iterating a push source with undefined values
+PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
 FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
 PASS Cancellation behavior when throwing inside loop body; preventCancel = false
-FAIL Cancellation behavior when throwing inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when throwing inside loop body; preventCancel = true
 PASS Cancellation behavior when breaking inside loop body; preventCancel = false
-FAIL Cancellation behavior when breaking inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when breaking inside loop body; preventCancel = true
 PASS Cancellation behavior when returning inside loop body; preventCancel = false
-FAIL Cancellation behavior when returning inside loop body; preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array ["pull"] length 1, got ["pull", "cancel", undefined] length 3
+PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
-FAIL Cancellation behavior when manually calling return(); preventCancel = true assert_array_equals: cancel() should not be called lengths differ, expected array [] length 0, got ["cancel", undefined] length 2
+PASS Cancellation behavior when manually calling return(); preventCancel = true
 FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL return() does not rejects if the stream has not errored yet assert_equals: done expected true but got false
+PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
 FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
 FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; return() assert_equals: return() done expected true but got false
-FAIL next() that succeeds; return() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() assert_equals: return() done expected true but got false
-FAIL return(); next() [no awaiting] assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() assert_equals: return() done expected true but got false
-FAIL return(); next() with delayed cancel() [no awaiting] assert_equals: return() should resolve with original reason done expected true but got false
-FAIL return(); return() assert_equals: 1st return() done expected true but got false
-FAIL return(); return() [no awaiting] assert_equals: 1st return() done expected true but got false
+PASS next() that succeeds; return()
+PASS next() that succeeds; return() [no awaiting]
+PASS return(); next()
+PASS return(); next() [no awaiting]
+PASS return(); next() with delayed cancel()
+PASS return(); next() with delayed cancel() [no awaiting]
+PASS return(); return()
+PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
 FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
 PASS Acquiring a reader after partially async-iterating a stream
-FAIL Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true assert_equals: value expected (number) 3 but got (undefined) undefined
+PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false
 PASS return() should unlock the stream synchronously when preventCancel = true
 PASS close() while next() is pending

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -128,7 +128,6 @@ bindings/js/JSCSSStyleDeclarationCustom.cpp
 bindings/js/JSCanvasRenderingContext2DCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSCustomElementRegistryCustom.cpp
-bindings/js/JSDOMAsyncIterator.h
 bindings/js/JSDOMBindingSecurity.cpp
 bindings/js/JSDOMBindingSecurity.h
 bindings/js/JSDOMBindingSecurityInlines.h

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -29,6 +29,7 @@
 #include "JSDOMBinding.h"
 #include "JSDOMConstructorNotConstructable.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertOptional.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMOperation.h"
@@ -230,7 +231,11 @@ static inline EncodedJSValue jsTestAsyncIterablePrototypeFunction_valuesCaller(J
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values, IDLInterface<TestNode>::ImplementationType { })));
+    EnsureStillAliveScope argument0 = callFrame->argument(0);
+    auto optionConversionResult = convert<IDLOptional<IDLInterface<TestNode>>>(*lexicalGlobalObject, argument0.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 0, "option"_s, "TestAsyncIterable"_s, "jsTestAsyncIterablePrototypeFunction_values"_s, "TestNode"_s); });
+    if (optionConversionResult.hasException(throwScope)) [[unlikely]]
+       return encodedJSValue();
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values, optionConversionResult.releaseReturnValue())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsTestAsyncIterablePrototypeFunction_values, (JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncIterable {
-    async iterable<TestNode>(TestNode option);
+    async iterable<TestNode>(optional TestNode option = { });
 };
 


### PR DESCRIPTION
#### 5ef993dbb7e08cc7bc08d1e63303404e139cd40a
<pre>
Add support for ReadableStream async iterable prevent cancel
<a href="https://rdar.apple.com/165607588">rdar://165607588</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303305">https://bugs.webkit.org/show_bug.cgi?id=303305</a>

Reviewed by Chris Dumez.

We add support for converting async iterable parameters in binding generator.
We rebase the binding tests accordingly.

We also update the async iterator handling of end of iteration.
Previously, we would use whether the promise resolves with undefined to detect the end of iteration.
This does not work with ReadableStreams since undefined is a valid value to queue/dequeue.

For that purpose, we do a preliminary step of introducing an IsFinished object that is handling whether the iterator is finished.
We use the IsFinished state to determine when creating the JS iterator tuple whether done is false or true.

Whenever reject is closed, we mark the IsFinished object as finished.
Ditto for now when the resolved value is undefined.
A follow-up patch will change this for ReadableStream.

We update the binding generator test to align with WebIDL requirement (arguments need to all be optional).

Canonical link: <a href="https://commits.webkit.org/303830@main">https://commits.webkit.org/303830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08bb8a659f6c87ce9029d24f10a751854be4439c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141325 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6b47e91-43b9-4d46-bb6b-6864134598eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a472a5c-c264-4439-90c9-37c770768c64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136697 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83118 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/027c1249-24df-44f1-a8cb-ddfc10951652) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143973 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110691 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28111 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4525 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5982 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->