### PR TITLE
[Site Isolation] window.opener is cleared after opener window does cross-site navigation

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -309,4 +309,18 @@ bool BrowsingContextGroup::hasRemotePages(const WebPageProxy& page)
     return it != m_remotePages.end() && !it->value.isEmpty();
 }
 
+bool BrowsingContextGroup::isFrameProcessInUseForMainFrame(const FrameProcess& process)
+{
+    for (Ref page : m_pages) {
+        RefPtr mainFrame = page->mainFrame();
+        if (!mainFrame)
+            continue;
+
+        if (&mainFrame->frameProcess() == &process)
+            return true;
+    }
+
+    return false;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -80,6 +80,7 @@ public:
     void transitionProvisionalPageToRemotePage(ProvisionalPageProxy&, const WebCore::Site& provisionalNavigationFailureSite);
 
     bool hasRemotePages(const WebPageProxy&);
+    bool isFrameProcessInUseForMainFrame(const FrameProcess&);
 
 private:
     BrowsingContextGroup();

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -105,7 +105,7 @@ public:
 
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
-    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
     WebProcessProxy& process();
     Ref<WebProcessProxy> protectedProcess();
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
@@ -225,7 +225,7 @@ private:
     ProcessSwapRequestedByClient m_processSwapRequestedByClient;
     bool m_wasCommitted { false };
     bool m_isProcessSwappingOnNavigationResponse { false };
-    const bool m_isProcessSwappingForNewWindow;
+    const bool m_shouldReuseMainFrame;
     bool m_needsCookieAccessAddedInNetworkProcess { false };
     bool m_needsDidStartProvisionalLoad { true };
     bool m_shouldClosePage { true };

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -72,7 +72,7 @@ public:
     WebProcessProxy& process() const { return m_process.get(); }
     Ref<WebProcessProxy> protectedProcess() const { return process(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& backForwardCache() const;
     Ref<WebBackForwardCache> protectedBackForwardCache() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2554,6 +2554,7 @@ public:
 
     void addOpenedPage(WebPageProxy&);
     bool hasOpenedPage() const;
+    bool hasPageOpenedByMainFrame() const;
 
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&, const String& sourceMIMEType)>&&);
 


### PR DESCRIPTION
#### 743831c332cced2a0272d8b27e0f160f1fb0c13a
<pre>
[Site Isolation] window.opener is cleared after opener window does cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303360">https://bugs.webkit.org/show_bug.cgi?id=303360</a>
<a href="https://rdar.apple.com/165671162">rdar://165671162</a>

Reviewed by Alex Christensen.

With current implementation, window.opener becomes null in opened window after the opener window performs cross-site
navigation. This is caused by new frame being created during provisional load of the opener page; i.e. opener page will
use a different frame as main frame after navigation, while window.opener in opened page still refers to old frame. And
when the old main frame is destroyed (as it is no longer in use), window.opener will be cleared.

To fix this issue, this patch borrows from previous solution to &quot;opener window loses access to opened window after
opened window performs cross-site navigation&quot; problem -- to reuse existing main frame for cross-site navigation. It
involves a few changes to support the new case:
1. ProvisionalPageProxy::m_isProcessSwappingForNewWindow is the flag to indicate navigation should reuse main frame. It
is renamed to m_shouldReuseMainFrame, and it will be true when page is opened by another page *or* page&apos;s main frame is
opener of another page (as the opened page might still need access to the main frame after navigation).
2. ProvisionalPageProxy::didCommitLoadForFrame currently only converts the navigating page in old process to remote if
the page&apos;s opener site is different. It works before this patch, as main frame is only reused for opened page. Now
that main frame could be reused for opener page, this patch updates the condition to &quot;convert navigating page in old
process to remote if other pages in that process need access to the navigating page&quot;. If no page in the same browsing
context group resides in old process, we could just let navigating page in the old process be closed after navigation.
3. WebPageProxy::commitProvisionalPage currently sends close page message to old process if navigating page does not
have opener. It works before this patch as only opened page will be transited to remote page. Now that opener page could
also be transited to remote page, this patch updates WebPageProxy::shouldClosePreviousPage to return true only if the
page has not been converted to remote page.

API Test: SiteIsolation.NavigateOpenerWindowCrossSite

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::isFrameProcessInUse):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::shouldClosePreviousPage):
(WebKit::WebPageProxy::hasPageOpenedByMainFrame const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateOpenerWindowCrossSite)):

Canonical link: <a href="https://commits.webkit.org/303836@main">https://commits.webkit.org/303836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b7e93aa60b461e1d38484f46394025182fdd0db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a952253d-2438-49d8-bbaf-fc5d18267108) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102254 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69599 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/27f776a9-d496-4794-bb22-a16f56cbd732) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7e2cc20-297b-4498-b30f-afb7115397fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2232 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143902 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110636 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4471 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5914 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34398 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->