### PR TITLE
Fix RefCountable naming and operators

### DIFF
--- a/Source/WTF/wtf/Box.h
+++ b/Source/WTF/wtf/Box.h
@@ -62,11 +62,11 @@ public:
     {
         if (!isValid())
             return nullptr;
-        return **m_data;
+        return &**m_data;
     }
 
-    T& operator*() const { RELEASE_ASSERT(isValid()); return ***m_data; }
-    T* operator->() const { RELEASE_ASSERT(isValid()); return **m_data; }
+    T& operator*() const { RELEASE_ASSERT(isValid()); return **m_data; }
+    T* operator->() const { RELEASE_ASSERT(isValid()); return &**m_data; }
 
     explicit operator bool() const { return isValid(); }
 

--- a/Source/WTF/wtf/RefCountable.h
+++ b/Source/WTF/wtf/RefCountable.h
@@ -49,27 +49,15 @@ public:
     {
     }
 
-    T* WTF_NONNULL operator*()
+    T& operator*()
     {
-        return &m_value;
+        return m_value;
     }
 
-    const T* WTF_NONNULL operator*() const
+    const T& operator*() const
     {
-        return &m_value;
+        return m_value;
     }
-
-#ifdef __swift__
-    void swiftRef()
-    {
-        WTF::ref(this);
-    }
-
-    void swiftDeref()
-    {
-        WTF::deref(this);
-    }
-#endif
 
 private:
     template<typename... Arguments>
@@ -80,6 +68,6 @@ private:
     }
 
     T m_value;
-} SWIFT_SHARED_REFERENCE(.swiftRef, .swiftDeref);
+} SWIFT_SHARED_REFERENCE(.ref, .deref);
 
 } // namespace WTF


### PR DESCRIPTION
#### eb65f1330ec20ed2c83a0b793042104deddfcfa7
<pre>
Fix RefCountable naming and operators
<a href="https://bugs.webkit.org/show_bug.cgi?id=303332">https://bugs.webkit.org/show_bug.cgi?id=303332</a>
<a href="https://rdar.apple.com/165635016">rdar://165635016</a>

Reviewed by Geoffrey Garen.

This changes two things in the RefCountable type:

* Removal of the ref/deref members as requested during code review.
* Changes operator* to return a reference rather than a pointer. This
  is more normal, and it unblocks use of .pointee syntax in Swift
  to call non-const member functions, which we were previously
  going to fix a different way in
  <a href="https://bugs.webkit.org/show_bug.cgi?id=303180">https://bugs.webkit.org/show_bug.cgi?id=303180</a>

Canonical link: <a href="https://commits.webkit.org/303735@main">https://commits.webkit.org/303735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a25e4c2e3c8d791fc17c5dde0c7b006dbaaef22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad0086e1-21d5-4a81-88c7-ec9c5f071626) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d15a41a-eb48-4389-90c5-bc314b6872c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82854 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6449875-7792-449f-b60b-3e4eccd93ae2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4436 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2030 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125486 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143616 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131925 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110434 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4296 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59335 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34175 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164890 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69092 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43086 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->