### PR TITLE
[WebXR Hit Test] Crashing due to empty Ref<WebXRHitTestResult> returned by WebXRFrame::getHitTestResults

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -399,10 +399,7 @@ ExceptionOr<Vector<Ref<WebXRHitTestResult>>> WebXRFrame::getHitTestResults(const
     if (platformResults == platformResultsHash.end())
         return Exception { ExceptionCode::InvalidStateError, "Unable to obtain hit test results for specified hit test source."_s };
 
-    Vector<Ref<WebXRHitTestResult>> results(platformResults->value.size());
-    for (auto& platformResult : platformResults->value)
-        results.append(WebXRHitTestResult::create(*this, platformResult));
-    return results;
+    return platformResults->value.map([&](auto& platformResult) { return WebXRHitTestResult::create(*this, platformResult); });
 }
 
 // https://immersive-web.github.io/hit-test/#dom-xrframe-gethittestresultsfortransientinput
@@ -418,14 +415,12 @@ ExceptionOr<Vector<Ref<WebXRTransientInputHitTestResult>>> WebXRFrame::getHitTes
     if (platformResults == platformResultsHash.end())
         return Exception { ExceptionCode::InvalidStateError, "Unable to obtain transient input hit test results for specified transient input hit test source."_s };
 
-    Vector<Ref<WebXRTransientInputHitTestResult>> results(platformResults->value.size());
+    Vector<Ref<WebXRTransientInputHitTestResult>> results;
     for (auto& platformResult : platformResults->value) {
         RefPtr inputSource = m_session->inputSources().itemByHandle(platformResult.inputSource);
         if (!inputSource)
             continue;
-        Vector<Ref<WebXRHitTestResult>> hitTestResults(platformResult.results.size());
-        for (auto platformHitTestResult : platformResult.results)
-            hitTestResults.append(WebXRHitTestResult::create(*this, platformHitTestResult));
+        Vector<Ref<WebXRHitTestResult>> hitTestResults = platformResult.results.map([&](auto& platformHitTestResult) { return WebXRHitTestResult::create(*this, platformHitTestResult); });
         results.append(WebXRTransientInputHitTestResult::create(inputSource.releaseNonNull(), WTFMove(hitTestResults)));
     }
     return results;


### PR DESCRIPTION
#### 1bac13ec19e9a11c7a5ed1b0741cce772a756b36
<pre>
[WebXR Hit Test] Crashing due to empty Ref&lt;WebXRHitTestResult&gt; returned by WebXRFrame::getHitTestResults
<a href="https://bugs.webkit.org/show_bug.cgi?id=303438">https://bugs.webkit.org/show_bug.cgi?id=303438</a>

Reviewed by Sergio Villar Senin.

getHitTestResults and getHitTestResultsForTransientInput of WebXRFrame returned
empty Ref&lt;WebXRHitTestResult&gt;, and failed an release assertion in Ref::get.

&gt; Vector&lt;Ref&lt;WebXRHitTestResult&gt;&gt; results(v.size());
&gt; for (auto&amp; x : v)
&gt;     results.append(...);

This was a misuse of Vector. The Vector constructor added empty items to
results. Use Vector::map instead.

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::getHitTestResults):
(WebCore::WebXRFrame::getHitTestResultsForTransientInput):

Canonical link: <a href="https://commits.webkit.org/303814@main">https://commits.webkit.org/303814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9f008a7743312e6488efbd1f8b3823526892b93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141242 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102243 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136616 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2224 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110624 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110808 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4462 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59595 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5901 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34388 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69369 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->