### PR TITLE
Implement heuristics to drop out of Enhanced Security

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -76,8 +76,9 @@ const OptionSet<WebsiteDataType>& WebResourceLoadStatisticsStore::monitoredDataT
         WebsiteDataType::ServiceWorkerRegistrations,
         WebsiteDataType::FileSystem,
 #if ENABLE(SCREEN_TIME)
-        WebsiteDataType::ScreenTime
+        WebsiteDataType::ScreenTime,
 #endif
+        WebsiteDataType::EnhancedSecurityRecord
     }));
 
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -267,6 +267,7 @@ public:
     void setPruneEntriesDownTo(PAL::SessionID, uint64_t pruneTargetCount, CompletionHandler<void()>&&);
     void hadUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void(bool)>&&);
     void isRelationshipOnlyInDatabaseOnce(PAL::SessionID, RegistrableDomain&& subDomain, RegistrableDomain&& topDomain, CompletionHandler<void(bool)>&&);
+    void hasLocalStorageOrCookies(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void hasLocalStorage(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void getAllStorageAccessEntries(PAL::SessionID, CompletionHandler<void(Vector<String> domains)>&&);
     void logFrameNavigation(PAL::SessionID, NavigatedToDomain&&, TopFrameDomain&&, NavigatedFromDomain&&, bool isRedirect, bool isMainFrame, Seconds delayAfterMainFrameDocumentLoad, bool wasPotentiallyInitiatedByUser);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -113,6 +113,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     HadUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
     IsRelationshipOnlyInDatabaseOnce(PAL::SessionID sessionID, WebCore::RegistrableDomain subDomain, WebCore::RegistrableDomain topDomain) -> (bool hadUserInteraction)
     HasLocalStorage(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
+    HasLocalStorageOrCookies(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> (bool hadUserInteraction)
     GetAllStorageAccessEntries(PAL::SessionID sessionID) -> (Vector<String> domains)
     IsRegisteredAsRedirectingTo(PAL::SessionID sessionID, WebCore::RegistrableDomain redirectedFromDomain, WebCore::RegistrableDomain redirectedToDomain) -> (bool isRedirectingTo)
     IsRegisteredAsSubFrameUnder(PAL::SessionID sessionID, WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain) -> (bool isSubframeUnder)

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -101,6 +101,7 @@ extern "C" {
     M(DiskPersistency) \
     M(DragAndDrop) \
     M(EME) \
+    M(EnhancedSecurity) \
     M(Extensions) \
     M(FrameTree) \
     M(Fullscreen) \

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
@@ -83,6 +83,8 @@ WebsiteDataProcessType WebsiteData::ownerProcess(WebsiteDataType dataType)
     case WebsiteDataType::ScreenTime:
         return WebsiteDataProcessType::UI;
 #endif
+    case WebsiteDataType::EnhancedSecurityRecord:
+        return WebsiteDataProcessType::UI;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
@@ -55,6 +55,7 @@ enum class WebsiteDataType : uint32_t {
 #if ENABLE(SCREEN_TIME)
     ScreenTime = 1 << 21,
 #endif
+    EnhancedSecurityRecord = 1 << 22,
 };
 
 inline ASCIILiteral toString(WebsiteDataType type)
@@ -106,6 +107,8 @@ inline ASCIILiteral toString(WebsiteDataType type)
     case WebsiteDataType::ScreenTime:
         return "ScreenTime"_s;
 #endif
+    case WebsiteDataType::EnhancedSecurityRecord:
+        return "EnhancedSecurityRecord"_s;
     default:
         break;
     }
@@ -140,10 +143,11 @@ template<> struct EnumTraitsForPersistence<WebKit::WebsiteDataType> {
         WebKit::WebsiteDataType::AlternativeServices,
 #endif
         WebKit::WebsiteDataType::FileSystem,
-        WebKit::WebsiteDataType::BackgroundFetchStorage
+        WebKit::WebsiteDataType::BackgroundFetchStorage,
 #if ENABLE(SCREEN_TIME)
-        , WebKit::WebsiteDataType::ScreenTime
+        WebKit::WebsiteDataType::ScreenTime,
 #endif
+        WebKit::WebsiteDataType::EnhancedSecurityRecord
     >;
 };
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
@@ -48,4 +48,5 @@ headers: "WebsiteDataType.h"
 #if ENABLE(SCREEN_TIME)
     ScreenTime,
 #endif
+    EnhancedSecurityRecord,
 };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -669,6 +669,8 @@ UIProcess/WebAuthentication/Authenticator.cpp
 UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
 UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
 
+UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
+UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/WebsiteData/WebsiteDataRecord.cpp
 UIProcess/WebsiteData/WebsiteDataStore.cpp

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -115,6 +115,7 @@ void Navigation::setCurrentRequest(ResourceRequest&& request, std::optional<Proc
 {
     m_currentRequest = WTFMove(request);
     m_currentRequestProcessIdentifier = processIdentifier;
+    m_hasStorageForCurrentSite = false;
 }
 
 void Navigation::appendRedirectionURL(const WTF::URL& url)
@@ -207,5 +208,12 @@ WTF::String Navigation::loggingString() const
 }
 
 #endif
+
+
+void Navigation::setHasStorageForCurrentSite(const WTF::URL& url, bool hasStorageForCurrentSite)
+{
+    ASSERT_UNUSED(url, url == m_currentRequest.url());
+    m_hasStorageForCurrentSite = hasStorageForCurrentSite;
+}
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -199,6 +199,9 @@ public:
 
     void setPendingSharedProcess(WebKit::FrameProcess&);
 
+    void setHasStorageForCurrentSite(const WTF::URL&, bool);
+    bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -229,6 +232,7 @@ private:
     bool m_requestIsFromClientInput : 1 { false };
     bool m_isFromLoadData : 1 { false };
     bool m_safeBrowsingCheckTimedOut : 1 { false };
+    bool m_hasStorageForCurrentSite : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
     MonotonicTime m_requestStart { MonotonicTime::now() };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -57,6 +57,7 @@ NSString * const _WKWebsiteDataTypeAdClickAttributions = @"_WKWebsiteDataTypeAdC
 NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTypePrivateClickMeasurements";
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
 NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
+NSString* const _WKWebsiteDataTypeEnhancedSecurityRecord = @"_WKWebsiteDataTypeEnhancedSecurityRecord";
 
 @implementation WKWebsiteDataRecord
 
@@ -116,6 +117,8 @@ static NSString *dataTypesToString(NSSet *dataTypes)
     if ([dataTypes containsObject:WKWebsiteDataTypeScreenTime])
         [array addObject:@"Screen Time"];
 #endif
+    if ([dataTypes containsObject:_WKWebsiteDataTypeEnhancedSecurityRecord])
+        [array addObject:@"Enhanced Security Record"];
 
     return [array componentsJoinedByString:@", "];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -82,6 +82,8 @@ static inline std::optional<WebsiteDataType> toWebsiteDataType(NSString *website
     if ([websiteDataType isEqualToString:WKWebsiteDataTypeScreenTime])
         return WebsiteDataType::ScreenTime;
 #endif
+    if ([websiteDataType isEqualToString:_WKWebsiteDataTypeEnhancedSecurityRecord])
+        return WebsiteDataType::EnhancedSecurityRecord;
     return std::nullopt;
 }
 
@@ -143,6 +145,8 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
     if (websiteDataTypes.contains(WebsiteDataType::ScreenTime))
         [wkWebsiteDataTypes addObject:WKWebsiteDataTypeScreenTime];
 #endif
+    if (websiteDataTypes.contains(WebsiteDataType::EnhancedSecurityRecord))
+        [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeEnhancedSecurityRecord];
 
     return wkWebsiteDataTypes;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -39,6 +39,7 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABL
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
+WK_EXTERN NSString * const _WKWebsiteDataTypeEnhancedSecurityRecord WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -739,7 +739,8 @@ struct WKWebsiteData {
             _WKWebsiteDataTypeCredentials,
             _WKWebsiteDataTypeAdClickAttributions,
             _WKWebsiteDataTypePrivateClickMeasurements,
-            _WKWebsiteDataTypeAlternativeServices
+            _WKWebsiteDataTypeAlternativeServices,
+            _WKWebsiteDataTypeEnhancedSecurityRecord
         ];
 
         return [retainPtr([self allWebsiteDataTypes]) setByAddingObjectsFromArray:privateTypes];

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -873,6 +873,16 @@ void NetworkProcessProxy::clearUserInteraction(PAL::SessionID sessionID, const R
     sendWithAsyncReply(Messages::NetworkProcess::ClearUserInteraction(sessionID, resourceDomain), WTFMove(completionHandler));
 }
 
+void NetworkProcessProxy::hasLocalStorageOrCookies(PAL::SessionID sessionID, const RegistrableDomain& resourceDomain, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (!canSendMessage()) {
+        completionHandler(false);
+        return;
+    }
+
+    sendWithAsyncReply(Messages::NetworkProcess::HasLocalStorageOrCookies(sessionID, resourceDomain), WTFMove(completionHandler));
+}
+
 void NetworkProcessProxy::hasLocalStorage(PAL::SessionID sessionID, const RegistrableDomain& resourceDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!canSendMessage()) {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -160,6 +160,7 @@ public:
     void updatePrevalentDomainsToBlockCookiesFor(PAL::SessionID, const Vector<RegistrableDomain>&, CompletionHandler<void()>&&);
     void hasHadUserInteraction(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isRelationshipOnlyInDatabaseOnce(PAL::SessionID, const RegistrableDomain& subDomain, const RegistrableDomain& topDomain, CompletionHandler<void(bool)>&&);
+    void hasLocalStorageOrCookies(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void hasLocalStorage(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isGrandfathered(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);
     void isPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -43,15 +43,16 @@ enum class ProcessSwapRequestedByClient : bool { No, Yes };
 enum class ShouldExpectSafeBrowsingResult : bool { No, Yes };
 enum class ShouldExpectAppBoundDomainResult : bool { No, Yes };
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool { No, Yes };
+enum class ShouldWaitForSiteHasStorageCheck : bool { No, Yes };
 enum class WasNavigationIntercepted : bool { No, Yes };
 
 class WebFramePolicyListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener>, public CanMakeWeakPtr<WebFramePolicyListenerProxy> {
 public:
 
     using Reply = CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>;
-    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData)
+    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
     {
-        return adoptRef(*new WebFramePolicyListenerProxy(WTFMove(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData));
+        return adoptRef(*new WebFramePolicyListenerProxy(WTFMove(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck));
     }
     ~WebFramePolicyListenerProxy();
 
@@ -63,13 +64,15 @@ public:
     void didReceiveAppBoundDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveManagedDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveInitialLinkDecorationFilteringData();
+    void didReceiveSiteHasStorageResults();
 
 private:
-    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData);
+    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
     std::optional<RefPtr<BrowsingWarning>> m_safeBrowsingWarning;
     std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
+    bool m_doneWaitingForSiteHasStorage { false };
     bool m_doneWaitingForLinkDecorationFilteringData { false };
     Reply m_reply;
 };

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -362,7 +362,7 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTFMove(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
 {
     if (RefPtr previousListener = m_activeListener)
         previousListener->ignore();
@@ -372,7 +372,7 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
         m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData);
+    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck);
     return *m_activeListener;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -104,6 +104,7 @@ enum class NavigatingToAppBoundDomain : bool;
 enum class ShouldExpectSafeBrowsingResult : bool;
 enum class ShouldExpectAppBoundDomainResult : bool;
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
+enum class ShouldWaitForSiteHasStorageCheck : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class WasNavigationIntercepted : bool;
 
@@ -182,7 +183,7 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData);
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTFMove(contentFilterUnblockHandler); }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3534,6 +3534,8 @@ private:
     Expected<DataStoreUpdateResult, WebCore::ResourceError> updateDataStoreForWebArchiveLoad(WebFrameProxy&, WebCore::PolicyAction, WebCore::NavigationType, API::Navigation&);
 #endif
 
+    void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
+
     const UniqueRef<Internals> m_internals;
     Identifier m_identifier;
     WebCore::PageIdentifier m_webPageID;

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EnhancedSecuritySitesHolder.h"
+
+#include "EnhancedSecuritySitesPersistence.h"
+#include <WebCore/SQLiteDatabase.h>
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebKit {
+
+WorkQueue& EnhancedSecuritySitesHolder::sharedWorkQueueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> workQueue = WorkQueue::create("EnhancedSecuritySitesHolder Work Queue"_s);
+    return workQueue.get();
+}
+
+Ref<EnhancedSecuritySitesHolder> EnhancedSecuritySitesHolder::create(const String& databaseDirectoryPath)
+{
+    return adoptRef(*new EnhancedSecuritySitesHolder(databaseDirectoryPath));
+}
+
+EnhancedSecuritySitesHolder::EnhancedSecuritySitesHolder(const String& databaseDirectoryPath)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, path = crossThreadCopy(databaseDirectoryPath)] mutable {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence = makeUnique<EnhancedSecuritySitesPersistence>(WTFMove(path));
+    });
+}
+
+EnhancedSecuritySitesHolder::~EnhancedSecuritySitesHolder()
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton().dispatch([container = WTFMove(m_enhancedSecurityPersistence)] { });
+}
+
+void EnhancedSecuritySitesHolder::fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainRunLoop([completionHandler = WTFMove(completionHandler)] mutable {
+                completionHandler({ });
+            });
+            return;
+        }
+
+        assertIsCurrent(sharedWorkQueueSingleton());
+        auto enhancedSecuritySites = protectedThis->m_enhancedSecurityPersistence->enhancedSecurityOnlyDomains();
+
+        callOnMainRunLoop([enhancedSecuritySites = crossThreadCopy(WTFMove(enhancedSecuritySites)), completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(WTFMove(enhancedSecuritySites));
+        });
+    });
+}
+
+void EnhancedSecuritySitesHolder::fetchAllEnhancedSecuritySites(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainRunLoop([completionHandler = WTFMove(completionHandler)] mutable {
+                completionHandler({ });
+            });
+            return;
+        }
+
+        assertIsCurrent(sharedWorkQueueSingleton());
+        auto enhancedSecuritySites = protectedThis->m_enhancedSecurityPersistence->allEnhancedSecuritySites();
+
+        callOnMainRunLoop([enhancedSecuritySites = crossThreadCopy(WTFMove(enhancedSecuritySites)), completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(WTFMove(enhancedSecuritySites));
+        });
+    });
+}
+
+void EnhancedSecuritySitesHolder::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& domain, EnhancedSecurity reason)
+{
+    ASSERT(isMainRunLoop());
+
+    if (domain.isEmpty())
+        return;
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, domain = crossThreadCopy(WTFMove(domain)), reason]() mutable {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->trackEnhancedSecurityForDomain(WTFMove(domain), reason);
+    });
+}
+
+void EnhancedSecuritySitesHolder::deleteSites(Vector<WebCore::RegistrableDomain>&& sites, CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    if (sites.isEmpty())
+        return completionHandler();
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, sites = crossThreadCopy(WTFMove(sites)), completionHandler = WTFMove(completionHandler)]() mutable {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->deleteSites(sites);
+
+        callOnMainRunLoop(WTFMove(completionHandler));
+    });
+}
+
+void EnhancedSecuritySitesHolder::deleteAllSites(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->m_enhancedSecurityPersistence->deleteAllSites();
+
+        callOnMainRunLoop(WTFMove(completionHandler));
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EnhancedSecuritySitesPersistence.h"
+
+#include "Logging.h"
+#include <WebCore/RegistrableDomain.h>
+#include <WebCore/SQLiteStatement.h>
+#include <wtf/FileSystem.h>
+#include <wtf/MainThread.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/MakeString.h>
+
+#define ENHANCEDSECURITY_RELEASE_LOG(fmt, ...) RELEASE_LOG(EnhancedSecurity, "EnhancedSecuritySitesPersistence::" fmt, ##__VA_ARGS__)
+
+namespace WebKit {
+
+static constexpr auto sitesTableName = "sites"_s;
+static constexpr auto siteIndexName = "idx_sites_site"_s;
+static constexpr auto enhancedSecurityStateIndexName = "idx_sites_enhanced_security_state"_s;
+
+static constexpr auto createSitesTableSQL = "CREATE TABLE sites (site TEXT PRIMARY KEY NOT NULL, enhanced_security_state INT NOT NULL)"_s;
+static constexpr auto createEnhancedSecurityStateIndexSQL = "CREATE INDEX idx_sites_enhanced_security_state ON sites(enhanced_security_state)"_s;
+
+static constexpr auto selectAllSitesSQL = "SELECT site FROM sites"_s;
+
+static_assert(!enumToUnderlyingType(EnhancedSecurity::Disabled), "EnhancedSecurity::Disabled is not 0 as expected");
+static constexpr auto selectEnhancedSecurityOnlySitesSQL = "SELECT site FROM sites WHERE enhanced_security_state != 0"_s;
+
+static constexpr auto selectSpecificSiteSQL = "SELECT enhanced_security_state FROM sites WHERE site = ?"_s;
+static constexpr auto deleteAllSitesSQL = "DELETE FROM sites"_s;
+static constexpr auto deleteSiteSQL = "DELETE FROM sites WHERE site = ?"_s;
+static constexpr auto insertSiteSQL = "INSERT OR REPLACE INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s;
+
+EnhancedSecuritySitesPersistence::EnhancedSecuritySitesPersistence(const String& databaseDirectoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    openDatabase(databaseDirectoryPath);
+}
+
+EnhancedSecuritySitesPersistence::~EnhancedSecuritySitesPersistence()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (m_sqliteDB)
+        closeDatabase();
+}
+
+void EnhancedSecuritySitesPersistence::reportSQLError(ASCIILiteral method, ASCIILiteral action)
+{
+    RELEASE_LOG_ERROR(EnhancedSecurity, "EnhancedSecuritySitesPersistence::%" PUBLIC_LOG_STRING ": Failed to %" PUBLIC_LOG_STRING " (%d) - %" PUBLIC_LOG_STRING, method.characters(), action.characters(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
+}
+
+static String databasePath(const String& directoryPath)
+{
+    ASSERT(!directoryPath.isEmpty());
+    return FileSystem::pathByAppendingComponent(directoryPath, "EnhancedSecuritySites.db"_s);
+}
+
+CheckedPtr<WebCore::SQLiteDatabase> EnhancedSecuritySitesPersistence::checkedDatabase() const
+{
+    return m_sqliteDB.get();
+}
+
+WebCore::SQLiteStatementAutoResetScope EnhancedSecuritySitesPersistence::cachedStatement(StatementType type)
+{
+    ASSERT(m_sqliteDB);
+
+    switch (type) {
+    case StatementType::SelectSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_selectSpecificSiteSQLStatement.get() };
+    case StatementType::InsertSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_insertSiteSQLStatement.get() };
+    case StatementType::DeleteSite:
+        return WebCore::SQLiteStatementAutoResetScope { m_deleteSQLStatement.get() };
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+bool EnhancedSecuritySitesPersistence::openDatabase(const String& directoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    ASSERT(!directoryPath.isEmpty());
+
+    FileSystem::makeAllDirectories(directoryPath);
+
+    m_sqliteDB = makeUnique<WebCore::SQLiteDatabase>();
+
+    CheckedPtr checkedDB = m_sqliteDB.get();
+
+    // This database is accessed from serial queue EnhancedSecuritySitesHolder::sharedWorkQueueSingleton().
+    checkedDB->disableThreadingChecks();
+
+    auto reportErrorAndCloseDatabase = [&](ASCIILiteral action) {
+        reportSQLError(__FUNCTION__, action);
+        checkedDB = nullptr;
+        closeDatabase();
+        return false;
+    };
+
+    const auto path = databasePath(directoryPath);
+
+    if (!checkedDB->open(path, WebCore::SQLiteDatabase::OpenMode::ReadWriteCreate, WebCore::SQLiteDatabase::OpenOptions::CanSuspendWhileLocked))
+        return reportErrorAndCloseDatabase("open database"_s);
+
+    if (!checkedDB->tableExists(sitesTableName)) {
+        if (!checkedDB->executeCommand(createSitesTableSQL))
+            return reportErrorAndCloseDatabase("create `sites` table"_s);
+
+        ENHANCEDSECURITY_RELEASE_LOG("%s: Table %" PUBLIC_LOG_STRING " created", __FUNCTION__, sitesTableName.characters());
+    }
+
+    if (!checkedDB->indexExists(enhancedSecurityStateIndexName)) {
+        if (!checkedDB->executeCommand(createEnhancedSecurityStateIndexSQL))
+            return reportErrorAndCloseDatabase("create `enhanced_security_state` index on `sites` table"_s);
+
+        ENHANCEDSECURITY_RELEASE_LOG("%s: Index %" PUBLIC_LOG_STRING " created", __FUNCTION__, enhancedSecurityStateIndexName.characters());
+    }
+
+    m_insertSiteSQLStatement = checkedDB->prepareStatement(insertSiteSQL);
+    if (!m_insertSiteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare insert statement"_s);
+
+    m_selectSpecificSiteSQLStatement = checkedDB->prepareStatement(selectSpecificSiteSQL);
+    if (!m_selectSpecificSiteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare select specific site statement"_s);
+
+    m_deleteSQLStatement = checkedDB->prepareStatement(deleteSiteSQL);
+    if (!m_deleteSQLStatement)
+        return reportErrorAndCloseDatabase("prepare delete statement"_s);
+
+    checkedDB->turnOnIncrementalAutoVacuum();
+
+    return true;
+}
+
+void EnhancedSecuritySitesPersistence::deleteSite(const WebCore::RegistrableDomain& site)
+{
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    CheckedPtr deleteStatement = cachedStatement(StatementType::DeleteSite).get();
+
+    if (!deleteStatement
+        || deleteStatement->bindText(1, site.string()) != SQLITE_OK
+        || !deleteStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "failed to delete site"_s);
+}
+
+void EnhancedSecuritySitesPersistence::deleteSites(const Vector<WebCore::RegistrableDomain>& sites)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    for (auto& site : sites)
+        deleteSite(site);
+}
+
+void EnhancedSecuritySitesPersistence::deleteAllSites()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Delete all attempted on closed database, trying file deletion instead.", __FUNCTION__);
+        return;
+    }
+
+    auto deleteStatement = checkedDatabase()->prepareStatement(deleteAllSitesSQL);
+    if (!deleteStatement || !deleteStatement->executeCommand())
+        return reportSQLError(__FUNCTION__, "delete all sites"_s);
+}
+
+HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::enhancedSecurityOnlyDomains()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Attempted operation on closed database.", __FUNCTION__);
+        return { };
+    }
+
+    auto selectStatement = checkedDatabase()->prepareStatement(selectEnhancedSecurityOnlySitesSQL);
+    if (!selectStatement) {
+        reportSQLError(__FUNCTION__, "fetch enhanced security only sites"_s);
+        return { };
+    }
+
+    HashSet<WebCore::RegistrableDomain> sites;
+    while (selectStatement->step() == SQLITE_ROW) {
+        auto site = selectStatement->columnText(0);
+        sites.add(WebCore::RegistrableDomain::fromRawString(String { site }));
+    }
+
+    return sites;
+}
+
+HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::allEnhancedSecuritySites()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Attempted operation on closed database.", __FUNCTION__);
+        return { };
+    }
+
+    auto selectStatement = checkedDatabase()->prepareStatement(selectAllSitesSQL);
+    if (!selectStatement) {
+        reportSQLError(__FUNCTION__, "fetch all sites"_s);
+        return { };
+    }
+
+    HashSet<WebCore::RegistrableDomain> sites;
+    while (selectStatement->step() == SQLITE_ROW) {
+        auto site = selectStatement->columnText(0);
+        sites.add(WebCore::RegistrableDomain::fromRawString(String { site }));
+    }
+
+    return sites;
+}
+
+void EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&& site, EnhancedSecurity reason)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(EnhancedSecurity, "%s: Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    CheckedPtr selectSiteStatement = cachedStatement(StatementType::SelectSite).get();
+
+    if (!selectSiteStatement
+        || selectSiteStatement->bindText(1, site.string()) != SQLITE_OK)
+        reportSQLError(__FUNCTION__, "Failed to query specific site"_s);
+
+    if (selectSiteStatement->step() == SQLITE_ROW) {
+        if (static_cast<EnhancedSecurity>(selectSiteStatement->columnInt(0)) == EnhancedSecurity::Disabled)
+            return;
+    }
+
+    CheckedPtr insertSiteStatement = cachedStatement(StatementType::InsertSite).get();
+
+    auto enhancedSecurityReason = enumToUnderlyingType(reason);
+    if (!insertSiteStatement
+        || insertSiteStatement->bindText(1, site.string()) != SQLITE_OK
+        || insertSiteStatement->bindInt(2, enhancedSecurityReason) != SQLITE_OK
+        || !insertSiteStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "Failed to insert or replace site"_s);
+}
+
+void EnhancedSecuritySitesPersistence::closeDatabase()
+{
+    ASSERT(!isMainRunLoop());
+
+    m_insertSiteSQLStatement = nullptr;
+    m_selectSpecificSiteSQLStatement = nullptr;
+    m_deleteSQLStatement = nullptr;
+
+    if (isDatabaseOpen()) {
+        ENHANCEDSECURITY_RELEASE_LOG("%s: Closing database", __FUNCTION__);
+        checkedDatabase()->close();
+    }
+
+    m_sqliteDB = nullptr;
+}
+
+} // namespace WebKit
+
+#undef ENHANCEDSECURITY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "EnhancedSecurity.h"
+#include <WebCore/SQLiteDatabase.h>
+#include <WebCore/SQLiteStatementAutoResetScope.h>
+#include <wtf/ContinuousApproximateTime.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class EnhancedSecuritySitesPersistence final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EnhancedSecuritySitesPersistence);
+public:
+    explicit EnhancedSecuritySitesPersistence(const String&);
+    ~EnhancedSecuritySitesPersistence();
+
+    bool openDatabase(const String& directoryPath);
+    bool isDatabaseOpen() const { return m_sqliteDB && m_sqliteDB->isOpen(); }
+
+    void deleteSites(const Vector<WebCore::RegistrableDomain>&);
+    void deleteAllSites();
+
+    HashSet<WebCore::RegistrableDomain> enhancedSecurityOnlyDomains();
+    HashSet<WebCore::RegistrableDomain> allEnhancedSecuritySites();
+
+    void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
+
+private:
+    CheckedPtr<WebCore::SQLiteDatabase> checkedDatabase() const;
+
+    enum class StatementType : uint8_t {
+        SelectSite,
+        InsertSite,
+        DeleteSite
+    };
+    WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
+
+    void deleteSite(const WebCore::RegistrableDomain&);
+
+    void closeDatabase();
+    void reportSQLError(ASCIILiteral method, ASCIILiteral action);
+
+    std::unique_ptr<WebCore::SQLiteDatabase> m_sqliteDB;
+    std::unique_ptr<WebCore::SQLiteStatement> m_selectSpecificSiteSQLStatement;
+    std::unique_ptr<WebCore::SQLiteStatement> m_insertSiteSQLStatement;
+    std::unique_ptr<WebCore::SQLiteStatement> m_deleteSQLStatement;
+};
+
+}

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -118,6 +118,7 @@ void WebsiteDataStoreConfiguration::initializePaths()
 #if PLATFORM(COCOA)
     setCookieStorageFile(WebsiteDataStore::defaultCookieStorageFile(m_baseDataDirectory));
     setSearchFieldHistoryDirectory(WebsiteDataStore::defaultSearchFieldHistoryDirectory(m_baseDataDirectory));
+    setEnhancedSecurityDirectory(WebsiteDataStore::defaultEnhancedSecurityDirectory(m_baseDataDirectory));
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -216,6 +217,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
 #if ENABLE(CONTENT_EXTENSIONS)
         crossThreadCopy(resourceMonitorThrottlerDirectory),
 #endif
+        crossThreadCopy(enhancedSecurityDirectory),
     };
 }
 
@@ -247,6 +249,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
 #if ENABLE(CONTENT_EXTENSIONS)
         crossThreadCopy(WTFMove(resourceMonitorThrottlerDirectory)),
 #endif
+        crossThreadCopy(WTFMove(enhancedSecurityDirectory)),
     };
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -261,6 +261,9 @@ public:
     void setAdditionalDomainsWithUserInteractionForTesting(String&& domains) { m_additionalDomainsWithUserInteractionForTesting = WTFMove(domains); }
     const String& additionalDomainsWithUserInteractionForTesting() const { return m_additionalDomainsWithUserInteractionForTesting; }
 
+    const String& enhancedSecurityDirectory() const { return m_directories.enhancedSecurityDirectory; }
+    void setEnhancedSecurityDirectory(String&& directory) { m_directories.enhancedSecurityDirectory = WTFMove(directory); }
+
     struct Directories {
         String alternativeServicesDirectory;
         String cacheStorageDirectory;
@@ -287,6 +290,7 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
         String resourceMonitorThrottlerDirectory;
 #endif
+        String enhancedSecurityDirectory;
         Directories isolatedCopy() const&;
         Directories isolatedCopy() &&;
     };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1342,6 +1342,8 @@
 		561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */; };
 		561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */; };
 		562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */; };
+		562844102ED9E5DD0080DD29 /* EnhancedSecuritySitesHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */; };
+		562844112ED9E5E30080DD29 /* EnhancedSecuritySitesPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */; };
 		564599972B71C3B700BC59E6 /* CoreIPCPresentationIntent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */; };
 		564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = 564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */; };
 		56487A242E951686009CB259 /* EnhancedSecurity.h in Headers */ = {isa = PBXBuildFile; fileRef = 56487A232E951667009CB259 /* EnhancedSecurity.h */; };
@@ -6221,6 +6223,10 @@
 		561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecKeychainItem.h; sourceTree = "<group>"; };
 		562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecTrust.h; sourceTree = "<group>"; };
 		562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecTrust.serialization.in; sourceTree = "<group>"; };
+		5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecuritySitesPersistence.h; sourceTree = "<group>"; };
+		5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecuritySitesPersistence.cpp; sourceTree = "<group>"; };
+		5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecuritySitesHolder.h; sourceTree = "<group>"; };
+		5628440F2ED9E5580080DD29 /* EnhancedSecuritySitesHolder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnhancedSecuritySitesHolder.cpp; sourceTree = "<group>"; };
 		564599932B71BBA000BC59E6 /* CoreIPCPresentationIntent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPresentationIntent.serialization.in; sourceTree = "<group>"; };
 		564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPresentationIntent.h; sourceTree = "<group>"; };
 		564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPresentationIntent.mm; sourceTree = "<group>"; };
@@ -9865,6 +9871,10 @@
 			isa = PBXGroup;
 			children = (
 				1A4832C01A965A33008B4DFE /* Cocoa */,
+				5628440F2ED9E5580080DD29 /* EnhancedSecuritySitesHolder.cpp */,
+				5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */,
+				5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */,
+				5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */,
 				46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */,
 				46B0524422668D2300265B97 /* WebDeviceOrientationAndMotionAccessController.h */,
 				1A4832D81A9D1FD2008B4DFE /* WebsiteDataRecord.cpp */,
@@ -17802,6 +17812,8 @@
 				BC032DA810F437D10058C15A /* Encoder.h in Headers */,
 				CDCDC99D248FE8DA00A69522 /* EndowmentStateTracker.h in Headers */,
 				56487A242E951686009CB259 /* EnhancedSecurity.h in Headers */,
+				562844102ED9E5DD0080DD29 /* EnhancedSecuritySitesHolder.h in Headers */,
+				562844112ED9E5E30080DD29 /* EnhancedSecuritySitesPersistence.h in Headers */,
 				56487A8D2EAFACEB009CB259 /* EnhancedSecurityTracking.h in Headers */,
 				DD4DB788280F9471001700D4 /* EnterFullscreen.js in Headers */,
 				51B15A8513843A3900321AD8 /* EnvironmentUtilities.h in Headers */,


### PR DESCRIPTION
#### 0c6fc3c778e57a5b66b2045881310b2a63068b0d
<pre>
Implement heuristics to drop out of Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=303390">https://bugs.webkit.org/show_bug.cgi?id=303390</a>
<a href="https://rdar.apple.com/165692583">rdar://165692583</a>

Reviewed by Matthew Finkel.

This change expands upon prior Enhanced Security adoption for HTTP which
now applies heuristics to determine when to drop out of Enhanced Security,
in particular, when we consider a site to have had meaningful prior
usage outside of Enhanced Security.

One requirement of this is to add a new WebsiteDataType for tracking when
sites have been seen outside of Enhanced Security, or only when Enhanced
Security was enabled. We persist this to a new db specifically for
Enhanced Security.

Additional tests have been implemented that check that these heuristics
apply successfully in conditions that we expect.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::monitoredDataTypes):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::hasLocalStorageOrCookies):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Shared/WebsiteData/WebsiteData.cpp:
(WebKit::WebsiteData::ownerProcess):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
(WebKit::toString):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setCurrentRequest):
(API::Navigation::setHasStorageForCurrentSite):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::hasStorageForCurrentSite const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
(WebKit::toWebsiteDataType):
(WebKit::toWKWebsiteDataTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::enabledSitesMap):
(WebKit::didSitePreviouslyUseEnhancedSecurity):
(WebKit::trackSiteSeenOutsideEnhancedSecurity):
(WebKit::updateEnhancedSecurityDomains):
(WebKit::EnhancedSecurityTracking::initializeWithWebsiteDataStore):
(WebKit::EnhancedSecurityTracking::enableFor):
(WebKit::EnhancedSecurityTracking::trackChangingSiteNavigation):
(WebKit::EnhancedSecurityTracking::trackSameSiteNavigation):
(WebKit::EnhancedSecurityTracking::trackNavigation):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::hasLocalStorageOrCookies):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::WebFramePolicyListenerProxy):
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::use):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h:
(WebKit::WebFramePolicyListenerProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setUpPolicyListenerProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::beginSiteHasStorageCheck):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultEnhancedSecurityDirectory):
(WebKit::WebsiteDataStore::enhancedSecuritySitesHolder):
(WebKit::WebsiteDataStore::trackEnhancedSecurityForDomain):
(WebKit::WebsiteDataStore::fetchEnhancedSecurityOnlyDomains):
(WebKit::WebsiteDataStore::fetchAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeAllEnhancedSecuritySites):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp: Added.
(WebKit::EnhancedSecuritySitesHolder::sharedWorkQueueSingleton):
(WebKit::EnhancedSecuritySitesHolder::create):
(WebKit::EnhancedSecuritySitesHolder::EnhancedSecuritySitesHolder):
(WebKit::EnhancedSecuritySitesHolder::~EnhancedSecuritySitesHolder):
(WebKit::EnhancedSecuritySitesHolder::fetchEnhancedSecurityOnlyDomains):
(WebKit::EnhancedSecuritySitesHolder::fetchAllEnhancedSecuritySites):
(WebKit::EnhancedSecuritySitesHolder::trackEnhancedSecurityForDomain):
(WebKit::EnhancedSecuritySitesHolder::deleteSites):
(WebKit::EnhancedSecuritySitesHolder::deleteAllSites):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesHolder.h: Copied from Source/WebKit/UIProcess/EnhancedSecurityTracking.h.
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp: Added.
(WebKit::EnhancedSecuritySitesPersistence::EnhancedSecuritySitesPersistence):
(WebKit::EnhancedSecuritySitesPersistence::~EnhancedSecuritySitesPersistence):
(WebKit::EnhancedSecuritySitesPersistence::reportSQLError):
(WebKit::databasePath):
(WebKit::EnhancedSecuritySitesPersistence::checkedDatabase const):
(WebKit::EnhancedSecuritySitesPersistence::cachedStatement):
(WebKit::EnhancedSecuritySitesPersistence::openDatabase):
(WebKit::EnhancedSecuritySitesPersistence::deleteSite):
(WebKit::EnhancedSecuritySitesPersistence::deleteSites):
(WebKit::EnhancedSecuritySitesPersistence::deleteAllSites):
(WebKit::EnhancedSecuritySitesPersistence::enhancedSecurityOnlyDomains):
(WebKit::EnhancedSecuritySitesPersistence::allEnhancedSecuritySites):
(WebKit::EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain):
(WebKit::EnhancedSecuritySitesPersistence::closeDatabase):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h: Added.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::resolveDirectories):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::hasLocalStorageOrCookies const):
(WebKit::WebsiteDataStore::removeEnhancedSecuritySites):
(WebKit::WebsiteDataStore::removeAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::fetchEnhancedSecurityOnlyDomains):
(WebKit::WebsiteDataStore::fetchAllEnhancedSecuritySites):
(WebKit::WebsiteDataStore::trackEnhancedSecurityForDomain):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::enhancedSecurityDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setEnhancedSecurityDirectory):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpThenNavigateToHttpsSiteWithCookies):
(runHttpThenNavigateToHttpsSiteWithLocalStorage):
(runHttpThenHttpsThenNavigateToHttpsSiteWithCookies):
(runHttpThenNavigateToHttpsSiteWithCookiesThenHttps):
(runHttpThenNavigateToHttpsSetCookiesThenNavigateToHttpsAgain):
(runHttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite):
(runWindowOpenThenNavigateToMeaningfulSite):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPI):
(enhancedSecuritySitesPath):
(emptyEnhancedSecuritySitesPath):
(createEnhancedSecuritySitesTable):
(addEnhancedSecuritySite):
(setUpEnhancedSecuritySeenValues):
(cleanUpEnhancedSecuritySites):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndNotSeenOutsideEnhancedSecurity):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity):

Canonical link: <a href="https://commits.webkit.org/303988@main">https://commits.webkit.org/303988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a62312f938c7fb99327bbc987d05bf4f034339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141796 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd15edbd-51f0-49a9-86f2-7041d2aee882) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137159 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83432 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d323fc3b-7563-4b25-aba6-0bafaface733) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2577 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144439 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111255 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4805 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116568 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60164 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6445 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34786 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6533 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->