### PR TITLE
ReadableStream::cancel is not handling the case of an empty JSValue

### DIFF
--- a/LayoutTests/http/wpt/streams/readablestream-cancel-exception-expected.txt
+++ b/LayoutTests/http/wpt/streams/readablestream-cancel-exception-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Stop worker while cancelling a readable stream
+

--- a/LayoutTests/http/wpt/streams/readablestream-cancel-exception.html
+++ b/LayoutTests/http/wpt/streams/readablestream-cancel-exception.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+  return new Promise(function(resolve) {
+      var frame = document.createElement('iframe');
+      frame.srcdoc = url;
+      frame.onload = function() { resolve(frame); };
+      document.body.appendChild(frame);
+    });
+}
+
+function toDataUrl(mediaType, payload) {
+    let encoded = btoa(payload);
+    return `data:${mediaType};base64,${encoded}`;
+}
+
+function jsUrl(contents) {
+    return toDataUrl('text/javascript', contents);
+}
+
+promise_test(async (t) => {
+    const workerURL = jsUrl(`
+       const workerFunction = async () => {
+          const stream = new ReadableStream();
+          await stream.cancel({ });
+       };
+       workerFunction();`);
+    const frame = await with_iframe('/');
+    const worker = new frame.contentWindow.Worker(workerURL);
+    frame.contentWindow.location = '/newpage';
+    await new Promise(resolve => setTimeout(resolve, 100));
+    frame.remove();
+}, "Stop worker while cancelling a readable stream");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -423,6 +423,11 @@ Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSV
 
     if (RefPtr internalStream = m_internalReadableStream) {
         auto result = internalStream->cancel(globalObject, reason);
+        if (!result) {
+            deferred->reject(Exception { ExceptionCode::ExistingExceptionError });
+            return promise;
+        }
+
         auto* jsPromise = jsCast<JSC::JSPromise*>(result);
         if (!jsPromise)
             return promise;

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -180,6 +180,9 @@ static RefPtr<DOMPromise> cancelReadableStream(JSDOMGlobalObject& globalObject, 
         return stream.cancel(globalObject, reason);
 
     auto value = internalReadableStream->cancel(globalObject, reason);
+    if (!value)
+        return nullptr;
+
     auto* promise = jsCast<JSC::JSPromise*>(value);
     if (!promise)
         return nullptr;
@@ -479,6 +482,8 @@ void StreamPipeToState::closingMustBePropagatedBackward()
             // FIXME: Check whether ok to take a strong.
             JSC::Strong<JSC::Unknown> error { vm, getError(*globalObject) };
             auto value = internalReadableStream->cancel(*globalObject, error.get());
+            if (!value)
+                return nullptr;
 
             auto getError2 = [error = WTFMove(error)](auto&) {
                 return error.get();

--- a/Source/WebCore/bindings/js/InternalReadableStream.h
+++ b/Source/WebCore/bindings/js/InternalReadableStream.h
@@ -46,8 +46,6 @@ public:
     void cancel(Exception&&);
     ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>> tee(bool shouldClone);
 
-    JSC::JSValue pipeTo(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
-    JSC::JSValue pipeThrough(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
     JSC::JSValue cancel(JSC::JSGlobalObject&, JSC::JSValue);
 
     enum class State : uint8_t { Readable, Closed, Errored };


### PR DESCRIPTION
#### f7319b018f79494c9680dde36e251049e3683daa
<pre>
ReadableStream::cancel is not handling the case of an empty JSValue
<a href="https://rdar.apple.com/165347557">rdar://165347557</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303378">https://bugs.webkit.org/show_bug.cgi?id=303378</a>

Reviewed by Chris Dumez.

InternalReadableStream::cancel s returning an empty value in case of exception, which cannot be jsCast.
We add null checks to prevent jsCasting empty values.
As a fly-by fix, we also remove some method declarations that are no longer needed after the pipeTo JS built-in implementation removal.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/303789@main">https://commits.webkit.org/303789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee70c260809eb231103eb8466933a3418f05af7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85581 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c2a9b06-cbec-4acf-810d-a74429cd573f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69528 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57d0f4e9-f67f-48a2-8fb4-322a74cb293d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82947 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5d310fd-058f-4218-89da-d76775228e9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4524 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2133 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143734 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110707 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28088 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4379 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59451 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5756 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34279 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->