### PR TITLE
[TextureMapper] Add support for physical/logical size difference in BitmapTexture

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -145,6 +145,12 @@ bool MemoryMappedGPUBuffer::isLinear() const
     return gbm_bo_get_plane_count(m_bo) == 1 && (m_modifier == DRM_FORMAT_MOD_INVALID || m_modifier == DRM_FORMAT_MOD_LINEAR);
 }
 
+IntSize MemoryMappedGPUBuffer::allocatedSize() const
+{
+    ASSERT(m_bo);
+    return IntSize(gbm_bo_get_width(m_bo), gbm_bo_get_height(m_bo));
+}
+
 bool MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject()
 {
     ASSERT(m_eglAttributes.isEmpty());

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -55,6 +55,10 @@ public:
     // Will only return a MemoryMappedGPUBuffer, if gbm_bo allocation + mapping to userland + EGLImage creation succeeded.
     static std::unique_ptr<MemoryMappedGPUBuffer> create(const IntSize&, OptionSet<BufferFlag>);
 
+    // Returns the actual allocated buffer size, which may be larger than size()
+    // due to GPU alignment requirements (e.g. tiled formats).
+    IntSize allocatedSize() const;
+
     const IntSize& size() const { return m_size; }
     const OptionSet<BufferFlag>& flags() const { return m_flags; }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -129,6 +129,11 @@ void BitmapTexture::allocateTexture()
 }
 
 #if USE(GBM)
+IntSize BitmapTexture::allocatedSize() const
+{
+    return m_memoryMappedGPUBuffer ? m_memoryMappedGPUBuffer->allocatedSize() : m_size;
+}
+
 bool BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer()
 {
     if (!m_memoryMappedGPUBuffer)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -104,6 +104,9 @@ public:
 
 #if USE(GBM)
     MemoryMappedGPUBuffer* memoryMappedGPUBuffer() const { return m_memoryMappedGPUBuffer.get(); }
+    IntSize allocatedSize() const;
+#else
+    IntSize allocatedSize() const { return m_size; }
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -76,6 +76,8 @@ public:
     void drawNumber(int number, const Color&, const FloatPoint&, const TransformationMatrix&);
 
     WEBCORE_EXPORT void drawTexture(const BitmapTexture&, const FloatRect& target, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0f, AllEdgesExposed = AllEdgesExposed::Yes);
+    void drawTextureWithPhysicalSize(const BitmapTexture&, const FloatRect& target, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0f, AllEdgesExposed = AllEdgesExposed::Yes);
+
 #if ENABLE(DAMAGE_TRACKING)
     void drawTextureFragment(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect);
 #endif
@@ -154,6 +156,8 @@ private:
     bool m_isMaskMode { false };
     TransformationMatrix m_patternTransform;
     WrapMode m_wrapMode { WrapMode::Stretch };
+    std::optional<FloatSize> m_uvClampMax;
+    std::optional<FloatSize> m_uvClampTexelSize;
     TextureMapperGLData* m_data;
     ClipStack m_clipStack;
 #if ENABLE(DAMAGE_TRACKING)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -211,6 +211,7 @@ static const char* fragmentTemplateCommon =
         uniform mat4 u_yuvToRgb;
         uniform vec4 u_color;
         uniform vec2 u_texelSize;
+        uniform vec2 u_uvMax;
         uniform float u_gaussianKernel[GAUSSIAN_KERNEL_MAX_HALF_SIZE];
         uniform float u_gaussianKernelOffset[GAUSSIAN_KERNEL_MAX_HALF_SIZE];
         uniform int u_gaussianKernelHalfSize;
@@ -239,6 +240,12 @@ static const char* fragmentTemplateCommon =
         vec2 vertexTransformTexCoord() { return v_transformedTexCoord; }
 
         void applyManualRepeat(inout vec2 pos) { pos = fract(pos); }
+
+        void applyClampUVBounds(inout vec2 texCoord)
+        {
+            vec2 uvMax = u_uvMax - u_texelSize / 2.;
+            texCoord = clamp(texCoord, vec2(0.), uvMax);
+        }
 
         void applyTextureRGB(inout vec4 color, vec2 texCoord) { color = u_textureColorSpaceMatrix * texture2D(s_sampler, texCoord); }
 
@@ -545,6 +552,7 @@ static const char* fragmentTemplateCommon =
             vec4 color = vec4(1., 1., 1., 1.);
             vec2 texCoord = transformTexCoord();
             applyManualRepeatIfNeeded(texCoord);
+            applyClampUVBoundsIfNeeded(texCoord);
             applyTextureRGBIfNeeded(color, texCoord);
             applyTextureYUVIfNeeded(color, texCoord);
             applyTextureYUVAIfNeeded(color, texCoord);
@@ -608,6 +616,7 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
     SET_APPLIER_FROM_OPTIONS(AlphaToShadow);
     SET_APPLIER_FROM_OPTIONS(ContentTexture);
     SET_APPLIER_FROM_OPTIONS(ManualRepeat);
+    SET_APPLIER_FROM_OPTIONS(ClampUVBounds);
     SET_APPLIER_FROM_OPTIONS(TextureExternalOES);
     SET_APPLIER_FROM_OPTIONS(RoundedRectClip);
     SET_APPLIER_FROM_OPTIONS(Premultiply);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -45,6 +45,7 @@ namespace WebCore {
     macro(yuvToRgb) \
     macro(filterAmount) \
     macro(texelSize) \
+    macro(uvMax) \
     macro(gaussianKernel) \
     macro(gaussianKernelOffset) \
     macro(gaussianKernelHalfSize) \
@@ -109,6 +110,7 @@ public:
         TextureCopy      = 1L << 26,
         AlphaToShadow    = 1L << 27,
         ToneMapPQ        = 1L << 28,
+        ClampUVBounds    = 1L << 29,
     };
 
     enum class VariableID {


### PR DESCRIPTION
#### e5654d7e3839a57e4245d7d99c32447ef3b791cf
<pre>
[TextureMapper] Add support for physical/logical size difference in BitmapTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=303312">https://bugs.webkit.org/show_bug.cgi?id=303312</a>

Reviewed by Carlos Garcia Campos.

Introduce m_allocatedSize to BitmapTexture to track the actual allocated
buffer size, which may differ from the logical m_size when using
specific tiled texture formats that require e.g. 64x64 alignment.

When rendering textures with allocated size differences, adjust UV
coordinates via drawTextureWithPhysicalSize() to sample only the logical
region, preventing rendering artifacts from the padding area.

Add a new ClampUVBounds shader option that clamps texture coordinates
to stay within the logical texture region. This prevents GPU bilinear
filtering from sampling texels in the padding area when the allocated
texture is larger than the logical size, which would otherwise cause
visible artifacts at texture edges.

* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::allocatedSize const):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::allocatedSize const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawTexture):
(WebCore::TextureMapper::drawTextureWithPhysicalSize):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::create):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:

Canonical link: <a href="https://commits.webkit.org/303849@main">https://commits.webkit.org/303849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07715c7a8b6123b281510426357ff0ce8f9099af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141358 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135653 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136730 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83135 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125860 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5962 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28120 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6015 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69479 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->