### PR TITLE
Speculation Rules - fix up the tag dedupe logic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Sec-Speculation-Tags: deduped and sorted tags assert_equals: expected (string) "prefetch" but got (object) null
-FAIL Sec-Speculation-Tags: deduped and sorted tags within rules assert_equals: expected (string) "prefetch" but got (object) null
-FAIL Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets assert_equals: expected "\"abc\", \"def\", \"ghi\", \"jkl\"" but got "\"def\", \"jkl\""
-FAIL Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets assert_equals: expected "null, \"abc\", \"def\", \"null\"" but got "null"
-FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "\"def\", \"jkl\""
+PASS Sec-Speculation-Tags: deduped and sorted tags
+PASS Sec-Speculation-Tags: deduped and sorted tags within rules
+PASS Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets
+PASS Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets
+FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "\"abc\", \"def\", \"ghi\", \"jkl\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point down assert_equals: Sec-Speculation-Tags expected "\"conservative\", \"moderate\"" but got "\"conservative\""
+PASS Sec-Speculation-Tags prefetch with eagerness triggered by point down
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point hover assert_equals: Sec-Speculation-Tags expected "\"moderate\"" but got "\"conservative\""
+FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point hover assert_equals: Sec-Speculation-Tags expected "\"moderate\"" but got "\"conservative\", \"moderate\""
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -886,6 +886,7 @@ public:
 
     // https://wicg.github.io/nav-speculation/speculation-rules.html#consider-speculation
     void considerSpeculationRules();
+    void processSpeculationRules();
     Ref<const SpeculationRules> speculationRules() const;
     Ref<SpeculationRules> speculationRules();
 
@@ -2274,6 +2275,7 @@ private:
     const std::unique_ptr<Quirks> m_quirks;
 
     const Ref<SpeculationRules> m_speculationRules;
+    bool m_speculationRulesConsiderationScheduled { false };
 
     RefPtr<LocalDOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -84,7 +84,10 @@ static ResourceRequest makePrefetchRequest(URL&& url, const Vector<String>& tags
         for (size_t i = 0; i < tags.size(); ++i) {
             if (i > 0)
                 builder.append(", "_s);
-            builder.append(tags[i]);
+            if (tags[i] == nullAtom())
+                builder.append("null"_s);
+            else
+                builder.append(tags[i]);
         }
         request.setHTTPHeaderField(HTTPHeaderName::SecSpeculationTags, builder.toString());
     }


### PR DESCRIPTION
#### dbb85c8b0f3ab1cc61837b3439c87c31113372a4
<pre>
Speculation Rules - fix up the tag dedupe logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=303314">https://bugs.webkit.org/show_bug.cgi?id=303314</a>

Reviewed by Alex Christensen.

The tag deduping test cases are failing for multiple reasons:
* Invalid tag rules are causing the entire Speculation Rules script to fail, rather than just the relevant rule.
* `null` rules are not being sorted properly, as they are treated as strings.
* Consecutive speculationrules scripts are being considered individually, rather than wait for the next microtask checkpoint.

This PR fixes all of the above, and with it most of the test cases of the relevant test.

No new tests, but this progresses a currently failing test.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt: Expectation change.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::considerSpeculationRules): Align to spec. Queue a microtask.
(WebCore::Document::processSpeculationRules): Moved the actual logic here. Aligned to spec when it comes to tag deduping.
* Source/WebCore/dom/Document.h: Add m_speculationRulesConsiderationScheduled.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::makePrefetchRequest): Handle null string as a tag.
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::parseSingleRule): Dedupe tag if identical to ruleset tag. Append null instead of &quot;null&quot;.
(WebCore::parseRules): Don&apos;t terminate speculation rules processing due to an invalid rule.
(WebCore::SpeculationRules::parseSpeculationRules): Add spec comments.

Canonical link: <a href="https://commits.webkit.org/303850@main">https://commits.webkit.org/303850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352eecf5095238bd2b2bd326b340e14c0efddb11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1989 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110566 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4266 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59274 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34130 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5425 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69031 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->