### PR TITLE
[GFC] Move gap computation to GridLayoutUtils

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -118,18 +118,8 @@ void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
         // For now, we handle fixed gaps only (not percentages or calc).
         CheckedRef gridStyle = root().style();
 
-        auto computeGapValue = [](const Style::GapGutter& gap) -> LayoutUnit {
-            if (gap.isNormal())
-                return 0_lu;
-            // Only handle fixed length gaps for now
-            if (auto fixedGap = gap.tryFixed())
-                return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
-            ASSERT_NOT_REACHED();
-            return 0_lu;
-        };
-
-        auto columnGap = computeGapValue(gridStyle->columnGap());
-        auto rowGap = computeGapValue(gridStyle->rowGap());
+        auto columnGap = GridLayoutUtils::computeGapValue(gridStyle->columnGap());
+        auto rowGap = GridLayoutUtils::computeGapValue(gridStyle->rowGap());
 
         for (auto& gridItemRect : gridItemRects) {
             auto& lineNumbersForGridArea = gridItemRect.lineNumbersForGridArea;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -30,6 +30,19 @@ namespace WebCore {
 namespace Layout {
 namespace GridLayoutUtils {
 
+LayoutUnit computeGapValue(const Style::GapGutter& gap)
+{
+    if (gap.isNormal())
+        return { };
+
+    // Only handle fixed length gaps for now
+    if (auto fixedGap = gap.tryFixed())
+        return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem)
 {
     auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -35,6 +35,8 @@ class PlacedGridItem;
 
 namespace GridLayoutUtils {
 
+LayoutUnit computeGapValue(const Style::GapGutter&);
+
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
 


### PR DESCRIPTION
#### ffc133c15ac451e85a1e8cbfa16112e8263c74c8
<pre>
[GFC] Move gap computation to GridLayoutUtils
<a href="https://bugs.webkit.org/show_bug.cgi?id=303351">https://bugs.webkit.org/show_bug.cgi?id=303351</a>
<a href="https://rdar.apple.com/165662046">rdar://165662046</a>

Reviewed by Vitor Roriz and Tim Nguyen.

Currently only GridFormattingContext uses gaps as part of determining
the location of the grid items after layout, but soon GridLayout will
need to know the gaps for the columns and rows as well. So that both
classes can have access to this logic we can have it live as part of
GridLayoutUtils for now.

Canonical link: <a href="https://commits.webkit.org/303731@main">https://commits.webkit.org/303731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12d0d6ef66157fcefe893ca0ef19339be07fc9ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141005 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/560089b6-be94-4a1d-a349-bc1b90b7c84e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102085 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b4c8387-a180-4f72-bc1b-c740ced75cbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/357693a3-730a-490f-b60a-d327bd05967c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143651 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110458 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4311 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59370 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5675 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34203 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69127 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5764 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->