### PR TITLE
[blocks-in-inline] Clicking below block line should move caret there

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block-expected.html
@@ -1,0 +1,55 @@
+<html> 
+<head>
+<script>
+
+function runTest()
+{
+    if (!window.eventSender)
+        return;
+
+    var target = document.getElementById("test");
+
+    x = target.offsetLeft + target.offsetWidth - 10;
+    y = target.offsetTop + target.offsetHeight - 10;
+
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+function setTestResultMessage()
+{
+    var line2Text = document.getElementById("line2").firstChild;
+
+    var result = "FAILED";
+    if (getSelection().rangeCount !== 1)
+        result = "FAILED: Selection had range count of " + getSelection().rangeCount;
+    else if (getSelection().getRangeAt(0).startContainer !== line2Text)
+        result = "FAILED: Selection was not within second line of text.";
+    else if (getSelection().getRangeAt(0).endContainer !== line2Text)
+        result = "FAILED: Selection end was not within second line of text.";
+    else if (getSelection().getRangeAt(0).startOffset !== getSelection().getRangeAt(0).endOffset)
+        result = "FAILED: Selection was not a caret.";
+    else if (getSelection().getRangeAt(0).startOffset !== 6)
+        result = "FAILED: Selection was not at the end of the line.";
+    else
+        result = "SUCCESS";
+
+    document.getElementById("message").firstChild.data = result;
+}
+
+</script>
+</head>
+<body onload="runTest()" onclick="setTestResultMessage()">
+<p>
+    This is a test for a bug where clicking below a block didn't work right if
+    the block was nested inside an inline.
+</p>
+<p>
+    To test interactively, click below and to the right of the 2 in line 2.
+    The caret should appear after the 2.
+</p>
+<p id="message">TEST HAS NOT RUN YET</p>
+<hr>
+<div contenteditable id="test" style="font-size: 48px; width: 250px; height: 250px"><div>line 1</div><div><span><div id="line2">line 2</div></span></div></div>
+</body>

--- a/LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<html>
+<head>
+<script>
+
+function runTest()
+{
+    if (!window.eventSender)
+        return;
+
+    var target = document.getElementById("test");
+
+    x = target.offsetLeft + target.offsetWidth - 10;
+    y = target.offsetTop + target.offsetHeight - 10;
+
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+function setTestResultMessage()
+{
+    var line2Text = document.getElementById("line2").firstChild;
+
+    var result = "FAILED";
+    if (getSelection().rangeCount !== 1)
+        result = "FAILED: Selection had range count of " + getSelection().rangeCount;
+    else if (getSelection().getRangeAt(0).startContainer !== line2Text)
+        result = "FAILED: Selection was not within second line of text.";
+    else if (getSelection().getRangeAt(0).endContainer !== line2Text)
+        result = "FAILED: Selection end was not within second line of text.";
+    else if (getSelection().getRangeAt(0).startOffset !== getSelection().getRangeAt(0).endOffset)
+        result = "FAILED: Selection was not a caret.";
+    else if (getSelection().getRangeAt(0).startOffset !== 6)
+        result = "FAILED: Selection was not at the end of the line.";
+    else
+        result = "SUCCESS";
+
+    document.getElementById("message").firstChild.data = result;
+}
+
+</script>
+</head>
+<body onload="runTest()" onclick="setTestResultMessage()">
+<p>
+    This is a test for a bug where clicking below a block didn't work right if
+    the block was nested inside an inline.
+</p>
+<p>
+    To test interactively, click below and to the right of the 2 in line 2.
+    The caret should appear after the 2.
+</p>
+<p id="message">TEST HAS NOT RUN YET</p>
+<hr>
+<div contenteditable id="test" style="font-size: 48px; width: 250px; height: 250px"><div>line 1</div><div><span><div id="line2">line 2</div></span></div></div>
+</body>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3758,6 +3758,10 @@ PositionWithAffinity RenderBlockFlow::positionForPointWithInlineChildren(const L
 
     if (lastLineBoxWithChildren) {
         // We hit this case for Mac behavior when the Y coordinate is below the last box.
+        if (auto blockBox = lastLineBoxWithChildren->blockLevelBox()) {
+            auto& childBlockRenderer = const_cast<RenderBox&>(downcast<RenderBox>(blockBox->renderer()));
+            return positionForPointRespectingEditingBoundaries(*this, childBlockRenderer, pointInLogicalContents, source);
+        }
         ASSERT(moveCaretToBoundary);
         InlineIterator::LineLogicalOrderCache orderCache;
         if (auto logicallyLastBox = InlineIterator::lastLeafOnLineInLogicalOrderWithNode(lastLineBoxWithChildren, orderCache))


### PR DESCRIPTION
#### 9e487a7fdf9e43575a09b1c86631730b7a80455e
<pre>
[blocks-in-inline] Clicking below block line should move caret there
<a href="https://bugs.webkit.org/show_bug.cgi?id=303370">https://bugs.webkit.org/show_bug.cgi?id=303370</a>
<a href="https://rdar.apple.com/165679258">rdar://165679258</a>

Reviewed by Alan Baradlay.

For editing/selection/click-after-nested-block.html

Test: fast/inline/blocks-in-inline-caret-click-after-block.html
* LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-caret-click-after-block.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::positionForPointWithInlineChildren):

Implement a behavior where a click below a block moves the caret to the end of the block.

Canonical link: <a href="https://commits.webkit.org/303754@main">https://commits.webkit.org/303754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e37e53844ef9c5fa299156bbd03f18fa1bc5ca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102122 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/74633dac-2ea2-4378-92c1-afe62b15ab47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82919 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a65abdf-d6f5-4f6c-9e7d-e8811348f4c1) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4490 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Passed layout tests; layout-tests (failure); Uploaded test results; 4 new passes 5 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2096 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110498 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4354 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59422 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5727 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34250 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->