### PR TITLE
[threaded-animations] WPT test `scroll-animations/css/scroll-timeline-frame-size-changed.html` fails with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3163,6 +3163,10 @@ void KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const 
 {
     AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(animationAttachmentRange);
     m_needsComputedKeyframeOffsetsUpdate = true;
+#if ENABLE(THREADED_ANIMATIONS)
+    if (canHaveAcceleratedRepresentation())
+        updateAcceleratedAnimationIfNecessary();
+#endif
 }
 
 void KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded()

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1523,12 +1523,13 @@ void WebAnimation::autoAlignStartTime()
     auto endOffset = interval.second;
 
     // 7. Set start time to start offset if effective playback rate ≥ 0, and end offset otherwise.
-    m_startTime = effectivePlaybackRate() >= 0 ? startOffset : endOffset;
+    auto previousStartTime = std::exchange(m_startTime, effectivePlaybackRate() >= 0 ? startOffset : endOffset);
 
     // 8. Clear hold time.
     m_holdTime = std::nullopt;
 
-    progressBasedTimelineSourceDidChangeMetrics();
+    if (previousStartTime != m_startTime)
+        progressBasedTimelineSourceDidChangeMetrics();
 }
 
 bool WebAnimation::needsTick() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
@@ -49,6 +49,15 @@ RemoteProgressBasedTimeline::RemoteProgressBasedTimeline(TimelineID identifier, 
     updateCurrentTime();
 }
 
+void RemoteProgressBasedTimeline::setResolutionData(const WebCore::ScrollingTreeScrollingNode* node, WebCore::ProgressResolutionData resolutionData)
+{
+    m_resolutionData = resolutionData;
+    if (node)
+        updateCurrentTime(*node);
+    else
+        updateCurrentTime();
+}
+
 void RemoteProgressBasedTimeline::updateCurrentTime(const WebCore::ScrollingTreeScrollingNode& node)
 {
     auto unconstrainedScrollOffset = m_resolutionData.isVertical ? node.currentScrollOffset().y() : node.currentScrollOffset().x();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h
@@ -47,7 +47,7 @@ public:
 
     WebCore::ScrollingNodeID source() const { return m_resolutionData.source; }
     WebCore::ProgressResolutionData resolutionData() const { return m_resolutionData; }
-    void setResolutionData(WebCore::ProgressResolutionData resolutionData) { m_resolutionData = resolutionData; }
+    void setResolutionData(const WebCore::ScrollingTreeScrollingNode*, WebCore::ProgressResolutionData);
 
     void updateCurrentTime(const WebCore::ScrollingTreeScrollingNode&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -33,13 +33,15 @@
 
 namespace WebKit {
 
+class RemoteScrollingTree;
+
 class RemoteProgressBasedTimelineRegistry {
     WTF_MAKE_TZONE_ALLOCATED(RemoteProgressBasedTimelineRegistry);
 public:
     RemoteProgressBasedTimelineRegistry() = default;
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
-    void update(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
+    void update(const RemoteScrollingTree&, WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
     RemoteProgressBasedTimeline* get(const TimelineID&) const;
     void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
     bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -304,7 +304,7 @@ void RemoteScrollingTree::updateTimelineRegistration(WebCore::ProcessIdentifier 
 {
     if (!m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry = makeUnique<RemoteProgressBasedTimelineRegistry>();
-    m_progressBasedTimelineRegistry->update(processIdentifier, timelineRepresentations);
+    m_progressBasedTimelineRegistry->update(*this, processIdentifier, timelineRepresentations);
     if (m_progressBasedTimelineRegistry->isEmpty())
         m_progressBasedTimelineRegistry = nullptr;
 }


### PR DESCRIPTION
#### eb920617601aa76e79ec3ac56f74f309938d3aac
<pre>
[threaded-animations] WPT test `scroll-animations/css/scroll-timeline-frame-size-changed.html` fails with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303317">https://bugs.webkit.org/show_bug.cgi?id=303317</a>
<a href="https://rdar.apple.com/165620505">rdar://165620505</a>

Reviewed by Simon Fraser.

Make sure we update the remote counterpart of an animation when the source of
its associated timeline changes metrics. Additionally, when we update the data
derived from the source metrics on the remote end, make sure to update the timeline&apos;s
current time to reflect that change, using the source node to compute the current
scroll offset.

Finally, because we also enter this &quot;source did change metrics&quot; code path when
a new auto-aligned animation start time is computed, and this can run on every
page rendering update, let&apos;s make sure we do so more sparingly by checking whether
the auto-aligned start time has changed.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedScrollDrivenAnimationsEnabled=true`.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::autoAlignStartTime):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp:
(WebKit::RemoteProgressBasedTimeline::setResolutionData):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::update):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::updateTimelineRegistration):

Canonical link: <a href="https://commits.webkit.org/303811@main">https://commits.webkit.org/303811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/991a01e70ae376585a7c884f9fb9a08a35a38dbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85621 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102185 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69551 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82981 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4558 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2164 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5746 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110563 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110741 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4413 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59495 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20664 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5798 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34342 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5645 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->