### PR TITLE
[iOS] Remove use of `-[UIScreen mainScreen]` in `WKInspectorHighlightView`

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+++ b/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
@@ -288,10 +288,8 @@ static void layerPath(CAShapeLayer *layer, const WebCore::FloatQuad& outerQuad)
     [self _removeAllLayers];
 
     _highlight = highlight;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: <rdar://131638772> UIScreen.mainScreen is deprecated.
-    self.contentScaleFactor = UIScreen.mainScreen.scale * scale;
-ALLOW_DEPRECATED_DECLARATIONS_END
+
+    self.contentScaleFactor = scale;
     self.frame = frame;
 
     if (highlight.type == WebCore::InspectorOverlay::Highlight::Type::Node || highlight.type == WebCore::InspectorOverlay::Highlight::Type::NodeList)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -610,7 +610,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
         _inspectorHighlightView = adoptNS([[WKInspectorHighlightView alloc] initWithFrame:CGRectZero]);
         [self insertSubview:_inspectorHighlightView.get() aboveSubview:_rootContentView.get()];
     }
-    [_inspectorHighlightView update:highlight scale:[self _contentZoomScale] frame:_page->unobscuredContentRect()];
+    [_inspectorHighlightView update:highlight scale:([self intrinsicDeviceScaleFactor] * [self _contentZoomScale]) frame:_page->unobscuredContentRect()];
 }
 
 - (void)_hideInspectorHighlight


### PR DESCRIPTION
#### 3ec152dd3bd7087aa613d6a69894ed552e29235d
<pre>
[iOS] Remove use of `-[UIScreen mainScreen]` in `WKInspectorHighlightView`
<a href="https://bugs.webkit.org/show_bug.cgi?id=303431">https://bugs.webkit.org/show_bug.cgi?id=303431</a>
<a href="https://rdar.apple.com/165724968">rdar://165724968</a>

Reviewed by Wenson Hsieh.

`-[UIScreen mainScreen]` was deprecated in iOS 26. Work towards removing its
use in WebKit.

* Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm:
(-[WKInspectorHighlightView update:scale:frame:]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _showInspectorHighlight:]):

`-intrinsicDeviceScaleFactor` gets the display scale from the view&apos;s trait
collection and falls back to using `UIScreen` if the value is unspecified.

Canonical link: <a href="https://commits.webkit.org/303846@main">https://commits.webkit.org/303846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26cab2284d3792be798ab85feb024ab5b31a48b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85709 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8b68d02-7eb8-4479-b2f9-f6f737bfffca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69583 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70f6eaf6-14c4-4521-8f7b-4d82097e4c21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83034 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d5690722-bd30-44a6-a720-fd87398ab6d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2213 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113733 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143868 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110615 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110799 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4451 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116067 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59581 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20678 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5893 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->