### PR TITLE
[AutoFill Debugging] Text extraction can incorrectly omit text from links

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -169,9 +169,14 @@ struct Item {
     String accessibilityRole;
     HashMap<String, String> clientAttributes;
 
+    template<typename T> bool hasData() const
+    {
+        return std::holds_alternative<T>(data);
+    }
+
     template<typename T> std::optional<T> dataAs() const
     {
-        if (std::holds_alternative<T>(data))
+        if (hasData<T>())
             return std::get<T>(data);
         return std::nullopt;
     }

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -716,10 +716,12 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
     );
 }
 
-static bool childTextNodeIsRedundant(const TextExtraction::Item& parent, const String& childText)
+static bool childTextNodeIsRedundant(const TextExtractionAggregator& aggregator, const TextExtraction::Item& parent, const String& childText)
 {
-    if (auto link = parent.dataAs<TextExtraction::LinkItemData>(); link && link->completedURL.string().containsIgnoringASCIICase(childText))
-        return true;
+    if (parent.hasData<TextExtraction::LinkItemData>()) {
+        if (valueOrDefault(aggregator.currentURLString()).containsIgnoringASCIICase(childText))
+            return true;
+    }
 
     if (auto formControl = parent.dataAs<TextExtraction::TextFormControlData>()) {
         auto& editable = formControl->editable;
@@ -782,7 +784,7 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
 
     if (item.children.size() == 1) {
         if (auto text = item.children[0].dataAs<TextExtraction::TextItemData>()) {
-            if (childTextNodeIsRedundant(item, text->content.trim(isASCIIWhitespace)))
+            if (childTextNodeIsRedundant(aggregator, item, text->content.trim(isASCIIWhitespace)))
                 return;
 
             if (aggregator.useHTMLOutput()) {


### PR DESCRIPTION
#### 87e6806cfe50025cb8b1176c5ba799bc763e08eb
<pre>
[AutoFill Debugging] Text extraction can incorrectly omit text from links
<a href="https://bugs.webkit.org/show_bug.cgi?id=303355">https://bugs.webkit.org/show_bug.cgi?id=303355</a>
<a href="https://rdar.apple.com/165665247">rdar://165665247</a>

Reviewed by Richard Robinson.

In 302898@main, I introduced logic to avoid surfacing the text inside of a link separately in the
case where the text is redundant with the link URL. However, it&apos;s also possible for clients to
override the extracted href of a link, in such a way that the text content may no longer be
redundant.

The existing logic doesn&apos;t account for this, and so we end up losing information about visible text
inside the link altogether, since the original URL is replaced by the client and we omit the text
content because we think it&apos;s already contained within the original URL.

To fix this, we instead check the `TextExtractionAggregator`&apos;s current URL (which accounts for the
client&apos;s overridden attribute).

Test: TextExtractionTests.FilterRedundantTextInLinks

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
(WebCore::TextExtraction::Item::hasData const):
(WebCore::TextExtraction::Item::dataAs const):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::childTextNodeIsRedundant):
(WebKit::addTextRepresentationRecursive):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, FilterRedundantTextInLinks)):

Canonical link: <a href="https://commits.webkit.org/303756@main">https://commits.webkit.org/303756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a7590b4330a507f0e58bac3896adfe7b71f547

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85501 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d6b4cd95-3a9a-497a-8a84-c09320d0f3de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102088 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69501 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/099d9482-fe27-4787-be62-344845a9a32f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82883 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29cadeb9-c8d4-46d0-9dda-260daee9f02b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4463 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2057 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143656 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110462 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4319 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115885 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59374 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5679 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34207 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->