### PR TITLE
Implement a fallback in CompactPtr for storing some pointers that don't fit within 36-bits.

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -952,6 +952,7 @@
 		FE7ACFEF285DC2F9007FC8E9 /* RawHex.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1A28B1453D0088C6E1 /* CodePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9B8B1928B1453D0088C6E1 /* CodePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1E28B1B1C70088C6E1 /* CodePtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE9B8B1D28B1B1C60088C6E1 /* CodePtr.cpp */; };
+		FEBD5A792EDAC1CE00E9E170 /* CompactPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEBD5A782EDAC1CE00E9E170 /* CompactPtr.cpp */; };
 		FEC26BF3289DBBD300639A59 /* FunctionPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC26BF2289DBBD300639A59 /* FunctionPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEDACD3D1630F83F00C69634 /* StackStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEDACD3B1630F83F00C69634 /* StackStats.cpp */; };
 		FEEA4DF9216D7BE400AC0602 /* StackPointer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEEA4DF8216D7BE400AC0602 /* StackPointer.cpp */; };
@@ -2050,6 +2051,7 @@
 		FE9B8B1928B1453D0088C6E1 /* CodePtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodePtr.h; sourceTree = "<group>"; };
 		FE9B8B1D28B1B1C60088C6E1 /* CodePtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CodePtr.cpp; sourceTree = "<group>"; };
 		FEB6B035201BE0B600B958C1 /* PointerPreparations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PointerPreparations.h; sourceTree = "<group>"; };
+		FEBD5A782EDAC1CE00E9E170 /* CompactPtr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompactPtr.cpp; sourceTree = "<group>"; };
 		FEC26BF2289DBBD300639A59 /* FunctionPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionPtr.h; sourceTree = "<group>"; };
 		FEDACD3B1630F83F00C69634 /* StackStats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackStats.cpp; sourceTree = "<group>"; };
 		FEDACD3C1630F83F00C69634 /* StackStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackStats.h; sourceTree = "<group>"; };
@@ -2339,6 +2341,7 @@
 				FE9B8B1928B1453D0088C6E1 /* CodePtr.h */,
 				0FC4EDE51696149600F65041 /* CommaPrinter.h */,
 				E3CF76902115D6BA0091DE48 /* CompactPointerTuple.h */,
+				FEBD5A782EDAC1CE00E9E170 /* CompactPtr.cpp */,
 				FFEE46F32825DF80003BC981 /* CompactPtr.h */,
 				FF895F10282AB96400E7BAE8 /* CompactRefPtr.h */,
 				E38020DB2401C0930037CA9E /* CompactRefPtrTuple.h */,
@@ -4381,6 +4384,7 @@
 				FE9B8B1E28B1B1C70088C6E1 /* CodePtr.cpp in Sources */,
 				A8A47460151A825B004123FF /* CollatorDefault.cpp in Sources */,
 				A8A47463151A825B004123FF /* CollatorICU.cpp in Sources */,
+				FEBD5A792EDAC1CE00E9E170 /* CompactPtr.cpp in Sources */,
 				0F8F2B92172E0103007DBDA5 /* CompilationThread.cpp in Sources */,
 				E3149A3B228BDCAC00BFA6C7 /* ConcurrentBuffer.cpp in Sources */,
 				0F30CB5A1FCDF134004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -529,6 +529,7 @@ set(WTF_SOURCES
     CPUTime.cpp
     ClockType.cpp
     CodePtr.cpp
+    CompactPtr.cpp
     CompilationThread.cpp
     ConcurrentBuffer.cpp
     ConcurrentPtrHashSet.cpp

--- a/Source/WTF/wtf/CompactPtr.cpp
+++ b/Source/WTF/wtf/CompactPtr.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/CompactPtr.h>
+
+#include <wtf/AccessibleAddress.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/SegmentedVector.h>
+#include <wtf/Threading.h>
+
+namespace WTF {
+
+#if HAVE(36BIT_ADDRESS)
+
+struct OutsizedCompactPtrManager {
+    HashMap<void*, OutsizedCompactPtr::Encoded> addedPointers;
+    SegmentedVector<void*> outsizedPointers;
+};
+
+static Lock outsizedCompactPtrLock;
+static OutsizedCompactPtrManager* outsizedCompactPtrManager;
+
+static void ensureOutsizedCompactPtrManager()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        // WTF::initialize() is only needed to ensure that lowestAccessibleAddress()
+        // is ready for use.
+        WTF::initialize();
+        RELEASE_ASSERT(lowestAccessibleAddress() >= OutsizedCompactPtr::addressRangeForOutsizedPtrEncoding);
+
+        static NeverDestroyed<OutsizedCompactPtrManager> manager;
+        outsizedCompactPtrManager = &manager.get();
+    });
+}
+
+OutsizedCompactPtr::Encoded OutsizedCompactPtr::encode(void* ptr)
+{
+    if (!outsizedCompactPtrManager)
+        ensureOutsizedCompactPtrManager();
+
+    Locker locker { outsizedCompactPtrLock };
+
+    auto& addedPointers = outsizedCompactPtrManager->addedPointers;
+    auto iter = addedPointers.find(ptr);
+    if (iter != addedPointers.end())
+        return iter->value;
+
+    auto& outsizedPointers = outsizedCompactPtrManager->outsizedPointers;
+    size_t entryIndex = outsizedPointers.size();
+    Encoded encoded = entryIndex + OutsizedCompactPtr::minEncoding;
+    RELEASE_ASSERT(encoded < OutsizedCompactPtr::maxEncoding, encoded, OutsizedCompactPtr::maxEncoding);
+    addedPointers.add(ptr, encoded);
+    outsizedPointers.append(ptr);
+
+    return encoded;
+}
+
+void* OutsizedCompactPtr::decode(uint32_t encoded)
+{
+    Locker locker { outsizedCompactPtrLock };
+    auto& outsizedPointers = outsizedCompactPtrManager->outsizedPointers;
+    size_t entryIndex = encoded - OutsizedCompactPtr::minEncoding;
+    RELEASE_ASSERT(entryIndex < outsizedPointers.size(), entryIndex, outsizedPointers.size());
+    return outsizedPointers[entryIndex];
+}
+
+#endif // HAVE(36BIT_ADDRESS)
+
+} // namespace WTF


### PR DESCRIPTION
#### 4d03df5acb1fcbcab2a05f510e956d3cb770d37a
<pre>
Implement a fallback in CompactPtr for storing some pointers that don&apos;t fit within 36-bits.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303343">https://bugs.webkit.org/show_bug.cgi?id=303343</a>
<a href="https://rdar.apple.com/165647792">rdar://165647792</a>

Reviewed by Dan Hecht.

The OS linker / loader (at its own discretion) may choose to locate statically allocated
objects at addresses that are beyond the 36-bits range (unlike heap addresses which are
always within 36-bits).  As such, for robustness, CompactPtr should have a fallback system
that allows it to encode such outsized pointers.

We observe that:
1. The OS will never allocate objects (heap or otherwise) within the __PAGEZERO region.
2. The number of such statically allocated objects that we&apos;ll ever store in CompactPtrs
   are finite and small-ish (on the order of &lt; 1100 instances).

Hence, we can use the addresses within __PAGEZERO to represent indexes into a table of
OutsizedCompactPtrs where the full (&gt; 36 bits) pointer value is actually stored.

__PAGEZERO is currently around 4G in size.  However, we&apos;ll conservatively reserve only
the first 256K of addresses for OutsizedCompactPtrs. This allows us to encode up to 16K
outsized pointers.

Meanwhile, we should also reduce the number of statically allocated objects that can be
stored in CompactPtrs.  It would be ideal if the number of such objects reduce to way
under 1022. With that, we would be able to encode all those pointers even if the size of
__PAGEZERO is literally reduced to the size of 1 16K page.  This will be left as an
exercise for future patches.  Until then, we&apos;ll work with the 256K heuristic.

Test: Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CompactPtr.cpp: Added.
(WTF::ensureOutsizedCompactPtrManager):
(WTF::OutsizedCompactPtr::encode):
(WTF::OutsizedCompactPtr::decode):
* Source/WTF/wtf/CompactPtr.h:
(WTF::CompactPtr::encode):
(WTF::CompactPtr::decode):
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp:
(TestWebKitAPI::TEST(WTF_CompactPtr, Basic)):

Canonical link: <a href="https://commits.webkit.org/303809@main">https://commits.webkit.org/303809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210c65b32493db13887e4831a0748da480f4e3cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85670 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102220 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d2233284-e92b-4eef-beca-32f163ea6fe6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f3ee8d6-85e8-469e-9fbc-61f1cab53e72) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4583 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2192 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125693 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143843 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110603 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110787 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4438 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59542 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5845 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34355 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165093 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69303 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43136 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->