### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PictureInPictureObserver

### DIFF
--- a/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
@@ -55,7 +55,7 @@ void DocumentPictureInPicture::exitPictureInPicture(Document& document, Ref<Defe
         return;
     }
 
-    HTMLVideoElementPictureInPicture::from(*element)->exitPictureInPicture(WTFMove(promise));
+    HTMLVideoElementPictureInPicture::protectedFrom(*element)->exitPictureInPicture(WTFMove(promise));
 }
 
 DocumentPictureInPicture* DocumentPictureInPicture::from(Document& document)

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -66,20 +66,34 @@ HTMLVideoElementPictureInPicture::~HTMLVideoElementPictureInPicture()
         videoElement->setPictureInPictureObserver(nullptr);
 }
 
-HTMLVideoElementPictureInPicture* HTMLVideoElementPictureInPicture::from(HTMLVideoElement& videoElement)
+void HTMLVideoElementPictureInPicture::ref() const
 {
-    auto* supplement = downcast<HTMLVideoElementPictureInPicture>(Supplement<HTMLVideoElement>::from(&videoElement, supplementName()));
-    if (!supplement) {
-        auto newSupplement = makeUnique<HTMLVideoElementPictureInPicture>(videoElement);
-        supplement = newSupplement.get();
+    m_videoElement->ref();
+}
+
+void HTMLVideoElementPictureInPicture::deref() const
+{
+    m_videoElement->deref();
+}
+
+HTMLVideoElementPictureInPicture& HTMLVideoElementPictureInPicture::from(HTMLVideoElement& videoElement)
+{
+    if (!Supplement<HTMLVideoElement>::from(&videoElement, supplementName())) {
+        auto newSupplement = makeUniqueWithoutRefCountedCheck<HTMLVideoElementPictureInPicture>(videoElement);
         provideTo(&videoElement, supplementName(), WTFMove(newSupplement));
     }
-    return supplement;
+    return *downcast<HTMLVideoElementPictureInPicture>(Supplement<HTMLVideoElement>::from(&videoElement, supplementName()));
+}
+
+Ref<HTMLVideoElementPictureInPicture> HTMLVideoElementPictureInPicture::protectedFrom(HTMLVideoElement& videoElement)
+{
+    return from(videoElement);
 }
 
 void HTMLVideoElementPictureInPicture::providePictureInPictureTo(HTMLVideoElement& videoElement)
 {
-    provideTo(&videoElement, supplementName(), makeUnique<HTMLVideoElementPictureInPicture>(videoElement));
+    auto newSupplement = makeUniqueWithoutRefCountedCheck<HTMLVideoElementPictureInPicture>(videoElement);
+    provideTo(&videoElement, supplementName(), WTFMove(newSupplement));
 }
 
 void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement& videoElement, Ref<DeferredPromise>&& promise)
@@ -105,7 +119,7 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
         return;
     }
 
-    auto videoElementPictureInPicture = HTMLVideoElementPictureInPicture::from(videoElement);
+    Ref videoElementPictureInPicture = HTMLVideoElementPictureInPicture::from(videoElement);
     if (videoElement.document().pictureInPictureElement() == &videoElement) {
         promise->resolve<IDLInterface<PictureInPictureWindow>>(*(videoElementPictureInPicture->m_pictureInPictureWindow));
         return;
@@ -125,22 +139,22 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
 
 bool HTMLVideoElementPictureInPicture::autoPictureInPicture(HTMLVideoElement& videoElement)
 {
-    return HTMLVideoElementPictureInPicture::from(videoElement)->m_autoPictureInPicture;
+    return HTMLVideoElementPictureInPicture::from(videoElement).m_autoPictureInPicture;
 }
 
 void HTMLVideoElementPictureInPicture::setAutoPictureInPicture(HTMLVideoElement& videoElement, bool autoPictureInPicture)
 {
-    HTMLVideoElementPictureInPicture::from(videoElement)->m_autoPictureInPicture = autoPictureInPicture;
+    HTMLVideoElementPictureInPicture::from(videoElement).m_autoPictureInPicture = autoPictureInPicture;
 }
 
 bool HTMLVideoElementPictureInPicture::disablePictureInPicture(HTMLVideoElement& videoElement)
 {
-    return HTMLVideoElementPictureInPicture::from(videoElement)->m_disablePictureInPicture;
+    return HTMLVideoElementPictureInPicture::from(videoElement).m_disablePictureInPicture;
 }
 
 void HTMLVideoElementPictureInPicture::setDisablePictureInPicture(HTMLVideoElement& videoElement, bool disablePictureInPicture)
 {
-    HTMLVideoElementPictureInPicture::from(videoElement)->m_disablePictureInPicture = disablePictureInPicture;
+    HTMLVideoElementPictureInPicture::from(videoElement).m_disablePictureInPicture = disablePictureInPicture;
 }
 
 void HTMLVideoElementPictureInPicture::exitPictureInPicture(Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -50,7 +50,8 @@ class HTMLVideoElementPictureInPicture
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLVideoElementPictureInPicture);
 public:
     HTMLVideoElementPictureInPicture(HTMLVideoElement&);
-    static HTMLVideoElementPictureInPicture* from(HTMLVideoElement&);
+    static HTMLVideoElementPictureInPicture& from(HTMLVideoElement&);
+    static Ref<HTMLVideoElementPictureInPicture> protectedFrom(HTMLVideoElement&);
     static void providePictureInPictureTo(HTMLVideoElement&);
     virtual ~HTMLVideoElementPictureInPicture();
 
@@ -72,6 +73,10 @@ public:
     ASCIILiteral logClassName() const final { return "HTMLVideoElementPictureInPicture"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
+
+    // PictureInPictureObserver.
+    void ref() const final;
+    void deref() const final;
 
 private:
     static ASCIILiteral supplementName() { return "HTMLVideoElementPictureInPicture"_s; }

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -615,8 +615,8 @@ void HTMLVideoElement::didEnterFullscreenOrPictureInPicture(const FloatSize& siz
         setChangingVideoFullscreenMode(false);
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-        if (m_pictureInPictureObserver)
-            m_pictureInPictureObserver->didEnterPictureInPicture(flooredIntSize(size));
+        if (RefPtr observer = m_pictureInPictureObserver.get())
+            observer->didEnterPictureInPicture(flooredIntSize(size));
 #else
         UNUSED_PARAM(size);
 #endif
@@ -626,8 +626,8 @@ void HTMLVideoElement::didEnterFullscreenOrPictureInPicture(const FloatSize& siz
     if (m_exitingPictureInPicture) {
         m_exitingPictureInPicture = false;
 #if ENABLE(PICTURE_IN_PICTURE_API)
-        if (m_pictureInPictureObserver)
-            m_pictureInPictureObserver->didExitPictureInPicture();
+        if (RefPtr observer = m_pictureInPictureObserver.get())
+            observer->didExitPictureInPicture();
 #endif
     }
 
@@ -644,8 +644,8 @@ void HTMLVideoElement::didExitFullscreenOrPictureInPicture()
         setChangingVideoFullscreenMode(false);
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-        if (m_pictureInPictureObserver)
-            m_pictureInPictureObserver->didExitPictureInPicture();
+        if (RefPtr observer = m_pictureInPictureObserver.get())
+            observer->didExitPictureInPicture();
 #endif
         return;
     }
@@ -684,8 +684,10 @@ void HTMLVideoElement::setVideoFullscreenFrame(const FloatRect& frame)
         return;
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    if (!m_enteringPictureInPicture && !m_exitingPictureInPicture && m_pictureInPictureObserver)
-        m_pictureInPictureObserver->pictureInPictureWindowResized(IntSize(frame.size()));
+    if (!m_enteringPictureInPicture && !m_exitingPictureInPicture) {
+        if (RefPtr observer = m_pictureInPictureObserver.get())
+            observer->pictureInPictureWindowResized(IntSize(frame.size()));
+    }
 #endif
 }
 

--- a/Source/WebCore/platform/PictureInPictureObserver.h
+++ b/Source/WebCore/platform/PictureInPictureObserver.h
@@ -27,22 +27,13 @@
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class PictureInPictureObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PictureInPictureObserver> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class IntSize;
 
-class PictureInPictureObserver : public CanMakeWeakPtr<PictureInPictureObserver> {
+class PictureInPictureObserver : public AbstractRefCountedAndCanMakeWeakPtr<PictureInPictureObserver> {
 public:
     virtual ~PictureInPictureObserver() { };
     virtual void didEnterPictureInPicture(const IntSize&) = 0;


### PR DESCRIPTION
#### d1447be88953e205408a5f2885d3a3c2a88af3ce
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PictureInPictureObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=303362">https://bugs.webkit.org/show_bug.cgi?id=303362</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp:
(WebCore::DocumentPictureInPicture::exitPictureInPicture):
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::ref const):
(WebCore::HTMLVideoElementPictureInPicture::deref const):
(WebCore::HTMLVideoElementPictureInPicture::from):
(WebCore::HTMLVideoElementPictureInPicture::protectedFrom):
(WebCore::HTMLVideoElementPictureInPicture::providePictureInPictureTo):
(WebCore::HTMLVideoElementPictureInPicture::requestPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::autoPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::setAutoPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::disablePictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::setDisablePictureInPicture):
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::didEnterFullscreenOrPictureInPicture):
(WebCore::HTMLVideoElement::didExitFullscreenOrPictureInPicture):
(WebCore::HTMLVideoElement::setVideoFullscreenFrame):
* Source/WebCore/platform/PictureInPictureObserver.h:

Canonical link: <a href="https://commits.webkit.org/303788@main">https://commits.webkit.org/303788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3366fc117c660bbc8c453ee6eafd3b879f596354

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b653bacc-f8ac-41b0-a1bb-9494dec9be8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102115 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69519 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be22058f-17f2-4788-970e-9c558e3c0c26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82912 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cdd68ca-50d4-4410-b879-6683f33114d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4508 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2087 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143694 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4347 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59412 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5806 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->