### PR TITLE
AX: live region announcements should respect language of changed element

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt
@@ -1,0 +1,13 @@
+This tests that live region notifications for elements with different languages include the right language attributes.
+
+Announcement received, notification: AXAnnouncementRequested, attributed string: Manzana{
+    UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
+    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
+    UIAccessibilitySpeechAttributeLanguage = es;
+}
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Apple: Manzana

--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages.html
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="region" aria-live="polite">
+<span lang="en">Apple:</span>
+<span lang="es" id="spanish-region"></span>
+</div>
+
+<script>
+var output = "This tests that live region notifications for elements with different languages include the right language attributes.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Announcement received, notification: ${notification}, attributed string: ${userInfo["AXAnnouncementRequested"]}\n\n`;
+
+        testFinished = true;
+    }	
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+
+    document.getElementById("spanish-region").textContent = "Manzana";
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
@@ -3,10 +3,12 @@ This test verifies that live region notifications are properly formatted on iOS 
 Announcement received, notification: AXAnnouncementRequested, attributed string: Price: $10{
     UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
     UIAccessibilitySpeechAttributeIsLiveRegion = 1;
+    UIAccessibilitySpeechAttributeLanguage = en;
 }
 Announcement received, notification: AXAnnouncementRequested, attributed string: Count: 5{
     UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityDefault;
     UIAccessibilitySpeechAttributeIsLiveRegion = 1;
+    UIAccessibilitySpeechAttributeLanguage = en;
 }
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt
@@ -1,7 +1,9 @@
 This tests alerts that are added to the page dynamically are announced.
 
 Received announcement request:
-AnnouncementKey: This is an alert!!
+AnnouncementKey: This is an alert!!{
+    AXLanguage = en;
+}
 AXPriorityKey: 90
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt
@@ -1,7 +1,9 @@
 This tests that when an alert (implicit live region) is initialized, it is announced.
 
 Received announcement request:
-AnnouncementKey: Important announcement
+AnnouncementKey: Important announcement{
+    AXLanguage = en;
+}
 AXPriorityKey: 90
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt
@@ -1,7 +1,9 @@
 This tests live regions that are added to the page dynamically behave correctly.
 
 Received announcement request:
-AnnouncementKey: Alert! Region changed
+AnnouncementKey: Alert! Region changed{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt
@@ -1,7 +1,9 @@
 This tests that changes to aria-hidden regions don't result in live region changes.
 
 Received announcement request:
-AnnouncementKey: More exposed content.
+AnnouncementKey: More exposed content.{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-languages-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-languages-expected.txt
@@ -1,0 +1,14 @@
+This tests that live region notifications for elements with different languages include the right language attributes.
+
+Received announcement request:
+AnnouncementKey: Manzana{
+    AXLanguage = es;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Apple: Manzana

--- a/LayoutTests/accessibility/mac/live-regions/live-region-languages.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-languages.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="region" aria-live="polite">
+<span lang="en">Apple:</span>
+<span lang="es" id="spanish-region"></span>
+</div>
+
+<script>
+var output = "This tests that live region notifications for elements with different languages include the right language attributes.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+
+        testFinished = true;
+    }	
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    document.getElementById("spanish-region").textContent = "Manzana";
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
@@ -1,7 +1,15 @@
 This tests that the notifications for aria-relevant=removals are correct.
 
 Received announcement request:
-AnnouncementKey: removed Mariners
+AnnouncementKey:
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: removed {
+}Mariners{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt
@@ -1,12 +1,16 @@
 This tests that the notifications for aria-live=polite and aria-live=assertive are properly formatted.
 
 Received announcement request:
-AnnouncementKey: Price: $10
+AnnouncementKey: Price: $10{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 
 Received announcement request:
-AnnouncementKey: Count: 5
+AnnouncementKey: Count: 5{
+    AXLanguage = en;
+}
 AXPriorityKey: 90
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
@@ -4,12 +4,16 @@ Received announcement request:
 AnnouncementKey: 1. California
 1. Cupertino
 2. San Francisco
-3. Los Angeles
+3. Los Angeles{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 
 Received announcement request:
-AnnouncementKey: 4. Washington
+AnnouncementKey: 4. Washington{
+    AXLanguage = en;
+}
 AXPriorityKey: 10
 AXAnnouncementIsLiveRegionKey: true
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1055,6 +1055,9 @@ accessibility/mac/iframe-hit-testing.html [ Skip ]
 accessibility/mac/aria-notify-with-options.html [ Skip ]
 accessibility/mac/aria-notify.html [ Skip ]
 
+# Skipping because announcement notifications don't work in the WK1 testrunner.
+accessibility/mac/live-regions/ [ Skip ]
+
 # DOM paste access requests are not implemented in WebKit1.
 editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
 editing/async-clipboard/clipboard-do-not-read-text-from-platform-if-text-changes.html [ Skip ]

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -28,7 +28,11 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+#if PLATFORM(COCOA)
+
 #include "AXCoreObject.h"
+#include "AttributedString.h"
 #include <wtf/HashMap.h>
 #include <wtf/text/WTFString.h>
 
@@ -48,6 +52,7 @@ enum class LiveRegionRelevant : uint8_t {
 struct LiveRegionObject {
     AXID objectID;
     String text;
+    String language;
 };
 
 struct LiveRegionSnapshot {
@@ -81,10 +86,12 @@ private:
     String textForObject(AccessibilityObject&) const;
     void postAnnouncementForChange(AccessibilityObject&, const LiveRegionSnapshot&, const LiveRegionSnapshot&);
     LiveRegionDiff computeChanges(const Vector<LiveRegionObject>&, const Vector<LiveRegionObject>&) const;
-    String computeAnnouncement(const LiveRegionSnapshot&, const LiveRegionDiff&) const;
+    AttributedString computeAnnouncement(const LiveRegionSnapshot&, const LiveRegionDiff&) const;
 
     CheckedRef<AXObjectCache> m_cache;
     HashMap<AXID, LiveRegionSnapshot> m_liveRegions;
 };
 
 } // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -44,6 +44,7 @@
 #include <wtf/WeakHashSet.h>
 
 #if PLATFORM(COCOA)
+#include <WebCore/AttributedString.h>
 #include <wtf/RetainPtr.h>
 #endif
 
@@ -152,13 +153,13 @@ struct AriaNotifyData {
     String language;
 };
 
+#if PLATFORM(COCOA)
 // When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
 struct LiveRegionAnnouncementData {
-    String message;
+    AttributedString message;
     LiveRegionStatus status { LiveRegionStatus::Polite };
 };
 
-#if PLATFORM(COCOA)
 struct AXTextChangeContext {
     AXTextStateChangeIntent intent;
     String deletedText;
@@ -533,7 +534,7 @@ public:
     }
     void postNotification(AccessibilityObject&, AXNotification);
     void postARIANotifyNotification(Node&, const String&, const AriaNotifyOptions&);
-    void postLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const String&);
+    void postLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const AttributedString&);
     // Requests clients to announce to the user the given message in the way they deem appropriate.
     WEBCORE_EXPORT void announce(const String&);
 
@@ -658,11 +659,11 @@ protected:
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT void postPlatformAnnouncementNotification(const String&);
     WEBCORE_EXPORT void postPlatformARIANotifyNotification(const String&, NotifyPriority, InterruptBehavior, const String&);
-    WEBCORE_EXPORT void postPlatformLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const String&);
+    WEBCORE_EXPORT void postPlatformLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const AttributedString&);
 #else
     void postPlatformAnnouncementNotification(const String&) { }
     void postPlatformARIANotifyNotification(const String&, NotifyPriority, InterruptBehavior, const String&) { }
-    void postPlatformLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const String&) { }
+    void postPlatformLiveRegionNotification(AccessibilityObject&, LiveRegionStatus, const AttributedString&) { }
 #endif
 
     void frameLoadingEventPlatformNotification(RenderView*, AXLoadingEvent);
@@ -737,7 +738,9 @@ private:
     void handleARIARoleDescriptionChanged(Element&);
     void handleMenuOpened(Element&);
     void handleLiveRegionCreated(Element&);
+#if PLATFORM(COCOA)
     void initializeLiveRegionManager();
+#endif
     void handleMenuItemSelected(Element*);
     void handleTabPanelSelected(Element*, Element*);
     void handleRowCountChanged(AccessibilityObject*, Document*);
@@ -820,7 +823,9 @@ private:
     WeakHashMap<RenderText, LineRange, SingleThreadWeakPtrImpl> m_mostRecentlyPaintedText;
 
     std::unique_ptr<AXComputedObjectAttributeCache> m_computedObjectAttributeCache;
+#if PLATFORM(COCOA)
     std::unique_ptr<AXLiveRegionManager> m_liveRegionManager;
+#endif
 
     WEBCORE_EXPORT static std::atomic<bool> gAccessibilityEnabled;
     static bool gAccessibilityEnhancedUserInterfaceEnabled;
@@ -868,9 +873,9 @@ private:
     bool m_modalNodesInitialized { false };
     bool m_isRetrievingCurrentModalNode { false };
 
+#if PLATFORM(COCOA)
     bool m_liveRegionManagerInitialized { false };
 
-#if PLATFORM(COCOA)
     static std::atomic<bool> gShouldRepostNotificationsForTests;
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9006,11 +9006,13 @@ header: <WebCore/AXObjectCache.h>
     String language;
 };
 
+#if PLATFORM(COCOA)
 header: <WebCore/AXObjectCache.h>
 [CustomHeader] struct WebCore::LiveRegionAnnouncementData {
-    String message;
+    WebCore::AttributedString message;
     WebCore::LiveRegionStatus status;
 };
+#endif
 
 header: <WebCore/ScriptTrackingPrivacyCategory.h>
 [OptionSet] enum class WebCore::ScriptTrackingPrivacyFlag : uint16_t {


### PR DESCRIPTION
#### 4f7a7f65db7a33c5fb5304def9ca231fa15ca915
<pre>
AX: live region announcements should respect language of changed element
<a href="https://bugs.webkit.org/show_bug.cgi?id=303321">https://bugs.webkit.org/show_bug.cgi?id=303321</a>
<a href="https://rdar.apple.com/100275523">rdar://100275523</a>

Reviewed by Tyler Wilcock.

Live regions are tied to elements that may have defined languages. If a live region announcement
is posted for one of these elements, the AT should speak this announcement in the right
voice for that language.

To make this possible, we now post announcement notifications on all platforms as attributed
strings (previously, this was limited to iOS). In doing so, we can supply the language
attribute for the AT to consume.

Tests: accessibility/ios-simulator/live-regions/live-region-languages.html
       accessibility/mac/live-regions/live-region-languages.html

* LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages.html: Added.
* LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-alert-added-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-alert-on-initial-load-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-dynamically-added-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-hidden-content-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-languages-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-languages.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-types-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::computeChanges const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):
(WebCore::AXLiveRegionManager::postAnnouncementForChange):
* Source/WebCore/accessibility/AXLiveRegionManager.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::postLiveRegionNotification):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::relayLiveRegionNotification):

Canonical link: <a href="https://commits.webkit.org/303732@main">https://commits.webkit.org/303732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beae535b0a26c037400c666cefcd752f8319e989

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140995 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82869 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2045 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4308 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59360 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5665 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34188 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->