### PR TITLE
macOS/iPadOS 26 memory leak in com.apple.Webkit.GPU process when running simple WebGPU app

### DIFF
--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -138,4 +138,13 @@ struct DrawIndexCacheContainerValue {
 using DrawIndexCacheContainer = HashMap<GenericHashKey<DrawIndexCacheContainerKey>, uint32_t>;
 using DrawIndexCacheContainerIterator = DrawIndexCacheContainer::const_iterator;
 
+using TrackedResourceContainer = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+struct TrackedResource {
+    mutable TrackedResourceContainer m_commandEncoders;
+    void removeEncoder(uint64_t identifier) const
+    {
+        m_commandEncoders.remove(identifier);
+    }
+};
+
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -58,7 +58,7 @@ class CommandEncoder;
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpubuffer
-class Buffer : public WGPUBufferImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Buffer> {
+class Buffer : public WGPUBufferImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Buffer>, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(Buffer);
 public:
     enum class State : uint8_t;
@@ -183,7 +183,6 @@ private:
     DrawIndexCacheContainer m_drawIndexedCache;
 
     const Ref<Device> m_device;
-    mutable Vector<uint64_t> m_commandEncoders; // NOLINT - https://bugs.webkit.org/show_bug.cgi?id=289718
     mutable HashMap<uint64_t, uint32_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_gpuResourceMap;
     HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_skippedValidationCommandEncoders;
     bool m_mustTakeSlowIndexValidationPath { false };

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -225,7 +225,7 @@ void Buffer::decrementBufferMapCount()
 void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuffer) const
 {
     UNUSED_PARAM(mayModifyBuffer);
-    CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
+    commandEncoder.trackEncoderForBuffer(*this, m_commandEncoders);
 #if !CPU(X86_64)
     if (m_device->isShaderValidationEnabled())
 #endif
@@ -247,12 +247,7 @@ void Buffer::destroy()
     }
 
     setState(State::Destroyed);
-    for (auto commandEncoder : m_commandEncoders) {
-        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
-            ptr->makeSubmitInvalid();
-    }
-
-    m_commandEncoders.clear();
+    m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
     m_device->removeBufferFromCache(m_buffer.gpuAddress);
     m_buffer = protectedDevice()->placeholderBuffer();
 }

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -78,6 +78,8 @@ void CommandBuffer::makeInvalid(NSString* lastError)
     retainTimestampsForOneUpdateLoop();
     m_commandBuffer = nil;
     m_cachedCommandBuffer = nil;
+    if (RefPtr commandEncoder = m_commandEncoder)
+        commandEncoder->clearTracking();
     m_commandEncoder = nullptr;
     m_preCommitHandlers.clear();
     m_postCommitHandlers.clear();
@@ -119,6 +121,9 @@ void CommandBuffer::makeInvalidDueToCommit(NSString* lastError)
         protectedThis->m_commandBufferComplete.signal();
         protectedThis->m_device->protectedQueue()->scheduleWork([protectedThis]() mutable {
             protectedThis->m_cachedCommandBuffer = nil;
+            if (RefPtr commandEncoder = protectedThis->m_commandEncoder)
+                commandEncoder->clearTracking();
+
             protectedThis->m_commandEncoder = nullptr;
         });
     }];

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -267,6 +267,7 @@ public:
     uint32_t appleGPUFamily() const { return m_appleGPUFamily; }
     void setRasterizationMapsForTexture(MTLResourceID, id<MTLRasterizationRateMap> left, id<MTLRasterizationRateMap> right);
     static id<MTLFunction> nopVertexFunction(id<MTLDevice>);
+    void makeSubmitInvalidClearingEncoders(TrackedResourceContainer&);
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -1074,6 +1074,15 @@ void Device::trackTimestampsBuffer(id<MTLCommandBuffer> commandBuffer, id<MTLCou
     [sampleBufferArray addObject:counterSampleBuffer];
 }
 
+void Device::makeSubmitInvalidClearingEncoders(TrackedResourceContainer& commandEncoders)
+{
+    auto encoders = std::exchange(commandEncoders, { });
+    for (auto commandEncoder : encoders) {
+        if (RefPtr ptr = commandEncoderFromIdentifier(commandEncoder))
+            ptr->makeSubmitInvalid();
+    }
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "BindableResource.h"
 #import "Device.h"
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -41,7 +42,7 @@ namespace WebGPU {
 
 class CommandEncoder;
 
-class ExternalTexture : public RefCountedAndCanMakeWeakPtr<ExternalTexture>, public WGPUExternalTextureImpl {
+class ExternalTexture : public RefCountedAndCanMakeWeakPtr<ExternalTexture>, public WGPUExternalTextureImpl, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(ExternalTexture);
 public:
     static Ref<ExternalTexture> create(CVPixelBufferRef pixelBuffer, WGPUColorSpace colorSpace, Device& device)
@@ -80,7 +81,6 @@ private:
     bool m_destroyed { false };
     id<MTLTexture> m_texture0 { nil };
     id<MTLTexture> m_texture1 { nil };
-    mutable Vector<uint64_t> m_commandEncoders;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -70,12 +70,7 @@ void ExternalTexture::destroy()
 {
     m_pixelBuffer = nil;
     m_destroyed = true;
-    for (auto commandEncoder : m_commandEncoders) {
-        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
-            ptr->makeSubmitInvalid();
-    }
-
-    m_commandEncoders.clear();
+    m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
 }
 
 void ExternalTexture::undestroy()

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "BindableResource.h"
 #import "WebGPU.h"
 #import "WebGPUExt.h"
 #import <optional>
@@ -32,7 +33,7 @@
 #import <wtf/Range.h>
 #import <wtf/RangeSet.h>
 #import <wtf/Ref.h>
-#import <wtf/RefCounted.h>
+#import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
@@ -51,7 +52,7 @@ class CommandEncoder;
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpuqueryset
-class QuerySet : public WGPUQuerySetImpl, public RefCounted<QuerySet> {
+class QuerySet : public WGPUQuerySetImpl, public RefCountedAndCanMakeWeakPtr<QuerySet>, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(QuerySet);
 public:
     struct CounterSampleBuffer {
@@ -114,7 +115,6 @@ private:
         Ref<QuerySet> other;
         uint32_t otherIndex;
     };
-    mutable Vector<uint64_t> m_commandEncoders;
     bool m_destroyed { false };
 
     // static is intentional here as the limit is per process

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -122,12 +122,7 @@ void QuerySet::destroy()
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
     m_visibilityBuffer = nil;
     m_timestampBufferWithOffset.buffer = nil;
-    for (auto commandEncoder : m_commandEncoders) {
-        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
-            ptr->makeSubmitInvalid();
-    }
-
-    m_commandEncoders.clear();
+    m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
 }
 
 void QuerySet::setLabel(String&& label)

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "BindableResource.h"
 #import <Metal/Metal.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
@@ -49,7 +50,7 @@ class Device;
 class TextureView;
 
 // https://gpuweb.github.io/gpuweb/#gputexture
-class Texture : public RefCountedAndCanMakeWeakPtr<Texture>, public WGPUTextureImpl {
+class Texture : public RefCountedAndCanMakeWeakPtr<Texture>, public WGPUTextureImpl, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(Texture);
 public:
     static Ref<Texture> create(id<MTLTexture> texture, const WGPUTextureDescriptor& descriptor, Vector<WGPUTextureFormat>&& viewFormats, Device& device)
@@ -183,7 +184,6 @@ private:
     Vector<WeakPtr<TextureView>> m_textureViews;
     bool m_destroyed { false };
     bool m_canvasBacking { false };
-    mutable Vector<uint64_t> m_commandEncoders;
     id<MTLSharedEvent> m_sharedEvent { nil };
     std::pair<id<MTLRasterizationRateMap>, id<MTLRasterizationRateMap>> m_leftRightRasterizationMaps;
 

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3592,12 +3592,9 @@ void Texture::destroy()
                 view->destroy();
         }
     }
-    if (!m_canvasBacking) {
-        for (auto commandEncoder : m_commandEncoders) {
-            if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
-                ptr->makeSubmitInvalid();
-        }
-    }
+    if (!m_canvasBacking)
+        m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
+
     m_commandEncoders.clear();
 
     m_textureViews.clear();

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "BindableResource.h"
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -45,7 +46,7 @@ class Device;
 class Texture;
 
 // https://gpuweb.github.io/gpuweb/#gputextureview
-class TextureView : public RefCountedAndCanMakeWeakPtr<TextureView>, public WGPUTextureViewImpl {
+class TextureView : public RefCountedAndCanMakeWeakPtr<TextureView>, public WGPUTextureViewImpl, public TrackedResource {
     WTF_MAKE_TZONE_ALLOCATED(TextureView);
 public:
     static Ref<TextureView> create(id<MTLTexture> texture, const WGPUTextureViewDescriptor& descriptor, const std::optional<WGPUExtent3D>& renderExtent, Texture& parentTexture, Device& device)
@@ -108,7 +109,6 @@ private:
 
     const Ref<Device> m_device;
     const Ref<Texture> m_parentTexture;
-    mutable Vector<uint64_t> m_commandEncoders;
 } SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -171,12 +171,8 @@ bool TextureView::isValid() const
 void TextureView::destroy()
 {
     m_texture = Ref { m_device }->placeholderTexture(format());
-    if (!m_parentTexture->isCanvasBacking()) {
-        for (auto commandEncoder : m_commandEncoders) {
-            if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
-                ptr->makeSubmitInvalid();
-        }
-    }
+    if (!m_parentTexture->isCanvasBacking())
+        m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
 
     m_commandEncoders.clear();
 }


### PR DESCRIPTION
#### f37648d6131256c4df0763551328f4669b30c88f
<pre>
macOS/iPadOS 26 memory leak in com.apple.Webkit.GPU process when running simple WebGPU app
<a href="https://bugs.webkit.org/show_bug.cgi?id=303203">https://bugs.webkit.org/show_bug.cgi?id=303203</a>
<a href="https://rdar.apple.com/165488672">rdar://165488672</a>

Reviewed by Tadeu Zagallo.

For resource validation purposes, the specification requires us to store
which resources and currently used by which command encoders and command buffers
so we can prevent data races.

We were tracking all the command encoders a resource was used in, but we only
cleared this list when the resource was destroyed.

A resource may live for the lifetime of an application and used in many command
encoders.

An application creating lots of command encoders could start to observe
a slow memory increase over ~30 minutes to several hours.

Test: existing CTS buffer mapping and command encoder
validation tests continue to pass.

* Source/WebGPU/WebGPU/BindableResource.h:
(WebGPU::TrackedResource::removeEncoder const):
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::setCommandEncoder const):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalid):
(WebGPU::CommandBuffer::makeInvalidDueToCommit):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::~CommandEncoder):
(WebGPU::CommandEncoder::computeSize):
(WebGPU::CommandEncoder::trackEncoder):
(WebGPU::CommandEncoder::clearTracking):
(WebGPU::CommandEncoder::trackEncoderForBuffer):
(WebGPU::CommandEncoder::trackEncoderForTexture):
(WebGPU::CommandEncoder::trackEncoderForTextureView):
(WebGPU::CommandEncoder::trackEncoderForExternalTexture):
(WebGPU::CommandEncoder::trackEncoderForQuerySet):
* Source/WebGPU/WebGPU/ExternalTexture.h:
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/TextureView.h:

Canonical link: <a href="https://commits.webkit.org/303984@main">https://commits.webkit.org/303984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e9e8ffd2dae7f88048ee34289e0035286e09502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86236 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e6be0c3-28f9-4785-b6c1-a9047d813d1b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102598 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/388e6439-87c1-407e-8c93-71a35d1437ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137118 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83392 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8becc968-2dd8-4637-a72f-de6f9ad8b43f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2544 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1566 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114086 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110973 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28213 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4775 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60123 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34752 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->