### PR TITLE
Downcast crash when grid item requests fullscreen with container-type parent

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8161,3 +8161,6 @@ imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe-r
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
+
+# Hits assert in debug, tracked by https://bugs.webkit.org/show_bug.cgi?id=303414
+[ Debug ] fullscreen/fullscreen-grid-item-container-type-crash.html [ Skip ]

--- a/LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash-expected.txt
@@ -1,0 +1,3 @@
+Passes if the test does not crash.
+
+

--- a/LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash.html
+++ b/LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html style="display: grid; container-type: size;">
+<style>
+frameset {
+  content: "test";
+}
+</style>
+<p>Passes if the test does not crash.</p>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.waitUntilDone();
+}
+
+(async () => {
+    internals.withUserGesture(() => {});
+    let frameset = document.createElement("frameset");
+    document.documentElement.appendChild(frameset);
+    await frameset.requestFullscreen({ keyboardLock: 'none' });
+    testRunner?.notifyDone();
+})();
+</script>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4820,6 +4820,9 @@ webkit.org/b/303130 media/media-source/media-source-ended.html [ Failure ]
 
 webkit.org/b/303208 imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html [ Pass ImageOnlyFailure ]
 
+# Hits assert in Debug, but since GTK/WPE bots run release with assertions enabled, skip. Tracked by https://bugs.webkit.org/show_bug.cgi?id=303414
+fullscreen/fullscreen-grid-item-container-type-crash.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3212,7 +3212,7 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
             marginEndLength = 0_css_px;
     }
 
-    if (isGridItem() && downcast<RenderGrid>(containingBlock).isComputingTrackSizes()) {
+    if (auto* grid = dynamicDowncast<RenderGrid>(containingBlock); grid && grid->isComputingTrackSizes()) {
         if (marginStartLength.isAuto())
             marginStartLength = 0_css_px;
         if (marginEndLength.isAuto())


### PR DESCRIPTION
#### 60c138fa85eaebab3407056462971fccf66f1d7c
<pre>
Downcast crash when grid item requests fullscreen with container-type parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=303417">https://bugs.webkit.org/show_bug.cgi?id=303417</a>
<a href="https://rdar.apple.com/163028025">rdar://163028025</a>

Reviewed by Sammy Gill.

When a frameset enters fullscreen while being a grid item of a parent with container-type: size, container query interleaving
(StyleTreeResolver.cpp:1382-1403) defers descendant style resolution, preventing StyleAdjuster from setting position:absolute on the top layer
element. This creates a broken invariant where isGridItem() returns true but containingBlock() returns RenderView (per top layer rules),
causing an invalid downcast from RenderView to RenderGrid in computeInlineDirectionMargins. The fix changes the downcast to dynamicDowncast,
returning nullptr when the containing block is RenderView and safely avoiding the crash. This is a defensive workaround; the deeper
architectural issue of container query interleaving blocking StyleAdjuster on top layer elements is tracked separately
in <a href="https://bugs.webkit.org/show_bug.cgi?id=303414#.">https://bugs.webkit.org/show_bug.cgi?id=303414#.</a>

This specific test/crash requires several specific conditions. display: grid on the parent makes the frameset a grid item.
container-type: size triggers both the container query interleaving and the shouldApplySizeContainment() check that causes a second track sizing
pass in RenderGrid. content: test on the frameset makes it a RenderBlockFlow instead of a RenderFrameSet, allowing it to participate in grid layout.
And the fullscreen request triggers the layout that exposes the type confusion.

Test: fullscreen/fullscreen-grid-item-container-type-crash.html

* LayoutTests/TestExpectations:
* LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-grid-item-container-type-crash.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeInlineDirectionMargins const):

Canonical link: <a href="https://commits.webkit.org/303857@main">https://commits.webkit.org/303857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20e6d7e591e751ae2a2eb533af1bcefa5309dfee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85757 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bdbe3480-f004-4bc8-84eb-abf4fb354d2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4cd97511-24b8-434e-b812-3d68404cc6d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83071 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8297f4eb-7086-42ff-a833-43608697bbae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2246 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143922 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5880 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110652 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4484 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59627 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5933 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34417 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->