### PR TITLE
[blocks-in-inline] Ignore in accessibility tree

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-ax-invalid-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-ax-invalid-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div role="group" aria-label="container">
+    <div id="listbox" role="listbox" aria-label="Submenu for Products">
+        <ul>
+            <li><a href=#>Explore products</a></li>
+        </ul>
+        <ul>
+            <li><a href=#>Category A</a></li>
+            <li><a href=#>Category B</a></li>
+            <li><a href=#>Category C</a></li>
+        </ul>
+    </div>
+</div>
+
+<div id="option-wrapper">
+    <!-- Add some generic elements in-between to ensure our algorithm is smart enough to traverse through them to find an options. -->
+    <div>
+        <div>
+            <span>
+                <div role="group" aria-label="i'm a group that contains an option, which is a valid child for a listbox">
+                    <div role="option">Foo</div>
+                </div>
+            </span>
+        </div>
+    </div>
+</div>
+<pre id=log></pre>
+<script>
+var output = "This test ensures we don't expose invalid role='listbox' elements as platform-role listboxes, as that can cause bad behavior for ATs.\n\n";
+
+if (window.accessibilityController) {
+    testRunner.waitUntilDone();
+
+    // The listbox in its initial state is invalid — it has no `option` descendants. We should map it to group.
+    output += expect("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXGroup'");
+
+    // Let's add an option descendant and ensure the role is now reported to be a proper listbox.
+    document.getElementById("listbox").appendChild(document.getElementById("option-wrapper"));
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXList'");
+
+        log.textContent = output;
+        testRunner.notifyDone();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-ax-invalid.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-ax-invalid.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div role="group" aria-label="container">
+    <div id="listbox" role="listbox" aria-label="Submenu for Products">
+        <ul>
+            <li><a href=#>Explore products</a></li>
+        </ul>
+        <ul>
+            <li><a href=#>Category A</a></li>
+            <li><a href=#>Category B</a></li>
+            <li><a href=#>Category C</a></li>
+        </ul>
+    </div>
+</div>
+
+<div id="option-wrapper">
+    <!-- Add some generic elements in-between to ensure our algorithm is smart enough to traverse through them to find an options. -->
+    <div>
+        <div>
+            <span>
+                <div role="group" aria-label="i'm a group that contains an option, which is a valid child for a listbox">
+                    <div role="option">Foo</div>
+                </div>
+            </span>
+        </div>
+    </div>
+</div>
+<pre id=log></pre>
+<script>
+var output = "This test ensures we don't expose invalid role='listbox' elements as platform-role listboxes, as that can cause bad behavior for ATs.\n\n";
+
+if (window.accessibilityController) {
+    testRunner.waitUntilDone();
+
+    // The listbox in its initial state is invalid — it has no `option` descendants. We should map it to group.
+    output += expect("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXGroup'");
+
+    // Let's add an option descendant and ensure the role is now reported to be a proper listbox.
+    document.getElementById("listbox").appendChild(document.getElementById("option-wrapper"));
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXList'");
+
+        log.textContent = output;
+        testRunner.notifyDone();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1412,7 +1412,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     // https://github.com/WebKit/WebKit/commit/ddeb923489b58fd890527bf0e432ebe6a477d2ef
     // Results in a lot of useless generics being exposed, which is wasteful. We should remove this.
     WeakPtr blockFlow = dynamicDowncast<RenderBlockFlow>(*m_renderer);
-    if (blockFlow && m_renderer->childrenInline() && !canSetFocusAttribute())
+    if (blockFlow && m_renderer->childrenInline() && !canSetFocusAttribute() && !blockFlow->hasBlocksInInlineLayout())
         return !blockFlow->hasLines() && !clickableSelfOrAncestor();
 
     if (isCanvas()) {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1417,6 +1417,11 @@ bool LineLayout::contentNeedsVisualReordering() const
     return m_inlineContentCache.inlineItems().requiresVisualReordering();
 }
 
+bool LineLayout::hasBlocks() const
+{
+    return m_inlineContent && m_inlineContent->hasBlockLevelBoxes();
+}
+
 #if ENABLE(TREE_DEBUGGING)
 void LineLayout::outputLineTree(WTF::TextStream& stream, size_t depth) const
 {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -143,6 +143,8 @@ public:
 
     FloatRect applySVGTextFragments(SVGTextFragmentMap&&);
 
+    bool hasBlocks() const;
+
 private:
     void preparePlacedFloats();
     FloatRect constructContent(const Layout::InlineLayoutState&, Layout::InlineLayoutResult&&);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3839,6 +3839,12 @@ bool RenderBlockFlow::hasLines() const
     return childrenInline() ? lineCount() : false;
 }
 
+bool RenderBlockFlow::hasBlocksInInlineLayout() const
+{
+    auto* inlineLayout = this->inlineLayout();
+    return inlineLayout && inlineLayout->hasBlocks();
+}
+
 void RenderBlockFlow::invalidateLineLayout(InvalidationReason invalidationReason)
 {
     if (lineLayoutPath() == UndeterminedPath)

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -355,6 +355,7 @@ public:
     void setChildrenInline(bool) final;
 
     bool hasLines() const;
+    bool hasBlocksInInlineLayout() const;
 
     enum InvalidationReason : uint8_t {
         InternalMove,       // (anon) block is moved or collapsed


### PR DESCRIPTION
#### f5c72db112d4e5cc08d7393540e2ff0c8d42affd
<pre>
[blocks-in-inline] Ignore in accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=303382">https://bugs.webkit.org/show_bug.cgi?id=303382</a>
<a href="https://rdar.apple.com/165686107">rdar://165686107</a>

Reviewed by Alan Baradlay.

Test: fast/inline/blocks-in-inline-ax-invalid.html
* LayoutTests/fast/inline/blocks-in-inline-ax-invalid-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-ax-invalid.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):

We should treat blocks with no ax role as ignored. For some unknown historical reasons (as indicated by the comment)
we don&apos;t ignore some block boxes that contain lines. Treat block-in-inline case like pure block content and let the
normal ignore logic complete.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::hasBlocks const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::hasBlocksInInlineLayout const):
* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/303753@main">https://commits.webkit.org/303753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/521adf095f5a610deb970e306e1df432e33edc39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141078 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102140 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82936 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2111 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143726 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5693 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110515 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4367 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59443 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5748 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34266 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69200 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->