### PR TITLE
[threaded-animations] many scroll-animations WPT tests involving programmatic scroll fail with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -58,7 +58,7 @@ public:
 
 #if PLATFORM(MAC)
     void initEffectsFromMainThread(PlatformLayer*);
-    void applyEffectsFromScrollingThread() const;
+    void applyEffects() const;
 #endif
 
     void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -146,7 +146,7 @@ void RemoteAnimationStack::initEffectsFromMainThread(PlatformLayer *layer)
     [m_presentationModifierGroup flushWithTransaction];
 }
 
-void RemoteAnimationStack::applyEffectsFromScrollingThread() const
+void RemoteAnimationStack::applyEffects() const
 {
     ASSERT(m_presentationModifierGroup);
 
@@ -166,7 +166,10 @@ void RemoteAnimationStack::applyEffectsFromScrollingThread() const
         [m_transformPresentationModifier setValue:transform.get()];
     }
 
-    [m_presentationModifierGroup flush];
+    if (isMainRunLoop())
+        [m_presentationModifierGroup flushWithTransaction];
+    else
+        [m_presentationModifierGroup flush];
 }
 #endif
 


### PR DESCRIPTION
#### 858f6109867c85f5f45a50ea996788ddad27074c
<pre>
[threaded-animations] many scroll-animations WPT tests involving programmatic scroll fail with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303313">https://bugs.webkit.org/show_bug.cgi?id=303313</a>
<a href="https://rdar.apple.com/165614575">rdar://165614575</a>

Reviewed by Matt Woodrow.

While we correctly update progress-based timelines during a programmatic scroll, eg. a scroll
initiated by JavaScript using the `scrollLeft` or `scrollTop` DOM property, we fail to update
animations themselves. We now call `updateAnimations()` within `RemoteLayerTreeEventDispatcher`
while in `waitForRenderingUpdateCompletionOrTimeout()`.

This patch fixes the following WPT tests which were ImageOnlyFailure failures:

- imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html
- imported/w3c/web-platform-tests/scroll-animations/css/deferred-timeline-composited.html
- imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default.html
- imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-inline-orientation.html
- imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html
- imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html
- imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedScrollDrivenAnimationsEnabled=true`.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::applyEffects const):
(WebKit::RemoteAnimationStack::applyEffectsFromScrollingThread const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::renderingUpdateComplete):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):

Canonical link: <a href="https://commits.webkit.org/303810@main">https://commits.webkit.org/303810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/484f545334d56432e160eb5d7851c7075f46880f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85655 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83002 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4575 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2182 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113711 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143810 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110766 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4431 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59527 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34347 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->