### PR TITLE
Find in Page should return results in the correct order with Site Isolation Enabled iOS

### DIFF
--- a/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCounted.h>
 
@@ -37,13 +38,14 @@ enum class FindOptions : uint16_t;
 
 class FindTextMatchCallbackAggregator : public RefCounted<FindTextMatchCallbackAggregator> {
 public:
-    static Ref<FindTextMatchCallbackAggregator> create(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
-    void foundMatches(Vector<WebFoundTextRange>&&);
+    static Ref<FindTextMatchCallbackAggregator> create(WebPageProxy&, CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
+    void foundMatches(HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&&);
     ~FindTextMatchCallbackAggregator();
 
 private:
-    FindTextMatchCallbackAggregator(CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
+    WeakPtr<WebPageProxy> m_page;
+    FindTextMatchCallbackAggregator(WebPageProxy&, CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
     CompletionHandler<void(Vector<WebFoundTextRange>&&)> m_completionHandler;
-    Vector<WebFoundTextRange> m_range;
+    HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>> m_frameMatches;
 };
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6397,11 +6397,11 @@ void WebPageProxy::findTextRangesForStringMatches(const String& string, OptionSe
         return;
     }
 
-    Ref aggregator = FindTextMatchCallbackAggregator::create(WTFMove(callbackFunction));
+    Ref aggregator = FindTextMatchCallbackAggregator::create(*this, WTFMove(callbackFunction));
 
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
-        webProcess.sendWithAsyncReply(Messages::WebPage::FindTextRangesForStringMatches(string, options, maxMatchCount), [aggregator](Vector<WebFoundTextRange>&& vector) {
-            aggregator->foundMatches(WTFMove(vector));
+        webProcess.sendWithAsyncReply(Messages::WebPage::FindTextRangesForStringMatches(string, options, maxMatchCount), [aggregator](HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&& frameMatches) {
+            aggregator->foundMatches(WTFMove(frameMatches));
         }, pageID);
     });
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6802,19 +6802,22 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
         WKFoundDOMTextPosition *fromPosition = (WKFoundDOMTextPosition *)from;
         WKFoundDOMTextPosition *toPosition = (WKFoundDOMTextPosition *)to;
 
-        if (fromPosition.order == toPosition.order)
-            return fromPosition.offset - toPosition.offset;
+        if (fromPosition.order != toPosition.order)
+            return fromPosition.order - toPosition.order;
+
+        return fromPosition.offset - toPosition.offset;
     }
 
     if ([from isKindOfClass:[WKFoundPDFTextPosition class]] && [to isKindOfClass:[WKFoundPDFTextPosition class]]) {
         WKFoundPDFTextPosition *fromPosition = (WKFoundPDFTextPosition *)from;
         WKFoundPDFTextPosition *toPosition = (WKFoundPDFTextPosition *)to;
 
-        if (fromPosition.order == toPosition.order) {
-            if (fromPosition.page == toPosition.page)
-                return fromPosition.offset - toPosition.offset;
-            return fromPosition.page - toPosition.page;
-        }
+        if (fromPosition.order != toPosition.order)
+            return fromPosition.order - toPosition.order;
+
+        if (fromPosition.page == toPosition.page)
+            return fromPosition.offset - toPosition.offset;
+        return fromPosition.page - toPosition.page;
     }
 
     if ([from isKindOfClass:[WKFoundTextPosition class]] && [to isKindOfClass:[WKFoundTextPosition class]]) {

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -28,6 +28,7 @@
 #include "WebFindOptions.h"
 #include "WebFoundTextRange.h"
 #include <WebCore/FindOptions.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/PlatformLayerIdentifier.h>
@@ -55,7 +56,7 @@ class WebFoundTextRangeController : private WebCore::PageOverlayClient {
 public:
     explicit WebFoundTextRangeController(WebPage&);
 
-    void findTextRangesForStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(Vector<WebKit::WebFoundTextRange>&&)>&&);
+    void findTextRangesForStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&&)>&&);
 
     void replaceFoundTextRangeWithString(const WebFoundTextRange&, const String&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5750,7 +5750,7 @@ void WebPage::findStringMatches(const String& string, OptionSet<FindOptions> opt
     findController().findStringMatches(string, options, maxMatchCount, WTFMove(completionHandler));
 }
 
-void WebPage::findTextRangesForStringMatches(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(Vector<WebFoundTextRange>&&)>&& completionHandler)
+void WebPage::findTextRangesForStringMatches(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&&)>&& completionHandler)
 {
     foundTextRangeController().findTextRangesForStringMatches(string, options, maxMatchCount, WTFMove(completionHandler));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2419,7 +2419,7 @@ private:
     void countStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(uint32_t)>&&);
     void replaceMatches(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly, CompletionHandler<void(uint64_t)>&&);
 
-    void findTextRangesForStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(Vector<WebFoundTextRange>&&)>&&);
+    void findTextRangesForStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&&)>&&);
     void replaceFoundTextRangeWithString(const WebFoundTextRange&, const String&);
     void decorateTextRangeWithStyle(const WebFoundTextRange&, WebKit::FindDecorationStyle);
     void scrollTextRangeToVisible(const WebFoundTextRange&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -345,7 +345,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     CountStringMatches(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount) -> (uint32_t matchCount)
     ReplaceMatches(Vector<uint32_t> matchIndices, String replacementText, bool selectionOnly) -> (uint64_t numberOfReplacements)
 
-    FindTextRangesForStringMatches(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount) -> (Vector<WebKit::WebFoundTextRange> ranges)
+    FindTextRangesForStringMatches(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount) -> (HashMap<WebCore::FrameIdentifier, Vector<WebKit::WebFoundTextRange>> frameOrderMap)
     ReplaceFoundTextRangeWithString(struct WebKit::WebFoundTextRange range, String string)
     DecorateTextRangeWithStyle(struct WebKit::WebFoundTextRange range, enum:uint8_t WebKit::FindDecorationStyle style)
     ScrollTextRangeToVisible(struct WebKit::WebFoundTextRange range)


### PR DESCRIPTION
#### 0f4a9392b89987302460c37d4f97b0be973f3d19
<pre>
Find in Page should return results in the correct order with Site Isolation Enabled iOS
<a href="https://rdar.apple.com/165724673">rdar://165724673</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303429">https://bugs.webkit.org/show_bug.cgi?id=303429</a>

Reviewed by Sihui Liu and Aditya Keerthi.

Currently, matches are returned in any order they are found.
This patch sorts the results by the order they appear in
the frame tree.

I added two new site isolation API tests to ensure that this
works correctly.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp:
(WebKit::FindTextMatchCallbackAggregator::create):
(WebKit::FindTextMatchCallbackAggregator::foundMatches):
(WebKit::FindTextMatchCallbackAggregator::~FindTextMatchCallbackAggregator):
(WebKit::FindTextMatchCallbackAggregator::FindTextMatchCallbackAggregator):
* Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::findTextRangesForStringMatches):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView offsetFromPosition:toPosition:]):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::findTextRangesForStringMatches):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, FindStringAcrossMultipleFramesOrderIOS)):
(TestWebKitAPI::(SiteIsolation, FindStringNestedFramesOrderIOS)):

Canonical link: <a href="https://commits.webkit.org/303929@main">https://commits.webkit.org/303929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6da04dcdfd268646ce62fb80f439602222387ce5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85943 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5886d82e-5254-4171-89ff-a4a19c98d071) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4aa77c04-5375-46f8-8b2a-25efcfe77df7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83215 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5e703b24-ac4b-4e0b-81ee-186feff4f7cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4758 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2377 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144106 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110783 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4610 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6116 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34549 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->