### PR TITLE
[GLib] Fix typo in Connection::sendCredentials error message

### DIFF
--- a/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
+++ b/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
@@ -477,7 +477,7 @@ void Connection::sendCredentials() const
         if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) || g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
             return;
 
-        g_error("Connection: Failed to send crendentials: %s", error->message);
+        g_error("Connection: Failed to send credentials: %s", error->message);
     }
     g_socket_set_blocking(m_socket.get(), FALSE);
 }


### PR DESCRIPTION
#### d741bc3ffd23f1461de8413c79c1eb5e92580177
<pre>
[GLib] Fix typo in Connection::sendCredentials error message
<a href="https://bugs.webkit.org/show_bug.cgi?id=303425">https://bugs.webkit.org/show_bug.cgi?id=303425</a>

Reviewed by Adrian Perez de Castro.

Canonical link: <a href="https://commits.webkit.org/303804@main">https://commits.webkit.org/303804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/713d957024ca5771a3693dcf720aa3170d6cd5b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141202 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136584 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83026 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5814 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38496 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28093 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116054 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34365 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69324 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->