### PR TITLE
Add support for CoreIPC to serialize NULLable RetainPtrs without wrapping in a std::optional.

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -164,18 +164,15 @@ struct FontPlatformDataAttributes {
 
 #if USE(CORE_TEXT)
 
-// FIXME: Some of these structures have std::optional<RetainPtr<>> which seems weird,
-// but generated encode/decode of RetainPtrs doesn't currently handle null values very well.
-// Once it does, remove the std::optional redirect.
 struct FontPlatformSerializedTraits {
     static std::optional<FontPlatformSerializedTraits> fromCF(CFDictionaryRef);
     RetainPtr<CFDictionaryRef> toCFDictionary() const;
 
     String uiFontDesign;
-    std::optional<RetainPtr<CFNumberRef>> weight;
-    std::optional<RetainPtr<CFNumberRef>> width;
-    std::optional<RetainPtr<CFNumberRef>> symbolic;
-    std::optional<RetainPtr<CFNumberRef>> grade;
+    RetainPtr<CFNumberRef> weight;
+    RetainPtr<CFNumberRef> width;
+    RetainPtr<CFNumberRef> symbolic;
+    RetainPtr<CFNumberRef> grade;
 };
 
 struct FontPlatformOpticalSize {
@@ -185,10 +182,10 @@ struct FontPlatformOpticalSize {
 };
 
 struct FontPlatformFeatureSetting {
-    std::optional<RetainPtr<CFNumberRef>> type;
-    std::optional<RetainPtr<CFNumberRef>> selector;
-    std::optional<RetainPtr<CFStringRef>> tag;
-    std::optional<RetainPtr<CFNumberRef>> value;
+    RetainPtr<CFNumberRef> type;
+    RetainPtr<CFNumberRef> selector;
+    RetainPtr<CFStringRef> tag;
+    RetainPtr<CFNumberRef> value;
 };
 
 struct FontPlatformSerializedAttributes {
@@ -199,19 +196,19 @@ struct FontPlatformSerializedAttributes {
     String descriptorLanguage;
     String descriptorTextStyle;
 
-    std::optional<RetainPtr<CFDataRef>> matrix;
+    RetainPtr<CFDataRef> matrix;
 
-    std::optional<RetainPtr<CFBooleanRef>> ignoreLegibilityWeight;
+    RetainPtr<CFBooleanRef> ignoreLegibilityWeight;
 
-    std::optional<RetainPtr<CFNumberRef>> baselineAdjust;
-    std::optional<RetainPtr<CFNumberRef>> fallbackOption;
-    std::optional<RetainPtr<CFNumberRef>> fixedAdvance;
-    std::optional<RetainPtr<CFNumberRef>> orientation;
-    std::optional<RetainPtr<CFNumberRef>> palette;
-    std::optional<RetainPtr<CFNumberRef>> size;
-    std::optional<RetainPtr<CFNumberRef>> sizeCategory;
-    std::optional<RetainPtr<CFNumberRef>> track;
-    std::optional<RetainPtr<CFNumberRef>> unscaledTracking;
+    RetainPtr<CFNumberRef> baselineAdjust;
+    RetainPtr<CFNumberRef> fallbackOption;
+    RetainPtr<CFNumberRef> fixedAdvance;
+    RetainPtr<CFNumberRef> orientation;
+    RetainPtr<CFNumberRef> palette;
+    RetainPtr<CFNumberRef> size;
+    RetainPtr<CFNumberRef> sizeCategory;
+    RetainPtr<CFNumberRef> track;
+    RetainPtr<CFNumberRef> unscaledTracking;
 
     std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CGColorRef>>>> paletteColors;
     std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CFNumberRef>>>> variations;
@@ -222,7 +219,7 @@ struct FontPlatformSerializedAttributes {
     std::optional<Vector<FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
-    std::optional<RetainPtr<CFNumberRef>> additionalNumber;
+    RetainPtr<CFNumberRef> additionalNumber;
     static CFStringRef additionalFontPlatformSerializedAttributesNumberDictionaryKey();
 #endif
 };

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -406,7 +406,7 @@ std::optional<FontPlatformSerializedAttributes> FontPlatformSerializedAttributes
 
 #define INJECT_CF_VALUE(key, value) { \
     if (value)\
-        CFDictionaryAddValue(result.get(), key, value->get());\
+        CFDictionaryAddValue(result.get(), key, value.get());\
     }
 
 #define PAIR_VECTOR_TO_DICTIONARY(key, vector) \
@@ -447,13 +447,13 @@ RetainPtr<CFDictionaryRef> FontPlatformSerializedAttributes::toCFDictionary() co
         for (const FontPlatformFeatureSetting& setting : *featureSettings) {
             RetainPtr destinationSetting = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
             if (setting.type)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureTypeIdentifierKey, setting.type->get());
+                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureTypeIdentifierKey, setting.type.get());
             if (setting.selector)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureSelectorIdentifierKey, setting.selector->get());
+                CFDictionaryAddValue(destinationSetting.get(), kCTFontFeatureSelectorIdentifierKey, setting.selector.get());
             if (setting.tag)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureTag, setting.tag->get());
+                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureTag, setting.tag.get());
             if (setting.value)
-                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureValue, setting.value->get());
+                CFDictionaryAddValue(destinationSetting.get(), kCTFontOpenTypeFeatureValue, setting.value.get());
             CFArrayAppendValue(settingsArray.get(), destinationSetting.get());
         }
         CFDictionaryAddValue(result.get(), kCTFontFeatureSettingsAttribute, settingsArray.get());

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -357,11 +357,7 @@
     [Legacy] StructureParam WebCore::FontPlatformDataAttributes.m_attributes
 }
 
-[UnsafeWrapper] std::optional<RetainPtr<CFArrayRef>> {
-    [Legacy] StructureParam WebCore::FontPlatformSerializedAttributes.featureSettings
-}
-
-[UnsafeWrapper] std::optional<RetainPtr<CFDataRef>> {
+[UnsafeWrapper] RetainPtr<CFDataRef> {
     [Legacy] StructureParam WebCore::FontPlatformSerializedAttributes.matrix
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -334,10 +334,7 @@ template<> struct ArgumentCoder<CFFooRef> {
     static void encode(Encoder&, CFFooRef);
 };
 template<> struct ArgumentCoder<RetainPtr<CFFooRef>> {
-    static void encode(Encoder& encoder, const RetainPtr<CFFooRef>& retainPtr)
-    {
-        ArgumentCoder<CFFooRef>::encode(encoder, retainPtr.get());
-    }
+    static void encode(Encoder&, const RetainPtr<CFFooRef>&);
     static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
 };
 
@@ -347,14 +344,8 @@ template<> struct ArgumentCoder<CFBarRef> {
     static void encode(StreamConnectionEncoder&, CFBarRef);
 };
 template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
-    static void encode(Encoder& encoder, const RetainPtr<CFBarRef>& retainPtr)
-    {
-        ArgumentCoder<CFBarRef>::encode(encoder, retainPtr.get());
-    }
-    static void encode(StreamConnectionEncoder& encoder, const RetainPtr<CFBarRef>& retainPtr)
-    {
-        ArgumentCoder<CFBarRef>::encode(encoder, retainPtr.get());
-    }
+    static void encode(Encoder&, const RetainPtr<CFBarRef>&);
+    static void encode(StreamConnectionEncoder&, const RetainPtr<CFBarRef>&);
     static std::optional<RetainPtr<CFBarRef>> decode(Decoder&);
 };
 #endif
@@ -365,14 +356,8 @@ template<> struct ArgumentCoder<CFStringRef> {
     static void encode(StreamConnectionEncoder&, CFStringRef);
 };
 template<> struct ArgumentCoder<RetainPtr<CFStringRef>> {
-    static void encode(Encoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
-    {
-        ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
-    }
-    static void encode(StreamConnectionEncoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
-    {
-        ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
-    }
+    static void encode(Encoder&, const RetainPtr<CFStringRef>&);
+    static void encode(StreamConnectionEncoder&, const RetainPtr<CFStringRef>&);
     static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
 };
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -381,8 +381,33 @@ void ArgumentCoder<CFStringRef>::encode(StreamConnectionEncoder& encoder, CFStri
     encoder << WTF::String { instance };
 }
 
+void ArgumentCoder<RetainPtr<CFStringRef>>::encode(Encoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
+{
+    if (!retainPtr) {
+        encoder << false;
+        return;
+    }
+    encoder << true;
+    ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
+}
+
+void ArgumentCoder<RetainPtr<CFStringRef>>::encode(StreamConnectionEncoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
+{
+    if (!retainPtr) {
+        encoder << false;
+        return;
+    }
+    encoder << true;
+    ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
+}
+
 std::optional<RetainPtr<CFStringRef>> ArgumentCoder<RetainPtr<CFStringRef>>::decode(Decoder& decoder)
 {
+    auto isEngaged = decoder.template decode<bool>();
+    if (!isEngaged)
+        return std::nullopt;
+    if (!*isEngaged)
+        return { nullptr };
     auto result = decoder.decode<WTF::String>();
     if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -246,12 +246,23 @@ template<typename T> struct ArgumentCoder<RetainPtr<T>> {
     template<typename U = T, typename = IsObjCObject<U>>
     static void encode(Encoder& encoder, const RetainPtr<U>& object)
     {
+        if (!object) {
+            encoder << false;
+            return;
+        }
+
+        encoder << true;
         ArgumentCoder<U *>::encode(encoder, object.get());
     }
 
     template<typename U = T, typename = IsObjCObject<U>>
     static std::optional<RetainPtr<U>> decode(Decoder& decoder)
     {
+        auto isEngaged = decoder.template decode<bool>();
+        if (!isEngaged)
+            return std::nullopt;
+        if (!*isEngaged)
+            return { nullptr };
         return decoder.decodeWithAllowedClasses<U>();
     }
 };

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -489,7 +489,8 @@ template<> void encodeObjectDirectly<NSObject<NSSecureCoding>>(Encoder& encoder,
     [archiver finishEncoding];
     [archiver setDelegate:nil];
 
-    encoder << (__bridge CFDataRef)[archiver encodedData];
+    RetainPtr<CFDataRef> archivedData = bridge_cast([archiver encodedData]);
+    encoder << archivedData;
 }
 
 static bool shouldEnableStrictMode(Decoder& decoder, const AllowedClassHashSet& allowedClasses)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
@@ -46,15 +46,15 @@ struct CoreIPCDDScannerResultData {
     RetainPtr<NSNumber> P;
     RetainPtr<NSNumber> VN;
     std::optional<Vector<RetainPtr<DDScannerResult>>> SR; // Recursive
-    std::optional<RetainPtr<NSString>> V;
-    std::optional<RetainPtr<NSNumber>> CF;
+    RetainPtr<NSString> V;
+    RetainPtr<NSNumber> CF;
 
     // "C" dictionary values
-    std::optional<RetainPtr<NSString>> AddressBookUID;
-    std::optional<RetainPtr<NSString>> Domain;
-    std::optional<RetainPtr<NSString>> UUID;
-    std::optional<RetainPtr<NSNumber>> UrlificationBegin;
-    std::optional<RetainPtr<NSNumber>> UrlificationLength;
+    RetainPtr<NSString> AddressBookUID;
+    RetainPtr<NSString> Domain;
+    RetainPtr<NSString> UUID;
+    RetainPtr<NSNumber> UrlificationBegin;
+    RetainPtr<NSNumber> UrlificationLength;
 };
 
 class CoreIPCDDScannerResult {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
@@ -125,24 +125,24 @@ RetainPtr<id> CoreIPCDDScannerResult::toID() const
     }
 
     if (m_data.V)
-        propertyList.get()[@"V"] = m_data.V->get();
+        propertyList.get()[@"V"] = m_data.V.get();
     if (m_data.CF)
-        propertyList.get()[@"CF"] = m_data.CF->get();
+        propertyList.get()[@"CF"] = m_data.CF.get();
 
     if (m_data.AddressBookUID || m_data.Domain || m_data.UUID
         || m_data.UrlificationBegin || m_data.UrlificationLength) {
         auto contextualData = [NSMutableDictionary dictionary];
 
         if (m_data.AddressBookUID)
-            contextualData[@"C"] = m_data.AddressBookUID->get();
+            contextualData[@"C"] = m_data.AddressBookUID.get();
         if (m_data.Domain)
-            contextualData[@"D"] = m_data.Domain->get();
+            contextualData[@"D"] = m_data.Domain.get();
         if (m_data.UUID)
-            contextualData[@"U"] = m_data.UUID->get();
+            contextualData[@"U"] = m_data.UUID.get();
         if (m_data.UrlificationBegin)
-            contextualData[@"urlificationBegin"] = m_data.UrlificationBegin->get();
+            contextualData[@"urlificationBegin"] = m_data.UrlificationBegin.get();
         if (m_data.UrlificationLength)
-            contextualData[@"urlificationLength"] = m_data.UrlificationLength->get();
+            contextualData[@"urlificationLength"] = m_data.UrlificationLength.get();
 
         propertyList.get()[@"C"] = contextualData;
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
@@ -32,14 +32,14 @@ header: "CoreIPCDDScannerResult.h"
     RetainPtr<NSNumber> P;
     RetainPtr<NSNumber> VN;
     std::optional<Vector<RetainPtr<DDScannerResult>>> SR;
-    std::optional<RetainPtr<NSString>> V;
-    std::optional<RetainPtr<NSNumber>> CF;
+    RetainPtr<NSString> V;
+    RetainPtr<NSNumber> CF;
 
-    std::optional<RetainPtr<NSString>> AddressBookUID;
-    std::optional<RetainPtr<NSString>> Domain;
-    std::optional<RetainPtr<NSString>> UUID;
-    std::optional<RetainPtr<NSNumber>> UrlificationBegin;
-    std::optional<RetainPtr<NSNumber>> UrlificationLength;
+    RetainPtr<NSString> AddressBookUID;
+    RetainPtr<NSString> Domain;
+    RetainPtr<NSString> UUID;
+    RetainPtr<NSNumber> UrlificationBegin;
+    RetainPtr<NSNumber> UrlificationLength;
 };
 
 [WebKitPlatform] class WebKit::CoreIPCDDScannerResult {

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -102,10 +102,10 @@ header: <WebCore/FontPlatformData.h>
 
 [CustomHeader] struct WebCore::FontPlatformSerializedTraits {
     String uiFontDesign;
-    std::optional<RetainPtr<CFNumberRef>> weight;
-    std::optional<RetainPtr<CFNumberRef>> width;
-    std::optional<RetainPtr<CFNumberRef>> symbolic;
-    std::optional<RetainPtr<CFNumberRef>> grade;
+    RetainPtr<CFNumberRef> weight;
+    RetainPtr<CFNumberRef> width;
+    RetainPtr<CFNumberRef> symbolic;
+    RetainPtr<CFNumberRef> grade;
 };
 
 [CustomHeader] struct WebCore::FontPlatformOpticalSize {
@@ -113,10 +113,10 @@ header: <WebCore/FontPlatformData.h>
 };
 
 [CustomHeader] struct WebCore::FontPlatformFeatureSetting {
-    std::optional<RetainPtr<CFNumberRef>> type;
-    std::optional<RetainPtr<CFNumberRef>> selector;
-    std::optional<RetainPtr<CFStringRef>> tag;
-    std::optional<RetainPtr<CFNumberRef>> value;
+    RetainPtr<CFNumberRef> type;
+    RetainPtr<CFNumberRef> selector;
+    RetainPtr<CFStringRef> tag;
+    RetainPtr<CFNumberRef> value;
 };
 
 [CustomHeader] struct WebCore::FontPlatformSerializedAttributes {
@@ -124,19 +124,19 @@ header: <WebCore/FontPlatformData.h>
     String descriptorLanguage;
     String descriptorTextStyle;
 
-    std::optional<RetainPtr<CFDataRef>> matrix;
+    RetainPtr<CFDataRef> matrix;
 
-    std::optional<RetainPtr<CFBooleanRef>> ignoreLegibilityWeight;
+    RetainPtr<CFBooleanRef> ignoreLegibilityWeight;
 
-    std::optional<RetainPtr<CFNumberRef>> baselineAdjust;
-    std::optional<RetainPtr<CFNumberRef>> fallbackOption;
-    std::optional<RetainPtr<CFNumberRef>> fixedAdvance;
-    std::optional<RetainPtr<CFNumberRef>> orientation;
-    std::optional<RetainPtr<CFNumberRef>> palette;
-    std::optional<RetainPtr<CFNumberRef>> size;
-    std::optional<RetainPtr<CFNumberRef>> sizeCategory;
-    std::optional<RetainPtr<CFNumberRef>> track;
-    std::optional<RetainPtr<CFNumberRef>> unscaledTracking;
+    RetainPtr<CFNumberRef> baselineAdjust;
+    RetainPtr<CFNumberRef> fallbackOption;
+    RetainPtr<CFNumberRef> fixedAdvance;
+    RetainPtr<CFNumberRef> orientation;
+    RetainPtr<CFNumberRef> palette;
+    RetainPtr<CFNumberRef> size;
+    RetainPtr<CFNumberRef> sizeCategory;
+    RetainPtr<CFNumberRef> track;
+    RetainPtr<CFNumberRef> unscaledTracking;
 
     std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CGColorRef>>>> paletteColors;
     std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CFNumberRef>>>> variations;
@@ -147,7 +147,7 @@ header: <WebCore/FontPlatformData.h>
     std::optional<Vector<WebCore::FontPlatformFeatureSetting>> featureSettings;
 
 #if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
-    std::optional<RetainPtr<CFNumberRef>> additionalNumber;
+    RetainPtr<CFNumberRef> additionalNumber;
 #endif
 };
 

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h
@@ -59,7 +59,7 @@ struct CoreIPCDDSecureActionContextData {
     RetainPtr<NSString> groupTranscript;
     RetainPtr<NSString> selectionString;
 
-    std::optional<RetainPtr<DDScannerResult>> mainResult;
+    RetainPtr<DDScannerResult> mainResult;
 
     bool immediate;
     bool isRightClick;

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm
@@ -184,7 +184,7 @@ RetainPtr<id> CoreIPCDDSecureActionContext::toID() const
     if (m_data.selectionString)
         [dict setObject:m_data.selectionString.get() forKey:@"selectionString"];
     if (m_data.mainResult)
-        [dict setObject:m_data.mainResult->get() forKey:@"mainResult"];
+        [dict setObject:m_data.mainResult.get() forKey:@"mainResult"];
 
     [dict setObject:@(m_data.immediate) forKey:@"immediate"];
     [dict setObject:@(m_data.isRightClick) forKey:@"isRightClick"];

--- a/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in
+++ b/Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in
@@ -44,7 +44,7 @@ webkit_platform_headers: "CoreIPCDDSecureActionContext.h"
     RetainPtr<NSString> groupTranscript;
     RetainPtr<NSString> selectionString;
 
-    std::optional<RetainPtr<DDScannerResult>> mainResult;
+    RetainPtr<DDScannerResult> mainResult;
 
     bool immediate;
     bool isRightClick;


### PR DESCRIPTION
#### 9324527cc7b65c245ae5f37cb0747cb686150b3f
<pre>
Add support for CoreIPC to serialize NULLable RetainPtrs without wrapping in a std::optional.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303311">https://bugs.webkit.org/show_bug.cgi?id=303311</a>
<a href="https://rdar.apple.com/165685885">rdar://165685885</a>

Reviewed by Alex Christensen.

CoreIPC wasn&apos;t able to handle NULL RetainPtrs. As a result,
places which expected to handle potentially null values were
wrapping RetainPtrs with std::optional. This change supports
direct serialization of NULL RetainPtr&apos;s by serializing an
initial populated bit like we do for other NULLable boxed typed.

* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformSerializedAttributes::toCFDictionary const):
* Source/WebKit/Scripts/generate-serializers.py:
(one_argument_coder_declaration_cf):
(decode_cf_type):
(decode_type):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ClassWithMemberPrecondition&gt;::decode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::encode): Deleted.
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;T&gt;&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::encodeObjectDirectly&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm:
(WebKit::CoreIPCDDScannerResult::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in:
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.h:
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.mm:
(WebKit::CoreIPCDDSecureActionContext::toID const):
* Source/WebKit/Shared/mac/CoreIPCDDSecureActionContext.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303792@main">https://commits.webkit.org/303792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba42e8c11bcc076afaf0492f928531b5c51cd69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f322e24-a85b-49db-afa5-3c184e467ae0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102206 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b46e7b19-a464-4362-8e37-9e4cdc75a273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136543 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83003 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11dd393d-5bff-42ea-8505-1f92a98321ae) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132945 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38469 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4430 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59522 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34339 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69283 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5780 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->