### PR TITLE
[GTK][WPE] Support Vivante super-tiled format for MemoryMappedGPUBuffer

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -81,6 +81,7 @@ platform/graphics/gbm/GBMDevice.cpp
 platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp @no-unify
 platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
+platform/graphics/gbm/VivanteSuperTiledTexture.cpp
 
 platform/graphics/glib/IconGLib.cpp
 platform/graphics/glib/ImageAdapterGLib.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -89,6 +89,7 @@ platform/graphics/gbm/GBMDevice.cpp
 platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp @no-unify
 platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
+platform/graphics/gbm/VivanteSuperTiledTexture.cpp
 
 platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -49,7 +49,8 @@ public:
     ~MemoryMappedGPUBuffer();
 
     enum class BufferFlag : uint8_t {
-        ForceLinear = 1 << 0
+        ForceLinear = 1 << 0,
+        ForceVivanteSuperTiled = 1 << 1
     };
 
     // Will only return a MemoryMappedGPUBuffer, if gbm_bo allocation + mapping to userland + EGLImage creation succeeded.
@@ -73,7 +74,6 @@ public:
     // You need to obtain an AccessScope, fencing the write operation.
     class AccessScope;
     void updateContents(AccessScope&, const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
-    void updateContents(AccessScope&, const MemoryMappedGPUBuffer& srcBuffer, const IntRect& targetRect);
 
     // You need to obtain an AccessScope, fencing the read operation.
     std::span<uint32_t> mappedDataSpan(AccessScope&) const;
@@ -103,6 +103,7 @@ public:
 
     bool isMapped() const { return !!m_mappedData; }
     bool isLinear() const;
+    bool isVivanteSuperTiled() const;
 
 private:
     MemoryMappedGPUBuffer(const IntSize&, OptionSet<BufferFlag>);
@@ -118,6 +119,9 @@ private:
     bool allocate(struct gbm_device*, const GLDisplay::BufferFormat&);
     bool createDMABufFromGBMBufferObject();
     UnixFileDescriptor exportGBMBufferObjectAsDMABuf(unsigned planeIndex);
+
+    void updateContentsInLinearFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
+    void updateContentsInVivanteSuperTiledFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
 
     int primaryPlaneDmaBufFD() const;
     uint32_t primaryPlaneDmaBufStride() const;

--- a/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.cpp
+++ b/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VivanteSuperTiledTexture.h"
+
+#if USE(GBM)
+
+namespace WebCore {
+
+// Interleave x and y coordinates to produce Morton code (z-curve index).
+static constexpr unsigned interleave(uint32_t x, uint32_t y)
+{
+    uint64_t z = 0;
+    for (uint32_t i = 0; i < 32; ++i) {
+        uint32_t xMasked = x & (1 << i);
+        uint32_t yMasked = y & (1 << i);
+
+        z |= static_cast<uint64_t>(xMasked) << i;
+        z |= static_cast<uint64_t>(yMasked) << (i + 1);
+    }
+
+    return static_cast<unsigned>(z);
+}
+
+const VivanteSuperTiledTexture::ZCurveLUT<VivanteSuperTiledTexture::TilesInSuperTileWidth>& VivanteSuperTiledTexture::zCurveTileLUT()
+{
+    static const auto lut = []() {
+        ZCurveLUT<TilesInSuperTileWidth> result;
+        for (unsigned y = 0; y < TilesInSuperTileWidth; ++y) {
+            for (unsigned x = 0; x < TilesInSuperTileWidth; ++x)
+                result[y][x] = interleave(x, y);
+        }
+        return result;
+    }();
+
+    return lut;
+}
+
+const VivanteSuperTiledTexture::ZCurveLUT<VivanteSuperTiledTexture::SuperTileWidth>& VivanteSuperTiledTexture::zCurveTexelLUT()
+{
+    static const auto lut = []() {
+        ZCurveLUT<SuperTileWidth> result;
+        const auto& tileLUT = zCurveTileLUT();
+        for (unsigned y = 0; y < SuperTileWidth; ++y) {
+            unsigned yTileInSuperTile = y / TileWidth;
+            unsigned yTexelInTile = y % TileWidth;
+            for (unsigned x = 0; x < SuperTileWidth; ++x) {
+                unsigned xTileInSuperTile = x / TileWidth;
+                unsigned xTexelInTile = x % TileWidth;
+
+                unsigned tileIndex = tileLUT[yTileInSuperTile][xTileInSuperTile];
+                result[y][x] = tileIndex * TileTexels + yTexelInTile * TileWidth + xTexelInTile;
+            }
+        }
+        return result;
+    }();
+
+    return lut;
+}
+
+} // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.h
+++ b/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(GBM)
+
+#include "IntSize.h"
+#include <array>
+#include <cstdint>
+
+#include <wtf/Noncopyable.h>
+
+namespace WebCore {
+
+// Abstraction layer to access Vivante super-tiled texture buffers.
+// Super-tiles are 64x64 texel blocks, subdivided into 4x4 tiles arranged in z-curve (Morton code) order.
+class VivanteSuperTiledTexture {
+    WTF_MAKE_NONCOPYABLE(VivanteSuperTiledTexture);
+public:
+    VivanteSuperTiledTexture(std::span<uint32_t> texels, unsigned stride);
+
+    void writeLine(unsigned x, unsigned y, unsigned width, std::span<const uint32_t> colors);
+
+    // Align an IntSize to super-tile boundaries (multiple of 64 in both dimensions).
+    static IntSize alignToSuperTileIntSize(const IntSize& size)
+    {
+        return IntSize(alignToSuperTile(size.width()), alignToSuperTile(size.height()));
+    }
+
+private:
+    static constexpr unsigned SuperTileWidth = 64;
+    static constexpr unsigned TileWidth = 4;
+    static constexpr unsigned TilesInSuperTileWidth = SuperTileWidth / TileWidth;
+    static constexpr unsigned SuperTileTexels = SuperTileWidth * SuperTileWidth;
+    static constexpr unsigned TileTexels = TileWidth * TileWidth;
+
+    template<unsigned size>
+    using ZCurveLUT = std::array<std::array<unsigned, size>, size>;
+
+    static const ZCurveLUT<TilesInSuperTileWidth>& zCurveTileLUT();
+    static const ZCurveLUT<SuperTileWidth>& zCurveTexelLUT();
+
+    // Align a dimension to super-tile boundary (multiple of 64).
+    static constexpr unsigned alignToSuperTile(unsigned value)
+    {
+        return (value + SuperTileWidth - 1) & ~(SuperTileWidth - 1);
+    }
+
+    std::span<uint32_t> m_texels;
+    unsigned m_superTilesInStride { 0 };
+};
+
+} // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTextureInlines.h
+++ b/Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTextureInlines.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(GBM)
+
+#include "VivanteSuperTiledTexture.h"
+#include <cstring>
+#include <wtf/StdLibExtras.h>
+
+// Cross-compiler loop unroll pragma.
+#if COMPILER(CLANG)
+#define VIVANTE_UNROLL(N) _Pragma(STRINGIZE(unroll N))
+#elif COMPILER(GCC)
+#define VIVANTE_UNROLL(N) _Pragma(STRINGIZE(GCC unroll N))
+#else
+#define VIVANTE_UNROLL(N)
+#endif
+
+namespace WebCore {
+
+ALWAYS_INLINE VivanteSuperTiledTexture::VivanteSuperTiledTexture(std::span<uint32_t> texels, unsigned stride)
+    : m_texels(texels)
+    , m_superTilesInStride(stride / sizeof(uint32_t) / SuperTileWidth)
+{
+    // Stride must be super-tile aligned.
+    ASSERT(!(stride % (SuperTileWidth * sizeof(uint32_t))));
+}
+
+// This implementation iterates over super-tiles first, then tiles within each super-tile,
+// avoiding repeated x-axis super-tile resolution for each tile.
+ALWAYS_INLINE void VivanteSuperTiledTexture::writeLine(unsigned x, unsigned y, unsigned width, std::span<const uint32_t> colors)
+{
+    unsigned ySuperTile = y / SuperTileWidth;
+    unsigned xSuperTile = x / SuperTileWidth;
+
+    unsigned currentSuperTileIndex = ySuperTile * m_superTilesInStride + xSuperTile;
+    auto currentSuperTile = m_texels.subspan(currentSuperTileIndex * SuperTileTexels);
+
+    unsigned xTexelInSuperTile = x % SuperTileWidth;
+    unsigned yTexelInSuperTile = y % SuperTileWidth;
+
+    const auto& zCurveTexelLUTY = zCurveTexelLUT()[yTexelInSuperTile];
+
+    unsigned texelsConsumed = 0;
+
+    auto writeTexels = [&zCurveTexelLUTY, &currentSuperTile, &colors](unsigned xTexelInSuperTile, unsigned sourceOffset, unsigned writeWidth) ALWAYS_INLINE_LAMBDA {
+        unsigned texelIndexInSuperTile = zCurveTexelLUTY[xTexelInSuperTile];
+        memcpySpan(currentSuperTile.subspan(texelIndexInSuperTile, writeWidth), colors.subspan(sourceOffset, writeWidth));
+    };
+
+    if (xTexelInSuperTile > 0) {
+        unsigned widthInSuperTile = SuperTileWidth - xTexelInSuperTile;
+        texelsConsumed = widthInSuperTile % TileWidth;
+        if (texelsConsumed > 0) {
+            if (width > texelsConsumed)
+                writeTexels(xTexelInSuperTile, 0, texelsConsumed);
+            else {
+                writeTexels(xTexelInSuperTile, 0, width);
+                return;
+            }
+        }
+
+        auto writeFirstSuperTileFullTiles = [xTexelInSuperTile, &texelsConsumed, &writeTexels](unsigned widthToWrite) ALWAYS_INLINE_LAMBDA {
+            unsigned fullTilesInSuperTileWidth = widthToWrite / TileWidth * TileWidth;
+            do {
+                writeTexels(xTexelInSuperTile + texelsConsumed, texelsConsumed, TileWidth);
+                texelsConsumed += TileWidth;
+            } while (texelsConsumed < fullTilesInSuperTileWidth);
+        };
+
+        if (width > widthInSuperTile) {
+            if (widthInSuperTile >= TileWidth)
+                writeFirstSuperTileFullTiles(widthInSuperTile);
+
+            ++currentSuperTileIndex;
+            currentSuperTile = m_texels.subspan(currentSuperTileIndex * SuperTileTexels);
+        } else {
+            widthInSuperTile = width - texelsConsumed;
+            if (widthInSuperTile > TileWidth) {
+                writeFirstSuperTileFullTiles(widthInSuperTile);
+
+                if (width > texelsConsumed)
+                    writeTexels(xTexelInSuperTile + texelsConsumed, texelsConsumed, width - texelsConsumed);
+            } else
+                writeTexels(xTexelInSuperTile + texelsConsumed, texelsConsumed, widthInSuperTile);
+
+            return;
+        }
+    }
+
+    auto writeLastSuperTile = [&texelsConsumed, &writeTexels](unsigned widthToWrite) ALWAYS_INLINE_LAMBDA {
+        if (widthToWrite > TileWidth) {
+            unsigned fullTilesInSuperTileWidth = widthToWrite / TileWidth * TileWidth;
+            unsigned i = 0;
+            do {
+                writeTexels(i, texelsConsumed, TileWidth);
+                i += TileWidth;
+                texelsConsumed += TileWidth;
+            } while (i < fullTilesInSuperTileWidth);
+
+            if (widthToWrite > fullTilesInSuperTileWidth)
+                writeTexels(i, texelsConsumed, widthToWrite - fullTilesInSuperTileWidth);
+        } else
+            writeTexels(0, texelsConsumed, widthToWrite);
+    };
+
+    unsigned widthLeft = width - texelsConsumed;
+    if (widthLeft >= SuperTileWidth) {
+        unsigned fullSuperTilesWidth = widthLeft / SuperTileWidth * SuperTileWidth;
+        do {
+            VIVANTE_UNROLL(16)
+            for (unsigned i = 0; i < SuperTileWidth; i += TileWidth, texelsConsumed += TileWidth)
+                writeTexels(i, texelsConsumed, TileWidth);
+
+            ++currentSuperTileIndex;
+            currentSuperTile = m_texels.subspan(currentSuperTileIndex * SuperTileTexels);
+        } while (texelsConsumed < fullSuperTilesWidth);
+
+        if (widthLeft > fullSuperTilesWidth) {
+            widthLeft -= fullSuperTilesWidth;
+            writeLastSuperTile(widthLeft);
+        }
+    } else
+        writeLastSuperTile(widthLeft);
+}
+
+#undef VIVANTE_UNROLL
+
+} // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -269,6 +269,22 @@ bool SkiaPaintingEngine::shouldUseLinearTileTextures()
     return shouldUseLinearTextures;
 }
 
+bool SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()
+{
+    static std::once_flag onceFlag;
+    static bool shouldUseVivanteSuperTiledTextures = false;
+
+    std::call_once(onceFlag, [] {
+        if (const char* envString = getenv("WEBKIT_SKIA_USE_VIVANTE_SUPER_TILED_TILE_TEXTURES")) {
+            auto envStringView = StringView::fromLatin1(envString);
+            if (envStringView == "1"_s)
+                shouldUseVivanteSuperTiledTextures = true;
+        }
+    });
+
+    return shouldUseVivanteSuperTiledTextures;
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -54,6 +54,7 @@ public:
     static unsigned numberOfCPUPaintingThreads();
     static unsigned numberOfGPUPaintingThreads();
     static bool shouldUseLinearTileTextures();
+    static bool shouldUseVivanteSuperTiledTileTextures();
 
     bool useThreadedRendering() const { return m_workerPool; }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -58,6 +58,7 @@ public:
 #if USE(GBM)
         BackedByDMABuf = 1 << 2,
         ForceLinearBuffer = 1 << 3,
+        ForceVivanteSuperTiledBuffer = 1 << 4,
 #endif
     };
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -58,6 +58,7 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
 #if USE(GBM)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::BackedByDMABuf) == flags.contains(BitmapTexture::Flags::BackedByDMABuf)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
+                && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
 #endif
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer);
         });

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -73,6 +73,9 @@ void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMa
         if (SkiaPaintingEngine::shouldUseLinearTileTextures()) {
             flags.add(BitmapTexture::Flags::BackedByDMABuf);
             flags.add(BitmapTexture::Flags::ForceLinearBuffer);
+        } else if (SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()) {
+            flags.add(BitmapTexture::Flags::BackedByDMABuf);
+            flags.add(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer);
         }
 #endif
 


### PR DESCRIPTION
#### ccc1c482610103def4e6ef0c535241f1064631d9
<pre>
[GTK][WPE] Support Vivante super-tiled format for MemoryMappedGPUBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=303307">https://bugs.webkit.org/show_bug.cgi?id=303307</a>

Reviewed by Carlos Garcia Campos.

Add VivanteSuperTiledTexture class to handle Vivante GPU&apos;s super-tiled
memory layout, which organizes textures as 64x64 super-tiles containing
4x4 tiles in Morton code (z-curve) order (e.g. used on i.MX6/i.MX8 platforms).

Extend MemoryMappedGPUBuffer to support ForceVivanteSuperTiled buffer
flag for allocating DMA buffers with DRM_FORMAT_MOD_VIVANTE_SUPER_TILED
modifier. Add updateContentsInVivanteSuperTiledFormat() for CPU writes
to super-tiled buffers.

The feature is controlled via WEBKIT_SKIA_USE_VIVANTE_SUPER_TILED_TILE_TEXTURES
environment variable and requires physical/logical size separation in
BitmapTexture due to 64x64 alignment requirements.

* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::MemoryMappedGPUBuffer):
(WebCore::MemoryMappedGPUBuffer::create):
(WebCore::MemoryMappedGPUBuffer::allocate):
(WebCore::MemoryMappedGPUBuffer::isVivanteSuperTiled const):
(WebCore::MemoryMappedGPUBuffer::mapIfNeeded):
(WebCore::MemoryMappedGPUBuffer::updateContents):
(WebCore::MemoryMappedGPUBuffer::updateContentsInLinearFormat):
(WebCore::MemoryMappedGPUBuffer::updateContentsInVivanteSuperTiledFormat):
(WebCore::MemoryMappedGPUBuffer::mappedDataSpan const):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.cpp: Added.
(WebCore::interleave):
(WebCore::VivanteSuperTiledTexture::zCurveTileLUT):
(WebCore::VivanteSuperTiledTexture::zCurveTexelLUT):
* Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTexture.h: Added.
(WebCore::VivanteSuperTiledTexture::alignToSuperTileIntSize):
(WebCore::VivanteSuperTiledTexture::alignToSuperTile):
* Source/WebCore/platform/graphics/gbm/VivanteSuperTiledTextureInlines.h: Added.
(WebCore::VivanteSuperTiledTexture::VivanteSuperTiledTexture):
(WebCore::VivanteSuperTiledTexture::writeLine):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::updateContents):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):

Canonical link: <a href="https://commits.webkit.org/303900@main">https://commits.webkit.org/303900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8307d4482a8fca0e6b3dee07be33b2dd2ea1e7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2328 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38656 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110806 "Found 2 new test failures: imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-window.html imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4568 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6044 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69509 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->