### PR TITLE
Add proper error forwarding for ReadableStream async iterable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any-expected.txt
@@ -5,7 +5,7 @@ PASS Async-iterating a pull source
 PASS Async-iterating a push source with undefined values
 PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
+PASS Async-iterating an errored stream throws
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
@@ -17,13 +17,13 @@ PASS Cancellation behavior when returning inside loop body; preventCancel = fals
 PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
 PASS Cancellation behavior when manually calling return(); preventCancel = true
-FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS next() rejects if the stream errors
 PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
-FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+PASS next() that succeeds; next() that reports an error; next()
+PASS next() that succeeds; next() that reports an error(); next() [no awaiting]
+PASS next() that succeeds; next() that reports an error(); return()
+PASS next() that succeeds; next() that reports an error(); return() [no awaiting]
 PASS next() that succeeds; return()
 PASS next() that succeeds; return() [no awaiting]
 PASS return(); next()
@@ -34,7 +34,7 @@ PASS return(); return()
 PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
-FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS Acquiring a reader after return()ing from a stream that errors
 PASS Acquiring a reader after partially async-iterating a stream
 PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.serviceworker-expected.txt
@@ -5,7 +5,7 @@ PASS Async-iterating a pull source
 PASS Async-iterating a push source with undefined values
 PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
+PASS Async-iterating an errored stream throws
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
@@ -17,13 +17,13 @@ PASS Cancellation behavior when returning inside loop body; preventCancel = fals
 PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
 PASS Cancellation behavior when manually calling return(); preventCancel = true
-FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS next() rejects if the stream errors
 PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
-FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+PASS next() that succeeds; next() that reports an error; next()
+PASS next() that succeeds; next() that reports an error(); next() [no awaiting]
+PASS next() that succeeds; next() that reports an error(); return()
+PASS next() that succeeds; next() that reports an error(); return() [no awaiting]
 PASS next() that succeeds; return()
 PASS next() that succeeds; return() [no awaiting]
 PASS return(); next()
@@ -34,7 +34,7 @@ PASS return(); return()
 PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
-FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS Acquiring a reader after return()ing from a stream that errors
 PASS Acquiring a reader after partially async-iterating a stream
 PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.sharedworker-expected.txt
@@ -5,7 +5,7 @@ PASS Async-iterating a pull source
 PASS Async-iterating a push source with undefined values
 PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
+PASS Async-iterating an errored stream throws
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
@@ -17,13 +17,13 @@ PASS Cancellation behavior when returning inside loop body; preventCancel = fals
 PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
 PASS Cancellation behavior when manually calling return(); preventCancel = true
-FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS next() rejects if the stream errors
 PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
-FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+PASS next() that succeeds; next() that reports an error; next()
+PASS next() that succeeds; next() that reports an error(); next() [no awaiting]
+PASS next() that succeeds; next() that reports an error(); return()
+PASS next() that succeeds; next() that reports an error(); return() [no awaiting]
 PASS next() that succeeds; return()
 PASS next() that succeeds; return() [no awaiting]
 PASS return(); next()
@@ -34,7 +34,7 @@ PASS return(); return()
 PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
-FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS Acquiring a reader after return()ing from a stream that errors
 PASS Acquiring a reader after partially async-iterating a stream
 PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.worker-expected.txt
@@ -5,7 +5,7 @@ PASS Async-iterating a pull source
 PASS Async-iterating a push source with undefined values
 PASS Async-iterating a pull source with undefined values
 PASS Async-iterating a pull source manually
-FAIL Async-iterating an errored stream throws assert_equals: expected (string) "e" but got (object) object "TypeError: Type error"
+PASS Async-iterating an errored stream throws
 PASS Async-iterating a closed stream never executes the loop body, but works fine
 PASS Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function
 PASS Async-iterating a partially consumed stream
@@ -17,13 +17,13 @@ PASS Cancellation behavior when returning inside loop body; preventCancel = fals
 PASS Cancellation behavior when returning inside loop body; preventCancel = true
 PASS Cancellation behavior when manually calling return(); preventCancel = false
 PASS Cancellation behavior when manually calling return(); preventCancel = true
-FAIL next() rejects if the stream errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS next() rejects if the stream errors
 PASS return() does not rejects if the stream has not errored yet
 PASS return() rejects if the stream has errored
-FAIL next() that succeeds; next() that reports an error; next() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); next() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
-FAIL next() that succeeds; next() that reports an error(); return() promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
-FAIL next() that succeeds; next() that reports an error(); return() [no awaiting] assert_equals: 2nd next() rejection reason expected object "Error: error1" but got object "TypeError: Type error"
+PASS next() that succeeds; next() that reports an error; next()
+PASS next() that succeeds; next() that reports an error(); next() [no awaiting]
+PASS next() that succeeds; next() that reports an error(); return()
+PASS next() that succeeds; next() that reports an error(); return() [no awaiting]
 PASS next() that succeeds; return()
 PASS next() that succeeds; return() [no awaiting]
 PASS return(); next()
@@ -34,7 +34,7 @@ PASS return(); return()
 PASS return(); return() [no awaiting]
 PASS values() throws if there's already a lock
 PASS Acquiring a reader after exhaustively async-iterating a stream
-FAIL Acquiring a reader after return()ing from a stream that errors promise_rejects_exactly: 2nd next() function "function() { throw e; }" threw object "TypeError: Type error" but we expected it to throw object "Error: error1"
+PASS Acquiring a reader after return()ing from a stream that errors
 PASS Acquiring a reader after partially async-iterating a stream
 PASS Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true
 PASS return() should unlock the stream synchronously when preventCancel = false

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -151,15 +151,13 @@ public:
 
     JSDOMGlobalObject* globalObject();
 
-    class Iterator : public RefCounted<Iterator> {
+    class Iterator : public RefCountedAndCanMakeWeakPtr<Iterator> {
     public:
         static Ref<Iterator> create(Ref<ReadableStreamDefaultReader>&&, bool preventCancel);
         ~Iterator();
 
-        using Result = std::optional<JSC::JSValue>;
-        using Callback = CompletionHandler<void(ExceptionOr<Result>&&)>;
-        void next(Callback&&);
-
+        Ref<DOMPromise> next(JSDOMGlobalObject&);
+        bool isFinished() const;
         Ref<DOMPromise> returnSteps(JSDOMGlobalObject&, JSC::JSValue);
 
     private:


### PR DESCRIPTION
#### 98d27146dcf5b6f44ffb3286b42acc199c694f42
<pre>
Add proper error forwarding for ReadableStream async iterable
<a href="https://rdar.apple.com/165607857">rdar://165607857</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303306">https://bugs.webkit.org/show_bug.cgi?id=303306</a>

Reviewed by Chris Dumez.

We finalize the support of end of iteration by having ReadableStream::Iterator implement a isFinished getter.
This is usd by JSDOMAsyncIteratorBase to identify when the next promise resolves whether the iteration is done.
We then mark the IsFinish object as finished according ReadableStream::Iterator isFinished getter.
This is done in getNextIterationResult.

We also add a way to iterate asynchronously via DOMPromise:
- ReadableStream::Iterator::next returns a Ref&lt;DOMPromise&gt;
- JSDOMAsyncIteratorBase::getNextIterationResult will return the promise.
This allows ReadableStream::Iterator to forward any error that may be given to it.

We use IsAsyncIteratorNextReturningPromise concept to detect whether ReadableStream::Iterator::next is using the new code path.
We keep the old code path and plan to rework it in a follow-up.

All ReadableStream async iterator tests are now passing.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/303865@main">https://commits.webkit.org/303865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c8720fa7f0a883d037451e831a25586a2aa5e6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85818 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5909785f-bb97-4288-bb47-2233eb8c4d9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53b989f9-e829-4524-8574-4b02cda4c742) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83120 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/316b6d18-0440-40ce-962a-2f9be7b9c860) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2288 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4533 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59688 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5991 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34459 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5945 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->