### PR TITLE
Unreviewed ASAN build fix for retag-on-scavenge

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -511,6 +511,30 @@ PAS_IGNORE_WARNINGS_END
         } \
     } while (0)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PAS_ALWAYS_INLINE uintptr_t
+pas_mte_maybe_tag_allocated_region(
+    uintptr_t begin,
+    size_t size,
+    pas_allocation_mode mode,
+    pas_allocator_homogeneity homogeneity,
+    pas_allocation_initiality initiality,
+    bool is_known_medium);
+
+PAS_ALWAYS_INLINE uintptr_t
+pas_mte_retag_freed_region_if_tagged(
+    uintptr_t begin,
+    size_t size,
+    pas_page_base_config page_config,
+    pas_allocator_homogeneity homogeneity);
+
+#ifdef __cplusplus
+}
+#endif
+
 /*
  * MTE can be used to protect against both spatial (e.g. out-of-bounds) and
  * temporal (e.g. use-after-free) memory safety violations.


### PR DESCRIPTION
#### ce6045858673f8ed970b7946099d99e6db029f3c
<pre>
Unreviewed ASAN build fix for retag-on-scavenge
<a href="https://bugs.webkit.org/show_bug.cgi?id=303334">https://bugs.webkit.org/show_bug.cgi?id=303334</a>
<a href="https://rdar.apple.com/165635398">rdar://165635398</a>

Unreviewed build fix.

Issue introduced in <a href="https://commits.webkit.org/303411@main">https://commits.webkit.org/303411@main</a>
The two new functions, pas_mte_maybe_tag_allocated_region and
pas_mte_retag_freed_region_if_tagged, need to be guarded by
`extern &quot;C&quot;` when pas_mte.h is used in C++ code.

* Source/bmalloc/libpas/src/libpas/pas_mte.h:

Canonical link: <a href="https://commits.webkit.org/303695@main">https://commits.webkit.org/303695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07c15970a9e8c6d3fbe30a59f8eea560172a2d18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68d16eb8-5c6b-447a-8eb7-062fe92d19ed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/38107d93-0c7b-4d26-bae1-a88c0b901f3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/82829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07dd046e-c3b5-4e3e-bdc3-e4a299562469) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125461 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131900 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5560 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110588 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28015 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115827 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164865 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43075 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->