### PR TITLE
Add a RAII type to hold virtual memory allocations

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
 		7B8486622ED5E5A400E34DC1 /* AllocSpanMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8486612ED5E5A400E34DC1 /* AllocSpanMixin.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B8486772ED869F600E34DC1 /* MachVMSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8486762ED869F600E34DC1 /* MachVMSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B8486792ED86A2C00E34DC1 /* VMAllocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8486782ED86A2C00E34DC1 /* VMAllocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
@@ -1426,6 +1428,8 @@
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
 		7B8486612ED5E5A400E34DC1 /* AllocSpanMixin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AllocSpanMixin.h; sourceTree = "<group>"; };
+		7B8486762ED869F600E34DC1 /* MachVMSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MachVMSpan.h; sourceTree = "<group>"; };
+		7B8486782ED86A2C00E34DC1 /* VMAllocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMAllocSpan.h; sourceTree = "<group>"; };
 		7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SequenceLocked.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		7C137942222326D500D7A824 /* ieee.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ieee.h; sourceTree = "<group>"; };
@@ -2166,6 +2170,7 @@
 				46335BEC2E778B1300860373 /* DispatchExtras.h */,
 				6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */,
 				6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */,
+				7B8486762ED869F600E34DC1 /* MachVMSpan.h */,
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
 				37C7CC291EA40A73007BD956 /* WeakLinking.h */,
@@ -2773,6 +2778,7 @@
 				0F95B63420CB53C100479635 /* Vector.cpp */,
 				A8A47370151A825B004123FF /* Vector.h */,
 				A8A47371151A825B004123FF /* VectorTraits.h */,
+				7B8486782ED86A2C00E34DC1 /* VMAllocSpan.h */,
 				A8A47372151A825B004123FF /* VMTags.h */,
 				0F66B2881DC97BAB004A1D3F /* WallTime.cpp */,
 				0F66B2891DC97BAB004A1D3F /* WallTime.h */,
@@ -3650,6 +3656,7 @@
 				DD3DC91727A4BF8E007E5B61 /* LogInitialization.h in Headers */,
 				DD3DC89227A4BF8E007E5B61 /* MachSendRight.h in Headers */,
 				E3BFBA792E05EE9F00A38E4F /* MachSendRightAnnotated.h in Headers */,
+				7B8486772ED869F600E34DC1 /* MachVMSpan.h in Headers */,
 				DDF306E027C08654006A526F /* MachVMSPI.h in Headers */,
 				DD3DC8B627A4BF8E007E5B61 /* MainThread.h in Headers */,
 				DD4901EC27B4748A00D7E50D /* MainThreadData.h in Headers */,
@@ -3938,6 +3945,7 @@
 				4448265228D18CA600D916E8 /* VectorCF.h in Headers */,
 				DDF3079727C086CD006A526F /* VectorCocoa.h in Headers */,
 				DD3DC95327A4BF8E007E5B61 /* VectorTraits.h in Headers */,
+				7B8486792ED86A2C00E34DC1 /* VMAllocSpan.h in Headers */,
 				DD3DC95127A4BF8E007E5B61 /* VMTags.h in Headers */,
 				DD3DC8EE27A4BF8E007E5B61 /* WallTime.h in Headers */,
 				E36DC1762DF0F9C20091549D /* WasmSIMD128.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -373,6 +373,7 @@ set(WTF_PUBLIC_HEADERS
     UniqueArray.h
     UniqueRef.h
     UniqueRefVector.h
+    VMAllocSpan.h
     VMTags.h
     ValidatedReinterpretCast.h
     ValueCheck.h
@@ -690,6 +691,7 @@ if (WIN32)
         win/PathWalker.h
         win/SoftLinking.h
         win/Win32Handle.h
+        win/WinVMSpan.h
     )
 elseif (APPLE)
     list(APPEND WTF_SOURCES
@@ -711,6 +713,7 @@ elseif (APPLE)
         cocoa/TypeCastsCocoa.h
         cocoa/VectorCocoa.h
 
+        darwin/MachVMSpan.h
         darwin/OSLogPrintStream.h
         darwin/WeakLinking.h
         darwin/XPCExtras.h

--- a/Source/WTF/wtf/VMAllocSpan.h
+++ b/Source/WTF/wtf/VMAllocSpan.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(DARWIN)
+#include <wtf/darwin/MachVMSpan.h>
+namespace WTF {
+// RAII class for allocating and holding virtual memory with std::span access.
+template<typename T> using VMAllocSpan = MachVMSpan<T>;
+}
+#elif OS(WINDOWS)
+#include <wtf/win/WinVMSpan.h>
+namespace WTF {
+// RAII class for allocating and holding virtual memory with std::span access.
+template<typename T> using VMAllocSpan = WinVMSpan<T>;
+}
+#elif HAVE(MMAP)
+#include <wtf/MmapSpan.h>
+namespace WTF {
+// RAII class for allocating and holding virtual memory with std::span access.
+template<typename T> using VMAllocSpan = MmapSpan<T>;
+}
+#else
+#error Unsupported OS.
+#endif
+
+
+using WTF::VMAllocSpan;

--- a/Source/WTF/wtf/darwin/MachVMSpan.h
+++ b/Source/WTF/wtf/darwin/MachVMSpan.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <mach/mach_init.h>
+#include <mach/mach_vm.h>
+#include <mach/vm_map.h>
+#include <wtf/AllocSpanMixin.h>
+#include <wtf/Expected.h>
+#include <wtf/spi/cocoa/MachVMSPI.h>
+
+namespace WTF {
+
+// RAII class for allocating and holding mach virtual memory with std::span access.
+template<typename T> class MachVMSpan : public AllocSpanMixin<T> {
+public:
+    static Expected<MachVMSpan, kern_return_t> allocate(mach_vm_size_t size, int flags)
+    {
+        mach_vm_address_t address = 0;
+        kern_return_t kr = mach_vm_allocate(mach_task_self(), &address, size, flags);
+        if (kr != KERN_SUCCESS)
+            return makeUnexpected(kr);
+        return MachVMSpan { toPointer(address), size };
+    }
+
+    static Expected<MachVMSpan, kern_return_t> map(mach_vm_size_t size, mach_vm_offset_t mask, int flags, mem_entry_name_port_t object, memory_object_offset_t offset, boolean_t copy, vm_prot_t curProtection, vm_prot_t maxProtection, vm_inherit_t inheritance)
+    {
+        mach_vm_address_t address = 0;
+        kern_return_t kr = mach_vm_map(mach_task_self(), &address, size, mask, flags, object, offset, copy, curProtection, maxProtection, inheritance);
+        if (kr != KERN_SUCCESS)
+            return makeUnexpected(kr);
+        return MachVMSpan { toPointer(address), size };
+    }
+
+    MachVMSpan() = default;
+    MachVMSpan(MachVMSpan&& other)
+        : AllocSpanMixin<T>(WTFMove(other))
+    {
+    }
+
+    template<typename U>
+    MachVMSpan(MachVMSpan<U>&& other) requires (std::is_same_v<T, uint8_t>)
+        : AllocSpanMixin<T>(asWritableBytes(other.leakSpan()))
+    {
+    }
+
+    ~MachVMSpan()
+    {
+        auto data = this->mutableSpan();
+        if (!data.data())
+            return;
+        auto kr = mach_vm_deallocate(mach_task_self(), toVMAddress(data.data()), data.size());
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+    }
+
+    MachVMSpan& operator=(MachVMSpan&& other)
+    {
+        MachVMSpan ptr { WTFMove(other) };
+        this->swap(ptr);
+        return *this;
+    }
+
+    mach_vm_address_t toVMAddress() const { return toVMAddress(this->span().data()); }
+private:
+    using AllocSpanMixin<T>::AllocSpanMixin;
+    static mach_vm_address_t toVMAddress(void* pointer) { return static_cast<mach_vm_address_t>(reinterpret_cast<uintptr_t>(pointer)); }
+    static T* toPointer(mach_vm_address_t address) { return reinterpret_cast<T*>(static_cast<uintptr_t>(address)); }
+};
+
+} // namespace WTF
+
+using WTF::MachVMSpan;

--- a/Source/WTF/wtf/win/WinVMSpan.h
+++ b/Source/WTF/wtf/win/WinVMSpan.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/AllocSpanMixin.h>
+#include <wtf/win/Win32Handle.h>
+
+namespace WTF {
+
+// RAII class for allocating and holding Windows virtual memory with std::span access.
+template<typename T> class WinVMSpan : public AllocSpanMixin<T> {
+public:
+    static WinVMSpan mapViewOfFileEx(HANDLE fileMappingObject, DWORD desiredAccess, DWORD fileOffsetHigh, DWORD fileOffsetLow, SIZE_T numberOfBytesToMap, LPVOID baseAddress)
+    {
+        void* data = ::MapViewOfFileEx(fileMappingObject, desiredAccess, fileOffsetHigh, fileOffsetLow, numberOfBytesToMap, baseAddress);
+        if (!data)
+            return { };
+        return WinVMSpan { data, numberOfBytesToMap };
+    }
+
+    WinVMSpan() = default;
+    WinVMSpan(WinVMSpan&& other)
+        : AllocSpanMixin<T>(WTFMove(other))
+    {
+    }
+
+    template<typename U>
+    WinVMSpan(WinVMSpan<U>&& other) requires (std::is_same_v<T, uint8_t>)
+        : AllocSpanMixin<T>(asWritableBytes(other.leakSpan()))
+    {
+    }
+
+    ~WinVMSpan()
+    {
+        auto data = this->mutableSpan();
+        if (!data.data())
+            return;
+        ::UnmapViewOfFile(m_data.data());
+    }
+
+    WinVMSpan& operator=(WinVMSpan&& other)
+    {
+        WinVMSpan ptr { WTFMove(other) };
+        this->swap(ptr);
+        return *this;
+    }
+
+private:
+    using AllocSpanMixin<T>::AllocSpanMixin;
+};
+
+} // namespace WTF
+
+using WTF::WinVMSpan;

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -67,6 +67,20 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
     return sharedMemory;
 }
 
+SharedMemory::SharedMemory(VMAllocSpan<uint8_t> data, Handle::Type&& handle, Protection protection)
+    : m_data(WTFMove(data))
+    , m_handle(WTFMove(handle))
+    , m_protection(WTFMove(protection))
+{
+}
+
+SharedMemory::SharedMemory(size_t wrapMapSize, Handle::Type&& handle, Protection protection)
+    : m_handle(WTFMove(handle))
+    , m_wrapMapSize(wrapMapSize)
+    , m_protection(WTFMove(protection))
+{
+}
+
 Ref<SharedBuffer> SharedMemory::createSharedBuffer(size_t dataSize) const
 {
     ASSERT(dataSize <= size());

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include <span>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/VMAllocSpan.h>
 
 #if USE(UNIX_DOMAIN_SOCKETS)
 #include <wtf/unix/UnixFileDescriptor.h>
@@ -92,6 +92,8 @@ public:
 
     size_t size() const { return m_size; }
 
+    VMAllocSpan<uint8_t> tryMap(SharedMemoryProtection);
+
     // Take ownership of the memory for process memory accounting purposes.
     WEBCORE_EXPORT void takeOwnershipOfMemory(MemoryLedger) const;
     // Transfer ownership of the memory for process memory accounting purposes.
@@ -128,41 +130,34 @@ public:
 
     WEBCORE_EXPORT std::optional<Handle> createHandle(Protection);
 
-    size_t size() const { return m_size; }
+    size_t size() const { return m_wrapMapSize ? m_wrapMapSize : m_data.sizeInBytes(); }
 
-    std::span<const uint8_t> span() const LIFETIME_BOUND { return unsafeMakeSpan(static_cast<const uint8_t*>(m_data), m_size); }
-    std::span<uint8_t> mutableSpan() const LIFETIME_BOUND { return unsafeMakeSpan(static_cast<uint8_t*>(m_data), m_size); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_data.span(); }
+    std::span<uint8_t> mutableSpan() const LIFETIME_BOUND { return const_cast<VMAllocSpan<uint8_t>&>(m_data).mutableSpan(); }
 
 #if OS(WINDOWS)
     HANDLE handle() const { return m_handle.get(); }
 #endif
 
-#if PLATFORM(COCOA)
     Protection protection() const { return m_protection; }
+#if PLATFORM(COCOA)
     WEBCORE_EXPORT RetainPtr<NSData> toNSData() const;
 #endif
 
     WEBCORE_EXPORT Ref<WebCore::SharedBuffer> createSharedBuffer(size_t) const;
 
 private:
+    SharedMemory(VMAllocSpan<uint8_t> data, Handle::Type&&, Protection);
+    // FIXME: Should be removed.
+    SharedMemory(size_t wrapMapSize, Handle::Type&&, Protection);
 #if OS(DARWIN)
-    MachSendRight createSendRight(Protection) const;
+    SharedMemory(VMAllocSpan<uint8_t> data);
 #endif
 
-    size_t m_size;
-    void* m_data;
-#if PLATFORM(COCOA)
-    Protection m_protection;
-#endif
-
-#if USE(UNIX_DOMAIN_SOCKETS)
-    UnixFileDescriptor m_fileDescriptor;
-    bool m_isWrappingMap { false };
-#elif OS(DARWIN)
-    MachSendRight m_sendRight;
-#elif OS(WINDOWS)
-    Win32Handle m_handle;
-#endif
+    VMAllocSpan<uint8_t> m_data;
+    Handle::Type m_handle;
+    size_t m_wrapMapSize { 0 };
+    Protection m_protection { Protection::ReadWrite };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
@@ -64,6 +64,30 @@ static int toVMMemoryLedger(MemoryLedger memoryLedger)
 }
 #endif
 
+static inline vm_prot_t machProtection(SharedMemory::Protection protection)
+{
+    switch (protection) {
+    case SharedMemory::Protection::ReadOnly:
+        return VM_PROT_READ;
+    case SharedMemory::Protection::ReadWrite:
+        return VM_PROT_READ | VM_PROT_WRITE;
+    }
+
+    ASSERT_NOT_REACHED();
+    return VM_PROT_NONE;
+}
+
+VMAllocSpan<uint8_t> SharedMemoryHandle::tryMap(SharedMemoryProtection protection)
+{
+    vm_prot_t vmProtection = machProtection(protection);
+    auto data = MachVMSpan<uint8_t>::map(m_size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_RETURN_DATA_ADDR, m_handle.sendRight(), 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+    if (!data) {
+        RELEASE_LOG_ERROR(VirtualMemory, "SharedMemoryHandle::map: Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(data.error()), data.error());
+        return { };
+    }
+    return WTFMove(*data);
+}
+
 void SharedMemoryHandle::takeOwnershipOfMemory(MemoryLedger memoryLedger) const
 {
     if (isMemoryAttributionDisabled())
@@ -93,62 +117,21 @@ void SharedMemoryHandle::setOwnershipOfMemory(const ProcessIdentity& processIden
 #endif
 }
 
-static inline void* toPointer(mach_vm_address_t address)
+SharedMemory::SharedMemory(VMAllocSpan<uint8_t> data)
+    : m_data(WTFMove(data))
 {
-    return reinterpret_cast<void*>(static_cast<uintptr_t>(address));
-}
-
-static inline mach_vm_address_t toVMAddress(void* pointer)
-{
-    return static_cast<mach_vm_address_t>(reinterpret_cast<uintptr_t>(pointer));
 }
 
 RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     ASSERT(size);
-
-    mach_vm_address_t address = 0;
     // Using VM_FLAGS_PURGABLE so that we can later transfer ownership of the memory via mach_memory_entry_ownership().
-    kern_return_t kr = mach_vm_allocate(mach_task_self(), &address, size, VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE);
-    if (kr != KERN_SUCCESS) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::allocate: Failed to allocate mach_vm_allocate shared memory (%zu bytes). %" PUBLIC_LOG_STRING " (%x)", nullptr, size, mach_error_string(kr), kr);
+    auto data = MachVMSpan<uint8_t>::allocate(size, VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE);
+    if (!data) {
+        RELEASE_LOG_ERROR(VirtualMemory, "SharedMemory::allocate: Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(data.error()), data.error());
         return nullptr;
     }
-
-    Ref sharedMemory = adoptRef(*new SharedMemory);
-    sharedMemory->m_size = size;
-    sharedMemory->m_data = toPointer(address);
-    sharedMemory->m_protection = Protection::ReadWrite;
-    return WTFMove(sharedMemory);
-}
-
-static inline vm_prot_t machProtection(SharedMemory::Protection protection)
-{
-    switch (protection) {
-    case SharedMemory::Protection::ReadOnly:
-        return VM_PROT_READ;
-    case SharedMemory::Protection::ReadWrite:
-        return VM_PROT_READ | VM_PROT_WRITE;
-    }
-
-    ASSERT_NOT_REACHED();
-    return VM_PROT_NONE;
-}
-
-static MachSendRight makeMemoryEntry(size_t size, vm_offset_t offset, SharedMemory::Protection protection, mach_port_t parentEntry)
-{
-    memory_object_size_t memoryObjectSize = size;
-    mach_port_t port = MACH_PORT_NULL;
-
-    kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_VM_SHARE | MAP_MEM_USE_DATA_ADDR, &port, parentEntry);
-    if (kr != KERN_SUCCESS) {
-        RELEASE_LOG_ERROR(VirtualMemory, "SharedMemory::makeMemoryEntry: Failed to create a mach port for shared memory. Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(kr), kr);
-        return { };
-    }
-
-    RELEASE_ASSERT(memoryObjectSize >= size);
-
-    return MachSendRight::adopt(port);
+    return adoptRef(*new SharedMemory(WTFMove(*data)));
 }
 
 RefPtr<SharedMemory> SharedMemory::wrapMap(std::span<const uint8_t> data, Protection protection)
@@ -158,33 +141,17 @@ RefPtr<SharedMemory> SharedMemory::wrapMap(std::span<const uint8_t> data, Protec
     auto handle = Handle::createVMShare(data, protection);
     if (!handle)
         return nullptr;
-
-    Ref sharedMemory = adoptRef(*new SharedMemory);
-    sharedMemory->m_size = data.size();
-    sharedMemory->m_data = nullptr;
-    sharedMemory->m_sendRight = WTFMove(handle->m_handle);
-    sharedMemory->m_protection = protection;
-
-    return sharedMemory;
+    // FIXME: wrapping map should be removed.
+    return adoptRef(*new SharedMemory(data.size(), WTFMove(handle->m_handle), protection));
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handleIn, Protection protection)
 {
-    vm_prot_t vmProtection = machProtection(protection);
-    mach_vm_address_t mappedAddress = 0;
-
-    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, handle.m_size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_RETURN_DATA_ADDR, handle.m_handle.sendRight(), 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
-    if (kr != KERN_SUCCESS) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::map: Failed to map shared memory. %" PUBLIC_LOG_STRING " (%x)", nullptr, mach_error_string(kr), kr);
+    auto data = handleIn.tryMap(protection);
+    if (!data)
         return nullptr;
-    }
-
-    Ref sharedMemory = adoptRef(*new SharedMemory);
-    sharedMemory->m_size = handle.m_size;
-    sharedMemory->m_data = toPointer(mappedAddress);
-    sharedMemory->m_protection = protection;
-
-    return WTFMove(sharedMemory);
+    auto handle = WTFMove(handleIn);
+    return adoptRef(*new SharedMemory(WTFMove(data), WTFMove(handle.m_handle), protection));
 }
 
 std::optional<SharedMemoryHandle> SharedMemoryHandle::createVMShare(std::span<const uint8_t> data, SharedMemoryProtection protection)
@@ -225,35 +192,17 @@ std::optional<SharedMemoryHandle> SharedMemoryHandle::createVMCopy(std::span<con
     return std::optional<SharedMemoryHandle> { std::in_place, WTFMove(result), data.size() };
 }
 
-SharedMemory::~SharedMemory()
-{
-    if (m_data) {
-        kern_return_t kr = mach_vm_deallocate(mach_task_self(), toVMAddress(m_data), m_size);
-        if (kr != KERN_SUCCESS) {
-            RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::~SharedMemory: Failed to deallocate shared memory. %" PUBLIC_LOG_STRING " (%x)", this, mach_error_string(kr), kr);
-            ASSERT_NOT_REACHED();
-        }
-    }
-}
+SharedMemory::~SharedMemory() = default;
 
 auto SharedMemory::createHandle(Protection protection) -> std::optional<Handle>
 {
-    auto sendRight = createSendRight(protection);
-    if (!sendRight)
-        return std::nullopt;
-    return { Handle(WTFMove(sendRight), m_size) };
-}
+    ASSERT(m_protection == Protection::ReadWrite || protection == Protection::ReadOnly);
 
-WTF::MachSendRight SharedMemory::createSendRight(Protection protection) const
-{
-    ASSERT(m_protection == protection || m_protection == Protection::ReadWrite && protection == Protection::ReadOnly);
-    ASSERT(!!m_data ^ !!m_sendRight);
-
-    if (m_sendRight && m_protection == protection)
-        return MachSendRight { m_sendRight };
+    if (m_handle && m_protection == protection)
+        return std::optional<Handle> { std::in_place, MachSendRight { m_handle }, size() };
 
     ASSERT(m_data);
-    return makeMemoryEntry(m_size, toVMAddress(m_data), protection, MACH_PORT_NULL);
+    return SharedMemoryHandle::createVMShare(m_data.span(), protection);
 }
 
 RetainPtr<NSData> SharedMemory::toNSData() const

--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -76,6 +76,11 @@ static inline int accessModeMMap(SharedMemory::Protection protection)
     return PROT_READ | PROT_WRITE;
 }
 
+VMAllocSpan SharedMemoryHandle::tryMap(SharedMemoryProtection protection)
+{
+    return MmapSpan::mmap(0, size(), accessModeMMap(protection), MAP_SHARED, m_handle.value(), 0);
+}
+
 static UnixFileDescriptor createSharedMemory()
 {
     int fileDescriptor = -1;
@@ -132,48 +137,33 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
             return nullptr;
     }
 
-    void* data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fileDescriptor.value(), 0);
-    if (data == MAP_FAILED)
+    auto data = MmapSpan<uint8_t>::mmap(nullptr, size,  PROT_READ | PROT_WRITE, MAP_SHARED, fileDescriptor.value());
+    if (!data)
         return nullptr;
-
-    RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
-    instance->m_data = data;
-    instance->m_fileDescriptor = WTFMove(fileDescriptor);
-    instance->m_size = size;
-    return instance;
+    return adoptRef(*new SharedMemory(WTFMove(data), Handle { WTFMove(fileDescriptor), size }, Protection::ReadWrite));
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handleIn, Protection protection)
 {
-    void* data = mmap(0, handle.size(), accessModeMMap(protection), MAP_SHARED, handle.m_handle.value(), 0);
-    if (data == MAP_FAILED)
+    auto data = handleIn.map(protection);
+    if (!data)
         return nullptr;
-
-    RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
-    instance->m_data = data;
-    instance->m_size = handle.size();
-    return instance;
+    auto handle = WTFMove(handleIn);
+    return adoptRef(*new SharedMemory(WTFMove(data), WTFMove(handle.handle), protection));
 }
 
 RefPtr<SharedMemory> SharedMemory::wrapMap(void* data, size_t size, int fileDescriptor)
 {
-    RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
-    instance->m_data = data;
-    instance->m_size = size;
-    instance->m_fileDescriptor = UnixFileDescriptor { fileDescriptor, UnixFileDescriptor::Adopt };
-    instance->m_isWrappingMap = true;
-    return instance;
+    return adoptRef(*new SharedMemory(size, Handle { UnixFileDescriptor { fileDescriptor, UnixFileDescriptor::Adopt }, Protection::ReadOnly }));
 }
 
 SharedMemory::~SharedMemory()
 {
-    if (m_isWrappingMap) {
-        auto wrapped = m_fileDescriptor.release();
-        UNUSED_VARIABLE(wrapped);
+    if (m_wrapMapSize) {
+        (void) m_data.leakSpan();
+        (void) m_fileDescriptor.release();
         return;
     }
-
-    munmap(m_data, m_size);
 }
 
 auto SharedMemory::createHandle(Protection) -> std::optional<Handle>

--- a/Source/WebCore/platform/win/SharedMemoryWin.cpp
+++ b/Source/WebCore/platform/win/SharedMemoryWin.cpp
@@ -36,17 +36,11 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
     auto handle = Win32Handle::adopt(::CreateFileMappingW(INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, 0, size, 0));
     if (!handle)
         return nullptr;
-
-    void* baseAddress = ::MapViewOfFileEx(handle.get(), FILE_MAP_ALL_ACCESS, 0, 0, size, nullptr);
-    if (!baseAddress)
+    auto data = WinVMSpan::mapViewOfFile(handle.get(), FILE_MAP_ALL_ACCESS, 0, 0, size, nullptr);
+    ASSERT_WITH_MESSAGE(data, "::MapViewOfFileEx failed with error %lu %p", ::GetLastError(), handle.m_handle.get());
+    if (!data)
         return nullptr;
-
-    RefPtr<SharedMemory> memory = adoptRef(new SharedMemory);
-    memory->m_size = size;
-    memory->m_data = baseAddress;
-    memory->m_handle = WTFMove(handle);
-
-    return memory;
+    return adoptRef(*new SharedMemory(WTFMove(data), WTFMove(handle.m_handle), Protection::ReadWrite));
 }
 
 static DWORD accessRights(SharedMemory::Protection protection)
@@ -62,27 +56,17 @@ static DWORD accessRights(SharedMemory::Protection protection)
     return 0;
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handleIn, Protection protection)
 {
-    void* data = ::MapViewOfFile(handle.m_handle.get(), accessRights(protection), 0, 0, handle.size());
-    ASSERT_WITH_MESSAGE(data, "::MapViewOfFile failed with error %lu %p", ::GetLastError(), handle.m_handle.get());
+    auto data = WinVMSpan::mapViewOfFile(handleIn.m_handle.get(), accessRights(protection), 0, 0, size, nullptr);
+    ASSERT_WITH_MESSAGE(data, "::MapViewOfFileEx failed with error %lu %p", ::GetLastError(), handleIn.m_handle.get());
     if (!data)
         return nullptr;
-
-    RefPtr<SharedMemory> memory = adoptRef(new SharedMemory);
-    memory->m_size = handle.size();
-    memory->m_data = data;
-    memory->m_handle = WTFMove(handle.m_handle);
-    return memory;
+    auto handle = WTFMove(handleIn);
+    return adoptRef(*new SharedMemory(WTFMove(data), WTFMove(handle.m_handle), protection));
 }
 
-SharedMemory::~SharedMemory()
-{
-    ASSERT(m_data);
-    ASSERT(m_handle);
-
-    ::UnmapViewOfFile(m_data);
-}
+SharedMemory::~SharedMemory() = default;
 
 auto SharedMemory::createHandle(Protection protection) -> std::optional<Handle>
 {


### PR DESCRIPTION
#### 532abc59e77882fc6dcba8589180a058d1f97cc8
<pre>
Add a RAII type to hold virtual memory allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=303309">https://bugs.webkit.org/show_bug.cgi?id=303309</a>
<a href="https://rdar.apple.com/problem/165611296">rdar://problem/165611296</a>

Reviewed by NOBODY (OOPS!).

Add VMAllocSpan, a RAII type that can hold virtual memory allocation
regions. It&apos;s a type alias with a shared interface between existing
MmapSpan and added MachVMSpan, WinVMSpan.

This makes it simpler to write common general purpose code related to
VM allocations, as the type system can express that the memory region
comes directly from the VM memory and the RAII construct will invoke
the platform-specific destructor consistently.

Use VMAllocSpan in SharedMemory as an initial example.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/VMAllocSpan.h: Added.
* Source/WTF/wtf/darwin/MachVMSpan.h: Added.
(WTF::MachVMSpan::allocate):
(WTF::MachVMSpan::map):
(WTF::MachVMSpan::MachVMSpan):
(WTF::MachVMSpan::requires):
(WTF::MachVMSpan::~MachVMSpan):
(WTF::MachVMSpan::operator=):
(WTF::MachVMSpan::toVMAddress const):
(WTF::MachVMSpan::toVMAddress):
(WTF::MachVMSpan::toPointer):
* Source/WTF/wtf/win/WinVMSpan.h: Added.
(WTF::WinVMSpan::mapViewOfFileEx):
(WTF::WinVMSpan::WinVMSpan):
(WTF::WinVMSpan::requires):
(WTF::WinVMSpan::~WinVMSpan):
(WTF::WinVMSpan::operator=):
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::SharedMemory):
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::size const):
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm:
(WebCore::machProtection):
(WebCore::SharedMemoryHandle::tryMap):
(WebCore::SharedMemory::SharedMemory):
(WebCore::SharedMemory::allocate):
(WebCore::SharedMemory::wrapMap):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::createHandle):
(WebCore::toPointer): Deleted.
(WebCore::toVMAddress): Deleted.
(WebCore::makeMemoryEntry): Deleted.
(WebCore::SharedMemory::~SharedMemory): Deleted.
(WebCore::SharedMemory::createSendRight const): Deleted.
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::SharedMemoryHandle::tryMap):
(WebCore::SharedMemory::allocate):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::wrapMap):
(WebCore::SharedMemory::~SharedMemory):
* Source/WebCore/platform/win/SharedMemoryWin.cpp:
(WebCore::SharedMemory::allocate):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::~SharedMemory): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/532abc59e77882fc6dcba8589180a058d1f97cc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133320 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5821 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44454 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140875 "Hash 532abc59 for PR 54628 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85367 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43289d58-ffc8-445f-8d18-5b1473fc2f82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135190 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6331 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5686 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/140875 "Hash 532abc59 for PR 54628 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/85367 "Hash 532abc59 for PR 54628 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136267 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/6331 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119505 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/140875 "Hash 532abc59 for PR 54628 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b4e68fb-7101-48c5-a02e-f7aa2bbb73d3) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/6331 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1964 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125392 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/6331 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37617 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143522 "Hash 532abc59 for PR 54628 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131829 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5491 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38199 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/143522 "Hash 532abc59 for PR 54628 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5573 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4716 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/143522 "Hash 532abc59 for PR 54628 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115760 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59241 "Hash 532abc59 for PR 54628 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5546 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34106 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164796 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5392 "Hash 532abc59 for PR 54628 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68998 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43062 "Build was cancelled. Recent messages:") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5635 "Hash 532abc59 for PR 54628 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5502 "Hash 532abc59 for PR 54628 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->