### PR TITLE
Safari/WebKit ignores vertical padding on a display:table element with 100% height

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6819,7 +6819,6 @@ imported/w3c/web-platform-tests/css/css-tables/fixup-dynamic-anonymous-inline-ta
 imported/w3c/web-platform-tests/css/css-tables/fixup-dynamic-anonymous-table-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/min-max-size-table-content-box.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/rules-groups.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-tables/table-has-box-sizing-border-box-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/tentative/paint/background-image-column-collapsed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/tentative/paint/background-image-column.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/tentative/paint/background-image-row-collapsed.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Reftest Reference</title>
+  <style>
+  div {
+    background-color: green;
+    height: 100px;
+    width: 100px;
+  }
+  </style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Tables: display:table with percentage height, padding, and border-box</title>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#mapping">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="A CSS display:table element with border-box, percentage height, and padding should size correctly with borders included in the specified height">
+
+<style>
+#table-border-box {
+  display: table;
+  box-sizing: border-box;
+  width: 100px;
+  height: 100%;
+  background: green;
+  border: 10px solid green;
+  padding: 10px;
+}
+
+#redSquare {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+  position: absolute;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="redSquare"></div>
+<div style="height: 100px">
+  <div id="table-border-box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Reftest Reference</title>
+  <style>
+  div {
+    background-color: green;
+    height: 100px;
+    width: 100px;
+  }
+  </style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Tables: display:table with percentage height and vertical padding (content-box)</title>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#mapping">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=155919">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="A CSS display:table element with content-box, height:100%, and vertical padding should not ignore the padding">
+
+<style>
+#table-content-box {
+  display: table;
+  box-sizing: content-box;
+  width: 100px;
+  height: 100%;
+  background: green;
+  padding-bottom: 35px;
+}
+
+#redSquare {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+  position: absolute;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="redSquare"></div>
+<div style="height: 65px">
+  <div id="table-content-box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Reftest Reference</title>
+  <style>
+  div {
+    background-color: green;
+    height: 100px;
+    width: 100px;
+  }
+  </style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Tables: display:table with height:stretch and padding</title>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#mapping">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="A CSS display:table element with height:stretch should stretch to fill its container, accounting for padding">
+
+<style>
+#container {
+  height: 100px;
+}
+
+#table {
+  display: table;
+  width: 100px;
+  height: -webkit-fill-available;
+  height: stretch;
+  background: green;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+#redSquare {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+  position: absolute;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="redSquare"></div>
+<div id="container">
+  <div id="table"></div>
+</div>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -387,20 +387,30 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToC
     LayoutUnit borderAndPaddingBefore = borderBefore() + (collapseBorders() ? 0_lu : paddingBefore());
     LayoutUnit borderAndPaddingAfter = borderAfter() + (collapseBorders() ? 0_lu : paddingAfter());
     LayoutUnit borderAndPadding = borderAndPaddingBefore + borderAndPaddingAfter;
-    if (auto fixedStyleLogicalHeight =  styleLogicalHeight.tryFixed()) {
-        // HTML tables size as though CSS height includes border/padding, CSS tables do not.
-        LayoutUnit borders;
+
+    // HTML tables' height styles already include borders and padding, but CSS tables' height styles do not.
+    bool isCSSTable = !is<HTMLTableElement>(element());
+
+    LayoutUnit borders;
+
+    if (auto fixedStyleLogicalHeight = styleLogicalHeight.tryFixed()) {
         // FIXME: We cannot apply box-sizing: content-box on <table> which other browsers allow.
-        if (is<HTMLTableElement>(element()) || style().boxSizing() == BoxSizing::BorderBox) {
+        if (!isCSSTable || style().boxSizing() == BoxSizing::BorderBox)
             borders = borderAndPadding;
-        }
-        return LayoutUnit(fixedStyleLogicalHeight->resolveZoom(style().usedZoomForLength()) - borders);
-    } else if (styleLogicalHeight.isPercentOrCalculated())
-        return computePercentageLogicalHeight(styleLogicalHeight).value_or(0);
-    else if (styleLogicalHeight.isIntrinsicOrStretch())
+        return LayoutUnit(fixedStyleLogicalHeight->resolveZoom(style().usedZoomForLength())) - borders;
+    }
+
+    if (styleLogicalHeight.isPercentOrCalculated()) {
+        LayoutUnit computedHeight = computePercentageLogicalHeight(styleLogicalHeight).value_or(0);
+        if (isCSSTable && style().boxSizing() == BoxSizing::ContentBox)
+            borders = borderAndPadding;
+        return computedHeight + borders;
+    }
+
+    if (styleLogicalHeight.isIntrinsicOrStretch())
         return computeSizingKeywordLogicalContentHeightUsing(styleLogicalHeight, logicalHeight() - borderAndPadding, borderAndPadding).value_or(0);
-    else
-        ASSERT_NOT_REACHED();
+
+    ASSERT_NOT_REACHED();
     return 0_lu;
 }
 


### PR DESCRIPTION
#### 1e2b76db371c59ac88bf5cd7ca83288ef7f4e328
<pre>
Safari/WebKit ignores vertical padding on a display:table element with 100% height
<a href="https://bugs.webkit.org/show_bug.cgi?id=155919">https://bugs.webkit.org/show_bug.cgi?id=155919</a>
<a href="https://rdar.apple.com/122587242">rdar://122587242</a>

Reviewed by NOBODY (OOPS!).

CSS tables with percentage heights were not accounting for borders and padding,
causing vertical padding to be ignored on display:table elements with height:100%.

This change adds border and padding to the computed height for CSS tables with
content-box sizing in the percentage height case. It also clarifies the
distinction between HTML tables (which always treat height as including
border/padding) and CSS tables (which respect box-sizing) by introducing an
isCSSTable variable and restructuring the conditionals.

Now passing table-has-box-sizing-border-box-002.html on WPT.

Tests: imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding.html
       imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding.html
       imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-border-box-padding-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-percentage-height-content-box-padding-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-css-display-stretch-height-with-padding-expected.html: Added.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::convertStyleLogicalHeightToComputedHeight):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e2b76db371c59ac88bf5cd7ca83288ef7f4e328

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105589 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117525 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83353 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98238 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18900 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163341 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125551 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125727 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13010 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24330 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88615 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->