### PR TITLE
[LFC] Add API to get the preferred minimum and maximum widths of a box.

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -62,6 +62,19 @@ LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box) const
     return m_globalLayoutState->logicalHeightWithFormattingContextForBox(box, LayoutIntegration::LogicalHeightType::MinContent);
 }
 
+LayoutUnit IntegrationUtils::preferredMinWidth(const ElementBox& box) const
+{
+    ASSERT(box.isGridItem());
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::PreferredMinimum);
+}
+
+
+LayoutUnit IntegrationUtils::preferredMaxWidth(const ElementBox& box) const
+{
+    ASSERT(box.isGridItem());
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::PreferredMaximum);
+}
+
 void IntegrationUtils::layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLogicalTopLeft, const InlineLayoutState& inlineLayoutState) const
 {
     ASSERT(block.isBlockLevelBox());

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -48,6 +48,8 @@ public:
     LayoutUnit maxContentWidth(const ElementBox&) const;
     LayoutUnit minContentWidth(const ElementBox&) const;
     LayoutUnit minContentHeight(const ElementBox&) const;
+    LayoutUnit preferredMinWidth(const ElementBox&) const;
+    LayoutUnit preferredMaxWidth(const ElementBox&) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLogicalTopLeft, const InlineLayoutState&) const;
 
     static BlockLayoutState::MarginState toMarginState(const RenderBlockFlow::MarginInfo&);

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -174,7 +174,7 @@ bool Box::establishesGridFormattingContext() const
 
 bool Box::establishesIndependentFormattingContext() const
 {
-    return isLayoutContainmentBox() || isAbsolutelyPositioned() || isFlexItem();
+    return isLayoutContainmentBox() || isAbsolutelyPositioned() || isFlexItem() || isGridItem();
 }
 
 bool Box::isRelativelyPositioned() const


### PR DESCRIPTION
#### a09df3a175d827276932c3a68fbfbbd4317710b8
<pre>
[LFC] Add API to get the preferred minimum and maximum widths of a box.
<a href="https://rdar.apple.com/165634646">rdar://165634646</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303330">https://bugs.webkit.org/show_bug.cgi?id=303330</a>

Reviewed by Alan Baradlay.

The grid track sizing algorithm may ask for a grid item&apos;s minimum and
maximum content contributions to use during track sizing.

<a href="https://drafts.csswg.org/css-grid-1/#algo-single-span-items">https://drafts.csswg.org/css-grid-1/#algo-single-span-items</a>

In RenderTree, this is done by calling into the preferred logical widths
API and using that value as the contribution (see GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem)
for the inline dimensions. Before we can add similar logic to GFC we
need to to have some sort of an equivalent API so in this patch we add a
couple more functions to LayoutIntegrationUtils to get these values to
keep behavior consistent with RenderTree.

Since only grid item&apos;s as of now will use this API, I added an ASSERT to
make sure this is valid when someone calls it. If someone wants to use
this for another purpose at some point in the future this should
hopefully make sure this is actually what they want, and as a result
modify the ASSERT, or help them realize they may want something else.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::establishesIndependentFormattingContext const):
This is ASSERTed by formattingContextRootLogicalWidthForType so we need
to modify this since grid items also establish an independent
formatting context for their content.

Canonical link: <a href="https://commits.webkit.org/303760@main">https://commits.webkit.org/303760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c47e301695c8569e9cc97ac1a8ecb34cf0c5cf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85437 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1def751a-d352-4937-ace7-82528ca509d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69475 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3da434a0-50ea-4479-adbf-5b29a40c2b1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82828 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/767dba58-83be-43f8-99da-059c13ab6b0a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4419 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2013 "Found 1 new API test failure: TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110409 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110589 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4286 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5616 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34149 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->