### PR TITLE
[iOS] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is constant failure

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -1,0 +1,255 @@
+
+
+Not a popover
+Dialog without popover attribute
+
+PASS The element <div popover="" id="boolean">Popover</div> should behave as a popover.
+PASS The element <div popover="">Popover</div> should behave as a popover.
+PASS The element <div popover="auto">Popover</div> should behave as a popover.
+PASS The element <div popover="hint">Popover</div> should behave as a popover.
+PASS The element <div popover="manual">Popover</div> should behave as a popover.
+PASS The element <article popover="">Different element type</article> should behave as a popover.
+PASS The element <header popover="">Different element type</header> should behave as a popover.
+PASS The element <nav popover="">Different element type</nav> should behave as a popover.
+PASS The element <input type="text" popover="" value="Different element type"> should behave as a popover.
+PASS The element <dialog popover="">Dialog with popover attribute</dialog> should behave as a popover.
+PASS The element <dialog popover="manual">Dialog with popover=manual</dialog> should behave as a popover.
+PASS The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div>Not a popover</div> should *not* behave as a popover.
+PASS The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover.
+PASS IDL attribute reflection
+PASS Popover attribute value should be case insensitive
+PASS Changing attribute values for popover should work
+FAIL Changing attribute values should close open popovers assert_false: expected false got true
+PASS Removing a visible popover=auto element from the document should close the popover
+PASS A showing popover=auto does not match :modal
+PASS A popover=auto never matches :open or :closed
+PASS Removing a visible popover=hint element from the document should close the popover
+PASS A showing popover=hint does not match :modal
+PASS A popover=hint never matches :open or :closed
+PASS Removing a visible popover=manual element from the document should close the popover
+PASS A showing popover=manual does not match :modal
+PASS A popover=manual never matches :open or :closed
+PASS Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover())
+PASS Changing the popover type in a "beforetoggle" event handler should not show the popover (during popovertarget invoking)
+PASS Changing the popover type in a "beforetoggle" event handler during hidePopover() should not throw an exception
+PASS Calling hidePopover on a disconnected popover should not throw.
+PASS Changing a popover from auto to auto (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to hint (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to hint (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to auto (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to hint (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to hint (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to hint (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to auto (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to auto (via idl), and then undefined during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to hint (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to null (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to null (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to undefined (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to manual (via idl), and then undefined during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works
+


### PR DESCRIPTION
#### 3b689c1eaf9d6cadce026f03632e0f17771bc9c3
<pre>
[iOS] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is constant failure
<a href="https://rdar.apple.com/164998514">rdar://164998514</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302741">https://bugs.webkit.org/show_bug.cgi?id=302741</a>

Unreviewed test gardening

Appling rebaseline that didn&apos;t merge in previous PR.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/303798@main">https://commits.webkit.org/303798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4839e02426dbf3efd689b41b3a9e4725f42ec19a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133666 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/6171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/6694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/6694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/6694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/6694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/5845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/143885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/5926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20658 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/5988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->