### PR TITLE
Fix WPT failure for `css/cssom/shorthand-values.html`

### DIFF
--- a/LayoutTests/fast/css/remove-shorthand-expected.txt
+++ b/LayoutTests/fast/css/remove-shorthand-expected.txt
@@ -13,16 +13,16 @@ removes "border"
 and adds "".
 Removing border-top
 removes "border"
-and adds "border-right-width, border-bottom-width, border-left-width, border-right-style, border-bottom-style, border-left-style, border-right-color, border-bottom-color, border-left-color, border-image".
+and adds "border-right, border-bottom, border-left, border-image".
 Removing border-right
 removes "border"
-and adds "border-top-width, border-bottom-width, border-left-width, border-top-style, border-bottom-style, border-left-style, border-top-color, border-bottom-color, border-left-color, border-image".
+and adds "border-top, border-bottom, border-left, border-image".
 Removing border-bottom
 removes "border"
-and adds "border-top-width, border-right-width, border-left-width, border-top-style, border-right-style, border-left-style, border-top-color, border-right-color, border-left-color, border-image".
+and adds "border-top, border-right, border-left, border-image".
 Removing border-left
 removes "border"
-and adds "border-top-width, border-right-width, border-bottom-width, border-top-style, border-right-style, border-bottom-style, border-top-color, border-right-color, border-bottom-color, border-image".
+and adds "border-top, border-right, border-bottom, border-image".
 Removing border-color
 removes "border"
 and adds "border-width, border-style, border-image".

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt
@@ -320,321 +320,321 @@ FAIL .child 80 assert_equals:
       </div>
 width expected 47 but got 13
 FAIL .child 81 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">1
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 82 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">2
         </div>
       </div>
 width expected 50 but got 5
 FAIL .child 83 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">3
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 84 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">4
         </div>
       </div>
 width expected 47 but got 5
 PASS .child 85
 FAIL .child 86 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">6
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 87
 FAIL .child 88 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">8
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 89
 FAIL .child 90 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">10
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 91
 FAIL .child 92 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">12
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 93
 FAIL .child 94 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">14
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 95
 FAIL .child 96 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">16
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 97
 FAIL .child 98 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">18
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 99
 FAIL .child 100 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">20
         </div>
       </div>
 width expected 47 but got 13
 FAIL .child 101 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">21
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 102 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">22
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 103 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">23
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 104 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">24
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 105
 FAIL .child 106 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">26
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 107
 FAIL .child 108 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">28
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 109
 FAIL .child 110 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">30
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 111
 FAIL .child 112 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">32
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 113
 FAIL .child 114 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">34
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 115
 FAIL .child 116 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">36
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 117
 FAIL .child 118 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">38
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 119
 FAIL .child 120 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">40
         </div>
       </div>
 width expected 47 but got 13
 FAIL .child 121 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">41
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 122 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">42
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 123 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">43
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 124 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">44
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 125
 FAIL .child 126 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">46
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 127
 FAIL .child 128 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">48
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 129
 FAIL .child 130 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">50
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 131
 FAIL .child 132 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">52
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 133
 FAIL .child 134 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">54
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 135
 FAIL .child 136 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">56
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 137
 FAIL .child 138 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">58
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 139
 FAIL .child 140 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">60
         </div>
       </div>
 width expected 47 but got 13
 FAIL .child 141 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">61
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 142 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">62
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 143 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">63
         </div>
       </div>
 height expected 44 but got 13
 FAIL .child 144 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">64
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 145
 FAIL .child 146 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">66
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 147
 FAIL .child 148 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">68
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 149
 FAIL .child 150 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">70
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 151
 FAIL .child 152 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">72
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 153
 FAIL .child 154 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">74
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 155
 FAIL .child 156 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">76
         </div>
       </div>
 width expected 47 but got 13
 PASS .child 157
 FAIL .child 158 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">78
         </div>
       </div>
 width expected 50 but got 13
 PASS .child 159
 FAIL .child 160 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">80
         </div>
       </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
@@ -7,7 +7,7 @@ PASS The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px
 PASS The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px; should be canonical.
 PASS The serialization of border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px; should be canonical.
 PASS The serialization of border: 1px; border-top: 2px; should be canonical.
-FAIL The serialization of border: 1px; border-top: 1px !important; should be canonical. assert_equals: expected "border-right: 1px; border-bottom: 1px; border-left: 1px; border-image: none; border-top: 1px !important;" but got "border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-style: none; border-bottom-style: none; border-left-style: none; border-right-color: currentcolor; border-bottom-color: currentcolor; border-left-color: currentcolor; border-image: none; border-top-width: 1px !important; border-top-style: none !important; border-top-color: currentcolor !important;"
+PASS The serialization of border: 1px; border-top: 1px !important; should be canonical.
 PASS The serialization of border: 1px; border-top-color: red; should be canonical.
 PASS The serialization of border: solid; border-style: dotted should be canonical.
 PASS The serialization of border-width: 1px; should be canonical.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt
@@ -320,321 +320,321 @@ FAIL .child 80 assert_equals:
       </div>
 width expected 47 but got 11
 FAIL .child 81 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">1
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 82 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">2
         </div>
       </div>
 width expected 50 but got 5
 FAIL .child 83 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">3
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 84 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">4
         </div>
       </div>
 width expected 47 but got 5
 PASS .child 85
 FAIL .child 86 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">6
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 87
 FAIL .child 88 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">8
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 89
 FAIL .child 90 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">10
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 91
 FAIL .child 92 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">12
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 93
 FAIL .child 94 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">14
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 95
 FAIL .child 96 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">16
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 97
 FAIL .child 98 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">18
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 99
 FAIL .child 100 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">20
         </div>
       </div>
 width expected 47 but got 11
 FAIL .child 101 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">21
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 102 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">22
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 103 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">23
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 104 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">24
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 105
 FAIL .child 106 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">26
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 107
 FAIL .child 108 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">28
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 109
 FAIL .child 110 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">30
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 111
 FAIL .child 112 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">32
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 113
 FAIL .child 114 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">34
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 115
 FAIL .child 116 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">36
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 117
 FAIL .child 118 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">38
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 119
 FAIL .child 120 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">40
         </div>
       </div>
 width expected 47 but got 11
 FAIL .child 121 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">41
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 122 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">42
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 123 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">43
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 124 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">44
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 125
 FAIL .child 126 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">46
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 127
 FAIL .child 128 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">48
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 129
 FAIL .child 130 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">50
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 131
 FAIL .child 132 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">52
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 133
 FAIL .child 134 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">54
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 135
 FAIL .child 136 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">56
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 137
 FAIL .child 138 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">58
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 139
 FAIL .child 140 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">60
         </div>
       </div>
 width expected 47 but got 11
 FAIL .child 141 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">61
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 142 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">62
         </div>
       </div>
 width expected 50 but got 10
 FAIL .child 143 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="20" data-expected-height="44" style="writing-mode: horizontal-tb; width: 20px; height: stretch;">63
         </div>
       </div>
 height expected 44 but got 11
 FAIL .child 144 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: horizontal-tb; width: stretch; height: 20px;">64
         </div>
       </div>
 width expected 47 but got 10
 PASS .child 145
 FAIL .child 146 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">66
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 147
 FAIL .child 148 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-rl; width: stretch; height: 20px;">68
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 149
 FAIL .child 150 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">70
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 151
 FAIL .child 152 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: vertical-lr; width: stretch; height: 20px;">72
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 153
 FAIL .child 154 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">74
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 155
 FAIL .child 156 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-rl; width: stretch; height: 20px;">76
         </div>
       </div>
 width expected 47 but got 11
 PASS .child 157
 FAIL .child 158 assert_equals:
-<div class="container" style="border-top-width: 5px; border-top-style: solid; border-top-color: currentcolor; direction: rtl;">
+<div class="container" style="border-top: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="50" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">78
         </div>
       </div>
 width expected 50 but got 11
 PASS .child 159
 FAIL .child 160 assert_equals:
-<div class="container" style="border-right-width: 5px; border-right-style: solid; border-right-color: currentcolor; direction: rtl;">
+<div class="container" style="border-right: 5px solid; direction: rtl;">
         <div class="child" data-expected-width="47" data-expected-height="20" style="writing-mode: sideways-lr; width: stretch; height: 20px;">80
         </div>
       </div>

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -232,14 +232,6 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     // FIXME: If font-variant-ligatures is none, this depends on the value of the longhand.
     case CSSPropertyFontVariant:
     // FIXME: These shorthands are avoided for unknown legacy reasons, probably shouldn't be avoided.
-    case CSSPropertyBorderBlockEnd:
-    case CSSPropertyBorderBlockStart:
-    case CSSPropertyBorderBottom:
-    case CSSPropertyBorderInlineEnd:
-    case CSSPropertyBorderInlineStart:
-    case CSSPropertyBorderLeft:
-    case CSSPropertyBorderRight:
-    case CSSPropertyBorderTop:
     case CSSPropertyColumnRule:
     case CSSPropertyColumns:
     case CSSPropertyContainer:


### PR DESCRIPTION
#### 4bcc6b54119d25022bbd333e24d3f2aa8b64e54a
<pre>
Fix WPT failure for `css/cssom/shorthand-values.html`
<a href="https://bugs.webkit.org/show_bug.cgi?id=299999">https://bugs.webkit.org/show_bug.cgi?id=299999</a>
<a href="https://rdar.apple.com/162244690">rdar://162244690</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch fixes an issue in serialization where in the past, we used to not serialize `border` property
and were not canonical. Now it aligns with other browsers and returns canonical reference.

CSS spec: <a href="https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block">https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block</a>

* LayoutTests/fast/css/remove-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-sizing/stretch/block-height-008-expected.txt:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::canUseShorthandForLonghand):

Canonical link: <a href="https://commits.webkit.org/303844@main">https://commits.webkit.org/303844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33895896742080dbad84eacc8609395187bf90ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102237 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69589 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2222 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5838 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110621 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110805 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4456 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59587 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5892 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34386 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69361 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->