### PR TITLE
Group filter input data into a `FilterGeometry` struct

### DIFF
--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
@@ -206,20 +206,36 @@ setTimeout(async () => {
                     }
                     }
                 ],
-                filterRenderingModes : 135,
-                filterScale :
-                    { width : 3.2175183536110756e-38, height : 1.4142135623730951 },
-                filterRegion : {
-                    location :
-                    { x : -509502506841300.9, y : -5.566387275235406e-27 },
-                    size : {
-                    width : 1.961817850054744e-44,
-                    height : 1.723597111119525e-43
+                geometry: {
+                    referenceBox : {
+                        location : {
+                            x : -509502506841300.9,
+                            y : -5.566387275235406e-27
+                        },
+                        size : {
+                            width : 1.961817850054744e-44,
+                            height : 1.723597111119525e-43
+                        }
+                    },
+                    filterRegion : {
+                        location : {
+                            x : -509502506841300.9,
+                            y : -5.566387275235406e-27
+                        },
+                        size : {
+                            width : 1.961817850054744e-44,
+                            height : 1.723597111119525e-43
+                        }
+                    },
+                    scale : {
+                        width : 3.2175183536110756e-38,
+                        height : 1.4142135623730951
                     }
-                }
-                }
+                },
+                filterRenderingModes : 135
             }
             }
+        }
         });
 
     o58.connection.invalidate();

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -66,13 +66,6 @@
                     subclasses: {
                         variantType: "WebCore::SVGFilterRenderer",
                         variant: {
-                            targetBoundingBox: {
-                                location: { x: 0, y: 0 },
-                                size: {
-                                    width: 1,
-                                    height: 1,
-                                },
-                            },
                             primitiveUnits: 0,
                             expression: { alias: [] },
                             effects: [
@@ -101,26 +94,38 @@
                                     },
                                 },
                             ],
-                            renderingResourceIdentifierIfExists: {},
-                            filterRenderingModes: 0,
-                            filterScale: {
-                                width: 1,
-                                height: 1,
+                            geometry: {
+                                referenceBox : {
+                                    location : {
+                                        x : 0,
+                                        y : 0
+                                    },
+                                    size : {
+                                        width : 1,
+                                        height : 1
+                                    }
+                                },
+                                filterRegion : {
+                                    location : {
+                                        x : 1,
+                                        y : 1
+                                    },
+                                    size : {
+                                        width : 1,
+                                        height : 1
+                                    }
+                                },
+                                scale : {
+                                    width : 1,
+                                    height : 1
+                                }
                             },
-                            filterRegion: {
-                                location: {
-                                    x: 1,
-                                    y: 1,
-                                },
-                                size: {
-                                    width: 1,
-                                    height: 1,
-                                },
+                            filterRenderingModes: 0,
+                            renderingResourceIdentifierIfExists: {},
                             },
                         },
                     },
-                },
-            });
+                });
         } catch (err) {
             // We expect validation to fail and return a TypeError to us. If we get any other kind of error,
             // log this so we can address the issue as this may indicate the test is non-functional. If the

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -65,13 +65,34 @@
                                 }
                             }
                         ],
-                        renderingResourceIdentifierIfExists: {},
-                        filterRenderingModes: 1,
-                        filterScale: {width: 0, height: 0},
-                        filterRegion: {
-                            location: {x: 0, y: 0},
-                            size: {width: 0, height: 0}
+                        geometry: {
+                            referenceBox : {
+                                location : {
+                                    x : 0,
+                                    y : 0
+                                },
+                                size : {
+                                    width : 0,
+                                    height : 0
+                                }
+                            },
+                            filterRegion : {
+                                location : {
+                                    x : 0,
+                                    y : 0
+                                },
+                                size : {
+                                    width : 0,
+                                    height : 0
+                                }
+                            },
+                            scale : {
+                                width : 0,
+                                height : 0
+                            }
                         },
+                        filterRenderingModes: 1,
+                        renderingResourceIdentifierIfExists: {},
                     }
                 },
             }

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -91,21 +91,34 @@
                                         }
                                     }
                                 }],
-                                filterRenderingModes: 1,
-                                filterScale: {
-                                    width: 68,
-                                    height: 3
-                                },
-                                filterRegion: {
-                                    location: {
-                                        x: 39,
-                                        y: 112
+                                geometry: {
+                                    referenceBox : {
+                                        location : {
+                                            x: 39,
+                                            y: 112
+                                        },
+                                        size : {
+                                            width: 32,
+                                            height: 110
+                                        }
                                     },
-                                    size: {
-                                        width: 32,
-                                        height: 110
+                                    filterRegion : {
+                                        location : {
+                                            x: 39,
+                                            y: 112
+                                        },
+                                        size : {
+                                            width: 32,
+                                            height: 110
+                                        }
+                                    },
+                                    scale : {
+                                        width : 68,
+                                        height : 3
                                     }
-                                }
+                                },
+                                filterRenderingModes: 1,
+                                renderingResourceIdentifierIfExists: {},
                             }
                         }
                     }

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -45,10 +45,6 @@ window.setTimeout(async () => {
                 subclasses: {
                     variantType: 'WebCore::SVGFilterRenderer',
                     variant: {
-                        targetBoundingBox: {
-                            location: {x: 0, y: 0},
-                            size: {width: 0, height: 0},
-                        },
                         primitiveUnits: 0,
                         expression: {
                             alias: [
@@ -66,13 +62,34 @@ window.setTimeout(async () => {
                                 }
                             }
                         ],
-                        renderingResourceIdentifierIfExists: {},
-                        filterRenderingModes: 1,
-                        filterScale: {width: 0, height: 0},
-                        filterRegion: {
-                            location: {x: 0, y: 0},
-                            size: {width: 0, height: 0}
+                        geometry: {
+                            referenceBox : {
+                                location : {
+                                    x: 0,
+                                    y: 0
+                                },
+                                size : {
+                                    width: 0,
+                                    height: 0
+                                }
+                            },
+                            filterRegion : {
+                                location : {
+                                    x: 0,
+                                    y: 0
+                                },
+                                size : {
+                                    width: 0,
+                                    height: 0
+                                }
+                            },
+                            scale : {
+                                width : 0,
+                                height : 0
+                            }
                         },
+                        filterRenderingModes: 1,
+                        renderingResourceIdentifierIfExists: {},
                     }
                 },
             }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -122,14 +122,18 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
     if (!page)
         return nullptr;
 
+    auto outsets = calculateFilterOutsets(bounds);
+    auto filterRegion = bounds + toFloatBoxExtent(outsets);
+
     auto preferredFilterRenderingModes = page->preferredFilterRenderingModes(*context);
-    auto filter = CSSFilterRenderer::create(*renderer, state().filter, preferredFilterRenderingModes, { 1, 1 }, bounds, *context);
+    auto filter = CSSFilterRenderer::create(*renderer, state().filter, {
+            .referenceBox = bounds,
+            .filterRegion = filterRegion,
+            .scale = { 1, 1 },
+        }, preferredFilterRenderingModes, *context);
     if (!filter)
         return nullptr;
 
-    auto outsets = calculateFilterOutsets(bounds);
-
-    filter->setFilterRegion(bounds + toFloatBoxExtent(outsets));
     return filter;
 }
 

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -35,6 +35,12 @@ class FilterEffect;
 class FilterImage;
 class FilterResults;
 
+struct FilterGeometry {
+    FloatRect referenceBox;
+    FloatRect filterRegion;
+    FloatSize scale;
+};
+
 class Filter : public FilterFunction {
     using FilterFunction::apply;
     using FilterFunction::createFilterStyles;
@@ -45,11 +51,15 @@ public:
     OptionSet<FilterRenderingMode> filterRenderingModes() const { return m_filterRenderingModes; }
     WEBCORE_EXPORT void setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes);
 
-    FloatSize filterScale() const { return m_filterScale; }
-    void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
+    const FilterGeometry& geometry() const { return m_geometry; }
 
-    FloatRect filterRegion() const { return m_filterRegion; }
-    void setFilterRegion(const FloatRect& filterRegion) { m_filterRegion = filterRegion; }
+    FloatSize filterScale() const { return m_geometry.scale; }
+    void setFilterScale(const FloatSize& filterScale) { m_geometry.scale = filterScale; }
+
+    FloatRect filterRegion() const { return m_geometry.filterRegion; }
+    void setFilterRegion(const FloatRect& filterRegion) { m_geometry.filterRegion = filterRegion; }
+
+    FloatRect referenceBox() const { return m_geometry.referenceBox; }
 
     virtual FloatSize resolvedSize(const FloatSize& size) const { return size; }
     virtual FloatPoint3D resolvedPoint3D(const FloatPoint3D& point) const { return point; }
@@ -70,15 +80,14 @@ public:
 
 protected:
     Filter(Filter::Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
-    Filter(Filter::Type, const FloatSize& filterScale, const FloatRect& filterRegion = { }, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    Filter(Filter::Type, const FilterGeometry&, std::optional<RenderingResourceIdentifier> = std::nullopt);
 
     virtual RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) = 0;
     virtual FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const = 0;
 
 private:
+    FilterGeometry m_geometry;
     OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };
-    FloatSize m_filterScale;
-    FloatRect m_filterRegion;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -43,13 +43,14 @@ struct Filter;
 class CSSFilterRenderer final : public Filter {
     WTF_MAKE_TZONE_ALLOCATED(CSSFilterRenderer);
 public:
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
+
     WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&);
-    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, const FilterGeometry&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
-
     void setFilterRegion(const FloatRect&);
 
     bool hasFilterThatMovesPixels() const { return m_hasFilterThatMovesPixels; }
@@ -66,23 +67,21 @@ public:
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:
-    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
 
-    CSSFilterRenderer(const FloatSize& filterScale, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
-    CSSFilterRenderer(Vector<Ref<FilterFunction>>&&);
-    CSSFilterRenderer(Vector<Ref<FilterFunction>>&&, const FloatSize& filterScale, const FloatRect& filterRegion);
+    CSSFilterRenderer(const FilterGeometry&, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
+    CSSFilterRenderer(Vector<Ref<FilterFunction>>&&, const FilterGeometry&);
 
-    RefPtr<FilterFunction> buildFilterFunction(RenderElement&, const FilterOperation&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
-    bool buildFilterFunctions(RenderElement&, const auto&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    RefPtr<FilterFunction> buildFilterFunction(RenderElement&, const FilterOperation&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
+    bool buildFilterFunctions(RenderElement&, const auto&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const final;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 
+    Vector<Ref<FilterFunction>> m_functions;
     bool m_hasFilterThatMovesPixels { false };
     bool m_hasFilterThatShouldBeRestrictedBySecurityOrigin { false };
-
-    Vector<Ref<FilterFunction>> m_functions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -182,7 +182,11 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_filter || m_targetBoundingBox != targetBoundingBox || m_preferredFilterRenderingModes != preferredFilterRenderingModes) {
         m_targetBoundingBox = targetBoundingBox;
         // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), preferredFilterRenderingModes, m_filterScale, m_targetBoundingBox, context);
+        m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), {
+            .referenceBox = m_targetBoundingBox, // FIXME: It's wrong for the dirty rect to feed into the reference box: webkit.org/b/279290.
+            .filterRegion = m_targetBoundingBox,
+            .scale = m_filterScale,
+        }, preferredFilterRenderingModes, context);
     }
 
     if (!m_filter)

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -136,7 +136,11 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     auto preferredFilterRenderingModes = renderer->protectedPage()->preferredFilterRenderingModes(destinationContext);
     auto sourceImageRect = FloatRect { { }, size };
 
-    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, preferredFilterRenderingModes, FloatSize { 1, 1 }, sourceImageRect, NullGraphicsContext());
+    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, {
+            .referenceBox = sourceImageRect,
+            .filterRegion = sourceImageRect,
+            .scale = { 1, 1 },
+        }, preferredFilterRenderingModes, NullGraphicsContext());
     if (!cssFilter)
         return &Image::nullImage();
 

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -458,12 +458,14 @@ void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceCont
         ts << '\n';
         // Creating a placeholder filter which is passed to the builder.
         Ref filterElement = filter.filterElement();
-        FloatRect dummyRect;
-        FloatSize dummyScale(1, 1);
-        auto dummyFilter = SVGFilterRenderer::create(filterElement.ptr(), filterElement, FilterRenderingMode::Software, dummyScale, dummyRect, dummyRect, NullGraphicsContext());
-        if (dummyFilter) {
+        auto placeholderFilter = SVGFilterRenderer::create(filterElement.ptr(), filterElement, {
+                .referenceBox = { },
+                .filterRegion = { },
+                .scale = { 1, 1},
+            }, FilterRenderingMode::Software, NullGraphicsContext());
+        if (placeholderFilter) {
             TextStream::IndentScope indentScope(ts);
-            dummyFilter->externalRepresentation(ts, FilterRepresentation::TestOutput);
+            placeholderFilter->externalRepresentation(ts, FilterRepresentation::TestOutput);
         }
     } else if (resource.resourceType() == ClipperResourceType) {
         const auto& clipper = static_cast<const LegacyRenderSVGResourceClipper&>(resource);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -131,7 +131,11 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     auto preferredFilterModes = renderer.page().preferredFilterRenderingModes(*context);
 
     // Create the SVGFilterRenderer object.
-    filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, preferredFilterModes, filterScale, filterRegion, targetBoundingBox, *context, RenderingResourceIdentifier::generate());
+    filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, {
+        .referenceBox = targetBoundingBox,
+        .filterRegion = filterRegion,
+        .scale = filterScale,
+    }, preferredFilterModes, *context, RenderingResourceIdentifier::generate());
     if (!filterData->filter) {
         m_rendererFilterDataMap.remove(renderer);
         return { };

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
@@ -38,13 +38,12 @@ class SVGFilterElement;
 
 class SVGFilterRenderer final : public Filter {
 public:
-    static RefPtr<SVGFilterRenderer> create(SVGElement* contextElement, SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
-    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    static RefPtr<SVGFilterRenderer> create(SVGElement* contextElement, SVGFilterElement&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, const FilterGeometry&, OptionSet<FilterRenderingMode>, std::optional<RenderingResourceIdentifier>);
 
     static bool isIdentity(SVGFilterElement&);
     static IntOutsets calculateOutsets(SVGFilterElement&, const FloatRect& targetBoundingBox);
 
-    FloatRect targetBoundingBox() const { return m_targetBoundingBox; }
     SVGUnitTypes::SVGUnitType primitiveUnits() const { return m_primitiveUnits; }
 
     const SVGFilterExpression& expression() const { return m_expression; }
@@ -65,8 +64,8 @@ public:
 
     WEBCORE_EXPORT static bool isValidSVGFilterExpression(const SVGFilterExpression&, const FilterEffectVector&);
 private:
-    SVGFilterRenderer(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
-    SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    SVGFilterRenderer(const FilterGeometry&, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
+    SVGFilterRenderer(const FilterGeometry&, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>);
 
     static std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> buildExpression(SVGElement* contextElement, SVGFilterElement&, const SVGFilterRenderer&, const GraphicsContext& destinationContext);
     void setExpression(SVGFilterExpression&& expression) { m_expression = WTFMove(expression); }
@@ -80,7 +79,6 @@ private:
     RefPtr<FilterImage> apply(const Filter&, FilterImage& sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle& sourceStyle) const final;
 
-    FloatRect m_targetBoundingBox;
     SVGUnitTypes::SVGUnitType m_primitiveUnits;
 
     SVGFilterExpression m_expression;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7569,6 +7569,13 @@ class WebCore::FilterOperations {
 }
 #endif // !USE(COORDINATED_GRAPHICS)
 
+header: <WebCore/Filter.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::FilterGeometry {
+    WebCore::FloatRect referenceBox;
+    WebCore::FloatRect filterRegion;
+    WebCore::FloatSize scale;
+}
+
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::Filter subclasses {
     WebCore::CSSFilterRenderer
     WebCore::SVGFilterRenderer
@@ -7576,22 +7583,17 @@ class WebCore::FilterOperations {
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::CSSFilterRenderer {
     Vector<Ref<WebCore::FilterFunction>> functions();
-
+    WebCore::FilterGeometry geometry();
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
-    WebCore::FloatSize filterScale();
-    WebCore::FloatRect filterRegion();
 }
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SVGFilterRenderer {
-    WebCore::FloatRect targetBoundingBox();
     WebCore::SVGUnitTypes::SVGUnitType primitiveUnits();
     WebCore::SVGFilterExpression expression();
     [Validator='WebCore::SVGFilterRenderer::isValidSVGFilterExpression(*expression, *effects)'] Vector<Ref<WebCore::FilterEffect>> effects();
-    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
-
+    WebCore::FilterGeometry geometry();
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
-    WebCore::FloatSize filterScale();
-    WebCore::FloatRect filterRegion();
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 }
 
 [Nested] enum class WebCore::UserStyleLevel : bool;


### PR DESCRIPTION
#### 0299cff7c92b4e40156ab9d6c84f72c865fd46fc
<pre>
Group filter input data into a `FilterGeometry` struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=303333">https://bugs.webkit.org/show_bug.cgi?id=303333</a>
<a href="https://rdar.apple.com/165636222">rdar://165636222</a>

Reviewed by Said Abou-Hallawa.

The fix for webkit.org/b/279290 needs to plumb `referenceBox` into filter creation,
but adding another argument makes things messy; do some initial refactoring
to plumb through `FilterGeometry`, which contain both the referenceBox and the
filterRegion, as well as the scale. The `Filter` base class now stores `FilterGeometry`.

No behavior change.

* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html:
* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html:
* LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html:
* LayoutTests/ipc/invalid-feConvolveMatrix-crash.html:
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::Filter):
(WebCore::Filter::scaledByFilterScale const):
(WebCore::Filter::maxEffectRect const):
(WebCore::Filter::clampFilterRegionIfNeeded):
(WebCore::Filter::apply):
(WebCore::Filter::createFilterStyles const):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::geometry const):
(WebCore::Filter::filterScale const):
(WebCore::Filter::setFilterScale):
(WebCore::Filter::filterRegion const):
(WebCore::Filter::setFilterRegion):
(WebCore::Filter::referenceBox const):
(WebCore::Filter::Filter): Deleted.
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::CSSFilterRenderer::createGeneric):
(WebCore::CSSFilterRenderer::create):
(WebCore::CSSFilterRenderer::CSSFilterRenderer):
(WebCore::createReferenceFilter):
(WebCore::CSSFilterRenderer::buildFilterFunction):
(WebCore::CSSFilterRenderer::buildFilterFunctions):
* Source/WebCore/rendering/CSSFilterRenderer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGResourceContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::create):
(WebCore::SVGFilterRenderer::SVGFilterRenderer):
(WebCore::buildFilterEffectGraph):
(WebCore::SVGFilterRenderer::resolvedSize const):
(WebCore::SVGFilterRenderer::resolvedPoint3D const):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/303930@main">https://commits.webkit.org/303930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b766be726f487331f9fcd34c5817b59979bce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134022 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45227 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c363493-8db0-43ed-93ca-06d25a1b0a5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135892 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6397 "Failed to checkout and rebase branch from PR 54651") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136969 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cd5b660a-61d0-416f-a8d0-c08b4c57118a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144248 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38852 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/6397 "Failed to checkout and rebase branch from PR 54651") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111105 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28175 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116411 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6255 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69719 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->