### PR TITLE
PDF annotations are correct in TestWebKitAPI.PDFSnapshot.InlineLinks

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm
@@ -212,13 +212,18 @@ TEST(PDFSnapshot, InlineLinks)
         RetainPtr page = [document pageAtIndex:0];
         EXPECT_NE(page.get(), nil);
 
-        // FIXME <rdar://problem/55086988>: There should be a link here, but due to the way we gather links for
-        // annotation using the RenderInline tree it is missed.
+        RetainPtr annotations = [page annotations];
+        EXPECT_EQ([annotations count], 1u);
+        if ([annotations count]) {
+            EXPECT_TRUE([[annotations objectAtIndex:0] isLink]);
+            EXPECT_TRUE([[[annotations objectAtIndex:0] linkURL] isEqual:[NSURL URLWithString:@"https://webkit.org/"]]);
 
-//        auto annotations = page->annotations();
-//        EXPECT_EQ(annotations.size(), 1u);
-//        EXPECT_TRUE(annotations[0].isLink());
-//        EXPECT_TRUE([annotations[0].linkURL() isEqual:[NSURL URLWithString:@"https://webkit.org/"]]);
+            auto cRect = [page rectForCharacterAtIndex:1];
+            auto cMidpoint = CGPointMake(CGRectGetMidX(cRect), CGRectGetMidY(cRect));
+            auto annotationBounds = [[annotations objectAtIndex:0] bounds];
+
+            EXPECT_TRUE(CGRectContainsPoint(annotationBounds, cMidpoint));
+        }
 
         didTakeSnapshot = true;
     }];


### PR DESCRIPTION
#### b58f588e2a83ce2c02dbda4bcbdce4c65fdda631
<pre>
PDF annotations are correct in TestWebKitAPI.PDFSnapshot.InlineLinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=303328">https://bugs.webkit.org/show_bug.cgi?id=303328</a>
<a href="https://rdar.apple.com/165632082">rdar://165632082</a>

Unreviewed, restore test expectations commented out in 215308@main since
they no longer seem to be failing.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFSnapshot.mm:
(TestWebKitAPI::TEST(PDFSnapshot, InlineLinks)):

Canonical link: <a href="https://commits.webkit.org/303712@main">https://commits.webkit.org/303712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d58948733bc14b7af6c97e0d64643e28d1e010e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140931 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3afb836e-280d-4992-a7f0-8493a2b521e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102030 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/808ec629-8657-4486-a706-e583b112149a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4534 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82821 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef29eec4-7b95-4228-9909-3857c4c0dbb8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2005 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113509 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143578 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5547 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110405 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110584 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4282 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/115852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59297 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20632 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5602 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5448 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->