### PR TITLE
Box with `box-sizing:border-box` causes incorrect width calculation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The computed width of box is 100px
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test border-box behavior when a box has an aspect ratio and is positioned, checking the width dimension </title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+* {
+    box-sizing: border-box;
+}
+
+#box {
+    position: absolute;
+    background-color: green;
+    top: 0;
+    left: 0;
+    border: 15px solid blue;
+    height: 100px;
+    aspect-ratio: 1;
+}
+</style>
+<div id="box"></div>
+<script>
+test(() => {
+    const el = document.getElementById("box");
+    const rect = el.getBoundingClientRect();
+    assert_equals(rect.width, 100, "The computed width of box must be exactly 100px");
+    }, "The computed width of box is 100px");
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4154,8 +4154,10 @@ void RenderBox::computeOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValu
     if (usedWidth < usedMinWidth)
         usedWidth = usedMinWidth;
 
+    bool hasWidthBorderBoxAspectRatio = style().hasAspectRatio() && style().boxSizingForAspectRatio() == BoxSizing::BorderBox && style().logicalWidth().isAuto();
+
     // Set the final width value.
-    computedValues.m_extent = usedWidth + inlineConstraints.bordersPlusPadding();
+    computedValues.m_extent = hasWidthBorderBoxAspectRatio ? usedWidth : usedWidth + inlineConstraints.bordersPlusPadding();
 
     // Calculate the position.
     inlineConstraints.resolvePosition(computedValues);


### PR DESCRIPTION
#### 7edec7b820967fa0c2988982366054dc96d91cf9
<pre>
Box with `box-sizing:border-box` causes incorrect width calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=267625">https://bugs.webkit.org/show_bug.cgi?id=267625</a>

Reviewed by Alan Baradlay.

Fix width calculation for boxes with `border-box`, `aspect-ratio` and `display: positioned`

When a box has `box-sizing: border-box` and an aspect ratio set and is positioned,
the width calculation incorrectly adds the border and padding to the box size.
Since the box uses `border-box`, this border and padding addition is wrong.

This patch fixes the behavior by checking if box has `box-sizing: border-box`
and an aspect ratio before setting the final width value.

Test: imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/box-sizing-aspect-ratio-positioned-expected.txt: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeOutOfFlowPositionedLogicalWidth const):

Canonical link: <a href="https://commits.webkit.org/303834@main">https://commits.webkit.org/303834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5268d57f269e44d2193bb599c43f8d3ae6829aff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69540 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2140 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143755 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5723 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110719 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4393 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59472 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5775 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5622 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69233 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5866 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->