### PR TITLE
[GFC] Add initial implementation for automatic inline sizes of grid items.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -221,6 +221,14 @@ BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridIt
         case ItemPosition::SelfStart:
         case ItemPosition::Start:
             return { };
+
+        // https://www.w3.org/TR/css-align-3/#justify-grid
+        // Sizes as either stretch (typical non-replaced elements) or start (typical replaced elements);
+        // see Grid Item Sizing in [CSS-GRID-1]. The resulting box is then start-aligned.
+        //
+        // Stretching should be handled by GridLayout::layoutGridItems.
+        case ItemPosition::Normal:
+            return { };
         default:
             ASSERT_NOT_IMPLEMENTED_YET();
             return { };
@@ -386,7 +394,7 @@ Vector<UsedMargins> GridLayout::computeBlockMargins(const PlacedGridItems& place
 }
 
 // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
-std::pair<UsedInlineSizes, UsedBlockSizes> GridLayout::layoutGridItems(const PlacedGridItems& placedGridItems, const UsedTrackSizes&) const
+std::pair<UsedInlineSizes, UsedBlockSizes> GridLayout::layoutGridItems(const PlacedGridItems& placedGridItems, const UsedTrackSizes& usedTrackSizes) const
 {
     UsedInlineSizes usedInlineSizes;
     UsedBlockSizes usedBlockSizes;
@@ -399,7 +407,8 @@ std::pair<UsedInlineSizes, UsedBlockSizes> GridLayout::layoutGridItems(const Pla
     for (auto& gridItem : placedGridItems) {
         auto& gridItemBoxGeometry = formattingContext.geometryForGridItem(gridItem.layoutBox());
 
-        auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem) + gridItemBoxGeometry.horizontalBorderAndPadding();
+        auto columnsGap = GridLayoutUtils::computeGapValue(formattingContext.root().style().columnGap());
+        auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem, gridItemBoxGeometry.horizontalBorderAndPadding(), usedTrackSizes.columnSizes, columnsGap);
         usedInlineSizes.append(usedInlineSizeForGridItem);
 
         auto usedBlockSizeForGridItem = GridLayoutUtils::usedBlockSizeForGridItem(gridItem) + gridItemBoxGeometry.verticalBorderAndPadding();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -37,7 +37,8 @@ namespace GridLayoutUtils {
 
 LayoutUnit computeGapValue(const Style::GapGutter&);
 
-LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizes& usedColumnSizes,
+    LayoutUnit columnsGap);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
 
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -65,6 +65,10 @@ public:
     const StyleSelfAlignmentData& inlineAxisAlignment() const { return m_inlineAxisAlignment; }
     const StyleSelfAlignmentData& blockAxisAlignment() const { return m_blockAxisAlignment; }
 
+    // FIXME: Add support for grid item's with preferred aspect ratios.
+    bool hasPreferredAspectRatio() const { return false; }
+    bool isReplacedElement() const { return m_layoutBox->isReplacedBox(); }
+
     const GridAreaLines& gridAreaLines() const { return m_gridAreaLines; }
 
     const Style::ZoomFactor& usedZoom() const { return m_usedZoom; }


### PR DESCRIPTION
#### ae84aaacde21b714ad14a945b08cd896950cc460
<pre>
[GFC] Add initial implementation for automatic inline sizes of grid items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303441">https://bugs.webkit.org/show_bug.cgi?id=303441</a>
<a href="https://rdar.apple.com/165728471">rdar://165728471</a>

Reviewed by Brandon Stewart and Alan Baradlay.

The automatic sizes of grid items is defined in:
<a href="https://drafts.csswg.org/css-grid-1/#grid-item-sizing">https://drafts.csswg.org/css-grid-1/#grid-item-sizing</a>

This patch adds some initial code to start supporting the automatic
*inline* sizes of grid items that we can build upon. In particular, this
is for content in which the grid item:

1.) is non-replaced element
2.) does not have a preferred aspect ratio
3.) has non-auto margins
4.) has an alignment position of normal

This ends up placing us into the &quot;Fill grid area,&quot; portion of this
section of the spec. &quot;Fill grid area,&quot; seems to refer to &quot;the grid item is
sized as for align-self: stretch,&quot; which after following a couple of
spec links leads to:
<a href="https://www.w3.org/TR/css-align-3/#justify-self-property">https://www.w3.org/TR/css-align-3/#justify-self-property</a>

This is the core logic that is implemented as part of
usedInlineSizeForGridItem.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performInlineAxisSelfAlignment):
Since &quot;Normal,&quot; is handled by grid item sizing there is nothing to do
here as part of alignment.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::usedInlineSizeForGridItem):
This is the core of the logic that is written to implement the
aforementioned portion of the spec. Basically we need to determine the
total size of the columns the grid item spans and then stretch it to fit
within that size while still respecting the min and max sizes specified
by style.

Note that there was was small change made when for the fixed inline size
case. Now we add in the border and padding within this function instead
of it being done on top of what we returned from this function. This is
because we need the border and padding in order to properly stretch the
grid item.

Canonical link: <a href="https://commits.webkit.org/303843@main">https://commits.webkit.org/303843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45f17b3d49ced82aa9124e81fa974a46e1154ab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85728 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/899ec579-6574-4642-a3db-7953ce72c4f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69594 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4bd3cb9a-0187-4611-996e-29ea099e56af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f26ede42-f489-4fb9-b6be-e76e3a9a6be1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4609 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2226 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143892 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110627 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4465 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59599 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5905 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34393 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5859 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->