### PR TITLE
[run-webkit-tests] Add -2 option

### DIFF
--- a/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
@@ -53,7 +53,7 @@ class ExpectationsTest(unittest.TestCase):
             "test1_two": {
                 "expected": {
                     "all": {"status": ["FAIL"], "bug": "1234"},
-                    "gtk": {"status": ["PASS"]}
+                    "gtk-wk2": {"status": ["PASS"]}
                 }
             }
         }
@@ -77,7 +77,7 @@ class ExpectationsTest(unittest.TestCase):
         "expected": {"all": {"status": ["SKIP"], "bug": "1234"}}
     },
     "imported/w3c/webdriver/tests/test2.py": {
-        "expected": {"gtk": {"status": ["SKIP"], "bug": "1234"}}
+        "expected": {"gtk-wk2": {"status": ["SKIP"], "bug": "1234"}}
     },
     "imported/w3c/webdriver/tests/test3.py": {
         "expected": {"all": {"status": ["SKIP"], "bug": "1234"}},
@@ -101,7 +101,7 @@ class ExpectationsTest(unittest.TestCase):
     "TestCookieManager": {
         "subtests": {
             "/webkit2/WebKitCookieManager/persistent-storage": {
-                "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "1234"}}
+                "expected": {"gtk-wk2": {"status": ["FAIL", "PASS"], "bug": "1234"}}
             }
         }
     },
@@ -111,7 +111,7 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all": {"status": ["CRASH", "PASS"], "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"wpe": {"status": ["FAIL", "TIMEOUT"], "bug": "1234"}}
+                "expected": {"wpe-wk2": {"status": ["FAIL", "TIMEOUT"], "bug": "1234"}}
             }
         }
     }
@@ -132,8 +132,8 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all@Debug": {"status": ["CRASH"], "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"gtk@Release": {"status": ["FAIL"], "bug": "1234"},
-                             "gtk@Debug": {"status": ["CRASH"], "bug": "1234"}}
+                "expected": {"gtk-wk2@Release": {"status": ["FAIL"], "bug": "1234"},
+                             "gtk-wk2@Debug": {"status": ["CRASH"], "bug": "1234"}}
             }
         }
     },
@@ -150,10 +150,10 @@ class ExpectationsTest(unittest.TestCase):
     },
     "TestWebViewEditor": {
         "expected": {"all@Release": {"status": ["SKIP"]},
-                     "wpe@Debug": {"status": ["SKIP"]}},
+                     "wpe-wk2@Debug": {"status": ["SKIP"]}},
         "subtests": {
             "/webkit2/WebKitWebView/editable/editable": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "1234"}}
+                "expected": {"gtk-wk2": {"status": ["FAIL"], "bug": "1234"}}
             }
         }
     }
@@ -165,7 +165,7 @@ class ExpectationsTest(unittest.TestCase):
         "expected": {"all": {"slow": true}},
         "subtests": {
             "/webkit2/WebKitCookieManager/persistent-storage": {
-                "expected": {"wpe": {"status": ["FAIL"], "slow": false, "bug": "1234"}}
+                "expected": {"wpe-wk2": {"status": ["FAIL"], "slow": false, "bug": "1234"}}
             }
         }
     },
@@ -175,7 +175,7 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all": {"status": ["FAIL"], "slow": true, "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"gtk": {"status": ["CRASH"], "bug": "1234"}}
+                "expected": {"gtk-wk2": {"status": ["CRASH"], "bug": "1234"}}
             }
         }
     }

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -448,7 +448,7 @@ class Manager(object):
 
             configuration = self._port.configuration_for_upload(self._port.target_host(0))
             if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
-                configuration['flavor'] = 'wk2' if self._options.webkit_test_runner else 'wk1'
+                configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
             temp_initial_results, temp_retry_results, temp_enabled_pixel_tests_in_retry = self._run_test_subset(test_inputs, device_type=device_type)
 
             skipped_results = TestRunResults(self._expectations[device_type], len(aggregate_tests_to_skip))

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -143,8 +143,10 @@ def parse_args(args):
             help="Enable Guard Malloc (OS X only)"),
         optparse.make_option("--threaded", action="store_true", default=False,
             help="Run a concurrent JavaScript thread with each test"),
-        optparse.make_option("--dump-render-tree", "-1", action="store_false", default=True, dest="webkit_test_runner",
+        optparse.make_option("--dump-render-tree", "-1", action='append_const', dest='driver_names', const="DumpRenderTree", default=[],
             help="Use DumpRenderTree rather than WebKitTestRunner. This runs the wk1 single-process architecture."),
+        optparse.make_option("--webkit-test-runner", "-2", action='append_const', dest='driver_names', const="WebKitTestRunner", default=[],
+            help="Use WebKitTestRunner exclusively, skip any wk1 specific tests."),
         # FIXME: We should merge this w/ --build-directory and only have one flag.
         optparse.make_option("--root", action="store",
             help="Path to a directory containing the executables needed to run tests."),
@@ -389,6 +391,10 @@ def parse_args(args):
         option_parser.add_option_group(option_group)
 
     options, args = option_parser.parse_args(args)
+
+    if len(options.driver_names) > 1:
+        raise ValueError('Too many drivers specified')
+
     if options.webgl_test_suite:
         if not args:
             args.append('webgl')
@@ -552,10 +558,6 @@ def _set_up_derived_options(port, options):
 
     if options.run_singly:
         options.verbose = True
-
-    # The GTK+ and WPE ports only support WebKit2 so they always use WKTR.
-    if options.platform in ["gtk", "wpe"]:
-        options.webkit_test_runner = True
 
 def run(port, options, args, logging_stream):
     logger = logging.getLogger()

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -732,6 +732,18 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         expected_crash_log = mock_crash_report
         self.assertEqual(host.filesystem.read_text_file('/tmp/layout-test-results/failures/unexpected/crash-with-stderr-crash-log.txt'), expected_crash_log)
 
+    def test_crash_log_webkit_test_runner(self):
+        # FIXME: Need to rewrite these tests to not be mac-specific, or move them elsewhere.
+        # Currently CrashLog uploading only works on Darwin and Windows.
+        if not self._platform.is_mac() or self._platform.is_win():
+            return
+        mock_crash_report = make_mock_crash_report_darwin('WebKitTestRunner', 12345)
+        host = MockHost()
+        host.filesystem.write_text_file('/tmp/layout-test-results/WebKitTestRunner_2011-06-13-150719_quadzen.crash', mock_crash_report)
+        _, regular_output, _ = logging_run(['failures/unexpected/crash-with-stderr.html', '-2'], tests_included=True, host=host)
+        expected_crash_log = mock_crash_report
+        self.assertEqual(host.filesystem.read_text_file('/tmp/layout-test-results/failures/unexpected/crash-with-stderr-crash-log.txt'), expected_crash_log)
+
     def test_web_process_crash_log(self):
         # FIXME: Need to rewrite these tests to not be mac-specific, or move them elsewhere.
         # Currently CrashLog uploading only works on Darwin and Windows.

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
@@ -121,7 +121,7 @@ class  Testprinter(unittest.TestCase):
         self.assertIn('Verbose baseline search path: platform/test-mac-leopard -> platform/test-mac-snowleopard -> generic', err.getvalue())
         self.assertIn('Baseline search path: platform/test-mac-leopard -> generic', err.getvalue())
 
-        self.assertIn('Verbose test expectations: platform/test-mac-leopard/TestExpectations -> platform/test/TestExpectations -> TestExpectations', err.getvalue())
+        self.assertIn('Verbose test expectations: platform/test-wk2/TestExpectations -> platform/wk2/TestExpectations -> platform/test-mac-leopard/TestExpectations -> platform/test/TestExpectations -> TestExpectations', err.getvalue())
         self.assertIn('Test expectations: platform/test/TestExpectations', err.getvalue())
 
         self.reset(err)

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
@@ -71,10 +71,6 @@ class PerfTestsRunner(object):
         # Timeouts are controlled by the Python Driver, so DRT/WTR runs with no-timeout.
         self._options.additional_drt_flag.append('--no-timeout')
 
-        # The GTK+ port only supports WebKit2, so it always uses WKTR.
-        if self._port.name().startswith("gtk"):
-            self._options.webkit_test_runner = True
-
         self._host.initialize_scm()
         self._webkit_base_dir_len = len(self._port.webkit_base())
         self._base_path = self._port.perf_tests_dir()
@@ -122,8 +118,10 @@ class PerfTestsRunner(object):
                 help="Don't launch a browser with results after the tests are done"),
             optparse.make_option("--test-results-server",
                 help="Upload the generated JSON file to the specified server when --output-json-path is present."),
-            optparse.make_option("--dump-render-tree", "-1", action="store_false", default=True, dest="webkit_test_runner",
-                help="Use DumpRenderTree rather than WebKitTestRunner."),
+            optparse.make_option("--dump-render-tree", "-1", action='append_const', dest='driver_names', const="DumpRenderTree", default=[],
+                help="Use DumpRenderTree rather than WebKitTestRunner. This runs the wk1 single-process architecture."),
+            optparse.make_option("--webkit-test-runner", "-2", action='append_const', dest='driver_names', const="WebKitTestRunner", default=[],
+                help="Use WebKitTestRunner exclusively, skip any wk1 specific tests."),
             optparse.make_option("--force", dest="use_skipped_list", action="store_false", default=True,
                 help="Run all tests, including the ones in the Skipped list."),
             optparse.make_option("--profile", action="store_true",

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -49,8 +49,8 @@ class ApplePort(Port):
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):
         options = options or {}
+        driver = (getattr(options, 'driver_names', []) or cls.DRIVER_NAMES)[0]
         if port_name in (cls.port_name, cls.port_name + '-wk2'):
-
             # Since IOS simulator run on mac, they need a special check
             if host.platform.os_name == 'mac' and 'ios-simulator' in port_name:
                 return port_name
@@ -62,11 +62,11 @@ class ApplePort(Port):
             # That convention means that we're supposed to use the version currently
             # being run, so this won't work if you're not on mac or win (respectively).
             # If you're not on the o/s in question, you must specify a full version (cf. above).
-            if port_name == cls.port_name and not getattr(options, 'webkit_test_runner', False):
+            if port_name == cls.port_name and cls.is_webkitlegacy_driver(driver):
                 port_name = cls.port_name + version_name_addition
             else:
                 port_name = cls.port_name + version_name_addition + '-wk2'
-        elif getattr(options, 'webkit_test_runner', False) and  '-wk2' not in port_name:
+        elif not cls.is_webkitlegacy_driver(driver) and '-wk2' not in port_name:
             port_name += '-wk2'
 
         return port_name

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -45,7 +45,7 @@ class DarwinPort(ApplePort):
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']
 
     def __init__(self, host, port_name, **kwargs):
-        ApplePort.__init__(self, host, port_name, **kwargs)
+        super(DarwinPort, self).__init__(host, port_name, **kwargs)
 
         self._leak_detector = LeakDetector(self)
         if self.get_option("leaks"):

--- a/Tools/Scripts/webkitpy/port/darwin_testcase.py
+++ b/Tools/Scripts/webkitpy/port/darwin_testcase.py
@@ -37,10 +37,6 @@ from webkitcorepy import OutputCapture
 
 class DarwinTest(port_testcase.PortTestCase):
 
-    def assert_skipped_file_search_paths(self, port_name, expected_paths, use_webkit2=False):
-        port = self.make_port(port_name=port_name, options=MockOptions(webkit_test_runner=use_webkit2))
-        self.assertEqual(port._skipped_file_search_paths(), expected_paths)
-
     def test_sharding_groups(self):
         port = self.make_port()
         self.assertEqual(sorted(port.sharding_groups().keys()), ['media'])

--- a/Tools/Scripts/webkitpy/port/device_port.py
+++ b/Tools/Scripts/webkitpy/port/device_port.py
@@ -69,11 +69,10 @@ class DevicePort(DarwinPort):
         return int(self.get_option('child_processes'))
 
     def driver_name(self):
-        if self.get_option('driver_name'):
-            return self.get_option('driver_name')
-        if self.get_option('webkit_test_runner'):
+        parent = super(DevicePort, self).driver_name()
+        if parent == 'WebKitTestRunner':
             return 'WebKitTestRunnerApp.app'
-        return 'DumpRenderTree.app'
+        return f'{parent}.app'
 
     # A device is the target host for a specific worker number.
     def target_host(self, worker_number=None):

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -213,9 +213,9 @@ class DriverTest(unittest.TestCase):
         port._config.build_directory = lambda configuration: '/mock-build'
         driver = Driver(port, 0, pixel_tests=True, no_timeout=True)
         if sys.platform.startswith('win'):
-            self.assertEqual(driver.cmd_line(True, []), ['/mock-build/DumpRenderTree.exe', '--no-timeout', '-'])
+            self.assertEqual(driver.cmd_line(True, []), ['/mock-build/WebKitTestRunner.exe', '--no-timeout', '-'])
         else:
-            self.assertEqual(driver.cmd_line(True, []), ['/mock-build/DumpRenderTree', '--no-timeout', '-'])
+            self.assertEqual(driver.cmd_line(True, []), ['/mock-build/WebKitTestRunner', '--no-timeout', '-'])
 
     def test_check_for_driver_crash(self):
         port = TestWebKitPort()

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -150,7 +150,10 @@ class PortFactory(object):
         for cls in classes:
             if port_name.startswith(cls.port_name):
                 port_name = cls.determine_full_port_name(self._host, options, port_name)
-                return cls(self._host, port_name, options=options, **kwargs)
+                try:
+                    return cls(self._host, port_name, options=options, **kwargs)
+                except ValueError:
+                    continue
         raise NotImplementedError('unsupported platform: "%s"' % port_name)
 
     def all_port_names(self, platform=None):

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -37,6 +37,7 @@ class IOSPort(DevicePort):
     port_name = "ios"
 
     DEVICE_TYPE = DeviceType(software_variant='iOS')
+    DRIVER_NAMES = ('WebKitTestRunner', 'DumpRenderTree')
 
     def __init__(self, host, port_name, **kwargs):
         super(IOSPort, self).__init__(host, port_name, **kwargs)
@@ -53,7 +54,7 @@ class IOSPort(DevicePort):
             device_type = self.DEVICE_TYPE
 
         wk_string = 'wk1'
-        if self.get_option('webkit_test_runner'):
+        if not self.is_webkitlegacy():
             wk_string = 'wk2'
 
         versions_to_fallback = []
@@ -105,7 +106,7 @@ class IOSPort(DevicePort):
                 expectations.append(self._apple_baseline_path(variant))
             expectations.append(self._webkit_baseline_path(variant))
 
-        if self.get_option('webkit_test_runner'):
+        if not self.is_webkitlegacy():
             expectations.append(self._webkit_baseline_path('wk2'))
 
         return expectations

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -117,22 +117,23 @@ class IOSDeviceTest(ios_testcase.IOSTest):
             search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            f'/additional_testing_path/ios-device-add-ios{major_os_version}-wk1',
-            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-device-add-ios{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}-wk2',
             f'/additional_testing_path/ios-device-add-ios{major_os_version}',
             f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}',
-            '/additional_testing_path/ios-device-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-device-wk1',
+            '/additional_testing_path/ios-device-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/additional_testing_path/ios-device',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            f'/additional_testing_path/ios-add-ios{major_os_version}-wk1',
-            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-add-ios{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
             f'/additional_testing_path/ios-add-ios{major_os_version}',
             f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
-            '/additional_testing_path/ios-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-wk1',
+            '/additional_testing_path/ios-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/additional_testing_path/ios',
             '/mock-checkout/LayoutTests/platform/ios',
+            '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):

--- a/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
@@ -88,22 +88,23 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
             search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            f'/additional_testing_path/ios-simulator-add-ios{major_os_version}-wk1',
-            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-simulator-add-ios{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}-wk2',
             f'/additional_testing_path/ios-simulator-add-ios{major_os_version}',
             f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}',
-            '/additional_testing_path/ios-simulator-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-wk1',
+            '/additional_testing_path/ios-simulator-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/additional_testing_path/ios-simulator',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            f'/additional_testing_path/ios-add-ios{major_os_version}-wk1',
-            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-add-ios{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
             f'/additional_testing_path/ios-add-ios{major_os_version}',
             f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
-            '/additional_testing_path/ios-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-wk1',
+            '/additional_testing_path/ios-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/additional_testing_path/ios',
             '/mock-checkout/LayoutTests/platform/ios',
+            '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):

--- a/Tools/Scripts/webkitpy/port/ios_testcase.py
+++ b/Tools/Scripts/webkitpy/port/ios_testcase.py
@@ -33,9 +33,10 @@ class IOSTest(darwin_testcase.DarwinTest):
         return port
 
     def test_driver_name(self):
-        self.assertEqual(self.make_port().driver_name(), 'DumpRenderTree.app')
+        self.assertEqual(self.make_port().driver_name(), 'WebKitTestRunnerApp.app')
 
     def test_baseline_searchpath(self):
         search_path = self.make_port().default_baseline_search_path()
-        self.assertEqual(search_path[-1], '/mock-checkout/LayoutTests/platform/ios')
-        self.assertEqual(search_path[-2], '/mock-checkout/LayoutTests/platform/ios-wk1')
+        self.assertEqual(search_path[-1], '/mock-checkout/LayoutTests/platform/wk2')
+        self.assertEqual(search_path[-2], '/mock-checkout/LayoutTests/platform/ios')
+        self.assertEqual(search_path[-3], '/mock-checkout/LayoutTests/platform/ios-wk2')

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -58,30 +58,30 @@ class MacTest(darwin_testcase.DarwinTest):
 
     def test_versions(self):
         # Note: these tests don't need to be exhaustive as long as we get path coverage.
-        self.assert_name('mac', 'snowleopard', 'mac-snowleopard')
-        self.assert_name('mac-snowleopard', 'leopard', 'mac-snowleopard')
-        self.assert_name('mac-snowleopard', 'lion', 'mac-snowleopard')
-        self.assert_name('mac', 'lion', 'mac-lion')
-        self.assert_name('mac-lion', 'lion', 'mac-lion')
-        self.assert_name('mac', 'mountainlion', 'mac-mountainlion')
-        self.assert_name('mac-mountainlion', 'lion', 'mac-mountainlion')
-        self.assert_name('mac', 'mavericks', 'mac-mavericks')
-        self.assert_name('mac-mavericks', 'mountainlion', 'mac-mavericks')
-        self.assert_name('mac', 'yosemite', 'mac-yosemite')
-        self.assert_name('mac-yosemite', 'mavericks', 'mac-yosemite')
-        self.assert_name('mac', 'elcapitan', 'mac-elcapitan')
-        self.assert_name('mac-elcapitan', 'mavericks', 'mac-elcapitan')
-        self.assert_name('mac-elcapitan', 'yosemite', 'mac-elcapitan')
-        self.assert_name('mac', 'sierra', 'mac-sierra')
-        self.assert_name('mac-sierra', 'yosemite', 'mac-sierra')
-        self.assert_name('mac-sierra', 'elcapitan', 'mac-sierra')
-        self.assert_name('mac', 'highsierra', 'mac-highsierra')
-        self.assert_name('mac-highsierra', 'elcapitan', 'mac-highsierra')
-        self.assert_name('mac-highsierra', 'sierra', 'mac-highsierra')
-        self.assert_name('mac', 'mojave', 'mac-mojave')
-        self.assert_name('mac-mojave', 'sierra', 'mac-mojave')
-        self.assert_name('mac-mojave', 'highsierra', 'mac-mojave')
-        self.assertRaises(AssertionError, self.assert_name, 'mac-tiger', 'leopard', 'mac-leopard')
+        self.assert_name('mac', 'snowleopard', 'mac-snowleopard-wk2')
+        self.assert_name('mac-snowleopard', 'leopard', 'mac-snowleopard-wk2')
+        self.assert_name('mac-snowleopard', 'lion', 'mac-snowleopard-wk2')
+        self.assert_name('mac', 'lion', 'mac-lion-wk2')
+        self.assert_name('mac-lion', 'lion', 'mac-lion-wk2')
+        self.assert_name('mac', 'mountainlion', 'mac-mountainlion-wk2')
+        self.assert_name('mac-mountainlion', 'lion', 'mac-mountainlion-wk2')
+        self.assert_name('mac', 'mavericks', 'mac-mavericks-wk2')
+        self.assert_name('mac-mavericks', 'mountainlion', 'mac-mavericks-wk2')
+        self.assert_name('mac', 'yosemite', 'mac-yosemite-wk2')
+        self.assert_name('mac-yosemite', 'mavericks', 'mac-yosemite-wk2')
+        self.assert_name('mac', 'elcapitan', 'mac-elcapitan-wk2')
+        self.assert_name('mac-elcapitan', 'mavericks', 'mac-elcapitan-wk2')
+        self.assert_name('mac-elcapitan', 'yosemite', 'mac-elcapitan-wk2')
+        self.assert_name('mac', 'sierra', 'mac-sierra-wk2')
+        self.assert_name('mac-sierra', 'yosemite', 'mac-sierra-wk2')
+        self.assert_name('mac-sierra', 'elcapitan', 'mac-sierra-wk2')
+        self.assert_name('mac', 'highsierra', 'mac-highsierra-wk2')
+        self.assert_name('mac-highsierra', 'elcapitan', 'mac-highsierra-wk2')
+        self.assert_name('mac-highsierra', 'sierra', 'mac-highsierra-wk2')
+        self.assert_name('mac', 'mojave', 'mac-mojave-wk2')
+        self.assert_name('mac-mojave', 'sierra', 'mac-mojave-wk2')
+        self.assert_name('mac-mojave', 'highsierra', 'mac-mojave-wk2')
+        self.assertRaises(AssertionError, self.assert_name, 'mac-tiger', 'leopard', 'mac-leopard-wk2')
 
     def test_setup_environ_for_server(self):
         port = self.make_port(options=MockOptions(leaks=True, guard_malloc=True))
@@ -180,88 +180,81 @@ class MacTest(darwin_testcase.DarwinTest):
     def test_layout_test_searchpath_with_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
             search_path = self.make_port().default_baseline_search_path()
-        self.assertEqual(search_path[0], '/additional_testing_path/mac-add-lion-wk1')
-        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-lion-wk1')
+        self.assertEqual(search_path[0], '/additional_testing_path/mac-add-lion-wk2')
+        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-lion-wk2')
         self.assertEqual(search_path[2], '/additional_testing_path/mac-add-lion')
         self.assertEqual(search_path[3], '/mock-checkout/LayoutTests/platform/mac-lion')
-        self.assertEqual(search_path[4], '/additional_testing_path/mac-add-mountainlion-wk1')
-        self.assertEqual(search_path[5], '/mock-checkout/LayoutTests/platform/mac-mountainlion-wk1')
+        self.assertEqual(search_path[4], '/additional_testing_path/mac-add-mountainlion-wk2')
+        self.assertEqual(search_path[5], '/mock-checkout/LayoutTests/platform/mac-mountainlion-wk2')
 
     def test_latest_baseline_search_path(self):
         search_path = self.make_port(port_name='macos-tahoe').default_baseline_search_path()
-        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-wk1')
+        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-wk2')
         self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac')
 
     def test_downlevel_baseline_search_path(self):
         search_path = self.make_port(port_name='macos-sequoia').default_baseline_search_path()
-        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-sequoia-wk1')
+        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-sequoia-wk2')
         self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-sequoia')
-        self.assertEqual(search_path[2], '/mock-checkout/LayoutTests/platform/mac-wk1')
+        self.assertEqual(search_path[2], '/mock-checkout/LayoutTests/platform/mac-wk2')
         self.assertEqual(search_path[3], '/mock-checkout/LayoutTests/platform/mac')
 
     def test_factory_with_future_version(self):
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+        port = self.make_port(os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
         self.assertEqual(port.version_name(), VersionNameMap().to_name(MacPort.CURRENT_VERSION, platform=MacPort.port_name))
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+        port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
         self.assertEqual(port.driver_name(), 'DumpRenderTree')
         self.assertEqual(port.version_name(), VersionNameMap().to_name(MacPort.CURRENT_VERSION, platform=MacPort.port_name))
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
-        self.assertEqual(port.driver_name(), 'WebKitTestRunner')
+        port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+        self.assertEqual(port.driver_name(), 'DumpRenderTree')
         self.assertEqual(port.version_name(), VersionNameMap().to_name(MacPort.CURRENT_VERSION, platform=MacPort.port_name))
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
+        port = self.make_port(os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
         self.assertEqual(port.version_name(), VersionNameMap().to_name(MacPort.CURRENT_VERSION, platform=MacPort.port_name))
 
     def test_factory_with_future_version_and_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
-            port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+            port = self.make_port(os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
             self.assertEqual(port.driver_name(), 'WebKitTestRunner')
             self.assertEqual(port.version_name(), None)
 
-            port = self.make_port(options=MockOptions(webkit_test_runner=False), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+            port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
             self.assertEqual(port.driver_name(), 'DumpRenderTree')
             self.assertEqual(port.version_name(), None)
 
-            port = self.make_port(options=MockOptions(webkit_test_runner=False), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
-            self.assertEqual(port.driver_name(), 'WebKitTestRunner')
+            port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')
+            self.assertEqual(port.driver_name(), 'DumpRenderTree')
             self.assertEqual(port.version_name(), None)
 
-            port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
+            port = self.make_port(os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac-wk2')
             self.assertEqual(port.driver_name(), 'WebKitTestRunner')
             self.assertEqual(port.version_name(), None)
 
     def test_factory_with_portname_version(self):
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), port_name='mac-mountainlion')
+        port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), port_name='mac-mountainlion')
         self.assertEqual(port.driver_name(), 'DumpRenderTree')
         self.assertEqual(port.version_name(), 'Mountain Lion')
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), port_name='mac-mountainlion')
+        port = self.make_port(port_name='mac-mountainlion')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
         self.assertEqual(port.version_name(), 'Mountain Lion')
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), port_name='mac-mountainlion-wk2')
-        self.assertEqual(port.driver_name(), 'WebKitTestRunner')
-        self.assertEqual(port.version_name(), 'Mountain Lion')
-
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), port_name='mac-mountainlion-wk2')
+        port = self.make_port(port_name='mac-mountainlion-wk2')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
         self.assertEqual(port.version_name(), 'Mountain Lion')
 
     def test_factory_with_portname_wk2(self):
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), port_name='mac')
+        port = self.make_port(options=MockOptions(driver_names=['DumpRenderTree']), port_name='mac')
         self.assertEqual(port.driver_name(), 'DumpRenderTree')
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), port_name='mac')
+        port = self.make_port(port_name='mac')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
 
-        port = self.make_port(options=MockOptions(webkit_test_runner=True), port_name='mac-wk2')
-        self.assertEqual(port.driver_name(), 'WebKitTestRunner')
-
-        port = self.make_port(options=MockOptions(webkit_test_runner=False), port_name='mac-wk2')
+        port = self.make_port(port_name='mac-wk2')
         self.assertEqual(port.driver_name(), 'WebKitTestRunner')
 
     def test_configuration_for_upload(self):

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -396,6 +396,7 @@ class TestPort(Port):
         'test-mac-snowleopard', 'test-mac-leopard',
         'test-win-vista', 'test-win-7sp0', 'test-win-xp',
     )
+    DRIVER_NAMES = ('WebKitTestRunner', 'DumpRenderTree')
 
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):

--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -38,17 +38,6 @@ class VisionOSPort(DevicePort):
 
     DEVICE_TYPE = DeviceType(software_variant='visionOS')
 
-    def __init__(self, *args, **kwargs):
-        super(VisionOSPort, self).__init__(*args, **kwargs)
-
-        if not self.get_option('webkit_test_runner', False):
-            raise ValueError('DumpRenderTree is not supported on this platform.')
-
-    def driver_name(self):
-        if self.get_option('driver_name'):
-            return self.get_option('driver_name')
-        return 'WebKitTestRunnerApp.app'
-
     def version_name(self):
         if self._os_version is None:
             return None

--- a/Tools/Scripts/webkitpy/port/visionos_testcase.py
+++ b/Tools/Scripts/webkitpy/port/visionos_testcase.py
@@ -31,9 +31,8 @@ class VisionOSTest(darwin_testcase.DarwinTest):
     def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=VisionOSPort.CURRENT_VERSION, **kwargs):
         if options:
             options.architecture = 'arm64'
-            options.webkit_test_runner = True
         else:
-            options = MockOptions(architecture='arm64', webkit_test_runner=True, configuration='Release')
+            options = MockOptions(architecture='arm64', configuration='Release')
         port = super(VisionOSTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=None, kwargs=kwargs)
         port.set_option('version', str(os_version))
         return port

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -38,17 +38,6 @@ class WatchPort(DevicePort):
 
     DEVICE_TYPE = DeviceType(software_variant='watchOS')
 
-    def __init__(self, *args, **kwargs):
-        super(WatchPort, self).__init__(*args, **kwargs)
-
-        if self.get_option('webkit_test_runner', False) == False:
-            raise RuntimeError('DumpRenderTree is not supported on this platform.')
-
-    def driver_name(self):
-        if self.get_option('driver_name'):
-            return self.get_option('driver_name')
-        return 'WebKitTestRunnerApp.app'
-
     def version_name(self):
         if self._os_version is None:
             return None

--- a/Tools/Scripts/webkitpy/port/watch_testcase.py
+++ b/Tools/Scripts/webkitpy/port/watch_testcase.py
@@ -33,9 +33,8 @@ class WatchTest(darwin_testcase.DarwinTest):
     def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=WatchPort.CURRENT_VERSION, **kwargs):
         if options:
             options.architecture = 'x86'
-            options.webkit_test_runner = True
         else:
-            options = MockOptions(architecture='x86', webkit_test_runner=True, configuration='Release')
+            options = MockOptions(architecture='x86', configuration='Release')
         port = super(WatchTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=None, kwargs=kwargs)
         port.set_option('version', str(os_version))
         return port

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -59,12 +59,10 @@ class WinPort(ApplePort):
 
     VERSION_MIN = Version(5, 1)
     VERSION_MAX = Version(10)
-
     ARCHITECTURES = ['x86', 'x86_64']
-
     DEFAULT_ARCHITECTURE = 'x86_64'
-
     CRASH_LOG_PREFIX = "CrashLog"
+    DRIVER_NAMES = ('WebKitTestRunner', 'DumpRenderTree')
 
     if sys.platform.startswith('win'):
         POST_MORTEM_DEBUGGER_KEY = r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug'
@@ -107,7 +105,7 @@ class WinPort(ApplePort):
 
     def do_text_results_differ(self, expected_text, actual_text):
         # Sanity was restored in WebKitTestRunner, so we don't need this hack there.
-        if not self.get_option('webkit_test_runner'):
+        if self.is_webkitlegacy():
             # Windows does not have an EDITING DELEGATE, so strip those messages to make more tests pass.
             # It's possible other ports might want this, and if so, this could move down into WebKitPort.
             delegate_regexp = re.compile("^EDITING DELEGATE: .*?\n", re.MULTILINE)
@@ -135,7 +133,7 @@ class WinPort(ApplePort):
         return env
 
     def driver_name(self):
-        return "WebKitTestRunnerWS"
+        return super(WinPort, self).driver_name() + 'WS'
 
     def run_minibrowser(self, args):
         miniBrowser = self._build_path('MiniBrowser.exe')
@@ -454,7 +452,7 @@ class WinPort(ApplePort):
         normalize = lambda version: version.lower().replace(' ', '')
         to_name = lambda version: version_name_map.to_name(version, platform=self.port_name)
 
-        wk_version = 'wk2' if self.get_option('webkit_test_runner') else 'wk1'
+        wk_version = 'wk1' if self.is_webkitlegacy() else 'wk2'
 
         for version in versions:
             version_name = to_name(version)
@@ -466,7 +464,7 @@ class WinPort(ApplePort):
 
         paths.append(self.port_name + '-' + wk_version)
         paths.append(self.port_name)
-        if self.get_option('webkit_test_runner'):
+        if not self.is_webkitlegacy():
             paths.append('wk2')
         paths.extend(self.get_option("additional_platform_directory", []))
 

--- a/Tools/Scripts/webkitpy/style/checkers/test_expectations.py
+++ b/Tools/Scripts/webkitpy/style/checkers/test_expectations.py
@@ -48,14 +48,17 @@ class TestExpectationsChecker(object):
 
     def _determine_port_from_expectations_path(self, host, expectations_path):
         # Pass a configuration to avoid calling default_configuration() when initializing the port (takes 0.5 seconds on a Mac Pro!).
-        options_wk1 = optparse.Values({'configuration': 'Release', 'webkit_test_runner': False})
-        options_wk2 = optparse.Values({'configuration': 'Release', 'webkit_test_runner': True})
+        options_wk1 = optparse.Values({'configuration': 'Release', 'driver_name': 'DumpRenderTree'})
+        options_wk2 = optparse.Values({'configuration': 'Release', 'driver_name': 'WebKitTestRunner'})
         for port_name in host.port_factory.all_port_names():
-            ports = [host.port_factory.get(port_name, options=options_wk1), host.port_factory.get(port_name, options=options_wk2)]
-            for port in ports:
-                for test_expectation_file in port.expectations_files():
-                    if test_expectation_file.replace(port.path_from_webkit_base() + host.filesystem.sep, '') == expectations_path:
-                        return port
+            for option in (options_wk1, options_wk2):
+                try:
+                    port = host.port_factory.get(port_name, options=option)
+                    for test_expectation_file in port.expectations_files():
+                        if test_expectation_file.replace(port.path_from_webkit_base() + host.filesystem.sep, '') == expectations_path:
+                            return port
+                except NotImplementedError:
+                    continue
         return None
 
     def __init__(self, file_path, handle_style_error, host=None):


### PR DESCRIPTION
#### 9f04f384e3f352b1156bec82cc3b14fb9d76f716
<pre>
[run-webkit-tests] Add -2 option
<a href="https://rdar.apple.com/165717647">rdar://165717647</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303418">https://bugs.webkit.org/show_bug.cgi?id=303418</a>

Reviewed by Sam Sneddon.

Add a -2 option which forces ports to run with modern WebKit. Lay down groundwork
for running with multiple drivers. Replace webkit_test_runner with the driver_name variable,
and refactor various checks into parent port classes.

* Tools/Scripts/webkitpy/common/test_expectations_unittest.py:
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run): Check driver_name to determine if we&apos;re running under WebKitLegacy.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args): Add -2 option. Check that the user did not specify multiple drivers.
(_set_up_derived_options): Remove special case for GTK and WPE.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py: Rebaseline.
* Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py: Ditto.
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py:
(PerfTestsRunner.__init__): Remove special case for GTK and WPE.
(PerfTestsRunner._parse_args): Add -2 option. Check that the user did not specify multiple drivers.
* Tools/Scripts/webkitpy/port/apple.py:
(ApplePort.determine_full_port_name): Use driver check.
* Tools/Scripts/webkitpy/port/base.py:
(Port): Set driver names as a constant.
(Port.is_webkitlegacy): Check if the specified driver is a WebKitLegacy driver.
(Port.determine_full_port_name): Use driver check.
(Port.determine_driver_name): Centralize options to driver name conversions.
(Port.__init__): Check that the specified driver is supported for this port.
(Port.default_baseline_search_path): Use a driver check.
(Port.driver_name): Standardize driver check.
(Port._port_specific_expectations_files): Use a driver check.
(Port._build_driver): Ditto.
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.__init__): Use modern `super()` call.
* Tools/Scripts/webkitpy/port/darwin_testcase.py:
(DarwinTest.assert_skipped_file_search_paths): Remove unused function.
* Tools/Scripts/webkitpy/port/device_port.py:
(DevicePort.driver_name): Convert driver name for Apple embedded platforms.
* Tools/Scripts/webkitpy/port/driver_unittest.py:
(DriverTest.test_no_timeout): Rebaseline.
* Tools/Scripts/webkitpy/port/factory.py:
(PortFactory.get): Never vend invalid ports.
* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort): Support both WebKitTestRunner and DumpRenderTree.
(IOSPort.default_baseline_search_path): Use a driver check.
* Tools/Scripts/webkitpy/port/ios_device_unittest.py: Rebaseline.
* Tools/Scripts/webkitpy/port/ios_simulator_unittest.py: Rebaseline.
* Tools/Scripts/webkitpy/port/ios_testcase.py: Rebaseline.
* Tools/Scripts/webkitpy/port/mac.py:
(MacPort): Support both WebKitTestRunner and DumpRenderTree.
(MacPort.__init__): Use modern `super()` call.
(MacPort.default_baseline_search_path): Use a driver check.
(MacPort.default_child_processes): Remove special cases for WebKit.
* Tools/Scripts/webkitpy/port/mac_unittest.py: Rebaseline.
* Tools/Scripts/webkitpy/port/port_testcase.py: Rebaeline.
* Tools/Scripts/webkitpy/port/test.py: Support both WebKitTestRunner and DumpRenderTree.
* Tools/Scripts/webkitpy/port/visionos.py:
(VisionOSPort.__init__): Deleted.
(VisionOSPort.driver_name): Deleted.
* Tools/Scripts/webkitpy/port/visionos_testcase.py:
(VisionOSTest.make_port): Remove special case.
* Tools/Scripts/webkitpy/port/watch.py:
(WatchPort.__init__): Deleted.
(WatchPort.driver_name): Deleted.
* Tools/Scripts/webkitpy/port/watch_testcase.py:
(WatchTest.make_port): Remove special case.
* Tools/Scripts/webkitpy/port/win.py:
(WinPort): Support both WebKitTestRunner and DumpRenderTree.
(WinPort.do_text_results_differ): Use a driver check.
(WinPort.driver_name): Convert driver name for Windows.
(WinPort._search_paths): Use a driver check.
* Tools/Scripts/webkitpy/port/win_unittest.py:
(WinPortTest._assert_search_path): Set driver.
(WinPortTest.test_compare_text): Rebaseline.
(WinPortTest.test_expectations_files): Rebaseline.
* Tools/Scripts/webkitpy/style/checkers/test_expectations.py:
(TestExpectationsChecker._determine_port_from_expectations_path): Handle ports which
do not support WebKitLegacy.

Canonical link: <a href="https://commits.webkit.org/304573@main">https://commits.webkit.org/304573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d203d4065fb840a6d7e0bec6a7c66fd02171f241

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135963 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143670 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a4755f23-c156-417b-8dcf-52b616eb9a83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103905 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c9d053a-e6a3-448d-8c3b-6f2afcac5332) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121847 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84782 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7d7ad29-e526-4b77-9128-3665be5903f8) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135311 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3850 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146421 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6722 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112649 "Found 36 new API test failures: WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/ignored-objects, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/extents, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/basic-hierarchy, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/action/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed/focus, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic ... (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6110 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118148 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20945 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8057 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36220 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7779 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->