### PR TITLE
Implement name only container queries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-parsing-expected.txt
@@ -83,8 +83,8 @@ PASS @container rule should be valid: @container not (width <= 500px) {} {}
 FAIL @container rule should be valid: @container (width: 100px), (height: 100px) {} {} assert_equals: expected 1 but got 0
 FAIL @container rule should be valid: @container (width),(height)  , (inline-size > 20px) {} {} assert_equals: expected 1 but got 0
 FAIL @container rule should be valid: @container (width), name (height) {} {} assert_equals: expected 1 but got 0
-FAIL @container rule should be valid: @container --foo {} {} assert_equals: expected 1 but got 0
-FAIL @container rule should be valid: @container container {} {} assert_equals: expected 1 but got 0
+PASS @container rule should be valid: @container --foo {} {}
+PASS @container rule should be valid: @container container {} {}
 FAIL @container rule should be valid: @container container, container2 {} {} assert_equals: expected 1 but got 0
 PASS @container rule should be invalid: @container  {} {}
 PASS @container rule should be invalid: @container (width), {} {}

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-container-name-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL match closest named container assert_equals: expected "yes" but got "no"
-FAIL match ancestor named container assert_equals: expected "yes" but got "no"
+PASS match closest named container
+PASS match ancestor named container
 PASS no match for unused container name
 

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -52,8 +52,13 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
     auto name = consumeName();
 
     auto condition = consumeCondition(range, context);
-    if (!condition)
-        return { };
+
+    if (!condition) {
+        if (name.isEmpty())
+            return { };
+        // it's valid to have a named container query without a condition, like "@container --name {}"
+        condition = MQ::Condition { };
+    }
 
     OptionSet<Axis> requiredAxes;
     auto containsUnknownFeature = ContainsUnknownFeature::No;

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -57,6 +57,9 @@ bool ContainerQueryEvaluator::evaluate(const CQ::ContainerQuery& containerQuery)
     if (!context)
         return false;
 
+    if (containerQuery.condition.queries.isEmpty() && !containerQuery.name.isEmpty())
+        return true;
+
     return evaluateCondition(containerQuery.condition, *context) == MQ::EvaluationResult::True;
 }
 


### PR DESCRIPTION
#### 6b8d8d4d09fee2cbbcf2b1835f3362d90f298922
<pre>
Implement name only container queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=302433">https://bugs.webkit.org/show_bug.cgi?id=302433</a>

Reviewed by Antti Koivisto.

Allows parsing of Container Queries where the query
is empty but there is a name.

Then allows the Evaluator to match a container when
there aren&apos;t conditions and there is a name.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-container-name-expected.txt:
* Source/WebCore/css/query/ContainerQueryParser.cpp:
(WebCore::CQ::ContainerQueryParser::consumeContainerQuery):
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::evaluate const):

Canonical link: <a href="https://commits.webkit.org/304388@main">https://commits.webkit.org/304388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aea69f70efc4d05fed07d77d8227521902e02f71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69496 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4450 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2046 "Found 1 new API test failure: TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110631 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4309 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115871 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59361 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5666 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69118 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->