### PR TITLE
Callers of OutlinePainter should test for hasOutline()

### DIFF
--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -64,6 +64,8 @@ static float deviceScaleFactor(const RenderElement& renderer)
 
 void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRect& paintRect) const
 {
+    ASSERT(renderer.hasOutline());
+
     CheckedRef styleToUse = renderer.style();
     auto hasThemedFocusRing = renderer.theme().supportsFocusRing(renderer, styleToUse.get());
 
@@ -120,10 +122,9 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
 
 void OutlinePainter::paintOutline(const RenderInline& renderer, const LayoutPoint& paintOffset) const
 {
-    CheckedRef styleToUse = renderer.style();
+    ASSERT(renderer.hasOutline());
 
-    if (!styleToUse->hasOutline())
-        return;
+    CheckedRef styleToUse = renderer.style();
 
     if (styleToUse->outlineStyle() == OutlineStyle::Auto) {
         CheckedPtr paintContainer = m_paintInfo.paintContainer;
@@ -136,7 +137,7 @@ void OutlinePainter::paintOutline(const RenderInline& renderer, const LayoutPoin
     if (renderer.hasOutlineAnnotation())
         addPDFURLAnnotationForLink(renderer, paintOffset);
 
-    if (m_paintInfo.context().paintingDisabled())
+    if (m_paintInfo.context().paintingDisabled() || !styleToUse->hasOutline())
         return;
 
     if (!renderer.containingBlock()) {
@@ -452,9 +453,8 @@ void OutlinePainter::collectFocusRingRectsForInlineChildren(const RenderBlockFlo
 
 void OutlinePainter::addPDFURLAnnotationForLink(const RenderElement& renderer, const LayoutPoint& paintOffset) const
 {
-    RefPtr element = renderer.element();
-    if (!element || !element->isLink())
-        return;
+    Ref element = *renderer.element();
+    ASSERT(element->isLink());
 
     CheckedPtr paintContainer = m_paintInfo.paintContainer;
     auto focusRingRects = collectFocusRingRects(renderer, paintOffset, paintContainer.get());


### PR DESCRIPTION
#### e06e8d628bd567fca9f3bbdbcc335751cbe06ed6
<pre>
Callers of OutlinePainter should test for hasOutline()
<a href="https://bugs.webkit.org/show_bug.cgi?id=303310">https://bugs.webkit.org/show_bug.cgi?id=303310</a>
<a href="https://rdar.apple.com/165612667">rdar://165612667</a>

Reviewed by Alan Baradlay.

* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):

Replace with assert.

(WebCore::OutlinePainter::addPDFURLAnnotationForLink const):

Also here we always have links.

Canonical link: <a href="https://commits.webkit.org/303679@main">https://commits.webkit.org/303679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45770d7c699eda41b3134187419de401eeb04947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2c71b5d-8d1c-42b9-8e44-14e03bc35d32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7e8db78-a3c8-47dd-bceb-1747ecd29505) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136258 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82768 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93c38c98-52cf-4a64-9b44-3c6aa04f0087) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1958 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113461 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143513 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5482 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110345 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4234 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59232 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5537 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->