### PR TITLE
generate-process-sync-data.py: support specifying multiple header files for each data

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -56,7 +56,7 @@ _header_license = """/*
 class SyncedData(object):
     def __init__(self, name, underlying_type_namespace, underlying_type, options):
         self.conditional = None
-        self.header = None
+        self.headers = None
         self.variant_index = None
 
         if options is not None:
@@ -64,8 +64,8 @@ class SyncedData(object):
             for option in option_list:
                 if option.startswith('Conditional='):
                     self.conditional = option[12:]
-                elif option.startswith('Header='):
-                    self.header = option[7:]
+                elif option.startswith('Headers='):
+                    self.headers = option[8:].split(",")
                 else:
                     raise Exception("Invalid option argument '%s' found" % option)
 
@@ -81,9 +81,9 @@ class SyncedData(object):
 def headers_from_datas(datas):
     header_list = []
     for data in datas:
-        if data.header is None:
+        if data.headers is None:
             continue
-        header_list.append(data.header)
+        header_list.extend(data.headers)
     return header_list
 
 
@@ -289,9 +289,9 @@ def generate_synched_data_header(prefix, variant_sorted_synched_datas, sync_data
     headers.append('<wtf/Ref.h>')
     headers.append('<wtf/RefCounted.h>')
     for data in sync_data_sorted_synched_datas:
-        if data.header is None:
+        if data.headers is None:
             continue
-        headers.append(data.header)
+        headers.extend(data.headers)
 
     for header in headers:
         result.append('#include %s' % header)

--- a/Source/WebCore/Scripts/tests/TestSyncClient.cpp
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.cpp
@@ -63,5 +63,11 @@ void TestSyncClient::broadcastAnotherOneToOtherProcesses(const StringifyThis& da
     dataVariant.emplace<enumToUnderlyingType(TestSyncDataType::AnotherOne)>(data);
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::AnotherOne, WTFMove(dataVariant) });
 }
+void TestSyncClient::broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>& data)
+{
+    TestSyncDataVariant dataVariant;
+    dataVariant.emplace<enumToUnderlyingType(TestSyncDataType::MultipleHeaders)>(data);
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataType::MultipleHeaders, WTFMove(dataVariant) });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/TestSyncClient.h
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.h
@@ -27,6 +27,8 @@
 #include "DOMAudioSession.h"
 #include <wtf/URL.h>
 #include "StringifyThis"
+#include <wtf/HashSet.h>
+#include <wtf/URL.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -50,6 +52,7 @@ public:
     void broadcastIsAutofocusProcessedToOtherProcesses(const bool&);
     void broadcastUserDidInteractWithPageToOtherProcesses(const bool&);
     void broadcastAnotherOneToOtherProcesses(const StringifyThis&);
+    void broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>&);
 
 protected:
     virtual void broadcastTestSyncDataToOtherProcesses(const TestSyncSerializationData&) { }

--- a/Source/WebCore/Scripts/tests/TestSyncData.cpp
+++ b/Source/WebCore/Scripts/tests/TestSyncData.cpp
@@ -42,13 +42,16 @@ void TestSyncData::update(const TestSyncSerializationData& data)
     case TestSyncDataType::UserDidInteractWithPage:
         userDidInteractWithPage = std::get<enumToUnderlyingType(TestSyncDataType::UserDidInteractWithPage)>(data.value);
         break;
+    case TestSyncDataType::AnotherOne:
+        anotherOne = std::get<enumToUnderlyingType(TestSyncDataType::AnotherOne)>(data.value);
+        break;
 #if ENABLE(DOM_AUDIO_SESSION)
     case TestSyncDataType::AudioSessionType:
         audioSessionType = std::get<enumToUnderlyingType(TestSyncDataType::AudioSessionType)>(data.value);
         break;
 #endif
-    case TestSyncDataType::AnotherOne:
-        anotherOne = std::get<enumToUnderlyingType(TestSyncDataType::AnotherOne)>(data.value);
+    case TestSyncDataType::MultipleHeaders:
+        multipleHeaders = std::get<enumToUnderlyingType(TestSyncDataType::MultipleHeaders)>(data.value);
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -59,18 +62,20 @@ TestSyncData::TestSyncData(
       URL mainFrameURLChange
     , bool isAutofocusProcessed
     , bool userDidInteractWithPage
+    , StringifyThis anotherOne
 #if ENABLE(DOM_AUDIO_SESSION)
     , WebCore::DOMAudioSessionType audioSessionType
 #endif
-    , StringifyThis anotherOne
+    , HashSet<URL> multipleHeaders
 )
     : mainFrameURLChange(mainFrameURLChange)
     , isAutofocusProcessed(isAutofocusProcessed)
     , userDidInteractWithPage(userDidInteractWithPage)
+    , anotherOne(anotherOne)
 #if ENABLE(DOM_AUDIO_SESSION)
     , audioSessionType(audioSessionType)
 #endif
-    , anotherOne(anotherOne)
+    , multipleHeaders(multipleHeaders)
 {
 }
 

--- a/Source/WebCore/Scripts/tests/TestSyncData.h
+++ b/Source/WebCore/Scripts/tests/TestSyncData.h
@@ -28,8 +28,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>
-#include "DOMAudioSession.h"
 #include "StringifyThis"
+#include "DOMAudioSession.h"
+#include <wtf/HashSet.h>
+#include <wtf/URL.h>
 
 namespace WebCore {
 
@@ -49,10 +51,11 @@ public:
     URL mainFrameURLChange = { };
     bool isAutofocusProcessed = { };
     bool userDidInteractWithPage = { };
+    StringifyThis anotherOne = { };
 #if ENABLE(DOM_AUDIO_SESSION)
     WebCore::DOMAudioSessionType audioSessionType = { };
 #endif
-    StringifyThis anotherOne = { };
+    HashSet<URL> multipleHeaders = { };
 
 private:
     TestSyncData() = default;
@@ -60,10 +63,11 @@ private:
         URL
       , bool
       , bool
+      , StringifyThis
 #if ENABLE(DOM_AUDIO_SESSION)
       , WebCore::DOMAudioSessionType
 #endif
-      , StringifyThis
+      , HashSet<URL>
     );
 };
 
@@ -75,16 +79,18 @@ enum class TestSyncDataType : uint8_t {
     IsAutofocusProcessed = 2,
     UserDidInteractWithPage = 3,
     AnotherOne = 4,
+    MultipleHeaders = 5,
 };
 
 static const TestSyncDataType allTestSyncDataTypes[] = {
     TestSyncDataType::MainFrameURLChange
     , TestSyncDataType::IsAutofocusProcessed
     , TestSyncDataType::UserDidInteractWithPage
+    , TestSyncDataType::AnotherOne
 #if ENABLE(DOM_AUDIO_SESSION)
     , TestSyncDataType::AudioSessionType
 #endif
-    , TestSyncDataType::AnotherOne
+    , TestSyncDataType::MultipleHeaders
 };
 
 #if !ENABLE(DOM_AUDIO_SESSION)
@@ -96,7 +102,8 @@ using TestSyncDataVariant = Variant<
     URL,
     bool,
     bool,
-    StringifyThis
+    StringifyThis,
+    HashSet<URL>
 >;
 
 struct TestSyncSerializationData {

--- a/Source/WebCore/Scripts/tests/TestSyncData.in
+++ b/Source/WebCore/Scripts/tests/TestSyncData.in
@@ -20,8 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-MainFrameURLChange : URL [Header=<wtf/URL.h>]
-AudioSessionType : WebCore::DOMAudioSessionType [Conditional=ENABLE(DOM_AUDIO_SESSION) Header="DOMAudioSession.h"]
+MainFrameURLChange : URL [Headers=<wtf/URL.h>]
+AudioSessionType : WebCore::DOMAudioSessionType [Conditional=ENABLE(DOM_AUDIO_SESSION) Headers="DOMAudioSession.h"]
 IsAutofocusProcessed : bool
 UserDidInteractWithPage : bool
-AnotherOne : StringifyThis [Header="StringifyThis"]
+AnotherOne : StringifyThis [Headers="StringifyThis"]
+MultipleHeaders : HashSet<URL> [Headers=<wtf/HashSet.h>,<wtf/URL.h>]

--- a/Source/WebCore/Scripts/tests/TestSyncData.serialization.in
+++ b/Source/WebCore/Scripts/tests/TestSyncData.serialization.in
@@ -29,10 +29,11 @@ header: <WebCore/TestSyncData.h>
     URL mainFrameURLChange;
     bool isAutofocusProcessed;
     bool userDidInteractWithPage;
+    StringifyThis anotherOne;
 #if ENABLE(DOM_AUDIO_SESSION)
     WebCore::DOMAudioSessionType audioSessionType;
 #endif
-    StringifyThis anotherOne;
+    HashSet<URL> multipleHeaders;
 };
 
 enum class WebCore::TestSyncDataType : uint8_t {
@@ -43,13 +44,14 @@ enum class WebCore::TestSyncDataType : uint8_t {
     IsAutofocusProcessed,
     UserDidInteractWithPage,
     AnotherOne,
+    MultipleHeaders,
 };
  
 #if !ENABLE(DOM_AUDIO_SESSION)
 using WebCore::DOMAudioSessionType = bool;
 #endif
 
-using WebCore::TestSyncDataVariant = Variant<WebCore::DOMAudioSessionType, URL, bool, bool, StringifyThis>;
+using WebCore::TestSyncDataVariant = Variant<WebCore::DOMAudioSessionType, URL, bool, bool, StringifyThis, HashSet<URL>>;
 
 [CustomHeader] struct WebCore::TestSyncSerializationData {
     WebCore::TestSyncDataType type;

--- a/Source/WebCore/page/DocumentSyncData.in
+++ b/Source/WebCore/page/DocumentSyncData.in
@@ -54,14 +54,16 @@
 #
 # Each entry can have a number of options in a [bracket enclosed, space delimited list]
 # These options currently include:
-#   - A compile time condition for inclusion of the data type
-#   - A header required to declare/define the type
+#   - `Conditional`: A compile time condition for inclusion of the data type
+#                    e.g: `Conditional=ENABLE(FEATURE_NAME)`
+#   - `Headers`: Comma-separated list of headers required to declare/define the type
+#                e.g: `Headers=<WebCore/Header.h>,<WebCore/AnotherHeader.h>`
 
-AudioSessionType : WebCore::DOMAudioSessionType [Conditional=ENABLE(DOM_AUDIO_SESSION) Header=<WebCore/DOMAudioSession.h>]
+AudioSessionType : WebCore::DOMAudioSessionType [Conditional=ENABLE(DOM_AUDIO_SESSION) Headers=<WebCore/DOMAudioSession.h>]
 IsAutofocusProcessed : bool
 UserDidInteractWithPage : bool
 IsClosing : bool
-DocumentURL : URL [Header=<wtf/URL.h>]
-DocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Header=<WebCore/SecurityOrigin.h>]
-DocumentClasses : OptionSet<WebCore::DocumentClass> [Header=<WebCore/DocumentClasses.h>]
+DocumentURL : URL [Headers=<wtf/URL.h>]
+DocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/SecurityOrigin.h>]
+DocumentClasses : OptionSet<WebCore::DocumentClass> [Headers=<WebCore/DocumentClasses.h>]
 HasInjectedUserScript : bool

--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -27,5 +27,5 @@
 # See DocumentSyncData.in for a full description of the format.
 
 FrameCanCreatePaymentSession : bool
-FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Header=<WebCore/SecurityOrigin.h>]
-FrameURLProtocol : String [Header=<wtf/text/WTFString.h>]
+FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/SecurityOrigin.h>]
+FrameURLProtocol : String [Headers=<wtf/text/WTFString.h>]


### PR DESCRIPTION
#### aa0e26ea522182af5fe4371cba95f161c474c39f
<pre>
generate-process-sync-data.py: support specifying multiple header files for each data
<a href="https://rdar.apple.com/165640236">rdar://165640236</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303337">https://bugs.webkit.org/show_bug.cgi?id=303337</a>

Reviewed by Brady Eidson.

Composited types like HashMap&lt;WebCore::FrameIdentifier, std::optional&lt;WebCore::LayoutRect&gt;&gt;
requires multiple header inclusions, which is currently not supported by the script.
Fix this by allowing multiple headers to be included, separated by comma. Also rename
the option from `Header=` to `Headers=` to signal that multiple headers can be specified.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(SyncedData.__init__):
(headers_from_datas):
(generate_synched_data_header):
* Source/WebCore/Scripts/tests/TestSyncClient.cpp:
(WebCore::TestSyncClient::broadcastMultipleHeadersToOtherProcesses):
* Source/WebCore/Scripts/tests/TestSyncClient.h:
* Source/WebCore/Scripts/tests/TestSyncData.cpp:
(WebCore::TestSyncData::update):
(WebCore::TestSyncData::TestSyncData):
* Source/WebCore/Scripts/tests/TestSyncData.h:
* Source/WebCore/Scripts/tests/TestSyncData.in:
* Source/WebCore/Scripts/tests/TestSyncData.serialization.in:
* Source/WebCore/page/DocumentSyncData.in:
* Source/WebCore/page/FrameTreeSyncData.in:

Canonical link: <a href="https://commits.webkit.org/303800@main">https://commits.webkit.org/303800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f978368c849673822eb8cf37d81ce8835d0f1ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133404 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85451 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a120c34b-74e0-47e8-b772-9873f7af1a5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69479 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/02144431-ac07-43b3-bad1-1fc200b07aea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82838 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4432 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2023 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143606 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110420 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4291 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5630 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34168 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->