### PR TITLE
AX: Live regions should track descendants to handle all aria-relevant values

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/atomic-region-node-added-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/atomic-region-node-added-expected.txt
@@ -1,0 +1,14 @@
+This tests that atomic regions are announced when aria-relevant=additions is set and an element is added as a child of an atomic region.
+
+Received announcement request:
+AnnouncementKey: Hello world{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world

--- a/LayoutTests/accessibility/mac/live-regions/atomic-region-node-added.html
+++ b/LayoutTests/accessibility/mac/live-regions/atomic-region-node-added.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body id="body">
+
+<div id="region" aria-live="polite" aria-relevant="additions" aria-atomic="true">Hello</div>
+
+<script>
+var output = "This tests that atomic regions are announced when aria-relevant=additions is set and an element is added as a child of an atomic region.\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    // Initialize the accessibility tree so that all the live regions are registered.
+    accessibilityController.accessibleElementById("region");
+
+    var region = document.getElementById("region");
+    var span = document.createElement("span").appendChild(document.createTextNode(" world"));
+    region.appendChild(span);
+
+    setTimeout(async function() {        
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -53,6 +53,7 @@ struct LiveRegionObject {
     AXID objectID;
     String text;
     String language;
+    HashSet<AXID> descendants; // For atomic regions only, to track additions/removals of descendants.
 };
 
 struct LiveRegionSnapshot {


### PR DESCRIPTION
#### 28782b6916c6f0378f75acbf4911925c1c7d2f4f
<pre>
AX: Live regions should track descendants to handle all aria-relevant values
<a href="https://bugs.webkit.org/show_bug.cgi?id=303393">https://bugs.webkit.org/show_bug.cgi?id=303393</a>
<a href="https://rdar.apple.com/165330472">rdar://165330472</a>

Reviewed by Tyler Wilcock.

Previously, we were not tracking descendant changes for aria-atomic=true regions. This meant
that all types of changes were treated as text-changes, rather than also considering node
additions and removals.

To properly support those last two values of aria-relevant, we can keep track of the
descendants of a region, and compute the added/removed/changed announcement more accurately.

Test: accessibility/mac/live-regions/atomic-region-node-added.html

* LayoutTests/accessibility/mac/live-regions/atomic-region-node-added-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/atomic-region-node-added.html: Added.
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::handleLiveRegionChange):
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::computeChanges const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):
* Source/WebCore/accessibility/AXLiveRegionManager.h:

Canonical link: <a href="https://commits.webkit.org/303812@main">https://commits.webkit.org/303812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f04bf5fbefcebcf796bd557505f26d2ee0cef10a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85654 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/40fad88a-a343-4b14-a783-c92903f40cb3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102204 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69565 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d4dac6b7-e8a7-4d13-9fc3-74f1a2860f62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a15a4c2b-1286-465e-a606-871b78814d88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4574 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2183 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143809 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4432 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5829 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34357 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->