### PR TITLE
[CSS Zoom] Remove unnecessary copy in conversionDataForStyle

### DIFF
--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -111,6 +111,12 @@ public:
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }
     CheckedPtr<Style::BuilderState> protectedStyleBuilderState() const;
 
+    void setRangeZoomAndOption(float zoom, CSS::RangeZoomOptions zoomOption)
+    {
+        m_zoom = zoom;
+        m_rangeZoomOption = zoomOption;
+    }
+
 private:
     const RenderStyle* m_style { nullptr };
     const RenderStyle* m_rootStyle { nullptr };

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1293,7 +1293,7 @@ static CSSToLengthConversionData conversionDataForStyle(const RenderStyle& style
 {
     CSSToLengthConversionData conversionData(style, nullptr, nullptr, nullptr);
     if (style.evaluationTimeZoomEnabled())
-        return conversionData.copyWithAdjustedZoom(1.0f, CSS::RangeZoomOptions::Unzoomed);
+        conversionData.setRangeZoomAndOption(1.0f, CSS::RangeZoomOptions::Unzoomed);
     return conversionData;
 }
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1192,20 +1192,18 @@ static NSControlSize controlSizeForFont(const RenderStyle& style)
 
 static IntSize sizeForFont(const RenderStyle& style, std::span<const IntSize, 4> sizes)
 {
-    if (style.usedZoom() != 1.0f && !style.evaluationTimeZoomEnabled()) {
-        IntSize result = sizes[controlSizeForFont(style)];
-        return IntSize(result.width() * style.usedZoom(), result.height() * style.usedZoom());
-    }
-    return sizes[controlSizeForFont(style)];
+    const IntSize& result = sizes[controlSizeForFont(style)];
+    if (style.usedZoom() != 1.0f && !style.evaluationTimeZoomEnabled())
+        return result.scaled(style.usedZoom());
+    return result;
 }
 
 static IntSize sizeForSystemFont(const RenderStyle& style, std::span<const IntSize, 4> sizes)
 {
-    if (style.usedZoom() != 1.0f) {
-        IntSize result = sizes[controlSizeForSystemFont(style)];
-        return IntSize(result.width() * style.usedZoom(), result.height() * style.usedZoom());
-    }
-    return sizes[controlSizeForSystemFont(style)];
+    const IntSize& result = sizes[controlSizeForSystemFont(style)];
+    if (style.usedZoom() != 1.0f)
+        return result.scaled(style.usedZoom());
+    return result;
 }
 
 static void setSizeFromFont(RenderStyle& style, std::span<const IntSize, 4> sizes)


### PR DESCRIPTION
#### 743714fa4401e83d84e809e178d5da122ce63fff
<pre>
[CSS Zoom] Remove unnecessary copy in conversionDataForStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=303409">https://bugs.webkit.org/show_bug.cgi?id=303409</a>
<a href="https://rdar.apple.com/165711554">rdar://165711554</a>

Reviewed by NOBODY (OOPS!).

The `conversionDataForStyle` method in RenderThemeCocoa.mm always makes a copy of
a new object just to change the value of two members. Since this object contains a
half dozen points, plus a few other members, this seems wasteful.

This patch simply sets the two members to the correct state when Evaluation Time
Zoom is enabled and avoids the copy.

This could be slightly improved by not setting the `m_zoom` member to 1.0f (since
that is the default constructed value in `CSSToLengthConversionData`, but I&apos;m keeping
this assignment to keep the logic consistent with the old patch, and to avoid any issues
if the implementation of `CSSToLengthConversionData` every changes.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::conversionDataForStyle): Avoid copy.
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::sizeForFont): Avoid extra copy.
(WebCore::sizeForSystemFont): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/743714fa4401e83d84e809e178d5da122ce63fff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85662 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/109a3c0b-d65f-471f-b7ca-6db1e091328f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102210 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69568 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9b1f902-224a-4728-bebf-e95589335f79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83007 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/058f785e-d256-43ab-b290-b5fedbb72cdb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4580 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2187 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5785 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110588 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110770 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4435 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5837 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34376 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->