### PR TITLE
[iOS] Introduce MediaDeviceRouteController

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		A10826FA1F576292004772AC /* WebPanel.mm in Sources */ = {isa = PBXBuildFile; fileRef = A10826F81F576292004772AC /* WebPanel.mm */; };
 		A1175B4F1F6B337300C4B9F0 /* PopupMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1175B4D1F6B337300C4B9F0 /* PopupMenu.mm */; };
 		A1175B581F6B470500C4B9F0 /* DefaultSearchProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */; };
+		A15E661B2EDA937A007FB56F /* AVRoutingSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = A15E66192EDA937A007FB56F /* AVRoutingSoftLink.mm */; };
+		A15E66242EDA972C007FB56F /* AVRoutingSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = A15E66182EDA937A007FB56F /* AVRoutingSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1F63CA021A4DBF7006FB43B /* PassKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */; };
 		A30D41221F0DD0EA00B71954 /* KillRing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A30D411F1F0DD0EA00B71954 /* KillRing.cpp */; };
 		A30D41251F0DD12D00B71954 /* KillRingMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = A30D41241F0DD12D00B71954 /* KillRingMac.mm */; };
@@ -694,6 +696,8 @@
 		A1175B551F6B470500C4B9F0 /* DefaultSearchProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DefaultSearchProvider.h; sourceTree = "<group>"; };
 		A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultSearchProvider.cpp; sourceTree = "<group>"; };
 		A1175B591F6B4A8400C4B9F0 /* NSScrollViewSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSScrollViewSPI.h; sourceTree = "<group>"; };
+		A15E66182EDA937A007FB56F /* AVRoutingSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVRoutingSoftLink.h; sourceTree = "<group>"; };
+		A15E66192EDA937A007FB56F /* AVRoutingSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AVRoutingSoftLink.mm; sourceTree = "<group>"; };
 		A169B040248EF03900EE8B7B /* PassKitInstallmentsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassKitInstallmentsSPI.h; sourceTree = "<group>"; };
 		A1F63C9D21A4DBF7006FB43B /* PassKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassKitSoftLink.h; sourceTree = "<group>"; };
 		A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PassKitSoftLink.mm; sourceTree = "<group>"; };
@@ -1206,6 +1210,8 @@
 		2E87C06E215A993100D6CD32 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				A15E66182EDA937A007FB56F /* AVRoutingSoftLink.h */,
+				A15E66192EDA937A007FB56F /* AVRoutingSoftLink.mm */,
 				5C7C787123AC3E770065F47E /* ManagedConfigurationSoftLink.h */,
 				5C7C787223AC3E770065F47E /* ManagedConfigurationSoftLink.mm */,
 				4450FC9E21F5F602004DFA56 /* QuickLookSoftLink.h */,
@@ -1411,6 +1417,7 @@
 				DD20DD1B27BC90D60093D175 /* AVFoundationSoftLink.h in Headers */,
 				DD20DDDB27BC90D70093D175 /* AVFoundationSPI.h in Headers */,
 				DD20DDDC27BC90D70093D175 /* AVKitSPI.h in Headers */,
+				A15E66242EDA972C007FB56F /* AVRoutingSoftLink.h in Headers */,
 				DD20DDDD27BC90D70093D175 /* AVStreamDataParserSPI.h in Headers */,
 				42EB2CA32D0388A400ECB173 /* AXRuntimeSPI.h in Headers */,
 				DD20DDDE27BC90D70093D175 /* AXSpeechManagerSPI.h in Headers */,
@@ -1743,6 +1750,7 @@
 				416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */,
 				41D99CC92C9C45590025844F /* AVFAudioSoftLink.mm in Sources */,
 				077E87B1226A460200A2AFF0 /* AVFoundationSoftLink.mm in Sources */,
+				A15E661B2EDA937A007FB56F /* AVRoutingSoftLink.mm in Sources */,
 				1D2B413425F05E3500A3F70A /* ClockGeneric.cpp in Sources */,
 				5157ADFE2B23B9F300C0E095 /* ContactsSoftLink.mm in Sources */,
 				7B47F2A428587B9700E793C8 /* CoreGraphicsSoftLink.cpp in Sources */,

--- a/Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.h
+++ b/Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <wtf/SoftLinking.h>
+
+#include <WebKitAdditions/AVRoutingSoftLinkAdditions.h>
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <wtf/SoftLinking.h>
+
+#import <WebKitAdditions/AVRoutingSoftLinkAdditions.mm>
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2566,6 +2566,7 @@ platform/graphics/LayoutRoundedRect.cpp
 platform/graphics/LayoutSize.cpp
 platform/graphics/MIMESniffer.cpp
 platform/graphics/MIMETypeCache.cpp
+platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/MediaPlayerPrivate.cpp
 platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -286,6 +286,7 @@ platform/audio/cocoa/WebAudioBufferList.cpp
 platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp @no-unify
 platform/audio/ios/AudioSessionIOS.mm @nonARC @no-unify
 platform/audio/ios/MediaDeviceRoute.mm @nonARC
+platform/audio/ios/MediaDeviceRouteController.mm @nonARC
 platform/audio/ios/MediaSessionHelperIOS.mm @nonARC @no-unify
 platform/audio/ios/MediaSessionManagerIOS.mm @nonARC @no-unify
 platform/audio/mac/AudioBusMac.mm @nonARC

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1354,7 +1354,7 @@ void HTMLMediaElement::checkPlaybackTargetCompatibility()
         return;
 
     Ref player = *m_player;
-    if (player->canPlayToWirelessPlaybackTarget())
+    if (player->supportedPlaybackTargetTypes().contains(protectedMediaSession()->playbackTargetType()))
         return;
 
     auto tryToSwitchEngines = !m_remotePlaybackConfiguration && m_loadState == LoadingFromSourceElement;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1002,7 +1002,15 @@ void MediaElementSession::mediaStateDidChange(MediaProducerMediaStateFlags state
     if (RefPtr element = m_element.get())
         element->document().playbackTargetPickerClientStateDidChange(*this, state);
 }
-#endif
+
+MediaPlaybackTargetType MediaElementSession::playbackTargetType() const
+{
+    if (RefPtr playbackTarget = m_playbackTarget)
+        return playbackTarget->targetType();
+    return MediaPlaybackTargetType::None;
+}
+
+#endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 MediaPlayer::Preload MediaElementSession::effectivePreloadForElement() const
 {

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -106,6 +106,8 @@ public:
     bool isPlayingToWirelessPlaybackTarget() const override;
 
     void mediaStateDidChange(MediaProducerMediaStateFlags);
+
+    MediaPlaybackTargetType playbackTargetType() const;
 #endif
 
     bool requiresFullscreenForVideoPlayback() const;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -27,10 +27,16 @@
 
 #if HAVE(AVROUTING_FRAMEWORK)
 
-#include <WebKitAdditions/MediaDeviceRouteInterfaceAdditions.h>
+#include <WebKitAdditions/MediaDeviceRouteAdditions.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
-#include <wtf/RefCounted.h>
+#include <wtf/Forward.h>
+#include <wtf/MediaTime.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UUID.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
 OBJC_CLASS WebMediaDeviceRoute;
 
@@ -112,7 +118,7 @@ public:
     virtual void volumeDidChange(MediaDeviceRoute&) = 0;
 };
 
-class MediaDeviceRoute : public RefCountedAndCanMakeWeakPtr<MediaDeviceRoute> {
+class MediaDeviceRoute final : public RefCountedAndCanMakeWeakPtr<MediaDeviceRoute> {
     WTF_MAKE_TZONE_ALLOCATED(MediaDeviceRoute);
 public:
     static Ref<MediaDeviceRoute> create(WebMediaDevicePlatformRoute *);
@@ -121,6 +127,9 @@ public:
 
     MediaDeviceRouteClient* client() const { return m_client.get(); }
     void setClient(MediaDeviceRouteClient* client) { m_client = client; }
+
+    const WTF::UUID& identifier() const { return m_identifier; }
+    WebMediaDevicePlatformRoute *platformRoute() const;
 
     float minValue() const;
     float maxValue() const;
@@ -153,6 +162,7 @@ public:
 private:
     explicit MediaDeviceRoute(WebMediaDevicePlatformRoute *);
 
+    WTF::UUID m_identifier;
     RetainPtr<WebMediaDeviceRoute> m_route;
     WeakPtr<MediaDeviceRouteClient> m_client;
 };

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -28,8 +28,8 @@
 
 #if HAVE(AVROUTING_FRAMEWORK)
 
-#include <WebKitAdditions/MediaDeviceRouteImplementationAdditions.h>
-#include <wtf/TZoneMallocInlines.h>
+#import <WebKitAdditions/MediaDeviceRouteAdditions.mm>
+#import <wtf/TZoneMallocInlines.h>
 
 #define FOR_EACH_READONLY_KEY_PATH(Macro) \
     Macro(minValue, MinValue, float) \
@@ -335,8 +335,14 @@ Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *plat
 }
 
 MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
-    : m_route { adoptNS([[WebMediaDeviceRoute alloc] initWithRoute:*this platformRoute:platformRoute]) }
+    : m_identifier { WTF::UUID::createVersion4() }
+    , m_route { adoptNS([[WebMediaDeviceRoute alloc] initWithRoute:*this platformRoute:platformRoute]) }
 {
+}
+
+WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
+{
+    return [m_route platformRoute];
 }
 
 MediaDeviceRoute::~MediaDeviceRoute() = default;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <WebKitAdditions/MediaDeviceRouteAdditions.h>
+#include <WebKitAdditions/MediaDeviceRouteControllerAdditions.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/Vector.h>
+
+OBJC_CLASS WebMediaDeviceRouteController;
+
+namespace WebCore {
+
+class MediaDeviceRoute;
+class MediaDeviceRouteController;
+
+class MediaDeviceRouteControllerClient : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
+public:
+    virtual ~MediaDeviceRouteControllerClient() = default;
+
+    virtual void activeRoutesDidChange(MediaDeviceRouteController&) = 0;
+};
+
+class MediaDeviceRouteController {
+    friend class NeverDestroyed<MediaDeviceRouteController>;
+
+public:
+    static MediaDeviceRouteController& singleton();
+
+    RefPtr<MediaDeviceRouteControllerClient> client() const { return m_client.get(); }
+    void setClient(MediaDeviceRouteControllerClient* client) { m_client = client; }
+
+    RefPtr<MediaDeviceRoute> mostRecentActiveRoute() const;
+    RefPtr<MediaDeviceRoute> routeForIdentifier(const std::optional<WTF::UUID>&) const;
+
+    bool handleEvent(WebMediaDevicePlatformRouteEvent *);
+
+private:
+    MediaDeviceRouteController();
+
+    bool activateRoute(WebMediaDevicePlatformRoute *);
+    bool deactivateRoute(WebMediaDevicePlatformRoute *);
+
+    RetainPtr<WebMediaDeviceRouteController> m_controller;
+    RetainPtr<WebMediaDevicePlatformRouteController> m_platformController;
+    ThreadSafeWeakPtr<MediaDeviceRouteControllerClient> m_client;
+    Vector<Ref<MediaDeviceRoute>> m_activeRoutes;
+};
+
+} // namespace WebCore
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MediaDeviceRouteController.h"
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#import <WebKitAdditions/MediaDeviceRouteControllerAdditions.mm>
+
+#import <pal/ios/AVRoutingSoftLink.h>
+
+namespace WebCore {
+
+MediaDeviceRouteController& MediaDeviceRouteController::singleton()
+{
+    static NeverDestroyed<MediaDeviceRouteController> controller;
+    return controller;
+}
+
+MediaDeviceRouteController::MediaDeviceRouteController()
+    : m_controller { adoptNS([[WebMediaDeviceRouteController alloc] init]) }
+    , m_platformController { [WebMediaDevicePlatformRouteControllerClass sharedRoutingSystemController] }
+{
+    ASSERT([m_platformController systemDelegate] == nil);
+    [m_platformController setSystemDelegate:m_controller.get()];
+}
+
+RefPtr<MediaDeviceRoute> MediaDeviceRouteController::mostRecentActiveRoute() const
+{
+    if (m_activeRoutes.isEmpty())
+        return nullptr;
+
+    return m_activeRoutes.last().get();
+}
+
+RefPtr<MediaDeviceRoute> MediaDeviceRouteController::routeForIdentifier(const std::optional<WTF::UUID>& identifier) const
+{
+    auto index = m_activeRoutes.findIf([&](auto& route) {
+        return route->identifier() == identifier;
+    });
+
+    if (index != notFound)
+        return m_activeRoutes[index].get();
+
+    return nullptr;
+}
+
+bool MediaDeviceRouteController::handleEvent(WebMediaDevicePlatformRouteEvent *event)
+{
+    switch (event.reason) {
+    case WebMediaDevicePlatformRouteEventReasonActivate:
+        return activateRoute(event.route);
+    case WebMediaDevicePlatformRouteEventReasonDeactivate:
+        return deactivateRoute(event.route);
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+bool MediaDeviceRouteController::activateRoute(WebMediaDevicePlatformRoute *platformRoute)
+{
+    m_activeRoutes.removeAllMatching([&](auto& route) { return route->platformRoute() == platformRoute; });
+    m_activeRoutes.append(MediaDeviceRoute::create(platformRoute));
+
+    if (RefPtr client = m_client.get())
+        client->activeRoutesDidChange(*this);
+
+    return true;
+}
+
+bool MediaDeviceRouteController::deactivateRoute(WebMediaDevicePlatformRoute *platformRoute)
+{
+    if (!m_activeRoutes.removeAllMatching([&](auto& route) { return route->platformRoute() == platformRoute; }))
+        return false;
+
+    if (RefPtr client = m_client.get())
+        client->activeRoutesDidChange(*this);
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -29,7 +29,10 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "Logging.h"
+#import "MediaDeviceRoute.h"
+#import "MediaDeviceRouteController.h"
 #import "MediaPlaybackTargetCocoa.h"
+#import "MediaPlaybackTargetWirelessPlayback.h"
 #import "PlatformMediaSessionManager.h"
 #import "WebCoreThreadRun.h"
 #import <AVFoundation/AVAudioSession.h>
@@ -85,9 +88,18 @@ class MediaSessionHelperIOS;
 
 @end
 
-class MediaSessionHelperIOS final : public MediaSessionHelper {
+class MediaSessionHelperIOS final
+    : public MediaSessionHelper
+#if HAVE(AVROUTING_FRAMEWORK)
+    , private MediaDeviceRouteControllerClient
+#endif
+{
 public:
     MediaSessionHelperIOS();
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
+#endif
 
     void externalOutputDeviceAvailableDidChange();
     void updateCarPlayIsConnected();
@@ -106,6 +118,10 @@ private:
     void providePresentingApplicationPID(ProcessID) final;
     void startMonitoringWirelessRoutesInternal() final;
     void stopMonitoringWirelessRoutesInternal() final;
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    void activeRoutesDidChange(MediaDeviceRouteController&) final;
+#endif
 
     const RetainPtr<WebMediaSessionHelper> m_objcObserver;
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
@@ -278,6 +294,11 @@ MediaSessionHelperIOS::MediaSessionHelperIOS()
     END_BLOCK_OBJC_EXCEPTIONS
 
     updateCarPlayIsConnected();
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    ASSERT(MediaDeviceRouteController::singleton().client() == nullptr);
+    MediaDeviceRouteController::singleton().setClient(this);
+#endif
 }
 
 std::optional<ProcessID> MediaSessionHelperIOS::presentedApplicationPID() const
@@ -381,6 +402,18 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
     MediaSessionHelper::externalOutputDeviceAvailableDidChange(hasAvailableTargets);
 }
+
+#if HAVE(AVROUTING_FRAMEWORK)
+void MediaSessionHelperIOS::activeRoutesDidChange(MediaDeviceRouteController& routeController)
+{
+    if (RefPtr mostRecentActiveRoute = routeController.mostRecentActiveRoute()) {
+        MediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo::Yes, MediaPlaybackTargetWirelessPlayback::create(*mostRecentActiveRoute));
+        return;
+    }
+
+    activeVideoRouteDidChange();
+}
+#endif // HAVE(AVROUTING_FRAMEWORK)
 
 @implementation WebMediaSessionHelper
 

--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -33,9 +33,11 @@
 namespace WebCore {
 
 enum class MediaPlaybackTargetType : uint8_t {
-    AVOutputContext,
-    Mock,
-    Serialized,
+    None = 0,
+    AVOutputContext = 1 << 0,
+    Mock = 1 << 1,
+    WirelessPlayback = 1 << 2,
+    Serialized = 1 << 3,
 };
 
 class MediaPlaybackTarget : public ThreadSafeRefCounted<MediaPlaybackTarget> {
@@ -45,6 +47,7 @@ public:
     virtual ~MediaPlaybackTarget() = default;
 
     Type type() const { return m_type; }
+    virtual Type targetType() const { return type(); }
 
     virtual bool hasActiveRoute() const = 0;
     virtual String deviceName() const = 0;

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaPlaybackTargetWirelessPlayback.h"
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include "MediaDeviceRoute.h"
+#include "MediaDeviceRouteController.h"
+#include <wtf/UUID.h>
+
+namespace WebCore {
+
+Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::create(std::optional<WTF::UUID> identifier)
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(MediaDeviceRouteController::singleton().routeForIdentifier(identifier)));
+#else
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(WTFMove(identifier)));
+#endif
+}
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::create(MediaDeviceRoute& route)
+{
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(route));
+}
+
+MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&& route)
+    : MediaPlaybackTarget { Type::WirelessPlayback }
+    , m_route { WTFMove(route) }
+{
+}
+
+#else
+
+MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier)
+    : MediaPlaybackTarget { Type::WirelessPlayback }
+    , m_identifier { WTFMove(identifier) }
+{
+}
+
+#endif // HAVE(AVROUTING_FRAMEWORK)
+
+MediaPlaybackTargetWirelessPlayback::~MediaPlaybackTargetWirelessPlayback() = default;
+
+std::optional<WTF::UUID> MediaPlaybackTargetWirelessPlayback::identifier() const
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    if (RefPtr route = m_route)
+        return m_route->identifier();
+    return std::nullopt;
+#else
+    return m_identifier;
+#endif
+}
+
+String MediaPlaybackTargetWirelessPlayback::deviceName() const
+{
+    // FIXME: provide a real device name
+    if (auto identifier = this->identifier())
+        return identifier->toString();
+    return { };
+}
+
+bool MediaPlaybackTargetWirelessPlayback::hasActiveRoute() const
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    return !!m_route;
+#else
+    return !!m_identifier;
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include <WebCore/MediaPlaybackTarget.h>
+#include <wtf/UUID.h>
+
+namespace WebCore {
+
+class MediaDeviceRoute;
+
+class MediaPlaybackTargetWirelessPlayback final : public MediaPlaybackTarget {
+public:
+    WEBCORE_EXPORT static Ref<MediaPlaybackTargetWirelessPlayback> create(std::optional<WTF::UUID> identifier);
+#if HAVE(AVROUTING_FRAMEWORK)
+    static Ref<MediaPlaybackTargetWirelessPlayback> create(MediaDeviceRoute&);
+#endif
+
+    ~MediaPlaybackTargetWirelessPlayback();
+
+    WEBCORE_EXPORT std::optional<WTF::UUID> identifier() const;
+
+private:
+#if HAVE(AVROUTING_FRAMEWORK)
+    explicit MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&);
+#else
+    explicit MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier);
+#endif
+
+    // MediaPlaybackTarget
+    String deviceName() const final;
+    bool hasActiveRoute() const final;
+    bool supportsRemoteVideoPlayback() const final { return hasActiveRoute(); }
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    RefPtr<MediaDeviceRoute> m_route;
+#else
+    std::optional<WTF::UUID> m_identifier;
+#endif
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlaybackTargetWirelessPlayback)
+static bool isType(const WebCore::MediaPlaybackTarget& target)
+{
+    return target.type() ==  WebCore::MediaPlaybackTargetType::WirelessPlayback;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1326,9 +1326,9 @@ void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackT
     protectedClient()->mediaPlayerCurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
 }
 
-bool MediaPlayer::canPlayToWirelessPlaybackTarget() const
+OptionSet<MediaPlaybackTargetType> MediaPlayer::supportedPlaybackTargetTypes() const
 {
-    return protectedPrivate()->canPlayToWirelessPlaybackTarget();
+    return protectedPrivate()->supportedPlaybackTargetTypes();
 }
 
 void MediaPlayer::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& device)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -85,6 +85,7 @@ using LayerHostingContextID = uint32_t;
 
 enum class AudioSessionCategory : uint8_t;
 enum class DynamicRangeMode : uint8_t;
+enum class MediaPlaybackTargetType : uint8_t;
 
 class AudioSourceProvider;
 class AudioTrackPrivate;
@@ -590,7 +591,7 @@ public:
     void playbackTargetAvailabilityChanged();
 
     bool isCurrentPlaybackTargetWireless() const;
-    bool canPlayToWirelessPlaybackTarget() const;
+    OptionSet<MediaPlaybackTargetType> supportedPlaybackTargetTypes() const;
     void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&);
 
     void setShouldPlayToPlaybackTarget(bool);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "MediaPlaybackTarget.h"
 #include "VideoFrame.h"
 #include "VideoFrameMetadata.h"
 #include <wtf/NativePromise.h>
@@ -72,7 +73,14 @@ MediaTime MediaPlayerPrivateInterface::currentOrPendingSeekTime() const
     return currentTime();
 }
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateInterface::supportedPlaybackTargetTypes() const
+{
+    return { };
 }
+#endif
+
+} // namespace WebCore
 
 #endif
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -47,6 +47,8 @@ namespace WebCore {
 class MessageClientForTesting;
 class VideoFrame;
 
+enum class MediaPlaybackTargetType : uint8_t;
+
 // MediaPlayerPrivateInterface subclasses should be ref-counted, but each subclass may choose whether
 // to be RefCounted or ThreadSafeRefCounted. Therefore, each subclass must implement a pair of
 // virtual ref()/deref() methods. See NullMediaPlayerPrivate for an example.
@@ -222,7 +224,7 @@ public:
     virtual bool wirelessVideoPlaybackDisabled() const { return true; }
     virtual void setWirelessVideoPlaybackDisabled(bool) { }
 
-    virtual bool canPlayToWirelessPlaybackTarget() const { return false; }
+    virtual OptionSet<MediaPlaybackTargetType> supportedPlaybackTargetTypes() const;
     virtual bool isCurrentPlaybackTargetWireless() const { return false; }
     virtual void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) { }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -310,7 +310,7 @@ private:
     MediaPlayer::WirelessPlaybackTargetType wirelessPlaybackTargetType() const final;
     bool wirelessVideoPlaybackDisabled() const final;
     void setWirelessVideoPlaybackDisabled(bool) final;
-    bool canPlayToWirelessPlaybackTarget() const final { return true; }
+    OptionSet<MediaPlaybackTargetType> supportedPlaybackTargetTypes() const final;
     void updateDisableExternalPlayback();
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -3450,6 +3450,11 @@ void MediaPlayerPrivateAVFoundationObjC::setWirelessVideoPlaybackDisabled(bool d
     [m_avPlayer setAllowsExternalPlayback:!disabled];
 }
 
+OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateAVFoundationObjC::supportedPlaybackTargetTypes() const
+{
+    return { MediaPlaybackTargetType::AVOutputContext, MediaPlaybackTargetType::Mock };
+}
+
 #if !PLATFORM(IOS_FAMILY)
 
 void MediaPlayerPrivateAVFoundationObjC::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& target)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -170,7 +170,7 @@ void RemoteMediaPlayerProxy::getConfiguration(RemoteMediaPlayerConfiguration& co
     configuration.supportsPauseAtHostTime = player->supportsPauseAtHostTime();
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    configuration.canPlayToWirelessPlaybackTarget = player->canPlayToWirelessPlaybackTarget();
+    configuration.supportedPlaybackTargetTypes = player->supportedPlaybackTargetTypes();
 #endif
     configuration.shouldIgnoreIntrinsicSize = player->shouldIgnoreIntrinsicSize();
 

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
@@ -30,6 +30,7 @@
 #include "CoreIPCAVOutputContext.h"
 #include <WebCore/MediaPlaybackTarget.h>
 #include <wtf/Forward.h>
+#include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -53,12 +54,13 @@ public:
     WebCore::MediaPlaybackTargetMockState mockState() const { return m_state; }
 #if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
     CoreIPCAVOutputContext context() const { return m_context; }
-    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, CoreIPCAVOutputContext&&);
+    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, CoreIPCAVOutputContext&&, std::optional<WTF::UUID>&&);
 #else
     String contextID() const { return m_contextID; }
     String contextType() const { return m_contextType; }
-    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, String&&, String&&);
+    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, String&&, String&&, std::optional<WTF::UUID>&&);
 #endif
+    const std::optional<WTF::UUID>& identifier() const { return m_identifier; }
 
 private:
     String m_deviceName;
@@ -73,6 +75,7 @@ private:
     String m_contextID;
     String m_contextType;
 #endif
+    std::optional<WTF::UUID> m_identifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
@@ -30,10 +30,12 @@ header: <WebCore/MediaPlaybackTargetMock.h>
 };
 
 header: <WebCore/MediaPlaybackTarget.h>
-[CustomHeader] enum class WebCore::MediaPlaybackTargetType : uint8_t {
+[CustomHeader, OptionSet] enum class WebCore::MediaPlaybackTargetType : uint8_t {
+    None,
     AVOutputContext,
     Mock,
-    Serialized
+    WirelessPlayback,
+    Serialized,
 };
 
 header: "MediaPlaybackTargetContextSerialized.h"
@@ -49,6 +51,7 @@ header: "MediaPlaybackTargetContextSerialized.h"
     String contextID();
     String contextType();
 #endif
+    std::optional<WTF::UUID> identifier();
 };
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
@@ -44,6 +44,7 @@ private:
     explicit MediaPlaybackTargetSerialized(MediaPlaybackTargetContextSerialized&&);
 
     // MediaPlaybackTarget
+    Type targetType() const final { return m_context.targetType(); }
     String deviceName() const final { return m_context.deviceName(); }
     bool hasActiveRoute() const final { return m_context.hasActiveRoute(); }
     bool supportsRemoteVideoPlayback() const final { return m_context.supportsRemoteVideoPlayback(); }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -658,9 +658,9 @@ void MediaPlayerPrivateRemote::updateConfiguration(RemoteMediaPlayerConfiguratio
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-bool MediaPlayerPrivateRemote::canPlayToWirelessPlaybackTarget() const
+OptionSet<WebCore::MediaPlaybackTargetType> MediaPlayerPrivateRemote::supportedPlaybackTargetTypes() const
 {
-    return m_configuration.canPlayToWirelessPlaybackTarget;
+    return m_configuration.supportedPlaybackTargetTypes;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -377,7 +377,7 @@ private:
     bool wirelessVideoPlaybackDisabled() const final;
     void setWirelessVideoPlaybackDisabled(bool) final;
 
-    bool canPlayToWirelessPlaybackTarget() const final;
+    OptionSet<WebCore::MediaPlaybackTargetType> supportedPlaybackTargetTypes() const final;
     bool isCurrentPlaybackTargetWireless() const final;
     void setWirelessPlaybackTarget(Ref<WebCore::MediaPlaybackTarget>&&) final;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include <WebCore/MediaPlaybackTarget.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformTimeRanges.h>
 #include <wtf/MediaTime.h>
@@ -41,8 +42,10 @@ struct RemoteMediaPlayerConfiguration {
     bool supportsAcceleratedRendering { false };
     bool supportsPlayAtHostTime { false };
     bool supportsPauseAtHostTime { false };
-    bool canPlayToWirelessPlaybackTarget { false };
     bool shouldIgnoreIntrinsicSize { false };
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    OptionSet<WebCore::MediaPlaybackTargetType> supportedPlaybackTargetTypes;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in
@@ -30,8 +30,10 @@ struct WebKit::RemoteMediaPlayerConfiguration {
     bool supportsAcceleratedRendering;
     bool supportsPlayAtHostTime;
     bool supportsPauseAtHostTime;
-    bool canPlayToWirelessPlaybackTarget;
     bool shouldIgnoreIntrinsicSize;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    OptionSet<WebCore::MediaPlaybackTargetType> supportedPlaybackTargetTypes;
+#endif
 };
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -81,10 +81,12 @@ void RemoteMediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo su
 {
     switch (targetContext.targetType()) {
     case WebCore::MediaPlaybackTargetType::AVOutputContext:
+    case WebCore::MediaPlaybackTargetType::WirelessPlayback:
         WebCore::MediaSessionHelper::activeVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetSerialized::create(WTFMove(targetContext)));
         break;
     case WebCore::MediaPlaybackTargetType::Mock:
     case WebCore::MediaPlaybackTargetType::Serialized:
+    case WebCore::MediaPlaybackTargetType::None:
         break;
     }
 }


### PR DESCRIPTION
#### 684acb93d5e6dde54932f8d17a433fd4fcc915b0
<pre>
[iOS] Introduce MediaDeviceRouteController
<a href="https://bugs.webkit.org/show_bug.cgi?id=303450">https://bugs.webkit.org/show_bug.cgi?id=303450</a>
<a href="https://rdar.apple.com/165738633">rdar://165738633</a>

Reviewed by Eric Carlson.

Introduced MediaDeviceRouteController. Its responsibility is to observe a new MediaDeviceRoute
becoming active, create a corresponding MediaPlaybackTargetWirelessPlayback, and propagate that to the
Now Playing-eligible media element. In a follow-on change this playback target will be used to
create a MediaPlayerPrivateWirelessPlayback for AirPlay playback.

Since MediaDeviceRoutes cannot be serialized from the GPU process to the WebContent process, a UUID
is associated with each route, and MediaPlaybackTargetWirelessPlayback stores this UUID so that the
corresponding MediaDeviceRoute can be looked up when the playback target is sent back to the GPU
process (via RemoteMediaPlayerProxy::SetWirelessPlaybackTarget).

MediaPlaybackTargetType enumeration values were also changed to be compatible with an OptionSet. In
a follow-on change, this will be used to determine which MediaPlayerPrivate subclass supports
MediaPlaybackTargetWirelessPlayback.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.h: Copied from Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h.
* Source/WebCore/PAL/pal/ios/AVRoutingSoftLink.mm: Copied from Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h.
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::playbackTargetType const):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRoute::client const): Deleted.
(WebCore::MediaDeviceRoute::setClient): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::MediaDeviceRoute::MediaDeviceRoute):
(WebCore::MediaDeviceRoute::platformRoute const):
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h: Added.
(WebCore::MediaDeviceRouteController::client const):
(WebCore::MediaDeviceRouteController::setClient):
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm: Added.
(WebCore::MediaDeviceRouteController::singleton):
(WebCore::MediaDeviceRouteController::MediaDeviceRouteController):
(WebCore::MediaDeviceRouteController::mostRecentActiveRoute const):
(WebCore::MediaDeviceRouteController::routeForIdentifier const):
(WebCore::MediaDeviceRouteController::handleEvent):
(WebCore::MediaDeviceRouteController::activateRoute):
(WebCore::MediaDeviceRouteController::deactivateRoute):
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelperIOS::MediaSessionHelperIOS):
(MediaSessionHelperIOS::activeRoutesDidChange):
* Source/WebCore/platform/graphics/MediaPlaybackTarget.h:
(WebCore::MediaPlaybackTarget::targetType const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp: Added.
(WebCore::MediaPlaybackTargetWirelessPlayback::create):
(WebCore::MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback):
(WebCore::MediaPlaybackTargetWirelessPlayback::identifier const):
(WebCore::MediaPlaybackTargetWirelessPlayback::deviceName const):
(WebCore::MediaPlaybackTargetWirelessPlayback::hasActiveRoute const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h: Copied from Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h.
(isType):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::supportedPlaybackTargetTypes const):
(WebCore::MediaPlayer::canPlayToWirelessPlaybackTarget const): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:
(WebCore::MediaPlayerPrivateInterface::supportedPlaybackTargetTypes const):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::canPlayToWirelessPlaybackTarget const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::supportedPlaybackTargetTypes const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::getConfiguration):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h:
(WebKit::MediaPlaybackTargetContextSerialized::identifier const):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized):
(WebKit::MediaPlaybackTargetContextSerialized::playbackTarget const):
(WTF::isValidEnum&lt;WebCore::MediaPlaybackTargetType&gt;):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::supportedPlaybackTargetTypes const):
(WebKit::MediaPlayerPrivateRemote::canPlayToWirelessPlaybackTarget const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::activeVideoRouteDidChange):

Canonical link: <a href="https://commits.webkit.org/303947@main">https://commits.webkit.org/303947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/243feedc66e4ca69d80cfe337a479884a4c7b7a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df2331c4-97d6-4a01-b39c-aafdf079d71a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c9c956e-b4ee-455c-866f-4fb28f3d82f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a9f747a8-0230-4337-8055-3ecf7216f37a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2459 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144242 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110883 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111098 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4701 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59967 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34651 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->