### PR TITLE
[webkitscmpy] Git._is_on_default_branch doesn't need to get all branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -654,16 +654,14 @@ class Git(Scm):
 
     def _is_on_default_branch(self, hash):
         self._maybe_update_default_branch_ref_from_fetch_head()
-        branches = self.branches_for(remote=None)
         remote_keys = [None] + self.source_remotes()
         default_branch = self.default_branch
         for key in remote_keys:
-            if default_branch in branches.get(key, []):
-                if run([self.executable(), 'merge-base', '--is-ancestor', hash,
-                       f'remotes/{key}/{default_branch}' if key else default_branch],
-                       cwd=self.root_path, capture_output=True, encoding='utf-8').returncode == 0:
-                    return True
-        return default_branch in self.branches_for(hash)
+            if run([self.executable(), 'merge-base', '--is-ancestor', hash,
+                    f'refs/remotes/{key}/{default_branch}' if key is not None else f'refs/heads/{default_branch}'],
+                   cwd=self.root_path, capture_output=True, encoding='utf-8').returncode == 0:
+                return True
+        return False
 
     def branch_point(self, ref='HEAD'):
         branches = self.branches_for(remote=None)


### PR DESCRIPTION
#### aca854d2444b163e7661e10a6f724c46b71a1cae
<pre>
[webkitscmpy] Git._is_on_default_branch doesn&apos;t need to get all branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=303442">https://bugs.webkit.org/show_bug.cgi?id=303442</a>

Reviewed by Jonathan Bedard.

We don&apos;t need to enumerate all branches and then check whether the
default branch name exists in each source remote: we can instead just
rely on merge-base to fail when the ref doesn&apos;t exist.

With a very large number of branches (mostly from numerous remotes),
this is a 3.9x speedup for
`git-webkit pickable origin/main~10..origin/main`.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git._is_on_default_branch):

Canonical link: <a href="https://commits.webkit.org/303847@main">https://commits.webkit.org/303847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fcf45e8612bcadb6a57b819d22a631832a4c162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb7875fc-fb74-464e-9616-74b6075ca010) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69612 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a19c5acd-4483-4dfc-8e6b-3861ed7a244e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51619249-e76d-4c9e-966a-92fbd4cf59ed) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133025 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2228 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110629 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/133104 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110813 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4466 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34389 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5862 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->