### PR TITLE
REGRESSION (Disabling Rich JavaScript APIs): Mail web content process crashes when attaching Web Inspector

### DIFF
--- a/LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled-expected.txt
+++ b/LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled-expected.txt
@@ -1,0 +1,5 @@
+
+== Running test suite: IndexedDB.requestDatabase
+-- Running test case: DatabaseNames
+PASS: Did not crash
+

--- a/LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled.html
+++ b/LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ IndexedDBAPIEnabled=false ] -->
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/utilities.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("IndexedDB.requestDatabase");
+
+    suite.addTestCase({
+        name: "DatabaseNames",
+        description: "Try to request database names",
+        test(resolve, reject) {
+            IndexedDBAgent.requestDatabaseNames(WI.networkManager.mainFrame.securityOrigin, (error, names) => {
+                InspectorTest.log(`PASS: Did not crash`);
+                resolve();
+            });
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -569,6 +569,11 @@ static bool getDocumentAndIDBFactoryFromFrameOrSendFailure(LocalFrame* frame, Do
         return false;
     }
 
+    if (!frame->settings().indexedDBAPIEnabled()) {
+        callback.sendFailure("IndexedDB is disabled"_s);
+        return false;
+    }
+
     auto idbFactory = IDBFactoryFromDocument(RefPtr { document.value() }.get());
     if (!idbFactory.has_value()) {
         callback.sendFailure(idbFactory.error());


### PR DESCRIPTION
#### 01812449af385a81b372f4973f615bd88cec1fb0
<pre>
REGRESSION (Disabling Rich JavaScript APIs): Mail web content process crashes when attaching Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=303338">https://bugs.webkit.org/show_bug.cgi?id=303338</a>
<a href="https://rdar.apple.com/165641768">rdar://165641768</a>

Reviewed by Devin Rousso and Aditya Keerthi.

When attaching Web Inspector to a web view configured with `-_disableRichJavaScriptFeatures`, we
immediately hit a `MESSAGE_CHECK` and terminate the inspected page&apos;s web content process, due to the
fact that Web Inspector will immediately try to read all IndexedDB database names.

To fix this, we avoid getting IDB database names in the case where the IndexedDB feature is
disabled to begin with.

Test: inspector/indexeddb/attachWithIndexedDBDisabled.html

* LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled-expected.txt: Added.
* LayoutTests/inspector/indexeddb/attachWithIndexedDBDisabled.html: Added.
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::getDocumentAndIDBFactoryFromFrameOrSendFailure):

Canonical link: <a href="https://commits.webkit.org/303729@main">https://commits.webkit.org/303729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/341d9408d5fe8ed67a77a5659e6e8e21c8b36d29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141006 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c5c40734-80c5-44ea-b1f2-edb80d352555) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102086 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20dcd38d-e450-4050-85dc-90bcc94ff33e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f03cbfab-8927-4f40-81f9-b43ffdfcd270) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2055 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143652 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5621 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110460 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110642 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4312 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5676 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34204 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->