### PR TITLE
[threaded-animations] WPT test `scroll-animations/css/animation-inactive-outside-range-test.html` fails with "Threaded Scroll-driven Animations" enabled

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -249,6 +249,13 @@ FloatPoint ScrollingTreeScrollingNode::maximumScrollPosition() const
     return ScrollableArea::scrollPositionFromOffset(maximumScrollOffset, toFloatSize(scrollOrigin()));
 }
 
+FloatPoint ScrollingTreeScrollingNode::clampedCurrentScrollOffset() const
+{
+    auto unconstrainedScrollPosition = currentScrollPosition();
+    auto clampedScrollPosition = clampScrollPosition(unconstrainedScrollPosition);
+    return ScrollableArea::scrollOffsetFromPosition(clampedScrollPosition, toFloatSize(scrollOrigin()));
+}
+
 bool ScrollingTreeScrollingNode::eventCanScrollContents(const PlatformWheelEvent& wheelEvent) const
 {
 #if PLATFORM(WPE) || PLATFORM(GTK)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -72,6 +72,7 @@ public:
     
     FloatPoint currentScrollPosition() const { return m_currentScrollPosition; }
     FloatPoint currentScrollOffset() const { return ScrollableArea::scrollOffsetFromPosition(m_currentScrollPosition, toFloatSize(m_scrollOrigin)); }
+    FloatPoint clampedCurrentScrollOffset() const;
     FloatPoint lastCommittedScrollPosition() const { return m_lastCommittedScrollPosition; }
     FloatSize scrollDeltaSinceLastCommit() const { return m_currentScrollPosition - m_lastCommittedScrollPosition; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
@@ -60,8 +60,7 @@ void RemoteProgressBasedTimeline::setResolutionData(const WebCore::ScrollingTree
 
 void RemoteProgressBasedTimeline::updateCurrentTime(const WebCore::ScrollingTreeScrollingNode& node)
 {
-    auto unconstrainedScrollOffset = m_resolutionData.isVertical ? node.currentScrollOffset().y() : node.currentScrollOffset().x();
-    m_resolutionData.scrollOffset = std::clamp(unconstrainedScrollOffset, m_resolutionData.rangeStart, m_resolutionData.rangeEnd);
+    m_resolutionData.scrollOffset = m_resolutionData.isVertical ? node.clampedCurrentScrollOffset().y() : node.clampedCurrentScrollOffset().x();
     updateCurrentTime();
 }
 


### PR DESCRIPTION
#### 5cdbe8e0b6b0bf55927a19c5bd3da681421747ce
<pre>
[threaded-animations] WPT test `scroll-animations/css/animation-inactive-outside-range-test.html` fails with &quot;Threaded Scroll-driven Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303407">https://bugs.webkit.org/show_bug.cgi?id=303407</a>
<a href="https://rdar.apple.com/165710235">rdar://165710235</a>

Reviewed by Simon Fraser.

We need to clamp the scroll offset for scroll timelines such that the current time does not
account for rubber-banding.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedScrollDrivenAnimationsEnabled=true`.

* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::clampedCurrentScrollOffset const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp:
(WebKit::RemoteProgressBasedTimeline::updateCurrentTime):

Canonical link: <a href="https://commits.webkit.org/303861@main">https://commits.webkit.org/303861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39692dd756b25867a322cda22acbbf783c1586b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141354 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102328 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83131 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2301 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113838 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5958 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110707 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110897 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4546 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59707 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20682 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6011 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->