### PR TITLE
Unreviewed, relanding "[JSC] Yarr ParenContext should be allocated from Stack"

### DIFF
--- a/JSTests/stress/regexp-paren-context-stack-exhaustion.js
+++ b/JSTests/stress/regexp-paren-context-stack-exhaustion.js
@@ -1,0 +1,58 @@
+//@ runDefault("--useConcurrentJIT=0")
+
+// Test for YarrJIT's allocateParenContext m_abortExecution path.
+// This path is taken when:
+// 1. Stack is exhausted due to repeatedly allocated ParenContext
+// 2. ParenContext is not freed before exhausting the stack
+//
+// ParenContext is allocated for quantified capturing groups. To exhaust
+// the stack without freeing, we create deeply nested quantified capturing
+// groups that all match, causing allocation of many ParenContexts on the
+// stack before any can be freed through backtracking.
+
+function createDeeplyNestedPattern(depth) {
+    let pattern = "a";
+    for (let i = 0; i < depth; i++) {
+        pattern = "(" + pattern + ")*";
+    }
+    return pattern;
+}
+
+function test(depth, inputLength) {
+    let pattern = createDeeplyNestedPattern(depth);
+    let input = "a".repeat(inputLength);
+    let regex = new RegExp(pattern);
+
+    // When stack is exhausted, the match should return null
+    // (the JIT aborts execution and falls back to interpreter,
+    // which may also fail or return null)
+    try {
+        let result = regex.exec(input);
+        // If we get here, the test didn't exhaust the stack
+        // Print for debugging but don't fail - stack limits vary by platform
+        if (result !== null) {
+            // print("Match succeeded (stack not exhausted): depth=" + depth + ", inputLength=" + inputLength);
+        }
+    } catch (e) {
+        // Some platforms might throw instead of returning null
+        // This is acceptable behavior for stack exhaustion
+        // print("Exception (expected for stack exhaustion): " + e);
+    }
+}
+
+// Test with deep nesting but very short input to avoid catastrophic backtracking
+// The key is to have many nested levels that each allocate a ParenContext,
+// but keep the input short enough to avoid exponential backtracking time
+
+// These should be fast (no backtracking explosion) but allocate many ParenContexts
+test(100, 1);
+test(200, 1);
+test(300, 1);
+test(500, 1);
+
+// With 2-character input, each level can match 0, 1, or 2 chars,
+// but with deep nesting this still triggers stack allocation
+test(100, 2);
+test(200, 2);
+
+// print("Test completed - stack exhaustion path exercised");

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1957,6 +1957,7 @@ if ARM64E
     jmp t5, YarrEntryPtrTag
     _vmEntryToYarrJITAfter:
 end
+    move cfr, sp
     functionEpilogue()
     ret
 

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -155,7 +155,7 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
     if (m_state == JITCode) {
         {
             ASSERT(m_regExpJITCode);
-            Yarr::MatchingContextHolder regExpContext(vm, m_regExpJITCode->usesPatternContextBuffer(), this, matchFrom);
+            Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
 
             if (s.is8Bit())
                 result = m_regExpJITCode->execute(s.span8(), startOffset, offsetVector, &regExpContext).start;
@@ -169,8 +169,7 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
             if (m_state == ParseError)
                 return throwError();
             {
-                constexpr bool usesPatternContextBuffer = false;
-                Yarr::MatchingContextHolder regExpContext(vm, usesPatternContextBuffer, this, matchFrom);
+                Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
                 result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
             }
         }
@@ -186,8 +185,7 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
     } else
 #endif
     {
-        constexpr bool usesPatternContextBuffer = false;
-        Yarr::MatchingContextHolder regExpContext(vm, usesPatternContextBuffer, this, matchFrom);
+        Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
         result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
     }
 
@@ -275,7 +273,7 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
         MatchResult result;
         {
             ASSERT(m_regExpJITCode);
-            Yarr::MatchingContextHolder regExpContext(vm, m_regExpJITCode->usesPatternContextBuffer(), this, matchFrom);
+            Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
 
             if (s.is8Bit())
                 result = m_regExpJITCode->execute(s.span8(), startOffset, &regExpContext);
@@ -303,8 +301,7 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
     nonReturnedOvector.grow(offsetVectorSize());
     offsetVector = nonReturnedOvector.mutableSpan().data();
     {
-        constexpr bool usesPatternContextBuffer = false;
-        Yarr::MatchingContextHolder regExpContext(vm, usesPatternContextBuffer, this, matchFrom);
+        Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
         result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
     }
 #if REGEXP_FUNC_TEST_DATA_GEN

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1170,26 +1170,6 @@ static void logSanitizeStack(VM& vm)
     }
 }
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-
-char* VM::acquireRegExpPatternContexBuffer()
-{
-    m_regExpPatternContextLock.lock();
-    ASSERT(m_regExpPatternContextLock.isLocked());
-    if (!m_regExpPatternContexBuffer)
-        m_regExpPatternContexBuffer = makeUniqueArray<char>(VM::patternContextBufferSize);
-    return m_regExpPatternContexBuffer.get();
-}
-
-void VM::releaseRegExpPatternContexBuffer()
-{
-    ASSERT(m_regExpPatternContextLock.isLocked());
-
-    m_regExpPatternContextLock.unlock();
-}
-
-#endif
-
 #if ENABLE(REGEXP_TRACING)
 
 void VM::addRegExpToTrace(RegExp* regExp)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -898,16 +898,6 @@ public:
     BumpPointerAllocator m_regExpAllocator;
     ConcurrentJSLock m_regExpAllocatorLock;
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-    static constexpr size_t patternContextBufferSize = 8192; // Space allocated to save nested parenthesis context
-    Lock m_regExpPatternContextLock;
-    UniqueArray<char> m_regExpPatternContexBuffer;
-    char* acquireRegExpPatternContexBuffer() WTF_ACQUIRES_LOCK(m_regExpPatternContextLock);
-    void releaseRegExpPatternContexBuffer() WTF_RELEASES_LOCK(m_regExpPatternContextLock);
-#else
-    static constexpr size_t patternContextBufferSize = 0; // Space allocated to save nested parenthesis context
-#endif
-
     const Ref<CompactTDZEnvironmentMap> m_compactVariableMap;
 
     LazyUniqueRef<VM, HasOwnPropertyCache> m_hasOwnPropertyCache;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -305,6 +305,9 @@ void BoyerMooreBitmap::dump(PrintStream& out) const
     out.print(m_map);
 }
 
+static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
+static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
+
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
 template<TryReadUnicodeCharGenFirstNonBMPOptimization useNonBMPOptimization>
 void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterID resultReg)
@@ -314,14 +317,6 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
     MacroAssembler::JumpList done;
 
     YarrJITDefaultRegisters regs;
-
-#if HAVE(YARR_SURROGATE_REGISTERS)
-    GPRReg surrogateTagMask = regs.surrogateTagMask;
-    GPRReg surrogatePairTags = regs.surrogatePairTags;
-#else
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
-    static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
-#endif
 
     if (resultReg != regs.regT0)
         jit.swap(regs.regT0, resultReg);
@@ -403,11 +398,6 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
     // regs.unicodeAndSubpatternIdTemp is used as a temporary.
     // The result is returned via regs.regT0.
 
-#if HAVE(YARR_SURROGATE_REGISTERS)
-    GPRReg surrogateTagMask = regs.surrogateTagMask;
-#else
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
-#endif
     auto resultReg = regs.regT0;
 
     // Check if we can read two UTF-16 characters at once.
@@ -623,57 +613,43 @@ class YarrGenerator final : public YarrJITInfo {
         }
     };
 
-    void initParenContextFreeList()
-    {
-        MacroAssembler::RegisterID parenContextPointer = m_regs.regT0;
-        MacroAssembler::RegisterID nextParenContextPointer = m_regs.regT2;
-
-        m_usesT2 = true;
-
-        size_t parenContextSize = ParenContext::sizeFor(m_parenContextSizes);
-
-        parenContextSize = WTF::roundUpToMultipleOf<sizeof(uintptr_t)>(parenContextSize);
-
-        if (parenContextSize > VM::patternContextBufferSize) {
-            m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
-            return;
-        }
-
-        m_jit.load32(MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfPatternContextBufferSize()), m_regs.freelistSizeRegister);
-        // Note that matchingContext and freelistRegister are likely the same register.
-        m_jit.loadPtr(MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfPatternContextBuffer()), m_regs.freelistRegister);
-        MacroAssembler::Jump emptyFreeList = m_jit.branchTestPtr(MacroAssembler::Zero, m_regs.freelistRegister);
-        m_jit.move(m_regs.freelistRegister, parenContextPointer);
-        m_jit.addPtr(MacroAssembler::TrustedImm32(parenContextSize), m_regs.freelistRegister, nextParenContextPointer);
-        m_jit.addPtr(m_regs.freelistRegister, m_regs.freelistSizeRegister);
-        m_jit.subPtr(MacroAssembler::TrustedImm32(parenContextSize), m_regs.freelistSizeRegister);
-
-        MacroAssembler::Label loopTop(&m_jit);
-        MacroAssembler::Jump initDone = m_jit.branchPtr(MacroAssembler::Above, nextParenContextPointer, m_regs.freelistSizeRegister);
-        m_jit.storePtr(nextParenContextPointer, MacroAssembler::Address(parenContextPointer, ParenContext::nextOffset()));
-        m_jit.move(nextParenContextPointer, parenContextPointer);
-        m_jit.addPtr(MacroAssembler::TrustedImm32(parenContextSize), parenContextPointer, nextParenContextPointer);
-        m_jit.jump(loopTop);
-
-        initDone.link(&m_jit);
-        m_jit.storePtr(MacroAssembler::TrustedImmPtr(nullptr), MacroAssembler::Address(parenContextPointer, ParenContext::nextOffset()));
-        emptyFreeList.link(&m_jit);
-    }
-
     void allocateParenContext(MacroAssembler::RegisterID result)
     {
-        m_abortExecution.append(m_jit.branchTestPtr(MacroAssembler::Zero, m_regs.freelistRegister));
-        m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.remainingMatchCount);
-        m_hitMatchLimit.append(m_jit.branchTestPtr(MacroAssembler::Zero, m_regs.remainingMatchCount));
-        m_jit.move(m_regs.freelistRegister, result);
-        m_jit.loadPtr(MacroAssembler::Address(m_regs.freelistRegister, ParenContext::nextOffset()), m_regs.freelistRegister);
+        m_hitMatchLimit.append(m_jit.branchSub32(MacroAssembler::Zero, MacroAssembler::TrustedImm32(1), m_regs.remainingMatchCount));
+
+        // Try to allocate from freelist first.
+        MacroAssembler::Jump allocateFromStack;
+        if (m_regs.freelistRegister != InvalidGPRReg) {
+            allocateFromStack = m_jit.branchTestPtr(MacroAssembler::Zero, m_regs.freelistRegister);
+            m_jit.move(m_regs.freelistRegister, result);
+            m_jit.loadPtr(MacroAssembler::Address(m_regs.freelistRegister, ParenContext::nextOffset()), m_regs.freelistRegister);
+        } else {
+            m_jit.loadPtr(MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()), result);
+            allocateFromStack = m_jit.branchTestPtr(MacroAssembler::Zero, result);
+            m_jit.transferPtr(MacroAssembler::Address(result, ParenContext::nextOffset()), MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()));
+        }
+        auto done = m_jit.jump();
+
+        // Freelist is null, allocate from stack.
+        allocateFromStack.link(&m_jit);
+        size_t parenContextSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(ParenContext::sizeFor(m_parenContextSizes));
+        m_jit.subPtr(MacroAssembler::stackPointerRegister, MacroAssembler::TrustedImm32(static_cast<int32_t>(parenContextSize)), result);
+
+        m_abortExecution.append(m_jit.branchPtr(MacroAssembler::Above, MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfStackLimit()), result));
+        m_jit.move(result, MacroAssembler::stackPointerRegister);
+
+        done.link(&m_jit);
     }
 
-    void freeParenContext(MacroAssembler::RegisterID headPtrRegister, MacroAssembler::RegisterID newHeadPtrRegister)
+    void freeParenContext(MacroAssembler::RegisterID headPtrRegister)
     {
-        m_jit.loadPtr(MacroAssembler::Address(headPtrRegister, ParenContext::nextOffset()), newHeadPtrRegister);
-        m_jit.storePtr(m_regs.freelistRegister, MacroAssembler::Address(headPtrRegister, ParenContext::nextOffset()));
-        m_jit.move(headPtrRegister, m_regs.freelistRegister);
+        if (m_regs.freelistRegister != InvalidGPRReg) {
+            m_jit.storePtr(m_regs.freelistRegister, MacroAssembler::Address(headPtrRegister, ParenContext::nextOffset()));
+            m_jit.move(headPtrRegister, m_regs.freelistRegister);
+        } else {
+            m_jit.transferPtr(MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()), MacroAssembler::Address(headPtrRegister, ParenContext::nextOffset()));
+            m_jit.storePtr(headPtrRegister, MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()));
+        }
     }
 
     void storeBeginAndMatchAmountToParenContext(MacroAssembler::RegisterID beginGPR, MacroAssembler::RegisterID matchAmountGPR, MacroAssembler::RegisterID parenContextGPR)
@@ -1223,52 +1199,51 @@ class YarrGenerator final : public YarrJITInfo {
 
     void storeToFrame(MacroAssembler::RegisterID reg, unsigned frameLocation)
     {
-        m_jit.poke(reg, frameLocation);
+        m_jit.storePtr(reg, frameAddress().withOffset(frameLocation * sizeof(void*)));
     }
 
     void storeToFrame(MacroAssembler::TrustedImm32 imm, unsigned frameLocation)
     {
-        m_jit.poke(imm, frameLocation);
+        m_jit.storePtr(imm, frameAddress().withOffset(frameLocation * sizeof(void*)));
     }
 
 #if CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)
     void storeToFrame(MacroAssembler::TrustedImmPtr imm, unsigned frameLocation)
     {
-        m_jit.poke(imm, frameLocation);
+        m_jit.storePtr(imm, frameAddress().withOffset(frameLocation * sizeof(void*)));
     }
 #endif
 
     MacroAssembler::DataLabelPtr storeToFrameWithPatch(unsigned frameLocation)
     {
-        return m_jit.storePtrWithPatch(MacroAssembler::TrustedImmPtr(nullptr), MacroAssembler::Address(MacroAssembler::stackPointerRegister, frameLocation * sizeof(void*)));
+        return m_jit.storePtrWithPatch(MacroAssembler::TrustedImmPtr(nullptr), frameAddress().withOffset(frameLocation * sizeof(void*)));
     }
 
     void loadFromFrame(unsigned frameLocation, MacroAssembler::RegisterID reg)
     {
-        m_jit.peek(reg, frameLocation);
+        m_jit.loadPtr(frameAddress().withOffset(frameLocation * sizeof(void*)), reg);
     }
 
     void loadFromFrameAndJump(unsigned frameLocation)
     {
-        m_jit.farJump(MacroAssembler::Address(MacroAssembler::stackPointerRegister, frameLocation * sizeof(void*)), YarrBacktrackPtrTag);
+        m_jit.farJump(frameAddress().withOffset(frameLocation * sizeof(void*)), YarrBacktrackPtrTag);
     }
 
-    unsigned alignCallFrameSizeInBytes(unsigned callFrameSize)
+    CCallHelpers::Address frameAddress()
     {
+        size_t stackSizeForCalleeSaves = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(m_calleeSaves.registerCount() * sizeof(UCPURegister));
+        return CCallHelpers::Address(GPRInfo::callFrameRegister, -(stackSizeForCalleeSaves + m_callFrameSizeInBytes));
+    }
+
+    static unsigned alignCallFrameSizeInBytes(unsigned originalCallFrameSize)
+    {
+        unsigned callFrameSize = originalCallFrameSize;
         if (!callFrameSize)
             return 0;
 
         callFrameSize *= sizeof(void*);
-        if (callFrameSize / sizeof(void*) != m_pattern.m_body->m_callFrameSize)
-            CRASH();
-        callFrameSize = (callFrameSize + 0x3f) & ~0x3f;
-        return callFrameSize;
-    }
-    void removeCallFrame()
-    {
-        unsigned callFrameSizeInBytes = alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize);
-        if (callFrameSizeInBytes)
-            m_jit.addPtr(MacroAssembler::Imm32(callFrameSizeInBytes), MacroAssembler::stackPointerRegister);
+        RELEASE_ASSERT(callFrameSize / sizeof(void*) == originalCallFrameSize);
+        return WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callFrameSize);
     }
 
     void generateFailReturn()
@@ -1304,7 +1279,6 @@ class YarrGenerator final : public YarrJITInfo {
         }
 
         finishExiting.link(&m_jit);
-        removeCallFrame();
         m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.returnRegister2);
         generateReturn();
     }
@@ -1883,6 +1857,7 @@ class YarrGenerator final : public YarrJITInfo {
         const MacroAssembler::RegisterID characterOrTemp = m_regs.regT0;
         const MacroAssembler::RegisterID patternTemp = m_regs.regT1;
         const MacroAssembler::RegisterID patternIndex = m_regs.regT2;
+        m_usesT2 = true;
 
         MacroAssembler::RegisterID subpatternIdReg = InvalidGPRReg;
 
@@ -3325,9 +3300,6 @@ class YarrGenerator final : public YarrJITInfo {
                     termMatchTargets.takeLast();
 
                 // If we get here, the prior alternative matched - return success.
-                
-                // Adjust the stack pointer to remove the pattern's frame.
-                removeCallFrame();
 
                 // Load appropriate values into the return register and the first output
                 // slot, and return. In the case of pattern with a fixed size, we will
@@ -3446,7 +3418,7 @@ class YarrGenerator final : public YarrJITInfo {
                 if (term->quantityType != QuantifierType::FixedCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
                     // If the previous alternative matched without consuming characters then
                     // backtrack to try to match while consumming some input.
-                    op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Address(MacroAssembler::stackPointerRegister, term->frameLocation * sizeof(void*)));
+                    op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*)));
                 }
 
                 if (op.m_op != YarrOpCode::StringListAlternativeNext) {
@@ -3499,7 +3471,7 @@ class YarrGenerator final : public YarrJITInfo {
                 if (term->quantityType != QuantifierType::FixedCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
                     // If the previous alternative matched without consuming characters then
                     // backtrack to try to match while consumming some input.
-                    op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Address(MacroAssembler::stackPointerRegister, term->frameLocation * sizeof(void*)));
+                    op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*)));
                 }
 
                 // If this set of alternatives contains more than one alternative,
@@ -3575,7 +3547,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=200786> Add ability for the YARR JIT to properly
                 // handle nested expressions that can match without consuming characters
                 if (term->quantityType != QuantifierType::FixedCount && !term->parentheses.disjunction->m_minimumSize)
-                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Address(MacroAssembler::stackPointerRegister, term->frameLocation * sizeof(void*))));
+                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*))));
 
                 // If the parenthese are capturing, store the ending index value to the
                 // captures array, offsetting as necessary.
@@ -3638,7 +3610,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=200786> Add ability for the YARR JIT to properly
                 // handle nested expressions that can match without consuming characters
                 if (term->quantityType != QuantifierType::FixedCount && !term->parentheses.disjunction->m_minimumSize)
-                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Address(MacroAssembler::stackPointerRegister, term->frameLocation * sizeof(void*))));
+                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*))));
 
                 // We know that the match is non-zero, we can accept it and
                 // loop back up to the head of the subpattern.
@@ -3689,7 +3661,7 @@ class YarrGenerator final : public YarrJITInfo {
 
                     loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), currParenContextReg);
                     allocateParenContext(newParenContextReg);
-                    m_jit.storePtr(currParenContextReg, MacroAssembler::Address(newParenContextReg));
+                    m_jit.storePtr(currParenContextReg, MacroAssembler::Address(newParenContextReg, ParenContext::nextOffset()));
                     storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
                     saveParenContext(newParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
                     storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
@@ -3728,7 +3700,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=200786> Add ability for the YARR JIT to properly
                 // handle nested expressions that can match without consuming characters
                 if (term->quantityType != QuantifierType::FixedCount && !term->parentheses.disjunction->m_minimumSize)
-                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Address(MacroAssembler::stackPointerRegister, parenthesesFrameLocation * sizeof(void*))));
+                    m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(parenthesesFrameLocation * sizeof(void*))));
 
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT1;
 
@@ -3819,7 +3791,6 @@ class YarrGenerator final : public YarrJITInfo {
             }
 
             case YarrOpCode::MatchFailed:
-                removeCallFrame();
                 generateFailReturn();
                 break;
             }
@@ -4085,7 +4056,6 @@ class YarrGenerator final : public YarrJITInfo {
                 }
 
                 lastStickyAlternativeFailures.link(&m_jit);
-                removeCallFrame();
                 generateFailReturn();
                 break;
             }
@@ -4298,7 +4268,7 @@ class YarrGenerator final : public YarrJITInfo {
                     // are currently in a state where we had skipped over the subpattern
                     // (in which case the flag value on the stack will be -1).
                     unsigned parenthesesFrameLocation = term->frameLocation;
-                    MacroAssembler::Jump hadSkipped = m_jit.branch32(MacroAssembler::Equal, MacroAssembler::Address(MacroAssembler::stackPointerRegister, (parenthesesFrameLocation + BackTrackInfoParenthesesOnce::beginIndex()) * sizeof(void*)), MacroAssembler::TrustedImm32(-1));
+                    MacroAssembler::Jump hadSkipped = m_jit.branch32(MacroAssembler::Equal, frameAddress().withOffset((parenthesesFrameLocation + BackTrackInfoParenthesesOnce::beginIndex()) * sizeof(void*)), MacroAssembler::TrustedImm32(-1));
 
                     if (term->quantityType == QuantifierType::Greedy) {
                         // For Greedy parentheses, we skip after having already tried going
@@ -4362,7 +4332,7 @@ class YarrGenerator final : public YarrJITInfo {
                 PatternTerm* term = op.m_term;
                 unsigned parenthesesFrameLocation = term->frameLocation;
 
-                if (term->quantityType != QuantifierType::FixedCount) {
+                if (term->quantityType == QuantifierType::Greedy || term->quantityType == QuantifierType::NonGreedy) {
                     m_backtrackingState.link(&m_jit);
 
                     MacroAssembler::RegisterID currParenContextReg = m_regs.regT0;
@@ -4371,8 +4341,9 @@ class YarrGenerator final : public YarrJITInfo {
                     loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), currParenContextReg);
                     
                     restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
-                    
-                    freeParenContext(currParenContextReg, newParenContextReg);
+
+                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
+                    freeParenContext(currParenContextReg);
                     storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
 
                     const MacroAssembler::RegisterID countTemporary = m_regs.regT0;
@@ -4419,7 +4390,7 @@ class YarrGenerator final : public YarrJITInfo {
                         // Check whether we should backtrack back into the parentheses, or if we
                         // are currently in a state where we had skipped over the subpattern
                         // (in which case the flag value on the stack will be -1).
-                        MacroAssembler::Jump hadSkipped = m_jit.branch32(MacroAssembler::Equal, MacroAssembler::Address(MacroAssembler::stackPointerRegister, (parenthesesFrameLocation  + BackTrackInfoParentheses::beginIndex()) * sizeof(void*)), MacroAssembler::TrustedImm32(-1));
+                        MacroAssembler::Jump hadSkipped = m_jit.branch32(MacroAssembler::Equal, frameAddress().withOffset((parenthesesFrameLocation  + BackTrackInfoParentheses::beginIndex()) * sizeof(void*)), MacroAssembler::TrustedImm32(-1));
 
                         // For Greedy parentheses, we skip after having already tried going
                         // through the subpattern, so if we get here we're done.
@@ -5064,64 +5035,58 @@ class YarrGenerator final : public YarrJITInfo {
         return pointer;
     }
 
+    RegisterSet calleeSaveRegisters()
+    {
+        RegisterSet registers;
+#if CPU(X86_64)
+        if (m_pattern.m_saveInitialStartValue)
+            registers.add(X86Registers::ebx, IgnoreVectors);
+
+        if (m_containsNestedSubpatterns)
+            registers.add(X86Registers::r12, IgnoreVectors);
+
+        if (mayCall()) {
+            registers.add(X86Registers::r13, IgnoreVectors);
+            registers.add(X86Registers::r14, IgnoreVectors);
+            registers.add(X86Registers::r15, IgnoreVectors);
+        } else if (m_pattern.hasDuplicateNamedCaptureGroups())
+            registers.add(X86Registers::r14, IgnoreVectors);
+#elif CPU(ARM64)
+#elif CPU(ARM_THUMB2)
+        registers.add(ARMRegisters::r4, IgnoreVectors);
+        registers.add(ARMRegisters::r5, IgnoreVectors);
+        registers.add(ARMRegisters::r6, IgnoreVectors);
+        registers.add(ARMRegisters::r8, IgnoreVectors);
+        registers.add(ARMRegisters::r10, IgnoreVectors);
+#elif CPU(RISCV64)
+#endif
+        return registers;
+    }
+
     void generateEnter()
     {
-        auto pushInEnter = [&](GPRReg gpr) {
-            m_jit.push(gpr);
-            m_pushCountInEnter += 1;
-        };
-
-        auto pushPairInEnter = [&](GPRReg gpr1, GPRReg gpr2) {
-            m_jit.pushPair(gpr1, gpr2);
-            m_pushCountInEnter += 2;
-        };
-
-#if CPU(X86_64)
-        UNUSED_VARIABLE(pushPairInEnter);
+#if CPU(X86_64) || CPU(ARM_THUMB2) || CPU(RISCV64)
         m_jit.emitFunctionPrologue();
-
-        if (m_pattern.m_saveInitialStartValue)
-            pushInEnter(X86Registers::ebx);
-
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns) {
-            pushInEnter(X86Registers::r12);
-        }
-#endif
-
-        if (mayCall()) {
-            pushInEnter(X86Registers::r13);
-            pushInEnter(X86Registers::r14);
-            pushInEnter(X86Registers::r15);
-        } else if (m_pattern.hasDuplicateNamedCaptureGroups())
-            pushInEnter(X86Registers::r14);
-
 #elif CPU(ARM64)
-        UNUSED_VARIABLE(pushInEnter);
-        if (!Options::useJITCage())
-            m_jit.tagReturnAddress();
-        if (mayCall()) {
-            if (!Options::useJITCage())
-                pushPairInEnter(MacroAssembler::framePointerRegister, MacroAssembler::linkRegister);
-
-            m_jit.move(MacroAssembler::TrustedImm32(0xdc00dc00), m_regs.surrogateTagMask);
-            m_jit.move(MacroAssembler::TrustedImm32(0xdc00d800), m_regs.surrogatePairTags);
+        // JITCage code is doing prologue and epilogue in thunk.
+        if (!Options::useJITCage()) {
+            if (mayCall() || m_containsNestedSubpatterns)
+                m_jit.emitFunctionPrologue();
+            else
+                m_jit.tagReturnAddress();
         }
-#elif CPU(ARM_THUMB2)
-        UNUSED_VARIABLE(pushPairInEnter);
-        pushInEnter(ARMRegisters::r4);
-        pushInEnter(ARMRegisters::r5);
-        pushInEnter(ARMRegisters::r6);
-        pushInEnter(ARMRegisters::r8);
-        pushInEnter(ARMRegisters::r10);
-#elif CPU(RISCV64)
-        UNUSED_VARIABLE(pushInEnter);
-        if (mayCall())
-            pushPairInEnter(MacroAssembler::framePointerRegister, MacroAssembler::linkRegister);
-#else
-        UNUSED_VARIABLE(pushInEnter);
-        UNUSED_VARIABLE(pushPairInEnter);
 #endif
+
+        if (m_calleeSaves.registerCount()) {
+            size_t stackSizeForCalleeSaves = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(m_calleeSaves.registerCount() * sizeof(UCPURegister));
+#if CPU(X86_64) || CPU(ARM64)
+            m_jit.subPtr(GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(stackSizeForCalleeSaves), MacroAssembler::stackPointerRegister);
+#else
+            m_jit.subPtr(GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(stackSizeForCalleeSaves), m_regs.regT0);
+            m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
+#endif
+            m_jit.emitSaveCalleeSavesFor(&m_calleeSaves);
+        }
     }
 
     void generateReturn()
@@ -5133,37 +5098,15 @@ class YarrGenerator final : public YarrJITInfo {
         }
 #endif
 
-#if CPU(X86_64)
-        if (mayCall()) {
-            m_jit.pop(X86Registers::r15);
-            m_jit.pop(X86Registers::r14);
-            m_jit.pop(X86Registers::r13);
-        } else if (m_pattern.hasDuplicateNamedCaptureGroups())
-            m_jit.pop(X86Registers::r14);
-
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns) {
-            m_jit.pop(X86Registers::r12);
-        }
-#endif
-
-        if (m_pattern.m_saveInitialStartValue)
-            m_jit.pop(X86Registers::ebx);
+        m_jit.emitRestoreCalleeSavesFor(&m_calleeSaves);
+#if CPU(X86_64) || CPU(ARM_THUMB2) || CPU(RISCV64)
         m_jit.emitFunctionEpilogue();
 #elif CPU(ARM64)
-        if (mayCall()) {
-            if (!Options::useJITCage())
-                m_jit.popPair(MacroAssembler::framePointerRegister, MacroAssembler::linkRegister);
+        // JITCage code is doing prologue and epilogue in thunk.
+        if (!Options::useJITCage()) {
+            if (mayCall() || m_containsNestedSubpatterns)
+                m_jit.emitFunctionEpilogue();
         }
-#elif CPU(ARM_THUMB2)
-        m_jit.pop(ARMRegisters::r10);
-        m_jit.pop(ARMRegisters::r8);
-        m_jit.pop(ARMRegisters::r6);
-        m_jit.pop(ARMRegisters::r5);
-        m_jit.pop(ARMRegisters::r4);
-#elif CPU(RISCV64)
-        if (mayCall())
-            m_jit.popPair(MacroAssembler::framePointerRegister, MacroAssembler::linkRegister);
 #endif
 
 #if CPU(ARM64E)
@@ -5212,6 +5155,7 @@ public:
         , m_decodeSurrogatePairs(m_charSize == CharSize::Char16 && m_pattern.eitherUnicode())
         , m_unicodeIgnoreCase(m_pattern.eitherUnicode() && m_pattern.ignoreCase())
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && m_pattern.ignoreCase())
+        , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         , m_parenContextSizes(compileMode == JITCompileMode::IncludeSubpatterns ? m_pattern.m_numSubpatterns : 0, compileMode == JITCompileMode::IncludeSubpatterns ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
@@ -5234,6 +5178,7 @@ public:
         , m_decodeSurrogatePairs(m_charSize == CharSize::Char16 && m_pattern.eitherUnicode())
         , m_unicodeIgnoreCase(m_pattern.eitherUnicode() && m_pattern.ignoreCase())
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && m_pattern.ignoreCase())
+        , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
         , m_parenContextSizes(compileMode == JITCompileMode::IncludeSubpatterns ? m_pattern.m_numSubpatterns : 0, compileMode == JITCompileMode::IncludeSubpatterns ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
@@ -5303,7 +5248,7 @@ public:
         // We need to compile before generating code since we set flags based on compilation that
         // are used during generation.
         opCompileBody(m_pattern.m_body);
-        
+
         if (m_failureReason) {
             codeBlock.setFallBackWithFailureReason(*m_failureReason);
             return;
@@ -5315,10 +5260,7 @@ public:
         if (m_disassembler)
             m_disassembler->setStartOfCode(m_jit.label());
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns)
-            codeBlock.setUsesPatternContextBuffer();
-#endif
+        m_calleeSaves = RegisterAtOffsetList(calleeSaveRegisters());
 
         generateEnter();
 
@@ -5328,10 +5270,9 @@ public:
         generateFailReturn();
         hasInput.link(&m_jit);
 
-        unsigned callFrameSizeInBytes = alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize);
-        if (callFrameSizeInBytes) {
+        if (m_callFrameSizeInBytes) {
             // Check stack size
-            m_jit.addPtr(MacroAssembler::TrustedImm32(-callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
+            m_jit.addPtr(MacroAssembler::TrustedImm32(-m_callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
 
             // Make sure that the JITed functions have 5 parameters and that the 5th argument is a MatchingContextHolder*
             functionChecks<YarrCodeBlock::YarrJITCode8>();
@@ -5341,12 +5282,8 @@ public:
 #if CPU(ARM_THUMB2)
             // Not enough argument registers: try to load the 5th argument from the stack
             MacroAssembler::RegisterID matchingContext = m_regs.regT1;
-
-            // The argument will be in an offset that depends on the arch and the number of registers we pushed into the stack
-            // POKE_ARGUMENT_OFFSET: MIPS reserves space in the stack for all arguments, so we add +4 offset
-            // m_pushCountInEnter: number of registers pushed into the stack (see generateEnter())
-            unsigned offset = POKE_ARGUMENT_OFFSET + m_pushCountInEnter;
-            m_jit.loadPtr(MacroAssembler::Address(MacroAssembler::stackPointerRegister, offset * sizeof(void*)), matchingContext);
+            unsigned offset = POKE_ARGUMENT_OFFSET;
+            m_jit.loadPtr(MacroAssembler::Address(GPRInfo::callFrameRegister, offset * sizeof(void*)), matchingContext);
 #else
             MacroAssembler::RegisterID matchingContext = m_regs.matchingContext;
 #endif
@@ -5367,8 +5304,16 @@ public:
 #endif
 
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns)
+        if (m_containsNestedSubpatterns) {
             m_jit.move(MacroAssembler::TrustedImm32(matchLimit), m_regs.remainingMatchCount);
+
+            // Initialize freelist to null - contexts will be allocated from stack
+            // and freed contexts will be added to the freelist for reuse
+            if (m_regs.freelistRegister != InvalidGPRReg)
+                m_jit.move(MacroAssembler::TrustedImmPtr(nullptr), m_regs.freelistRegister);
+            else
+                m_jit.storePtr(MacroAssembler::TrustedImmPtr(nullptr), MacroAssembler::Address(m_regs.matchingContext, MatchingContextHolder::offsetOfFreeList()));
+        }
 #endif
 
         // Initialize subpatterns' starts. And initialize matchStart if `!m_pattern.m_body->m_hasFixedSize`.
@@ -5389,16 +5334,6 @@ public:
                 setMatchStart(m_regs.index);
         }
 
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns) {
-            initParenContextFreeList();
-            if (m_failureReason) {
-                codeBlock.setFallBackWithFailureReason(*m_failureReason);
-                return;
-            }
-        }
-#endif
-        
         if (m_pattern.m_saveInitialStartValue)
             m_jit.move(m_regs.index, m_regs.initialStart);
 
@@ -5410,13 +5345,28 @@ public:
             m_disassembler->setEndOfBacktrack(m_jit.label());
 
         ptrdiff_t codeSize = MacroAssembler::differenceBetween(startOfMainCode, m_jit.label());
-        bool canInline = m_compileMode != JITCompileMode::IncludeSubpatterns
-            && !m_pattern.global() && !m_pattern.sticky() && !m_pattern.eitherUnicode()
+        bool canInline = ([&] -> bool {
+            if (m_compileMode == JITCompileMode::IncludeSubpatterns)
+                return false;
+            if (m_pattern.global())
+                return false;
+            if (m_pattern.sticky())
+                return false;
+            if (m_pattern.eitherUnicode())
+                return false;
+            if (mayCall())
+                return false;
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-            && !m_containsNestedSubpatterns
+            if (m_containsNestedSubpatterns)
+                return false;
 #endif
-            && !m_pattern.m_containsBackreferences
-            && !m_pattern.m_saveInitialStartValue;
+            if (m_pattern.m_containsBackreferences)
+                return false;
+            if (m_pattern.m_saveInitialStartValue)
+                return false;
+
+            return true;
+        }());
 
         generateJITFailReturn();
 
@@ -5446,10 +5396,10 @@ public:
         if (m_compileMode == JITCompileMode::MatchOnly) {
             if (m_charSize == CharSize::Char8) {
                 codeBlock.set8BitCodeMatchOnly(FINALIZE_REGEXP_CODE(linkBuffer, YarrMatchOnly8BitPtrTag, nullptr, "Match-only 8-bit regular expression"), WTFMove(m_bmMaps));
-                codeBlock.set8BitInlineStats(codeSize, callFrameSizeInBytes, canInline, m_usesT2);
+                codeBlock.set8BitInlineStats(codeSize, m_callFrameSizeInBytes, canInline, m_usesT2);
             } else {
                 codeBlock.set16BitCodeMatchOnly(FINALIZE_REGEXP_CODE(linkBuffer, YarrMatchOnly16BitPtrTag, nullptr, "Match-only 16-bit regular expression"), WTFMove(m_bmMaps));
-                codeBlock.set16BitInlineStats(codeSize, callFrameSizeInBytes, canInline, m_usesT2);
+                codeBlock.set16BitInlineStats(codeSize, m_callFrameSizeInBytes, canInline, m_usesT2);
             }
         } else {
             if (m_charSize == CharSize::Char8)
@@ -5470,7 +5420,7 @@ public:
         // are used during generation.
         opCompileBody(m_pattern.m_body);
 
-#ifndef JIT_UNICODE_EXPRESSIONS
+#if !ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         RELEASE_ASSERT(!m_decodeSurrogatePairs);
 #endif
 
@@ -5497,11 +5447,10 @@ public:
         generateFailReturn();
         hasInput.link(&m_jit);
 
-        unsigned callFrameSizeInBytes = alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize);
-        if (callFrameSizeInBytes) {
+        if (m_callFrameSizeInBytes) {
             // Create space on stack for matching context data.
             // Note that this stack check cannot clobber m_regs.regT1 as it is needed for the slow path we call if we fail the stack check.
-            m_jit.addPtr(MacroAssembler::TrustedImm32(-callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
+            m_jit.addPtr(MacroAssembler::TrustedImm32(-m_callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
             MacroAssembler::Jump stackOk = m_jit.branchPtr(MacroAssembler::LessThanOrEqual, MacroAssembler::AbsoluteAddress(const_cast<VM*>(m_vm)->addressOfSoftStackLimit()), m_regs.regT0);
 
             // Exceeded stack limit, punt to the interpreter.
@@ -5513,14 +5462,9 @@ public:
             m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
         }
 
-#ifdef JIT_UNICODE_EXPRESSIONS
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         if (m_decodeSurrogatePairs)
             m_jit.getEffectiveAddress(MacroAssembler::BaseIndex(m_regs.input, m_regs.length, MacroAssembler::TimesTwo), m_regs.endOfStringAddress);
-#endif
-
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        if (m_containsNestedSubpatterns)
-            m_jit.move(MacroAssembler::TrustedImm32(matchLimit), m_regs.remainingMatchCount);
 #endif
 
         if (m_compileMode == JITCompileMode::IncludeSubpatterns) {
@@ -5782,7 +5726,7 @@ public:
 
     bool mayCall() const
     {
-        return m_decodeSurrogatePairs || m_decode16BitForBackreferencesWithCalls;
+        return m_decodeSurrogatePairs || m_decode16BitForBackreferencesWithCalls || m_callFrameSizeInBytes;
     }
 
 private:
@@ -5807,7 +5751,8 @@ private:
     const bool m_unicodeIgnoreCase : 1;
     const bool m_decode16BitForBackreferencesWithCalls : 1;
 
-    bool m_usesT2 { false };
+    bool m_usesT2 : 1 { false };
+    unsigned m_callFrameSizeInBytes;
     const CanonicalMode m_canonicalMode;
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
     bool m_containsNestedSubpatterns { false };
@@ -5816,6 +5761,7 @@ private:
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
     bool m_useFirstNonBMPCharacterOptimization { false };
 #endif
+    RegisterAtOffsetList m_calleeSaves;
     MacroAssembler::JumpList m_abortExecution;
     MacroAssembler::JumpList m_hitMatchLimit;
     MacroAssembler::Label m_tryReadUnicodeCharacterEntry;
@@ -5831,12 +5777,6 @@ private:
     BacktrackingState m_backtrackingState;
     
     std::unique_ptr<YarrDisassembler> m_disassembler;
-
-    // Member is used to count the number of GPR pushed into the stack when
-    // entering JITed code. It is used to figure out if an function argument
-    // offset in the stack if there wasn't enough registers to pass it, e.g.,
-    // ARMv7 and MIPS only use 4 registers to pass function arguments.
-    unsigned m_pushCountInEnter { 0 };
 
     std::optional<StringView> m_sampleString;
     SubjectSampler m_sampler;

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -314,11 +314,6 @@ public:
         saveMaps(WTFMove(maps));
     }
 
-    bool usesPatternContextBuffer() { return m_usesPatternContextBuffer; }
-#if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-    void setUsesPatternContextBuffer() { m_usesPatternContextBuffer = true; }
-#endif
-
     void set8BitInlineStats(unsigned insnCount, unsigned stackSize, bool canInline, bool needsT2)
     {
         m_matchOnly8Stats.set(insnCount, stackSize, canInline, needsT2);
@@ -432,7 +427,6 @@ private:
     InlineStats m_matchOnly16Stats;
     RegExp* m_regExp { nullptr };
 
-    bool m_usesPatternContextBuffer { false };
     std::optional<JITFailureReason> m_failureReason;
 };
 

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -63,8 +63,7 @@ public:
     static constexpr GPRReg length = ARM64Registers::x2;
     static constexpr GPRReg output = ARM64Registers::x3;
     static constexpr GPRReg matchingContext = ARM64Registers::x4;
-    static constexpr GPRReg freelistRegister = ARM64Registers::x4; // Loaded from the MatchingContextHolder in the prologue.
-    static constexpr GPRReg freelistSizeRegister = ARM64Registers::x5; // Only used during initialization.
+    static constexpr GPRReg freelistRegister = ARM64Registers::x13;
 
     // Scratch registers
     static constexpr GPRReg regT0 = ARM64Registers::x6;
@@ -75,15 +74,7 @@ public:
     static constexpr GPRReg unicodeAndSubpatternIdTemp = ARM64Registers::x5;
     static constexpr GPRReg initialStart = ARM64Registers::x11;
 
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
     static constexpr GPRReg firstCharacterAdditionalReadSize { ARM64Registers::x12 };
-#else
-    static constexpr GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
-#endif
-
-#define HAVE_YARR_SURROGATE_REGISTERS 1
-    static constexpr GPRReg surrogateTagMask = ARM64Registers::x13;
-    static constexpr GPRReg surrogatePairTags = ARM64Registers::x14;
     static constexpr GPRReg endOfStringAddress = ARM64Registers::x15;
 
     static constexpr GPRReg returnRegister = ARM64Registers::x0;
@@ -95,8 +86,7 @@ public:
     static constexpr GPRReg length = X86Registers::edx;
     static constexpr GPRReg output = X86Registers::ecx;
     static constexpr GPRReg matchingContext = X86Registers::r8;
-    static constexpr GPRReg freelistRegister = X86Registers::r8; // Loaded from the MatchingContextHolder in the prologue.
-    static constexpr GPRReg freelistSizeRegister = X86Registers::r9; // Only used during initialization.
+    static constexpr GPRReg freelistRegister = InvalidGPRReg;
 
     // Scratch registers
     static constexpr GPRReg regT0 = X86Registers::eax;
@@ -111,9 +101,6 @@ public:
 
     static constexpr GPRReg returnRegister = X86Registers::eax;
     static constexpr GPRReg returnRegister2 = X86Registers::edx;
-
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
-    static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 #elif CPU(RISCV64)
     // Argument registers
     static constexpr GPRReg input = RISCV64Registers::x10;
@@ -121,8 +108,7 @@ public:
     static constexpr GPRReg length = RISCV64Registers::x12;
     static constexpr GPRReg output = RISCV64Registers::x13;
     static constexpr GPRReg matchingContext = RISCV64Registers::x14;
-    static constexpr GPRReg freelistRegister = RISCV64Registers::x14; // Loaded from the MatchingContextHolder in the prologue.
-    static constexpr GPRReg freelistSizeRegister = RISCV64Registers::x15; // Only used during initialization.
+    static constexpr GPRReg freelistRegister = InvalidGPRReg;
 
     // Scratch registers
     static constexpr GPRReg regT0 = RISCV64Registers::x16;
@@ -136,9 +122,6 @@ public:
 
     static constexpr GPRReg returnRegister = RISCV64Registers::x10;
     static constexpr GPRReg returnRegister2 = RISCV64Registers::x11;
-
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
-    static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 #endif
 };
 
@@ -175,7 +158,6 @@ public:
 
     GPRReg matchingContext { InvalidGPRReg };
     GPRReg freelistRegister { InvalidGPRReg };
-    GPRReg freelistSizeRegister { InvalidGPRReg };
 
     GPRReg returnRegister { InvalidGPRReg };
     GPRReg returnRegister2 { InvalidGPRReg };


### PR DESCRIPTION
#### 879906c7a7715e3ae6d853be8baa7bd04c7b01bb
<pre>
Unreviewed, relanding &quot;[JSC] Yarr ParenContext should be allocated from Stack&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=303427">https://bugs.webkit.org/show_bug.cgi?id=303427</a>
<a href="https://rdar.apple.com/165723642">rdar://165723642</a>

Relanding the change with a bug fix on iOS (JITCage) environment.
The change is that LowLevelInterpreter.asm&apos;s `move cfr, sp` is necessary.

* JSTests/stress/regexp-paren-context-stack-exhaustion.js: Added.
(createDeeplyNestedPattern):
(test):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::acquireRegExpPatternContexBuffer): Deleted.
(JSC::VM::releaseRegExpPatternContexBuffer): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharImpl):
(JSC::Yarr::tryReadUnicodeCharSlowImpl):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:
* Source/JavaScriptCore/yarr/YarrMatchingContextHolder.h:
(JSC::Yarr::MatchingContextHolder::offsetOfFreeList):
(JSC::Yarr::MatchingContextHolder::stackLimit const):
(JSC::Yarr::MatchingContextHolder::freeList const):
(JSC::Yarr::MatchingContextHolder::MatchingContextHolder):
(JSC::Yarr::MatchingContextHolder::~MatchingContextHolder):
(JSC::Yarr::MatchingContextHolder::offsetOfPatternContextBuffer): Deleted.
(JSC::Yarr::MatchingContextHolder::offsetOfPatternContextBufferSize): Deleted.

Canonical link: <a href="https://commits.webkit.org/303796@main">https://commits.webkit.org/303796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a31fbb9c12b9e0ff5cdb8a4f1526fb401359bc46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44806 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2653741-55e5-4d85-9fe2-f5ed2e1707a4) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9c33623-dc4c-4459-9838-6a13c1db0c60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136589 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd6ebc60-fe2b-47dc-a304-d8aee5459a9f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125719 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132156 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/5819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/143855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20656 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165119 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69329 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->