### PR TITLE
[RenderStyleGen] Generate getter/setter functions that were missed

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -456,7 +456,6 @@ rendering/ImageQualityController.cpp
 rendering/InlineBoxPainter.cpp
 rendering/LayoutRepainter.cpp
 rendering/LegacyInlineBox.cpp
-rendering/LegacyInlineBox.h
 rendering/LegacyInlineFlowBox.cpp
 rendering/LegacyInlineFlowBox.h
 rendering/LegacyInlineIterator.h

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -382,6 +382,8 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "style-builder-custom": "All",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
                 "parser-grammar": "auto | <color>"
             },
             "specification": {
@@ -454,6 +456,7 @@
                 "render-style-getter-custom": true,
                 "render-style-setter-custom": true,
                 "render-style-has-explicitly-set-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
                 "render-style-type": "TextDirection",
                 "high-priority": true,
                 "parser-grammar": "<<values>>"
@@ -546,6 +549,12 @@
                 "animation-wrapper": "NonNormalizedDiscreteWrapper<DisplayType>",
                 "animation-wrapper-requires-non-normalized-discrete-interpolation": true,
                 "high-priority": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-name": "effectiveDisplay",
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "DisplayType",
                 "parser-function": "consumeDisplay",
                 "parser-grammar-unused": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <-webkit-display>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -624,6 +633,9 @@
                 "style-extractor-custom": true,
                 "style-builder-custom": "All",
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-type": "Style::FontFamilies",
                 "parser-function": "consumeFontFamily",
                 "parser-grammar-unused": "[ <family-name> | <generic-family> | <-webkit-generic-family> ]#",
                 "parser-grammar-unused-reason": "Needs support for primitive <family-name>."
@@ -664,6 +676,9 @@
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-type": "float",
                 "parser-grammar": "<absolute-size> | <relative-size> | <length-percentage [0,inf]> | <-webkit-absolute-size> | <-webkit-relative-size>",
                 "parser-exported": true
             },
@@ -690,6 +705,10 @@
                 "font-property": true,
                 "high-priority": true,
                 "separator": " ",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontSizeAdjust",
                 "parser-function": "consumeFontSizeAdjust",
                 "parser-function-allows-number-or-integer-input": true,
                 "parser-grammar-unused": "none | [ [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,inf]> ] ]",
@@ -714,6 +733,10 @@
                 "style-converter": "StyleType<FontStyle>",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontStyle",
                 "parser-function": "consumeFontStyle",
                 "parser-grammar-unused": "normal | italic | [ oblique <angle>? ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups with a keyword/literal first term differentiator."
@@ -738,6 +761,10 @@
                 "font-property": true,
                 "high-priority": true,
                 "style-converter": "StyleType<FontWeight>",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontWeight",
                 "parser-grammar": "<font-weight-absolute> | bolder | lighter",
                 "parser-exported": true
             },
@@ -769,6 +796,10 @@
                     "font-property": true,
                     "high-priority": true,
                     "style-converter": "StyleType<FontWidth>",
+                    "render-style-getter-custom": true,
+                    "render-style-setter-custom": true,
+                    "render-style-storage-kind": "value",
+                    "render-style-type": "Style::FontWidth",
                     "parser-grammar": "<font-width-absolute> | <percentage [0,inf]>"
                 },
                 {
@@ -778,6 +809,10 @@
                     "font-property": true,
                     "high-priority": true,
                     "style-converter": "StyleType<FontWidth>",
+                    "render-style-getter-custom": true,
+                    "render-style-setter-custom": true,
+                    "render-style-storage-kind": "value",
+                    "render-style-type": "Style::FontWidth",
                     "parser-grammar": "<font-width-absolute>"
                 }
             ],
@@ -870,6 +905,10 @@
                 "font-description-name-for-methods": "TextRenderingMode",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextRenderingMode",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -889,6 +928,10 @@
                 "font-description-name-for-methods": "FeatureSettings",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontFeatureSettings",
                 "parser-grammar": "normal | <feature-tag-value>#@(no-single-item-opt)",
                 "parser-exported": true
             },
@@ -905,11 +948,15 @@
                 "normal"
             ],
             "codegen-properties": {
+                "enable-if": "ENABLE_VARIATION_FONTS",
                 "style-converter": "StyleType<FontVariationSettings>",
                 "font-description-name-for-methods": "VariationSettings",
                 "font-property": true,
                 "high-priority": true,
-                "enable-if": "ENABLE_VARIATION_FONTS",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontVariationSettings",
                 "parser-grammar": "normal | <variation-tag-value>#@(no-single-item-opt)"
             },
             "specification": {
@@ -933,6 +980,10 @@
                 "font-description-name-for-methods": "Kerning",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Kerning",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -949,6 +1000,10 @@
                 "style-converter": "StyleType<FontPalette>",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontPalette",
                 "parser-grammar": "normal | light | dark | <palette-identifier>"
             },
             "specification": {
@@ -969,6 +1024,10 @@
             "codegen-properties": {
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontSmoothingMode",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -994,6 +1053,10 @@
                 "font-description-name-for-methods": "VariantLigatures",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontVariantLigatures",
                 "parser-grammar": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]@(no-single-item-opt)"
             },
             "specification": {
@@ -1014,6 +1077,10 @@
                 "font-description-name-for-methods": "VariantPosition",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontVariantPosition",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -1039,6 +1106,10 @@
                 "font-description-name-for-methods": "VariantCaps",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "VariantCaps",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -1067,6 +1138,10 @@
                 "font-description-name-for-methods": "VariantNumeric",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::FontVariantNumeric",
                 "parser-grammar": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]@(no-single-item-opt)"
             },
             "specification": {
@@ -1083,6 +1158,10 @@
                 "font-description-name-for-methods": "VariantAlternates",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::VariantAlternates",
                 "parser-grammar": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]@(no-single-item-opt)",
                 "parser-exported": true
             },
@@ -1112,6 +1191,10 @@
                 "font-description-name-for-methods": "VariantEastAsian",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::VariantEastAsian",
                 "parser-grammar": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]@(no-single-item-opt)",
                 "parser-exported": true
             },
@@ -1132,10 +1215,14 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssFontVariantEmojiEnabled",
-                "parser-grammar": "<<values>>",
                 "font-description-name-for-methods": "VariantEmoji",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "VariantEmoji",
+                "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
             "specification": {
@@ -1171,6 +1258,10 @@
             "codegen-properties": {
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontSynthesisLonghandValue",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -1189,6 +1280,10 @@
             "codegen-properties": {
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontSynthesisLonghandValue",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -1207,6 +1302,10 @@
             "codegen-properties": {
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontSynthesisLonghandValue",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -1223,10 +1322,14 @@
                 "none"
             ],
             "codegen-properties": {
+                "enable-if": "ENABLE_VARIATION_FONTS",
                 "font-description-name-for-methods": "OpticalSizing",
                 "font-property": true,
                 "high-priority": true,
-                "enable-if": "ENABLE_VARIATION_FONTS",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "FontOpticalSizing",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -1307,6 +1410,10 @@
                 "font-description-name-for-methods": "SpecifiedLocale",
                 "font-property": true,
                 "high-priority": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::WebkitLocale",
                 "parser-grammar": "auto | <string>"
             },
             "status": "non-standard"
@@ -1322,7 +1429,11 @@
             ],
             "codegen-properties": {
                 "style-builder-custom": "Value",
-                "render-style-getter": "writingMode().computedTextOrientation",
+                "render-style-getter": "computedTextOrientation",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextOrientation",
                 "high-priority": true,
                 "parser-grammar": "<<values>>"
             },
@@ -1418,6 +1529,10 @@
                 "high-priority": true,
                 "sink-priority": true,
                 "style-converter": "StyleType<TextSpacingTrim>",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::TextSpacingTrim",
                 "parser-grammar": "<<values>>",
                 "parser-grammar-comment": "Current spec grammar is 'space-all | normal | space-first | trim-start | trim-both | trim-all | auto'"
             },
@@ -1445,6 +1560,10 @@
                 "high-priority": true,
                 "sink-priority": true,
                 "style-converter": "StyleType<TextAutospace>",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::TextAutospace",
                 "parser-grammar": "normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric ]@(no-single-item-opt)",
                 "parser-grammar-comment": "Current spec grammar is 'normal | auto | no-autospace | [ [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ] ]'"
             },
@@ -1510,6 +1629,7 @@
                 "render-style-getter-custom": true,
                 "render-style-setter-custom": true,
                 "render-style-has-explicitly-set-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
                 "render-style-type": "StyleWritingMode",
                 "top-priority": true,
                 "top-priority-reason": "This is top priority because vi/vb units (depending on writing-mode) may be used by other properties",
@@ -1554,6 +1674,10 @@
             "codegen-properties": {
                 "style-builder-custom": "All",
                 "high-priority": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "value",
+                "render-style-type": "float",
                 "parser-grammar": "normal | <percentage [0,inf]> | <number [0,inf]>",
                 "parser-grammar-comment": "Current spec grammar is '<number [0,inf]> || <percentage [0,inf]>'"
             },
@@ -2815,6 +2939,10 @@
                 "separate"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BorderCollapse",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -3945,6 +4073,10 @@
                 "aliases": [
                     "-epub-caption-side"
                 ],
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "CaptionSide",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -3970,6 +4102,10 @@
                 }
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Clear",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -4309,6 +4445,8 @@
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyCounterIncrement"],
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
                 "parser-function": "consumeCounterIncrement",
                 "parser-grammar-unused": "[ <counter-name> <integer>? ]+ | none",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals."
@@ -4329,6 +4467,8 @@
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyCounterReset"],
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
                 "parser-function": "consumeCounterReset",
                 "parser-grammar-unused": "[ <counter-name> <integer>? ]+ | none",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals.",
@@ -4350,6 +4490,8 @@
                 "animation-wrapper-requires-override-parameters": ["CSSPropertyCounterSet"],
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
                 "parser-function": "consumeCounterSet",
                 "parser-grammar-unused": "[ <counter-name> <integer>? ]+ | none",
                 "parser-grammar-unused-reason": "Needs support for default values on optionals."
@@ -4419,6 +4561,9 @@
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<Cursor>",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-type": "Style::Cursor",
                 "parser-function": "consumeCursor",
                 "parser-grammar-unused": "[ [ <url> [ <x> <y> ]? ]#{0,} [ <<values>> ] ]",
                 "parser-grammar-unused-reason": "Needs support for different parsing based on the current mode."
@@ -4438,6 +4583,10 @@
             ],
             "codegen-properties": {
                 "enable-if": "ENABLE_CURSOR_VISIBILITY",
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "CursorVisibility",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -4554,6 +4703,10 @@
                 "hide"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "EmptyCell",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -4650,6 +4803,11 @@
             "codegen-properties": {
                 "render-style-name-for-methods": "Floating",
                 "style-extractor-custom": true,
+                "render-style-storage-name": "floating",
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Float",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -5119,6 +5277,11 @@
                 "font-property": true,
                 "high-priority": true,
                 "sink-priority": true,
+                "render-style-getter": "computedLetterSpacing",
+                "render-style-storage-name": "letterSpacing",
+                "render-style-storage-path": ["m_inheritedData", "fontData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::LetterSpacing",
                 "parser-grammar": "normal | <length-percentage>"
             },
             "specification": {
@@ -5179,18 +5342,25 @@
             ],
             "codegen-properties": [
                 {
+                    "enable-if": "ENABLE_TEXT_AUTOSIZING",
                     "animation-wrapper-requires-getter": "specifiedLineHeight",
                     "style-builder-custom": "All",
                     "style-extractor-custom": true,
-                    "enable-if": "ENABLE_TEXT_AUTOSIZING",
+                    "render-style-getter-custom": true,
+                    "render-style-storage-path": ["m_inheritedData"],
+                    "render-style-storage-kind": "reference",
+                    "render-style-type": "Style::LineHeight",
                     "parser-grammar": "normal | <number [0,inf]> | <length-percentage [0,inf]>",
                     "parser-exported": true
                 },
                 {
-                    "render-style-getter": "specifiedLineHeight",
+                    "enable-if": "!ENABLE_TEXT_AUTOSIZING",
                     "style-builder-converter": "StyleType<LineHeight>",
                     "style-extractor-custom": true,
-                    "enable-if": "!ENABLE_TEXT_AUTOSIZING",
+                    "render-style-getter-custom": true,
+                    "render-style-storage-path": ["m_inheritedData"],
+                    "render-style-storage-kind": "reference",
+                    "render-style-type": "Style::LineHeight",
                     "parser-grammar": "normal | <number [0,inf]> | <length-percentage [0,inf]>",
                     "parser-exported": true
                 }
@@ -5246,6 +5416,10 @@
                 "outside"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "ListStylePosition",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7064,11 +7238,15 @@
                 }
             ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>",
                 "logical-property-group": {
                     "name": "overflow",
                     "resolver": "horizontal"
-                }
+                },
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Overflow",
+                "parser-grammar": "<<values>>"
             },
             "specification": {
                 "category": "css-overflow",
@@ -7098,11 +7276,15 @@
                 }
             ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>",
                 "logical-property-group": {
                     "name": "overflow",
                     "resolver": "vertical"
-                }
+                },
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Overflow",
+                "parser-grammar": "<<values>>"
             },
             "specification": {
                 "category": "css-overflow",
@@ -7499,6 +7681,7 @@
             "codegen-properties": {
                 "skip-style-builder": true,
                 "skip-style-extractor": true,
+                "skip-render-style": true,
                 "parser-grammar": "auto | <custom-ident>"
             },
             "specification": {
@@ -7598,6 +7781,10 @@
                 "none"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "PointerEvents",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -7620,6 +7807,10 @@
                 }
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "PositionType",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -8165,6 +8356,10 @@
             ],
             "codegen-properties": {
                 "style-builder-converter": "StyleType<TextAlign>",
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Style::TextAlign",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -8392,6 +8587,10 @@
                 "nowrap"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextWrapMode",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -8418,6 +8617,10 @@
                 }
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "TextWrapStyle",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -8600,6 +8803,10 @@
                 }
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_nonInheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "UnicodeBidi",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -8683,6 +8890,10 @@
             "codegen-properties": {
                 "animation-wrapper": "VisibilityWrapper",
                 "animation-wrapper-requires-override-parameters": [],
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Visibility",
                 "parser-grammar": "<<values>>",
                 "fast-path-inherited": true
             },
@@ -8726,6 +8937,10 @@
                 "break-spaces"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "WhiteSpaceCollapse",
                 "parser-grammar": "<<values>>",
                 "parser-exported": true
             },
@@ -8883,6 +9098,11 @@
                 "font-property": true,
                 "high-priority": true,
                 "sink-priority": true,
+                "render-style-getter": "computedWordSpacing",
+                "render-style-storage-name": "wordSpacing",
+                "render-style-storage-path": ["m_inheritedData", "fontData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::WordSpacing",
                 "parser-grammar": "normal | <length-percentage>"
             },
             "specification": {
@@ -8927,8 +9147,12 @@
                 "auto"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "SpecifiedZIndex",
                 "style-converter": "StyleType<ZIndex>",
+                "render-style-name-for-methods": "SpecifiedZIndex",
+                "render-style-getter-custom": true,
+                "render-style-setter-custom": true,
+                "render-style-storage-kind": "value",
+                "render-style-type": "Style::ZIndex",
                 "parser-grammar": "auto | <integer>"
             },
             "specification": {
@@ -8987,6 +9211,10 @@
                 "aliases": [
                     "-webkit-appearance"
                 ],
+                "render-style-setter-custom": true,
+                "render-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "StyleAppearance",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -9354,6 +9582,10 @@
                 "reverse"
             ],
             "codegen-properties": {
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BoxDirection",
                 "parser-grammar": "<<values>>"
             },
             "status": "obsolete",
@@ -9906,6 +10138,11 @@
             ],
             "codegen-properties": {
                 "render-style-name-for-methods": "BlendMode",
+                "render-style-setter-custom": true,
+                "render-style-storage-name": "effectiveBlendMode",
+                "render-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "render-style-storage-kind": "enum",
+                "render-style-type": "BlendMode",
                 "parser-grammar": "<<values>>"
             },
             "specification":  {
@@ -10348,6 +10585,7 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "skip-style-builder": true,
+                "skip-render-style": true,
                 "internal-only": true,
                 "parser-grammar": "<length>"
             },
@@ -11343,6 +11581,10 @@
                     "-webkit-print-color-adjust",
                     "color-adjust"
                 ],
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "PrintColorAdjust",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -11361,6 +11603,10 @@
             "codegen-properties": {
                 "render-style-initial": "initialRTLOrdering",
                 "render-style-setter": "setRTLOrdering",
+                "render-style-storage-path": ["m_inheritedFlags"],
+                "render-style-storage-container": "struct",
+                "render-style-storage-kind": "enum",
+                "render-style-type": "Order",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"
@@ -11625,9 +11871,10 @@
             "animation-type": "not animatable (internal)",
             "inherited": true,
             "codegen-properties": {
+                "enable-if": "ENABLE_TEXT_AUTOSIZING",
                 "skip-style-builder": true,
                 "skip-parser": true,
-                "enable-if": "ENABLE_TEXT_AUTOSIZING",
+                "skip-render-style": true,
                 "internal-only": true
             },
             "status": "non-standard"

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -516,6 +516,7 @@ class StylePropertyCodeGenProperties:
         Schema.Entry("shorthand-style-extractor-pattern", allowed_types=[str]),
         Schema.Entry("skip-codegen", allowed_types=[bool], default_value=False),
         Schema.Entry("skip-parser", allowed_types=[bool], default_value=False),
+        Schema.Entry("skip-render-style", allowed_types=[bool], default_value=False),
         Schema.Entry("skip-style-builder", allowed_types=[bool], default_value=False),
         Schema.Entry("skip-style-extractor", allowed_types=[bool], default_value=False),
         Schema.Entry("status", allowed_types=[str]),
@@ -5384,6 +5385,17 @@ class GenerateRenderStyleGenerated:
 
     def _generate_render_style_inlines_generated_h_function_implementations(self, *, to):
         for property in self.style_properties.all:
+            if property.codegen_properties.skip_render_style:
+                continue
+            if property.codegen_properties.is_logical:
+                continue
+            if property.codegen_properties.longhands:
+                continue
+            if property.codegen_properties.cascade_alias:
+                continue
+            if property.codegen_properties.coordinated_value_list_property:
+                continue
+
             if property.codegen_properties.render_style_storage_path and not property.codegen_properties.render_style_getter_custom:
                 function_name = property.codegen_properties.render_style_getter
                 return_type = self._compute_getter_return_type(property)
@@ -5399,6 +5411,8 @@ class GenerateRenderStyleGenerated:
                     return_type=return_type,
                     get_expression=self._compute_get_expression(property, container_kind, container_path, storage_type, storage_name, storage_kind)
                 )
+            elif not property.codegen_properties.render_style_getter_custom:
+                raise Exception(f"Missing RenderStyle getter for property {property.id}.")
 
             if property.codegen_properties.render_style_visited_link_storage_path:
                 function_name = f"visitedLink{property.codegen_properties.render_style_name_for_methods}"
@@ -5493,6 +5507,17 @@ class GenerateRenderStyleGenerated:
 
     def _generate_render_style_setters_generated_h_function_implementations(self, *, to):
         for property in self.style_properties.all:
+            if property.codegen_properties.skip_render_style:
+                continue
+            if property.codegen_properties.is_logical:
+                continue
+            if property.codegen_properties.longhands:
+                continue
+            if property.codegen_properties.cascade_alias:
+                continue
+            if property.codegen_properties.coordinated_value_list_property:
+                continue
+
             if property.codegen_properties.render_style_storage_path and not property.codegen_properties.render_style_setter_custom:
                 function_name = property.codegen_properties.render_style_setter
                 argument_name = f"value"
@@ -5511,6 +5536,8 @@ class GenerateRenderStyleGenerated:
                     get_expression=self._compute_get_expression(property, container_kind, container_path, storage_type, storage_name, storage_kind),
                     set_expression=self._compute_set_expression(property, container_kind, container_path, storage_type, storage_name, storage_kind, argument_name)
                 )
+            elif not property.codegen_properties.render_style_setter_custom:
+                raise Exception(f"Missing RenderStyle setter for property {property.id}.")
 
             if property.codegen_properties.render_style_visited_link_storage_path:
                 function_name = f"setVisitedLink{property.codegen_properties.render_style_name_for_methods}"

--- a/Source/WebCore/css/scripts/test/TestCSSProperties.json
+++ b/Source/WebCore/css/scripts/test/TestCSSProperties.json
@@ -5,6 +5,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>"
             }
         },
@@ -13,6 +14,7 @@
             "initial": "0",
             "values": [ "auto" ],
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "auto | <shared-rule-one>"
             }
         },
@@ -21,6 +23,7 @@
             "initial": "0",
             "values": [ "auto" ],
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "auto | <shared-rule-exported>"
             }
         },
@@ -29,6 +32,7 @@
             "initial": "0",
             "values": [ "auto" ],
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "auto | <shared-rule-with-override-function>"
             }
         },
@@ -36,6 +40,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "sink-priority": true,
                 "parser-grammar": "<number>"
             }
@@ -44,6 +49,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "high-priority": true,
                 "parser-grammar": "<number>"
             }
@@ -52,6 +58,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "top-priority": true,
                 "top-priority-reason": "justification string",
                 "parser-grammar": "<number>"
@@ -61,6 +68,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "medium-priority": true,
                 "parser-grammar": "<number>"
             }
@@ -69,6 +77,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "animation-wrapper": "DiscreteCoordinatedValueListPropertyWrapper",
                 "coordinated-value-list-property": true,
                 "parser-grammar": "<number>#"
@@ -78,6 +87,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "coordinated-value-list-property": true,
                 "parser-grammar": "<number>#"
             }
@@ -86,6 +96,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "coordinated-value-list-property": true,
                 "style-converter": "FillTestConverter",
                 "parser-grammar": "<number>#"
@@ -95,6 +106,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number [-inf, -10]> | <length [0, inf]> | <angle [-90,90]> | <percentage [1,100]>"
             }
         },
@@ -102,6 +114,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "settings-flag": "cssSettingsOneEnabled",
                 "parser-grammar": "<number>"
             }
@@ -111,6 +124,7 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "animation-wrapper": "Wrapper<float>",
                 "parser-grammar": "<number>"
             }
@@ -119,6 +133,7 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "animation-wrapper": "Wrapper<float>",
                 "animation-wrapper-acceleration": "always",
                 "parser-grammar": "<number>"
@@ -128,6 +143,7 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "animation-wrapper": "Wrapper<float>",
                 "animation-wrapper-acceleration": "threaded-only",
                 "parser-grammar": "<number>"
@@ -138,6 +154,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "logical-property-group": {
                     "name": "test-group",
                     "resolver": "horizontal"
@@ -149,6 +166,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "logical-property-group": {
                     "name": "test-group",
                     "resolver": "vertical"
@@ -158,6 +176,7 @@
         },
         "test-logical-property-group-logical-block": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "skip-style-builder": true,
                 "logical-property-group": {
                     "name": "test-group",
@@ -168,6 +187,7 @@
         },
         "test-logical-property-group-logical-inline": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "skip-style-builder": true,
                 "logical-property-group": {
                     "name": "test-group",
@@ -179,6 +199,7 @@
 
         "test-shorthand-one": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "longhands": [
                     "test-logical-property-group-physical-horizontal",
                     "test-logical-property-group-physical-vertical"
@@ -191,6 +212,7 @@
         },
         "test-shorthand-two": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "longhands": [
                     "test-logical-property-group-logical-block",
                     "test-logical-property-group-logical-inline"
@@ -203,6 +225,7 @@
         },
         "font": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "longhands": [
                     "test-sink-priority",
                     "test-high-priority"
@@ -214,6 +237,7 @@
         },
         "all": {
             "codegen-properties": {
+                "skip-render-style": true,
                 "longhands": [
                     "all"
                 ],
@@ -226,6 +250,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>*"
             }
         },
@@ -233,6 +258,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>*@(no-single-item-opt)"
             }
         },
@@ -240,6 +266,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{2,}"
             }
         },
@@ -247,6 +274,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,}"
             }
         },
@@ -254,6 +282,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,}@(no-single-item-opt)"
             }
         },
@@ -262,6 +291,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{2,}"
             }
         },
@@ -269,6 +299,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{1,}"
             }
         },
@@ -276,6 +307,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{1,}@(no-single-item-opt)"
             }
         },
@@ -284,6 +316,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{2,3}"
             }
         },
@@ -291,6 +324,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,3}"
             }
         },
@@ -298,6 +332,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,3}@(no-single-item-opt)"
             }
         },
@@ -305,6 +340,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{2}"
             }
         },
@@ -312,6 +348,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,2}@(type=CSSValuePair)"
             }
         },
@@ -319,6 +356,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,2}@(type=CSSValuePair no-single-item-opt)"
             }
         },
@@ -326,6 +364,7 @@
             "animation-type": "discrete",
             "initial": "0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,2}@(type=CSSValuePair default=previous)"
             }
         },
@@ -333,6 +372,7 @@
             "animation-type": "discrete",
             "initial": "0 0 0 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>{1,4}@(type=CSSValuePair default=previous)"
             }
         },
@@ -341,6 +381,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{2,3}"
             }
         },
@@ -348,6 +389,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{1,3}"
             }
         },
@@ -355,6 +397,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{1,3}@(no-single-item-opt)"
             }
         },
@@ -362,6 +405,7 @@
             "animation-type": "discrete",
             "initial": "0, 0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<number>#{2}"
             }
         },
@@ -370,6 +414,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> | <custom-ident> | <length> ]"
             }
         },
@@ -377,6 +422,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> | foo | bar | baz | [ <custom-ident> && <dashed-ident> ] ]"
             }
         },
@@ -384,6 +430,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> | foo@(settings-flag=cssSettingsFooDisabled) | bar | baz | [ <custom-ident> && <dashed-ident> ] ]"
             }
         },
@@ -391,6 +438,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number>@(settings-flag=cssSettingsReferenceDisabled) | foo | bar | baz | [ <custom-ident> && <dashed-ident> ] ]"
             }
         },
@@ -398,6 +446,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> | foo | bar | baz | [ <custom-ident> && <dashed-ident> ]@(settings-flag=cssSettingsGroupDisabled) ]"
             }
         },
@@ -405,6 +454,7 @@
             "animation-type": "discrete",
             "initial": "none",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "none || [ foo | bar ]@(settings-flag=cssSettingsGroupDisabled)"
             }
         },
@@ -412,6 +462,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident> <length> ]"
             }
         },
@@ -419,6 +470,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident>? <length> ]"
             }
         },
@@ -426,6 +478,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident>? <length>? ]"
             }
         },
@@ -433,6 +486,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident>? <length>? ]@(no-single-item-opt)"
             }
         },
@@ -440,6 +494,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident> <length>? ]"
             }
         },
@@ -447,6 +502,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident> <length> ]@(type=CSSCustomType)"
             }
         },
@@ -454,6 +510,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident>? <length>? ]@(type=CSSCustomType)"
             }
         },
@@ -461,6 +518,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident>? <length>? ]@(type=CSSCustomType no-single-item-opt)"
             }
         },
@@ -468,6 +526,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> <custom-ident> <length>? ]@(type=CSSCustomType)"
             }
         },
@@ -475,6 +534,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length> ]"
             }
         },
@@ -482,6 +542,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length> ]"
             }
         },
@@ -489,6 +550,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]"
             }
         },
@@ -496,6 +558,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]@(no-single-item-opt)"
             }
         },
@@ -503,6 +566,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length> ]@(preserve-order)"
             }
         },
@@ -510,6 +574,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length> ]@(preserve-order no-single-item-opt)"
             }
         },
@@ -517,6 +582,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]@(preserve-order)"
             }
         },
@@ -524,6 +590,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]@(preserve-order no-single-item-opt)"
             }
         },
@@ -531,6 +598,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length> ]@(type=CSSCustomType)"
             }
         },
@@ -538,6 +606,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length> ]@(preserve-order type=CSSCustomType)"
             }
         },
@@ -545,6 +614,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]@(type=CSSCustomType)"
             }
         },
@@ -552,6 +622,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident>? && <length>? ]@(preserve-order type=CSSCustomType)"
             }
         },
@@ -559,6 +630,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length>? ]@(type=CSSCustomType)"
             }
         },
@@ -566,6 +638,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length>? ]@(type=CSSCustomType no-single-item-opt)"
             }
         },
@@ -573,6 +646,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length>? ]@(preserve-order type=CSSCustomType)"
             }
         },
@@ -580,6 +654,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> && <custom-ident> && <length>? ]@(preserve-order type=CSSCustomType no-single-item-opt)"
             }
         },
@@ -587,6 +662,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]"
             }
         },
@@ -594,6 +670,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(no-single-item-opt)"
             }
         },
@@ -601,6 +678,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(preserve-order)"
             }
         },
@@ -608,6 +686,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(preserve-order no-single-item-opt)"
             }
         },
@@ -615,6 +694,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(type=CSSCustomType)"
             }
         },
@@ -622,6 +702,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(type=CSSCustomType no-single-item-opt)"
             }
         },
@@ -629,6 +710,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(preserve-order type=CSSCustomType)"
             }
         },
@@ -636,6 +718,7 @@
             "animation-type": "discrete",
             "initial": "0 foo 1px",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "[ <number> || <custom-ident> || <length> ]@(preserve-order type=CSSCustomType no-single-item-opt)"
             }
         },
@@ -643,6 +726,7 @@
             "animation-type": "discrete",
             "initial": "foo()",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo()"
             }
         },
@@ -650,6 +734,7 @@
             "animation-type": "discrete",
             "initial": "foo(1)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> )"
             }
         },
@@ -657,6 +742,7 @@
             "animation-type": "discrete",
             "initial": "foo(1)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> | <string> | bar | baz )"
             }
         },
@@ -664,6 +750,7 @@
             "animation-type": "discrete",
             "initial": "foo()",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number>? )"
             }
         },
@@ -671,6 +758,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number>#{1,4} )"
             }
         },
@@ -678,6 +766,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2, 3)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number>#{3} )"
             }
         },
@@ -685,6 +774,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number># )"
             }
         },
@@ -692,6 +782,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number>#{2,} )"
             }
         },
@@ -699,6 +790,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> <string> )"
             }
         },
@@ -706,6 +798,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> <string>? )"
             }
         },
@@ -713,6 +806,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> && <string> )"
             }
         },
@@ -720,6 +814,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> && <string>? )"
             }
         },
@@ -727,6 +822,7 @@
             "animation-type": "discrete",
             "initial": "foo(1, 2)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo( <number> || <string> )"
             }
         },
@@ -734,6 +830,7 @@
             "animation-type": "discrete",
             "initial": "currentColor",
             "codegen-properties": {
+                "skip-render-style": true,
                 "color-property": true,
                 "parser-grammar": "<color>"
             }
@@ -742,6 +839,7 @@
             "animation-type": "discrete",
             "initial": "currentColor",
             "codegen-properties": {
+                "skip-render-style": true,
                 "color-property": true,
                 "parser-grammar": "<color allowed-types=absolute>"
             }
@@ -750,6 +848,7 @@
             "animation-type": "discrete",
             "initial": "url(about:blank)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<image>"
             }
         },
@@ -757,6 +856,7 @@
             "animation-type": "discrete",
             "initial": "url(about:blank)",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "<image allowed-types=url,generated>"
             }
         },
@@ -764,6 +864,7 @@
             "animation-type": "discrete",
             "initial": "foo",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo | bar"
             }
         },
@@ -771,6 +872,7 @@
             "animation-type": "discrete",
             "initial": "foo",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "foo@(aliased-to=baz) | bar"
             }
         },
@@ -778,6 +880,7 @@
             "animation-type": "discrete",
             "initial": "none",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "none | <url>"
             }
         },
@@ -785,6 +888,7 @@
             "animation-type": "discrete",
             "initial": "none",
             "codegen-properties": {
+                "skip-render-style": true,
                 "parser-grammar": "none | <url allowed-modifiers=crossorigin,integrity,referrerpolicy>"
             }
         },
@@ -793,6 +897,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "style-extractor-converter": "TestExtractorOnlyConversion",
                 "parser-grammar": "<number>"
             }
@@ -801,6 +906,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "style-converter": "TestSharedBuilderExtractorConversion",
                 "parser-grammar": "<number>"
             }
@@ -809,6 +915,7 @@
             "animation-type": "discrete",
             "initial": "0",
             "codegen-properties": {
+                "skip-render-style": true,
                 "style-extractor-custom": true,
                 "parser-grammar": "<number>"
             }
@@ -817,6 +924,7 @@
             "animation-type": "discrete",
             "initial": "currentColor",
             "codegen-properties": {
+                "skip-render-style": true,
                 "color-property": true,
                 "parser-grammar": "<color>"
             }
@@ -825,6 +933,7 @@
             "animation-type": "discrete",
             "initial": "currentColor",
             "codegen-properties": {
+                "skip-render-style": true,
                 "visited-link-color-support": true,
                 "color-property": true,
                 "parser-grammar": "<color>"

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -251,6 +251,7 @@
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
+#include "RenderStyleSetters.h"
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
 #include "RenderWidgetInlines.h"

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -42,6 +42,7 @@
 #include "NavigationDisabler.h"
 #include "RemoteFrame.h"
 #include "RemoteFrameView.h"
+#include "RenderStyleInlines.h"
 #include "RenderWidgetInlines.h"
 #include "SVGDocumentExtensions.h"
 #include "ScriptController.h"

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
@@ -29,6 +29,7 @@
 #include "BlockFormattingGeometry.h"
 #include "BlockFormattingState.h"
 #include "BlockMarginCollapse.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutChildIterator.h"
 #include "LayoutContext.h"

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -27,6 +27,7 @@
 #include "FlexFormattingUtils.h"
 
 #include "FlexFormattingContext.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutContext.h"
 #include "LogicalFlexItem.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp
@@ -27,6 +27,7 @@
 #include "InlineContentAligner.h"
 
 #include "InlineFormattingContext.h"
+#include "LayoutBoxInlines.h"
 #include "TextUtil.h"
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -34,6 +34,7 @@
 #include "InlineLineBoxVerticalAligner.h"
 #include "InlineLineTypes.h"
 #include "InlineQuirks.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutElementBox.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -28,6 +28,7 @@
 
 #include "CSSPrimitiveKeywordList.h"
 #include "InlineLevelBox.h"
+#include "LayoutBoxInlines.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -31,6 +31,7 @@
 #include "InlineFormattingUtils.h"
 #include "InlineTextBoxStyle.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutInitialContainingBlock.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TableFormattingState.h"
 
+#include "LayoutBoxInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderObject.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -27,6 +27,7 @@
 #include "LayoutBox.h"
 
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutContainingBlockChainIterator.h"
 #include "LayoutElementBox.h"
 #include "LayoutInitialContainingBlock.h"

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -127,34 +127,34 @@ public:
     bool isInterlinearRubyAnnotationBox() const;
 
     bool isDocumentBox() const { return m_nodeType == NodeType::DocumentElement; }
-    bool isBodyBox() const { return m_nodeType == NodeType::Body; }
-    bool isRuby() const { return style().display() == DisplayType::Ruby; }
-    bool isRubyBase() const { return style().display() == DisplayType::RubyBase; }
-    bool isRubyInlineBox() const { return isRuby() || isRubyBase(); }
     bool isTableWrapperBox() const { return m_nodeType == NodeType::TableWrapperBox; }
     bool isTableBox() const { return m_nodeType == NodeType::TableBox; }
-    bool isTableCaption() const { return style().display() == DisplayType::TableCaption; }
-    bool isTableHeader() const { return style().display() == DisplayType::TableHeaderGroup; }
-    bool isTableBody() const { return style().display() == DisplayType::TableRowGroup; }
-    bool isTableFooter() const { return style().display() == DisplayType::TableFooterGroup; }
-    bool isTableRow() const { return style().display() == DisplayType::TableRow; }
-    bool isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
-    bool isTableColumn() const { return style().display() == DisplayType::TableColumn; }
-    bool isTableCell() const { return style().display() == DisplayType::TableCell; }
-    bool isInternalTableBox() const;
-    bool isFlexBox() const { return style().display() == DisplayType::Flex || style().display() == DisplayType::InlineFlex || m_nodeType == NodeType::ImplicitFlexBox; }
-    bool isFlexItem() const;
-    bool isGridFormattingContext() const { return isGridBox() || isGridLanesBox(); }
-    bool isGridBox() const { return style().display() == DisplayType::Grid || style().display() == DisplayType::InlineGrid; }
-    bool isGridLanesBox() const { return style().display() == DisplayType::GridLanes || style().display() == DisplayType::InlineGridLanes; }
-    bool isGridItem() const;
+    bool isBodyBox() const { return m_nodeType == NodeType::Body; }
+    bool isLineBreakBox() const { return m_nodeType == NodeType::LineBreak || m_nodeType == NodeType::WordBreakOpportunity; }
     bool isIFrame() const { return m_nodeType == NodeType::IFrame; }
     bool isImage() const { return m_nodeType == NodeType::Image; }
-    bool isLineBreakBox() const { return m_nodeType == NodeType::LineBreak || m_nodeType == NodeType::WordBreakOpportunity; }
-    bool isWordBreakOpportunity() const { return m_nodeType == NodeType::WordBreakOpportunity; }
-    bool isListItem() const { return style().display() == DisplayType::ListItem; }
     bool isListMarkerBox() const { return m_nodeType == NodeType::ListMarker; }
     bool isReplacedBox() const { return m_nodeType == NodeType::ReplacedElement || m_nodeType == NodeType::Image || m_nodeType == NodeType::ListMarker; }
+    bool isWordBreakOpportunity() const { return m_nodeType == NodeType::WordBreakOpportunity; }
+    bool isInternalTableBox() const;
+    inline bool isRuby() const;
+    inline bool isRubyBase() const;
+    inline bool isRubyInlineBox() const;
+    inline bool isTableCaption() const;
+    inline bool isTableHeader() const;
+    inline bool isTableBody() const;
+    inline bool isTableFooter() const;
+    inline bool isTableRow() const;
+    inline bool isTableColumnGroup() const;
+    inline bool isTableColumn() const;
+    inline bool isTableCell() const;
+    inline bool isFlexBox() const;
+    bool isFlexItem() const;
+    inline bool isGridFormattingContext() const;
+    inline bool isGridBox() const;
+    inline bool isGridLanesBox() const;
+    bool isGridItem() const;
+    inline bool isListItem() const;
 
     bool isInlineIntegrationRoot() const { return m_isInlineIntegrationRoot; }
     bool isAnonymousTextIndentCandidateForIntegration() const { return m_isAnonymousTextIndentCandidateForIntegration; }

--- a/Source/WebCore/layout/layouttree/LayoutBoxInlines.h
+++ b/Source/WebCore/layout/layouttree/LayoutBoxInlines.h
@@ -26,10 +26,28 @@
 #pragma once
 
 #include "LayoutBox.h"
+#include "RenderStyleInlines.h"
 
 namespace WebCore {
 
 namespace Layout {
+
+inline bool Box::isRuby() const { return style().display() == DisplayType::Ruby; }
+inline bool Box::isRubyBase() const { return style().display() == DisplayType::RubyBase; }
+inline bool Box::isRubyInlineBox() const { return isRuby() || isRubyBase(); }
+inline bool Box::isTableCaption() const { return style().display() == DisplayType::TableCaption; }
+inline bool Box::isTableHeader() const { return style().display() == DisplayType::TableHeaderGroup; }
+inline bool Box::isTableBody() const { return style().display() == DisplayType::TableRowGroup; }
+inline bool Box::isTableFooter() const { return style().display() == DisplayType::TableFooterGroup; }
+inline bool Box::isTableRow() const { return style().display() == DisplayType::TableRow; }
+inline bool Box::isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
+inline bool Box::isTableColumn() const { return style().display() == DisplayType::TableColumn; }
+inline bool Box::isTableCell() const { return style().display() == DisplayType::TableCell; }
+inline bool Box::isFlexBox() const { return style().display() == DisplayType::Flex || style().display() == DisplayType::InlineFlex || m_nodeType == NodeType::ImplicitFlexBox; }
+inline bool Box::isGridFormattingContext() const { return isGridBox() || isGridLanesBox(); }
+inline bool Box::isGridBox() const { return style().display() == DisplayType::Grid || style().display() == DisplayType::InlineGrid; }
+inline bool Box::isGridLanesBox() const { return style().display() == DisplayType::GridLanes || style().display() == DisplayType::InlineGridLanes; }
+inline bool Box::isListItem() const { return style().display() == DisplayType::ListItem; }
 
 inline bool Box::isContainingBlockForFixedPosition() const
 {

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -23,6 +23,7 @@
 
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/RenderBoxModelObject.h>
+#include <WebCore/RenderStyleInlines.h>
 #include <WebCore/RenderText.h>
 #include <WebCore/TextFlags.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -448,17 +448,17 @@ public:
     bool hasAutoScrollbar(ScrollbarOrientation) const;
     bool hasAlwaysPresentScrollbar(ScrollbarOrientation) const;
 
-    bool scrollsOverflow() const { return scrollsOverflowX() || scrollsOverflowY(); }
-    bool scrollsOverflowX() const { return hasNonVisibleOverflow() && (style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Auto); }
-    bool scrollsOverflowY() const { return hasNonVisibleOverflow() && (style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Auto); }
+    inline bool scrollsOverflow() const;
+    inline bool scrollsOverflowX() const;
+    inline bool scrollsOverflowY() const;
 
     inline bool hasHorizontalOverflow() const;
     inline bool hasVerticalOverflow() const;
     inline bool hasScrollableOverflowX() const;
     inline bool hasScrollableOverflowY() const;
 
-    bool isScrollContainerX() const { return style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Hidden || style().overflowX() == Overflow::Auto;  }
-    bool isScrollContainerY() const { return style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Hidden || style().overflowY() == Overflow::Auto; }
+    inline bool isScrollContainerX() const;
+    inline bool isScrollContainerY() const;
 
     LayoutBoxExtent scrollPaddingForViewportRect(const LayoutRect& viewportRect);
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -71,6 +71,31 @@ inline bool RenderBox::shouldTrimChildMargin(Style::MarginTrimSide type, const R
 inline bool RenderBox::stretchesToViewport() const { return document().inQuirksMode() && style().logicalHeight().isAuto() && !isFloatingOrOutOfFlowPositioned() && (isDocumentElementRenderer() || isBody()) && !shouldComputeLogicalHeightFromAspectRatio() && !isInline(); }
 inline bool RenderBox::isColumnSpanner() const { return style().columnSpan() == ColumnSpan::All; }
 
+inline bool RenderBox::scrollsOverflow() const
+{
+    return scrollsOverflowX() || scrollsOverflowY();
+}
+
+inline bool RenderBox::scrollsOverflowX() const
+{
+    return hasNonVisibleOverflow() && (style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Auto);
+}
+
+inline bool RenderBox::scrollsOverflowY() const
+{
+    return hasNonVisibleOverflow() && (style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Auto);
+}
+
+inline bool RenderBox::isScrollContainerX() const
+{
+    return style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Hidden || style().overflowX() == Overflow::Auto;
+}
+
+inline bool RenderBox::isScrollContainerY() const
+{
+    return style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Hidden || style().overflowY() == Overflow::Auto;
+}
+
 inline LayoutPoint RenderBox::topLeftLocation() const
 {
     // This is inlined for speed, since it is used by updateLayerPosition() during scrolling.

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -329,8 +329,8 @@ public:
     // Returns the renderer which was mapped to (container or ancestorToStopAt).
     virtual const RenderElement* pushMappingToContainer(const RenderLayerModelObject* ancestorToStopAt, RenderGeometryMap&) const;
 
-    bool isFixedPositioned() const { return isOutOfFlowPositioned() && style().position() == PositionType::Fixed; }
-    bool isAbsolutelyPositioned() const { return isOutOfFlowPositioned() && style().position() == PositionType::Absolute; }
+    inline bool isFixedPositioned() const;
+    inline bool isAbsolutelyPositioned() const;
 
     bool isViewTransitionContainer() const { return style().pseudoElementType() == PseudoElementType::ViewTransition || style().pseudoElementType() == PseudoElementType::ViewTransitionGroup || style().pseudoElementType() == PseudoElementType::ViewTransitionImagePair; }
     bool isViewTransitionPseudo() const { return isRenderViewTransitionCapture() || isViewTransitionContainer(); }

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -36,6 +36,16 @@ inline RefPtr<Element> RenderElement::protectedElement() const { return element(
 inline Element* RenderElement::nonPseudoElement() const { return downcast<Element>(RenderObject::nonPseudoNode()); }
 inline RefPtr<Element> RenderElement::protectedNonPseudoElement() const { return nonPseudoElement(); }
 
+inline bool RenderElement::isFixedPositioned() const
+{
+    return isOutOfFlowPositioned() && style().position() == PositionType::Fixed;
+}
+
+inline bool RenderElement::isAbsolutelyPositioned() const
+{
+    return isOutOfFlowPositioned() && style().position() == PositionType::Absolute;
+}
+
 inline bool RenderElement::isBlockLevelBox() const
 {
     // block-level boxes are boxes that participate in a block formatting context.

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -113,6 +113,7 @@
 #include "RenderLayerCompositor.h"
 #include "RenderLayerFilters.h"
 #include "RenderLayerInlines.h"
+#include "RenderLayerModelObjectInlines.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderMarquee.h"
 #include "RenderMultiColumnFlow.h"

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -611,7 +611,7 @@ public:
     bool rendererHasHDRContent() const;
 #endif
 
-    bool isViewportConstrained() const { return renderer().isFixedPositioned() || renderer().isStickilyPositioned(); }
+    inline bool isViewportConstrained() const;
 
     // FIXME: We should ASSERT(!m_hasSelfPaintingLayerDescendantDirty); here but we hit the same bugs as visible content above.
     // Part of the issue is with subtree relayout: we don't check if our ancestors have some descendant flags dirty, missing some updates.

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -47,6 +47,11 @@ inline bool RenderLayer::hasAppleVisualEffect() const { return renderer().hasApp
 inline bool RenderLayer::hasAppleVisualEffectRequiringBackdropFilter() const { return renderer().hasAppleVisualEffectRequiringBackdropFilter(); }
 #endif
 
+inline bool RenderLayer::isViewportConstrained() const
+{
+    return renderer().isFixedPositioned() || renderer().isStickilyPositioned();
+}
+
 inline bool RenderLayer::isTransformed() const
 {
     // If the scroll offset is present, a transform is applied on top of existing

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -126,7 +126,7 @@ public:
     virtual void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const = 0;
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
-    bool shouldUsePositionedClipping() const { return isAbsolutelyPositioned() || isRenderSVGForeignObject(); }
+    inline bool shouldUsePositionedClipping() const;
 
 protected:
     RenderLayerModelObject(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);

--- a/Source/WebCore/rendering/RenderLayerModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderLayerModelObjectInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderElementInlines.h"
+#include "RenderLayerModelObject.h"
+
+namespace WebCore {
+
+inline bool RenderLayerModelObject::shouldUsePositionedClipping() const
+{
+    return isAbsolutelyPositioned() || isRenderSVGForeignObject();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -35,6 +35,7 @@
 #include "RenderBlock.h"
 #include "RenderListMarker.h"
 #include "RenderObjectInlines.h"
+#include "RenderStyleSetters.h"
 #include "RenderText.h"
 #include "RenderTextFragment.h"
 #include "RenderTreeBuilder.h"

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2432,23 +2432,9 @@ const Style::LineHeight& RenderStyle::specifiedLineHeight() const
 #endif
 }
 
-#if ENABLE(TEXT_AUTOSIZING)
-
-void RenderStyle::setSpecifiedLineHeight(Style::LineHeight&& lineHeight)
-{
-    SET_VAR(m_inheritedData, specifiedLineHeight, WTFMove(lineHeight));
-}
-
-#endif
-
 const Style::LineHeight& RenderStyle::lineHeight() const
 {
     return m_inheritedData->lineHeight;
-}
-
-void RenderStyle::setLineHeight(Style::LineHeight&& lineHeight)
-{
-    SET_VAR(m_inheritedData, lineHeight, WTFMove(lineHeight));
 }
 
 float RenderStyle::computedLineHeight() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -558,8 +558,8 @@ public:
     inline LayoutBoxExtent borderImageOutsets() const;
     inline LayoutBoxExtent maskBorderOutsets() const;
 
-    Order rtlOrdering() const { return static_cast<Order>(m_inheritedFlags.rtlOrdering); }
-    void setRTLOrdering(Order ordering) { m_inheritedFlags.rtlOrdering = static_cast<unsigned>(ordering); }
+    inline Order rtlOrdering() const;
+    inline void setRTLOrdering(Order);
 
     bool isStyleAvailable() const;
 
@@ -572,7 +572,7 @@ public:
 
     // attribute getter methods
 
-    constexpr DisplayType display() const { return static_cast<DisplayType>(m_nonInheritedFlags.effectiveDisplay); }
+    inline DisplayType display() const;
     constexpr WritingMode writingMode() const { return m_inheritedFlags.writingMode; }
     bool isLeftToRightDirection() const { return writingMode().isBidiLTR(); } // deprecated, because of confusion between physical inline directions and bidi / line-relative directions
 
@@ -592,13 +592,13 @@ public:
     inline bool hasStaticInlinePosition(bool horizontal) const;
     inline bool hasStaticBlockPosition(bool horizontal) const;
 
-    PositionType position() const { return static_cast<PositionType>(m_nonInheritedFlags.position); }
+    inline PositionType position() const;
     inline bool hasOutOfFlowPosition() const;
     inline bool hasInFlowPosition() const;
     inline bool hasViewportConstrainedPosition() const;
-    Float floating() const { return static_cast<Float>(m_nonInheritedFlags.floating); }
+    inline Float floating() const;
     static UsedFloat usedFloat(const RenderElement&); // Returns logical left/right (block-relative).
-    Clear clear() const { return static_cast<Clear>(m_nonInheritedFlags.clear); }
+    inline Clear clear() const;
     static UsedClear usedClear(const RenderElement&); // Returns logical left/right (block-relative).
 
     inline const Style::PreferredSize& width() const;
@@ -701,14 +701,14 @@ public:
     inline OutlineStyle outlineStyle() const;
     inline bool hasOutlineInVisualOverflow() const;
     
-    Overflow overflowX() const { return static_cast<Overflow>(m_nonInheritedFlags.overflowX); }
-    Overflow overflowY() const { return static_cast<Overflow>(m_nonInheritedFlags.overflowY); }
+    inline Overflow overflowX() const;
+    inline Overflow overflowY() const;
     inline bool isOverflowVisible() const;
 
     inline OverscrollBehavior overscrollBehaviorX() const;
     inline OverscrollBehavior overscrollBehaviorY() const;
     
-    Visibility visibility() const { return static_cast<Visibility>(m_inheritedFlags.visibility); }
+    inline Visibility visibility() const;
     inline Visibility usedVisibility() const;
 
     const Style::VerticalAlign& verticalAlign() const;
@@ -716,7 +716,7 @@ public:
     inline const Style::Clip& clip() const;
     inline bool hasClip() const;
 
-    UnicodeBidi unicodeBidi() const { return static_cast<UnicodeBidi>(m_nonInheritedFlags.unicodeBidi); }
+    inline UnicodeBidi unicodeBidi() const;
 
     inline FieldSizing fieldSizing() const;
 
@@ -760,7 +760,7 @@ public:
     inline TextRenderingMode textRendering() const;
 
     inline const Style::TextIndent& textIndent() const;
-    inline Style::TextAlign textAlign() const { return static_cast<Style::TextAlign>(m_inheritedFlags.textAlign); }
+    inline Style::TextAlign textAlign() const;
     inline Style::TextAlignLast textAlignLast() const;
     inline TextGroupAlign textGroupAlign() const;
     inline Style::TextTransform textTransform() const;
@@ -808,9 +808,9 @@ public:
     inline bool breakOnlyAfterWhiteSpace() const;
     inline bool breakWords() const;
 
-    WhiteSpaceCollapse whiteSpaceCollapse() const { return static_cast<WhiteSpaceCollapse>(m_inheritedFlags.whiteSpaceCollapse); }
-    TextWrapMode textWrapMode() const { return static_cast<TextWrapMode>(m_inheritedFlags.textWrapMode); }
-    TextWrapStyle textWrapStyle() const { return static_cast<TextWrapStyle>(m_inheritedFlags.textWrapStyle); }
+    inline WhiteSpaceCollapse whiteSpaceCollapse() const;
+    inline TextWrapMode textWrapMode() const;
+    inline TextWrapStyle textWrapStyle() const;
 
     inline Style::BackgroundLayers& ensureBackgroundLayers();
     inline const Style::BackgroundLayers& backgroundLayers() const;
@@ -830,15 +830,15 @@ public:
     inline NinePieceImageRule maskBorderVerticalRule() const;
     static inline Style::MaskBorder initialMaskBorder();
 
-    BorderCollapse borderCollapse() const { return static_cast<BorderCollapse>(m_inheritedFlags.borderCollapse); }
+    inline BorderCollapse borderCollapse() const;
     inline Style::WebkitBorderSpacing borderHorizontalSpacing() const;
     inline Style::WebkitBorderSpacing borderVerticalSpacing() const;
-    EmptyCell emptyCells() const { return static_cast<EmptyCell>(m_inheritedFlags.emptyCells); }
-    CaptionSide captionSide() const { return static_cast<CaptionSide>(m_inheritedFlags.captionSide); }
+    inline EmptyCell emptyCells() const;
+    inline CaptionSide captionSide() const;
 
     inline const Style::ListStyleType& listStyleType() const;
     inline const Style::ImageOrNone& listStyleImage() const;
-    ListStylePosition listStylePosition() const { return static_cast<ListStylePosition>(m_inheritedFlags.listStylePosition); }
+    inline ListStylePosition listStylePosition() const;
     inline bool isFixedTableLayout() const;
 
     inline const Style::MarginBox& marginBox() const;
@@ -879,7 +879,7 @@ public:
     Style::Cursor cursor() const;
 
 #if ENABLE(CURSOR_VISIBILITY)
-    CursorVisibility cursorVisibility() const { return static_cast<CursorVisibility>(m_inheritedFlags.cursorVisibility); }
+    inline CursorVisibility cursorVisibility() const;
 #endif
 
     InsideLink insideLink() const { return static_cast<InsideLink>(m_inheritedFlags.insideLink); }
@@ -930,7 +930,7 @@ public:
     inline bool hasAutoLengthContainIntrinsicSize() const;
 
     inline BoxAlignment boxAlign() const;
-    BoxDirection boxDirection() const { return static_cast<BoxDirection>(m_inheritedFlags.boxDirection); }
+    inline BoxDirection boxDirection() const;
     inline Style::WebkitBoxFlex boxFlex() const;
     inline Style::WebkitBoxFlexGroup boxFlexGroup() const;
     inline BoxLines boxLines() const;
@@ -1107,7 +1107,7 @@ public:
     inline LineSnap lineSnap() const;
     inline LineAlign lineAlign() const;
 
-    PointerEvents pointerEvents() const { return static_cast<PointerEvents>(m_inheritedFlags.pointerEvents); }
+    inline PointerEvents pointerEvents() const;
     inline PointerEvents usedPointerEvents() const;
 
     inline const Style::ScrollTimelines& scrollTimelines() const;
@@ -1275,14 +1275,10 @@ public:
     inline const Style::ViewTransitionClasses& viewTransitionClasses() const;
     inline const Style::ViewTransitionName& viewTransitionName() const;
 
-    void setDisplay(DisplayType value)
-    {
-        m_nonInheritedFlags.originalDisplay = static_cast<unsigned>(value);
-        m_nonInheritedFlags.effectiveDisplay = m_nonInheritedFlags.originalDisplay;
-    }
-    void setEffectiveDisplay(DisplayType v) { m_nonInheritedFlags.effectiveDisplay = static_cast<unsigned>(v); }
-    void setPosition(PositionType v) { m_nonInheritedFlags.position = static_cast<unsigned>(v); }
-    void setFloating(Float v) { m_nonInheritedFlags.floating = static_cast<unsigned>(v); }
+    inline void setDisplay(DisplayType);
+    inline void setEffectiveDisplay(DisplayType);
+    inline void setPosition(PositionType);
+    inline void setFloating(Float);
 
     inline void setInsetBox(Style::InsetBox&&);
     inline void setLeft(Style::InsetEdge&&);
@@ -1356,18 +1352,18 @@ public:
     inline void setOutlineStyle(OutlineStyle);
     inline void setOutlineColor(Style::Color&&);
 
-    void setOverflowX(Overflow v) { m_nonInheritedFlags.overflowX =  static_cast<unsigned>(v); }
-    void setOverflowY(Overflow v) { m_nonInheritedFlags.overflowY = static_cast<unsigned>(v); }
+    inline void setOverflowX(Overflow);
+    inline void setOverflowY(Overflow);
     inline void setOverscrollBehaviorX(OverscrollBehavior);
     inline void setOverscrollBehaviorY(OverscrollBehavior);
-    void setVisibility(Visibility v) { m_inheritedFlags.visibility = static_cast<unsigned>(v); }
+    inline void setVisibility(Visibility);
     void setVerticalAlign(Style::VerticalAlign&&);
 
     inline void setClip(Style::Clip&&);
 
-    void setUnicodeBidi(UnicodeBidi v) { m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(v); }
+    inline void setUnicodeBidi(UnicodeBidi);
 
-    void setClear(Clear v) { m_nonInheritedFlags.clear = static_cast<unsigned>(v); }
+    inline void setClear(Clear);
 
     inline void setFieldSizing(FieldSizing);
 
@@ -1403,7 +1399,7 @@ public:
 
     inline void setColor(Color&&);
 
-    void setTextAlign(Style::TextAlign v) { m_inheritedFlags.textAlign = static_cast<unsigned>(v); }
+    inline void setTextAlign(Style::TextAlign);
     inline void setTextAlignLast(Style::TextAlignLast);
     inline void setTextGroupAlign(TextGroupAlign);
     inline void addToTextDecorationLineInEffect(Style::TextDecorationLine);
@@ -1428,18 +1424,18 @@ public:
 
     inline void setMarginTrim(Style::MarginTrim);
 
-    void setLineHeight(Style::LineHeight&&);
+    inline void setLineHeight(Style::LineHeight&&);
 #if ENABLE(TEXT_AUTOSIZING)
-    void setSpecifiedLineHeight(Style::LineHeight&&);
+    inline void setSpecifiedLineHeight(Style::LineHeight&&);
 #endif
 
     inline void setImageOrientation(Style::ImageOrientation);
     inline void setImageRendering(ImageRendering);
 
-    void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
+    inline void setWhiteSpaceCollapse(WhiteSpaceCollapse);
 
-    void setTextWrapMode(TextWrapMode v) { m_inheritedFlags.textWrapMode = static_cast<unsigned>(v); }
-    void setTextWrapStyle(TextWrapStyle v) { m_inheritedFlags.textWrapStyle = static_cast<unsigned>(v); }
+    inline void setTextWrapMode(TextWrapMode);
+    inline void setTextWrapStyle(TextWrapStyle);
 
     inline void setLetterSpacing(Style::LetterSpacing&&);
     inline void setWordSpacing(Style::WordSpacing&&);
@@ -1453,11 +1449,11 @@ public:
     inline void setMaskBorderOutset(Style::MaskBorderOutset&&);
     inline void setMaskBorderRepeat(Style::MaskBorderRepeat&&);
 
-    void setBorderCollapse(BorderCollapse collapse) { m_inheritedFlags.borderCollapse = static_cast<unsigned>(collapse); }
+    inline void setBorderCollapse(BorderCollapse);
     inline void setBorderHorizontalSpacing(Style::WebkitBorderSpacing);
     inline void setBorderVerticalSpacing(Style::WebkitBorderSpacing);
-    void setEmptyCells(EmptyCell v) { m_inheritedFlags.emptyCells = static_cast<unsigned>(v); }
-    void setCaptionSide(CaptionSide v) { m_inheritedFlags.captionSide = static_cast<unsigned>(v); }
+    inline void setEmptyCells(EmptyCell);
+    inline void setCaptionSide(CaptionSide);
 
     inline void setAspectRatio(Style::AspectRatio&&);
 
@@ -1475,8 +1471,8 @@ public:
     inline void setUsedContentVisibility(ContentVisibility);
 
     inline void setListStyleType(Style::ListStyleType&&);
-    void setListStyleImage(Style::ImageOrNone&&);
-    void setListStylePosition(ListStylePosition v) { m_inheritedFlags.listStylePosition = static_cast<unsigned>(v); }
+    inline void setListStyleImage(Style::ImageOrNone&&);
+    inline void setListStylePosition(ListStylePosition);
 
     inline void resetMargin();
     inline void setMarginBox(Style::MarginBox&&);
@@ -1508,14 +1504,14 @@ public:
     inline void setCursor(Style::Cursor&&);
 
 #if ENABLE(CURSOR_VISIBILITY)
-    void setCursorVisibility(CursorVisibility c) { m_inheritedFlags.cursorVisibility = static_cast<unsigned>(c); }
+    inline void setCursorVisibility(CursorVisibility);
 #endif
 
     void setInsideLink(InsideLink insideLink) { m_inheritedFlags.insideLink = static_cast<unsigned>(insideLink); }
     void setIsLink(bool v) { m_nonInheritedFlags.isLink = v; }
 
-    PrintColorAdjust printColorAdjust() const { return static_cast<PrintColorAdjust>(m_inheritedFlags.printColorAdjust); }
-    void setPrintColorAdjust(PrintColorAdjust value) { m_inheritedFlags.printColorAdjust = static_cast<unsigned>(value); }
+    inline PrintColorAdjust printColorAdjust() const;
+    inline void setPrintColorAdjust(PrintColorAdjust);
 
     inline Style::ZIndex specifiedZIndex() const;
     inline void setSpecifiedZIndex(Style::ZIndex);
@@ -1538,7 +1534,7 @@ public:
     inline void setAppearance(StyleAppearance);
     inline void setUsedAppearance(StyleAppearance);
     inline void setBoxAlign(BoxAlignment);
-    void setBoxDirection(BoxDirection d) { m_inheritedFlags.boxDirection = static_cast<unsigned>(d); }
+    inline void setBoxDirection(BoxDirection);
     inline void setBoxFlex(Style::WebkitBoxFlex);
     inline void setBoxFlexGroup(Style::WebkitBoxFlexGroup);
     inline void setBoxLines(BoxLines);
@@ -1659,7 +1655,7 @@ public:
     inline void setLineSnap(LineSnap);
     inline void setLineAlign(LineAlign);
 
-    void setPointerEvents(PointerEvents p) { m_inheritedFlags.pointerEvents = static_cast<unsigned>(p); }
+    inline void setPointerEvents(PointerEvents);
 
     void adjustAnimations();
     void adjustTransitions();
@@ -1949,6 +1945,7 @@ public:
     inline bool hasExplicitlySetWritingMode() const;
     inline void setHasExplicitlySetWritingMode(bool);
 
+    inline TextOrientation computedTextOrientation() const;
     inline bool setTextOrientation(TextOrientation);
 
     bool emptyState() const { return m_nonInheritedFlags.emptyState; }

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1086,6 +1086,8 @@ constexpr Style::TextSizeAdjust RenderStyle::initialTextSizeAdjust() { return CS
 
 inline TextDirection RenderStyle::computedDirection() const { return writingMode().computedTextDirection(); }
 inline StyleWritingMode RenderStyle::computedWritingMode() const { return writingMode().computedWritingMode(); }
+inline TextOrientation RenderStyle::computedTextOrientation() const { return writingMode().computedTextOrientation(); }
+
 inline Style::LineWidth RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
 inline Style::LineWidth RenderStyle::borderLeftWidth() const { return border().borderLeftWidth(); }
 inline Style::LineWidth RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
@@ -1093,11 +1095,6 @@ inline Style::LineWidth RenderStyle::borderTopWidth() const { return border().bo
 inline Style::LineWidth RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->columnRuleWidth(); }
 
 // FIXME: - Below are property getters that are not yet generated
-
-// FIXME: Support properties that set more than one value when set.
-inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
-inline BlendMode RenderStyle::blendMode() const { return static_cast<BlendMode>(m_nonInheritedData->rareData->effectiveBlendMode); }
-inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 
 // FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
 inline const Style::Color& RenderStyle::caretColor() const { return m_rareInheritedData->caretColor; }
@@ -1111,10 +1108,6 @@ inline Style::ZIndex RenderStyle::specifiedZIndex() const { return m_nonInherite
 
 // FIXME: Support descriptors
 inline const Style::PageSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
-
-// FIXME: Support generating getter and setter with different names (or rename computedLetterSpacing() to letterSpacing() and computedWordSpacing() to wordSpacing())
-inline const Style::LetterSpacing& RenderStyle::computedLetterSpacing() const { return m_inheritedData->fontData->letterSpacing; }
-inline const Style::WordSpacing& RenderStyle::computedWordSpacing() const { return m_inheritedData->fontData->wordSpacing; }
 
 // FIXME: Support generated font-property getters
 inline Style::FontFamilies RenderStyle::fontFamily() const { return { fontDescription().families(), fontDescription().isSpecifiedFont() }; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -88,6 +88,20 @@ inline void RenderStyle::setPseudoElementIdentifier(std::optional<Style::PseudoE
     }
 }
 
+inline void RenderStyle::setEffectiveDisplay(DisplayType effectiveDisplay)
+{
+    m_nonInheritedFlags.effectiveDisplay = static_cast<unsigned>(effectiveDisplay);
+}
+
+#if ENABLE(TEXT_AUTOSIZING)
+
+inline void RenderStyle::setSpecifiedLineHeight(Style::LineHeight&& lineHeight)
+{
+    SET(m_inheritedData, specifiedLineHeight, WTFMove(lineHeight));
+}
+
+#endif
+
 // MARK: - Style adjustment utilities
 
 inline void RenderStyle::containIntrinsicWidthAddAuto() { setContainIntrinsicWidth(containIntrinsicWidth().addingAuto()); }
@@ -276,6 +290,12 @@ inline void RenderStyle::setBlendMode(BlendMode mode)
     SET(m_rareInheritedData, isInSubtreeWithBlendMode, mode != BlendMode::Normal);
 }
 
+inline void RenderStyle::setDisplay(DisplayType value)
+{
+    m_nonInheritedFlags.originalDisplay = static_cast<unsigned>(value);
+    m_nonInheritedFlags.effectiveDisplay = m_nonInheritedFlags.originalDisplay;
+}
+
 // FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
 inline void RenderStyle::setCaretColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, caretColor, WTFMove(color), hasAutoCaretColor, false); }
 inline void RenderStyle::setHasAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Style::Color::currentColor()); }
@@ -288,10 +308,6 @@ inline void RenderStyle::setCursor(Style::Cursor&& cursor) { m_inheritedFlags.cu
 
 // FIXME: Support descriptors
 inline void RenderStyle::setPageSize(Style::PageSize&& pageSize) { SET_NESTED(m_nonInheritedData, rareData, pageSize, WTFMove(pageSize)); }
-
-// FIXME: Support generating getter and setter with different names (or rename computedLetterSpacing() to letterSpacing() and computedWordSpacing() to wordSpacing())
-inline void RenderStyle::setWordSpacing(Style::WordSpacing&& wordSpacing) { SET_NESTED(m_inheritedData, fontData, wordSpacing, WTFMove(wordSpacing)); }
-inline void RenderStyle::setLetterSpacing(Style::LetterSpacing&& letterSpacing) { SET_NESTED(m_inheritedData, fontData, letterSpacing, WTFMove(letterSpacing)); }
 
 #undef SET
 #undef SET_DOUBLY_NESTED

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -444,6 +444,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'shorthand-style-extractor-pattern': self.validate_string,
             'skip-codegen': self.validate_boolean,
             'skip-parser': self.validate_boolean,
+            'skip-render-style': self.validate_boolean,
             'skip-style-builder': self.validate_boolean,
             'skip-style-extractor': self.validate_boolean,
             'skip-style-extractor-comment': self.validate_comment,


### PR DESCRIPTION
#### 8aa1e5bdbca5cd799671d9336bfc488ed7f8de3e
<pre>
[RenderStyleGen] Generate getter/setter functions that were missed
<a href="https://bugs.webkit.org/show_bug.cgi?id=303398">https://bugs.webkit.org/show_bug.cgi?id=303398</a>

Reviewed by Darin Adler.

While I knew that a few classes of properties still did not have generated
getter/setters, I hadn&apos;t noticed that there were a bunch that were missed
just due to them being implemented in purely in RenderStyle.h. To ensure
that I didn&apos;t miss any more, I added a check to the generator that raises
an exception if the metadata necessary for getter/setter generation is not
available. As an escape hatch, we now exclude the following classes of
properties for that check:
    - has the new &quot;skip-render-style&quot; entry (needed for a few internal properties that don&apos;t have any storage, and for tests)
    - is a logical property
    - is a shorthand property
    - is a cascade alias
    - is a coordinated list value

For all other properties, either a storage path or being marked as having
a custom getter/setter is now required.

Due to some properties getter/setters now being available via RenderStyleInlines.h
and RenderStyleSetters.h, rather than RenderStyle.h itself, a bit of shuffling was
needed to avoid including those files in non-Inlines headers.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/scripts/test/TestCSSProperties.json:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/history/CachedFrame.cpp:
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineContentAligner.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/layout/layouttree/LayoutBoxInlines.h:
* Source/WebCore/rendering/LegacyInlineBox.h:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxInlines.h:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderElementInlines.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLayerModelObjectInlines.h: Added.
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:

Canonical link: <a href="https://commits.webkit.org/303805@main">https://commits.webkit.org/303805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea19ac73dc1d02351c6e78c5b54411d421940360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141203 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136585 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83027 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132987 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4589 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143851 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110610 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28095 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5867 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69325 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->