### PR TITLE
Prepare the model player for the immersive presentation

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
@@ -1,13 +1,14 @@
 
 PASS Immersive API exists on model and document
 PASS Model immersive request fails without user activation
-FAIL Model enters immersive mode with user activation promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Document.exitImmersive() exits immersive model promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Immersivechange events fire when entering immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Only one model can be immersive at a time promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Removing immersive model from DOM exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Model enters immersive mode with user activation promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Document.exitImmersive() exits immersive model promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Immersivechange events fire when entering immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Only one model can be immersive at a time promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Exiting immersive model after an immersive update exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Removing immersive model from DOM exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
 PASS Immersiveerror event fires when request fails
-FAIL CSS :immersive pseudo-class matches correctly promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Model is complete once presented as immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
-FAIL Multiple concurrent requestImmersive calls are handled correctly promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL CSS :immersive pseudo-class matches correctly promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Model is complete once presented as immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+FAIL Multiple concurrent requestImmersive calls are handled correctly promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
 

--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -84,7 +84,7 @@ promise_test(async t => {
 
 promise_test(async t => {
     const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
-    const [model2, source2] = createModelAndSource(t, "../resources/sphere.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/heart.usdz");
     
     await test_driver.bless("immersive");
     await model1.requestImmersive();
@@ -96,6 +96,26 @@ promise_test(async t => {
     
     assert_equals(document.immersiveElement, model2, 'Document should reference second model');
 }, 'Only one model can be immersive at a time');
+
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/heart.usdz");
+    
+    await test_driver.bless("immersive");
+    await model1.requestImmersive();
+    
+    assert_equals(document.immersiveElement, model1, 'Document should reference first model');
+    
+    await test_driver.bless("immersive");
+    await model2.requestImmersive();
+    
+    assert_equals(document.immersiveElement, model2, 'Document should reference second model');
+
+    await document.exitImmersive();
+    
+    assert_equals(document.immersiveElement, null, 'Document immersive element should be null');
+}, 'Exiting immersive model after an immersive update exits immersive mode');
 
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
@@ -118,7 +138,10 @@ promise_test(async t => {
         errorFired = true;
     });
     
-    try { await model.requestImmersive(); } catch { }
+    await promise_rejects_js(t, TypeError, 
+        model.requestImmersive(),
+        'Should reject without user activation'
+    );
     
     await new Promise(resolve => setTimeout(resolve, 100));
     
@@ -151,7 +174,7 @@ promise_test(async t => {
 
 promise_test(async t => {
     const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
-    const [model2, source2] = createModelAndSource(t, "../resources/sphere.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/heart.usdz");
     
     await test_driver.bless("immersive");
     const promise1 = model1.requestImmersive();

--- a/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Hidden inline model should successfully enter immersive promise_test: Unhandled rejection with value: object "TypeError: Model Player created, but next steps are not implemented"
+FAIL Hidden inline model should successfully enter immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -149,7 +149,7 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool immersive() const;
     void requestImmersive(DOMPromiseDeferred<void>&&);
-    void ensureImmersivePresentation(CompletionHandler<void(ExceptionOr<const LayerHostingContextIdentifier>)>&&);
+    void ensureImmersivePresentation(CompletionHandler<void(ExceptionOr<LayerHostingContextIdentifier>)>&&);
     void exitImmersivePresentation(CompletionHandler<void()>&&);
 #endif
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -209,4 +209,20 @@ void ModelPlayer::resetModelTransformAfterDrag()
 
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+
+void ModelPlayer::ensureImmersivePresentation(CompletionHandler<void(std::optional<LayerHostingContextIdentifier>)>&& completion)
+{
+    ASSERT_NOT_REACHED("ModelPlayer cannot provide a layer context identifier");
+    completion(std::nullopt);
+}
+
+void ModelPlayer::exitImmersivePresentation(CompletionHandler<void()>&& completion)
+{
+    ASSERT_NOT_REACHED("ModelPlayer cannot exit an immersive presentation");
+    completion();
+}
+
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/HTMLModelElementCamera.h>
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutSize.h>
 #include <WebCore/ModelPlayerAccessibilityChildren.h>
@@ -149,6 +150,11 @@ public:
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
     virtual void setStageMode(StageModeOperation);
+#endif
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    virtual void ensureImmersivePresentation(CompletionHandler<void(std::optional<LayerHostingContextIdentifier>)>&&);
+    virtual void exitImmersivePresentation(CompletionHandler<void()>&&);
 #endif
 };
 

--- a/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
@@ -44,6 +44,8 @@ public:
     virtual std::optional<FloatPoint3D> boundingBoxCenter() const = 0;
     virtual std::optional<FloatPoint3D> boundingBoxExtents() const = 0;
 
+    virtual void invalidateTransform() = 0;
+
 #if ENABLE(MODEL_ELEMENT_PORTAL)
     virtual bool hasPortal() const = 0;
     virtual void setHasPortal(bool) = 0;

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -286,4 +286,19 @@ ModelPlayerAccessibilityChildren PlaceholderModelPlayer::accessibilityChildren()
 
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+
+void PlaceholderModelPlayer::ensureImmersivePresentation(CompletionHandler<void(std::optional<LayerHostingContextIdentifier>)>&& completion)
+{
+    ASSERT_NOT_REACHED("PlaceholderModelPlayer cannot provide a layer context identifier");
+    completion(std::nullopt);
+}
+void PlaceholderModelPlayer::exitImmersivePresentation(CompletionHandler<void()>&& completion)
+{
+    ASSERT_NOT_REACHED("PlaceholderModelPlayer cannot exit an immersive presentation");
+    completion();
+}
+
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -77,6 +77,11 @@ private:
     void setStageMode(WebCore::StageModeOperation) final;
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void ensureImmersivePresentation(CompletionHandler<void(std::optional<LayerHostingContextIdentifier>)>&&) final;
+    void exitImmersivePresentation(CompletionHandler<void()>&&) final;
+#endif
+
     // Empty implementation
     void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) final;
     void sizeDidChange(LayoutSize) final;

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -59,7 +59,7 @@ public:
     RefPtr<HTMLModelElement> protectedImmersiveElement() const { return immersiveElement(); }
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
-    void exitImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
+    void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitRemovedImmersiveElement(HTMLModelElement*);
 
     enum class EventType : bool { Change, Error };
@@ -75,6 +75,7 @@ protected:
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_immersiveElement;
+    void updateElementIsImmersive(HTMLModelElement*, bool);
 
     Deque<std::pair<EventType, GCReachableRef<Element>>> m_pendingEvents;
 };

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -142,6 +142,11 @@ public:
     void stageModeInteractionDidUpdateModel();
     void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&&) final;
+    void exitImmersivePresentation(CompletionHandler<void()>&&) final;
+#endif
+
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 
     void disableUnloadDelayForTesting() { m_unloadDelayDisabledForTesting = true; }
@@ -152,7 +157,7 @@ private:
 
     void computeTransform(bool);
     void updateTransform();
-    void applyEnvironmentMapDataAndRelease();
+    void applyEnvironmentMapDataAndRelease(CompletionHandler<void()>&&);
     void applyStageModeOperationToDriver();
     bool stageModeInteractionInProgress() const;
     void updateTransformSRT();
@@ -203,6 +208,16 @@ private:
     // For testing
     bool m_unloadDelayDisabledForTesting { false };
     static uint64_t gObjectCountForTesting;
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool m_immersivePresentation { false };
+    WebCore::LayoutSize m_layoutSize { };
+    Vector<CompletionHandler<void(bool)>> m_modelLoadedCallbacks;
+
+    void triggerModelLoadedCallbacks(bool);
+    void ensureModelLoaded(CompletionHandler<void(bool)>&&);
+    void setImmersivePresentation(bool);
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -51,6 +51,11 @@ messages -> ModelProcessModelPlayerProxy {
     EndStageModeInteraction()
     AnimateModelToFitPortal() -> (bool success)
     ResetModelTransformAfterDrag()
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    EnsureImmersivePresentation() -> (std::optional<WebCore::LayerHostingContextIdentifier> contextID) Async
+    ExitImmersivePresentation() -> () Async
+#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -483,6 +483,20 @@ void ModelProcessModelPlayer::disableUnloadDelayForTesting()
     send(Messages::ModelProcessModelPlayerProxy::DisableUnloadDelayForTesting());
 }
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+
+void ModelProcessModelPlayer::ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&& completion)
+{
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::EnsureImmersivePresentation(), WTFMove(completion));
+}
+
+void ModelProcessModelPlayer::exitImmersivePresentation(CompletionHandler<void()>&& completion)
+{
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::ExitImmersivePresentation(), WTFMove(completion));
+}
+
+#endif
+
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -129,6 +129,11 @@ private:
     void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
     void resetModelTransformAfterDrag() final;
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&&) final;
+    void exitImmersivePresentation(CompletionHandler<void()>&&) final;
+#endif
+
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::ModelPlayerClient> m_client;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
@@ -103,9 +103,7 @@ void ModelProcessModelPlayerTransformState::setHasPortal(bool hasPortal)
         return;
 
     m_hasPortal = hasPortal;
-    // FIXME: Recalculate entity transform
-    // Invalidate m_entityTransform for now so the entityTransform can be recomputed on reload.
-    m_entityTransform = std::nullopt;
+    invalidateTransform();
 }
 
 void ModelProcessModelPlayerTransformState::setStageMode(WebCore::StageModeOperation stageModeOperation)
@@ -114,6 +112,11 @@ void ModelProcessModelPlayerTransformState::setStageMode(WebCore::StageModeOpera
         return;
 
     m_stageModeOperation = stageModeOperation;
+    invalidateTransform();
+}
+
+void ModelProcessModelPlayerTransformState::invalidateTransform()
+{
     // FIXME: recalculate entity transform
     // Invalidate m_entityTransform for now so the entityTransform can be recomputed on reload.
     m_entityTransform = std::nullopt;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
@@ -56,6 +56,7 @@ private:
     void setHasPortal(bool) final;
     WebCore::StageModeOperation stageMode() const final { return m_stageModeOperation; }
     void setStageMode(WebCore::StageModeOperation) final;
+    void invalidateTransform() final;
 
     std::optional<WebCore::TransformationMatrix> m_entityTransform;
     std::optional<WebCore::FloatPoint3D> m_boundingBoxCenter;


### PR DESCRIPTION
#### 42a042b2f09f8d9f1ce03936a13be5360df66b41
<pre>
Prepare the model player for the immersive presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303400">https://bugs.webkit.org/show_bug.cgi?id=303400</a>
<a href="https://rdar.apple.com/165702118">rdar://165702118</a>

Reviewed by Etienne Segonzac.

Add logic in the model player to prepare for an immersive presentation.
Ensure the model player is ready and the model is loaded before allowing
the immersive presentation.
Add the exitImmersive plumbing to exit an immersive presentation.

* LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt:
Test results updated.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::ensureImmersivePresentation):
(WebCore::HTMLModelElement::exitImmersivePresentation):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::ensureImmersivePresentation):
(WebCore::ModelPlayer::exitImmersivePresentation):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerTransformState.h:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::ensureImmersivePresentation):
(WebCore::PlaceholderModelPlayer::exitImmersivePresentation):
Invalidate the transform if an exit immersive transition is performed on
a placeholder model player.

* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::exitImmersive):
(WebCore::DocumentImmersive::requestImmersive):
(WebCore::DocumentImmersive::updateElementIsImmersive):
* Source/WebCore/dom/DocumentImmersive.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::computeSRT):
Compute the tranform for an immersive presentation - scaled for the physical
world.

(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
(WebKit::ModelProcessModelPlayerProxy::setEnvironmentMap):
(WebKit::ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease):
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::exitImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::setImmersivePresentation):
(WebKit::ModelProcessModelPlayerProxy::ensureModelLoaded):
(WebKit::ModelProcessModelPlayerProxy::triggerModelLoadedCallbacks):
Ensure the model is fully loaded before completing the immersive transition.

* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::ensureImmersivePresentation):
(WebKit::ModelProcessModelPlayer::exitImmersivePresentation):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp:
(WebKit::ModelProcessModelPlayerTransformState::setHasPortal):
(WebKit::ModelProcessModelPlayerTransformState::setStageMode):
(WebKit::ModelProcessModelPlayerTransformState::invalidateTransform):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h:

Canonical link: <a href="https://commits.webkit.org/303901@main">https://commits.webkit.org/303901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b839b08dc451dca742882c53395356a8fdd161

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85913 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102394 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2357 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6034 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110964 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4593 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116250 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59781 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6086 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34530 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69550 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->