### PR TITLE
Block parser on stylesheet loads in body

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6339,7 +6339,7 @@ void Document::flushAutofocusCandidates()
             continue;
         }
 
-        if (RefPtr parser = scriptableDocumentParser(); parser && parser->hasScriptsWaitingForStylesheets())
+        if (RefPtr parser = scriptableDocumentParser(); parser && parser->isWaitingForStylesheets())
             break;
         m_autofocusCandidates.removeFirst();
 

--- a/Source/WebCore/dom/ScriptableDocumentParser.cpp
+++ b/Source/WebCore/dom/ScriptableDocumentParser.cpp
@@ -49,7 +49,7 @@ void ScriptableDocumentParser::executeScriptsWaitingForStylesheetsSoon()
 
     if (m_scriptsWaitingForStylesheetsExecutionTimer.isActive())
         return;
-    if (!hasScriptsWaitingForStylesheets())
+    if (!isWaitingForStylesheets())
         return;
 
     m_scriptsWaitingForStylesheetsExecutionTimer.startOneShot(0_s);

--- a/Source/WebCore/dom/ScriptableDocumentParser.h
+++ b/Source/WebCore/dom/ScriptableDocumentParser.h
@@ -40,7 +40,7 @@ public:
 
     virtual TextPosition textPosition() const = 0;
 
-    virtual bool hasScriptsWaitingForStylesheets() const { return false; }
+    virtual bool isWaitingForStylesheets() const { return false; }
 
     void executeScriptsWaitingForStylesheetsSoon();
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -95,8 +95,10 @@ private:
     void prepareToStopParsing() final;
     void stopParsing() final;
     bool isWaitingForScripts() const;
+    bool isWaitingForScriptsOrStylesheets() const;
+    bool shouldWaitForBodyStylesheets() const;
     bool isExecutingScript() const final;
-    bool hasScriptsWaitingForStylesheets() const final;
+    bool isWaitingForStylesheets() const final;
     void executeScriptsWaitingForStylesheets() final;
     void suspendScheduledTasks() final;
     void resumeScheduledTasks() final;
@@ -155,6 +157,7 @@ private:
     bool m_endWasDelayed { false };
     unsigned m_pumpSessionNestingLevel { 0 };
     bool m_shouldEmitTracePoints { false };
+    bool m_isWaitingForBodyStylesheets { false };
 };
 
 inline HTMLTokenizer& HTMLDocumentParser::tokenizer()

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1671,7 +1671,7 @@ bool DocumentLoader::isLoadingInAPISense() const
         if (document->hasActiveParser())
             return true;
         RefPtr scriptableParser = document->scriptableDocumentParser();
-        if (scriptableParser && scriptableParser->hasScriptsWaitingForStylesheets())
+        if (scriptableParser && scriptableParser->isWaitingForStylesheets())
             return true;
     }
     return protectedFrameLoader()->subframeIsLoading();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -986,7 +986,7 @@ void FrameLoader::checkCompleted()
         return;
 
     RefPtr scriptableParser = document->scriptableDocumentParser();
-    if (scriptableParser && scriptableParser->hasScriptsWaitingForStylesheets())
+    if (scriptableParser && scriptableParser->isWaitingForStylesheets())
         return;
 
     // Any frame that hasn't completed yet?


### PR DESCRIPTION
#### 1de01045f611e300e890dbad65c389252ae2f4b9
<pre>
Block parser on stylesheet loads in body
<a href="https://bugs.webkit.org/show_bug.cgi?id=303308">https://bugs.webkit.org/show_bug.cgi?id=303308</a>
<a href="https://rdar.apple.com/165609959">rdar://165609959</a>

Reviewed by NOBODY (OOPS!).
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushAutofocusCandidates):
* Source/WebCore/dom/ScriptableDocumentParser.cpp:
(WebCore::ScriptableDocumentParser::executeScriptsWaitingForStylesheetsSoon):
* Source/WebCore/dom/ScriptableDocumentParser.h:
(WebCore::ScriptableDocumentParser::isWaitingForStylesheets const):
(WebCore::ScriptableDocumentParser::hasScriptsWaitingForStylesheets const): Deleted.
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::shouldDelayEnd const):
(WebCore::HTMLDocumentParser::pumpTokenizerIfPossible):
(WebCore::HTMLDocumentParser::pumpTokenizerLoop):
(WebCore::HTMLDocumentParser::pumpTokenizer):
(WebCore::HTMLDocumentParser::insert):
(WebCore::HTMLDocumentParser::append):
(WebCore::HTMLDocumentParser::isWaitingForScriptsOrStylesheets const):
(WebCore::HTMLDocumentParser::shouldWaitForBodyStylesheets const):
(WebCore::HTMLDocumentParser::resumeParsingAfterScriptExecution):
(WebCore::HTMLDocumentParser::notifyFinished):
(WebCore::HTMLDocumentParser::isWaitingForStylesheets const):
(WebCore::HTMLDocumentParser::executeScriptsWaitingForStylesheets):
(WebCore::HTMLDocumentParser::hasScriptsWaitingForStylesheets const): Deleted.
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::isLoadingInAPISense const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkCompleted):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de01045f611e300e890dbad65c389252ae2f4b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85343 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd743b99-f84e-4ff3-8864-0039484bbfcb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5663 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101959 "Found 37 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-004.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-005.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-005.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69414 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/15c18fba-86ff-4178-8126-41bcfb828efd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136244 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4479 "Found 1 new test failure: fast/tokenizer/inline-script-stylesheet-write.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/313813eb-7db6-4e78-9b23-63a3c86864ce) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4363 "Found 20 new test failures: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-classic.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-module.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-classic.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-module.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1949 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113443 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37597 "Found 19 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-classic.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-module.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-module.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5468 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38176 "Found 21 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-classic.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-module.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-classic.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110337 "Found 37 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-004.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-005.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-005.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5550 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4701 "Found 33 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-004.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-005.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-001.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-002.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-003.html imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-rtl-005.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110522 "Found 1 new API test failure: WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4228 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59218 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5523 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34089 "Found 21 new test failures: fast/tokenizer/inline-script-stylesheet-write.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-classic.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-module.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-classic.html ... (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->