### PR TITLE
Further reduce use of unsafeGet() in WebCore/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -253,7 +253,6 @@ mathml/MathMLSelectElement.cpp
 page/CaptionUserPreferences.cpp
 [ iOS ] page/Chrome.cpp
 [ Mac ] page/ContextMenuController.cpp
-page/DebugPageOverlays.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/FocusController.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1003,13 +1003,13 @@ public:
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     bool onlyAddsUnignoredChildren() const { return isTableColumn() || role() == AccessibilityRole::TableHeaderContainer; }
     AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
-    AXCoreObject* firstUnignoredChild();
+    bool hasUnignoredChild();
 #else
     const AccessibilityChildrenVector& unignoredChildren(bool updateChildrenIfNeeded = true) { return children(updateChildrenIfNeeded); }
-    AXCoreObject* firstUnignoredChild()
+    bool hasUnignoredChild()
     {
         const auto& children = this->children();
-        return children.size() ? children[0].ptr() : nullptr;
+        return !children.isEmpty();
     }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     AccessibilityChildrenVector stitchedUnignoredChildren();
@@ -1039,8 +1039,8 @@ public:
     // is the default, we should rename this function to childrenIDsIncludingIgnored, as that is what all
     // callers will expect at the time this comment was written.
     Vector<AXID> childrenIDs(bool updateChildrenIfNeeded = true);
-    AXCoreObject* nextInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
-    AXCoreObject* nextInPreOrder(bool updateChildrenIfNeeded, AXCoreObject* stayWithin, bool includeCrossFrame);
+    RefPtr<AXCoreObject> nextInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
+    RefPtr<AXCoreObject> nextInPreOrder(bool updateChildrenIfNeeded, AXCoreObject* stayWithin, bool includeCrossFrame);
     AXCoreObject* nextSiblingIncludingIgnored(bool updateChildrenIfNeeded) const;
     AXCoreObject* nextSiblingIncludingIgnored(bool updateChildrenIfNeeded, bool includeCrossFrame) const;
     AXCoreObject* nextUnignoredSibling(bool updateChildrenIfNeeded, AXCoreObject* unignoredParent = nullptr) const;
@@ -1051,7 +1051,7 @@ public:
         return object ? std::optional(object->objectID()) : std::nullopt;
     }
 
-    AXCoreObject* previousInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
+    RefPtr<AXCoreObject> previousInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
     AXCoreObject* previousSiblingIncludingIgnored(bool updateChildrenIfNeeded);
     AXCoreObject* deepestLastChildIncludingIgnored(bool updateChildrenIfNeeded);
 

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -221,7 +221,7 @@ bool AXLiveRegionManager::shouldIncludeInSnapshot(AccessibilityObject& object) c
         return true;
 
     // If an object has unignored children, there isn't a need to include it in the snapshot since the children will return YES.
-    if (object.firstUnignoredChild())
+    if (object.hasUnignoredChild())
         return false;
 
     // For leaf objects, include if they have a value (e.g., form controls).

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -454,7 +454,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // descendants. These anonymous renderers are the only accessible objects
         // containing the operator.
         role = AccessibilityRole::StaticText;
-    } else if (role == AccessibilityRole::Canvas && firstUnignoredChild() && !containsOnlyStaticText()) {
+    } else if (role == AccessibilityRole::Canvas && hasUnignoredChild() && !containsOnlyStaticText()) {
         // If this is a canvas with fallback content (one or more non-text thing), re-map to group.
         role = AccessibilityRole::Group;
     } else {
@@ -487,7 +487,7 @@ bool AXCoreObject::isEmptyGroup()
         return false;
 
     return [rolePlatformString().createNSString() isEqual:NSAccessibilityGroupRole]
-        && !firstUnignoredChild()
+        && !hasUnignoredChild()
         && ![renderWidgetChildren(*this) count];
 }
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -118,12 +118,12 @@ ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
     m_scroller = scroller;
 }
 
-Element* ScrollTimeline::bindingsSource() const
+RefPtr<Element> ScrollTimeline::bindingsSource() const
 {
     return source();
 }
 
-Element* ScrollTimeline::source() const
+RefPtr<Element> ScrollTimeline::source() const
 {
     auto source = m_source.styleable();
     if (!source)
@@ -137,12 +137,12 @@ Element* ScrollTimeline::source() const
                     Ref document = nearestSource->document();
                     RefPtr documentElement = document->documentElement();
                     if (nearestSource != documentElement)
-                        return nearestSource.unsafeGet();
+                        return nearestSource;
                     // RenderObject::enclosingScrollableContainer() will return the document element even in
                     // quirks mode, but the scrolling element in that case is the <body> element, so we must
                     // make sure to return Document::scrollingElement() in case the document element is
                     // returned by enclosingScrollableContainer() but it was not explicitly set as the source.
-                    return &source->element == documentElement ? nearestSource.unsafeGet() : document->scrollingElement();
+                    return &source->element == documentElement ? nearestSource : document->scrollingElement();
                 }
             }
         }

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -51,8 +51,8 @@ public:
     static Ref<ScrollTimeline> createInactiveStyleOriginatedTimeline(const AtomString& name);
 
     const WeakStyleable& sourceStyleable() const { return m_source; }
-    virtual Element* bindingsSource() const;
-    virtual Element* source() const;
+    virtual RefPtr<Element> bindingsSource() const;
+    virtual RefPtr<Element> source() const;
     void setSource(Element*);
     void setSource(const Styleable&);
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -433,14 +433,14 @@ Style::SingleAnimationRange ViewTimeline::defaultRange() const
     return Style::SingleAnimationRange::defaultForViewTimeline();
 }
 
-Element* ViewTimeline::bindingsSource() const
+RefPtr<Element> ViewTimeline::bindingsSource() const
 {
     if (auto subject = m_subject.styleable())
         subject->element.protectedDocument()->updateStyleIfNeeded();
     return ScrollTimeline::bindingsSource();
 }
 
-Element* ViewTimeline::source() const
+RefPtr<Element> ViewTimeline::source() const
 {
     if (CheckedPtr sourceRender = sourceScrollerRenderer())
         return sourceRender->element();

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -89,8 +89,8 @@ public:
 
     const RenderBox* sourceScrollerRenderer() const;
     CheckedPtr<const RenderElement> stickyContainer() const;
-    Element* bindingsSource() const override;
-    Element* source() const override;
+    RefPtr<Element> bindingsSource() const override;
+    RefPtr<Element> source() const override;
     Style::SingleAnimationRange defaultRange() const final;
 
     std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const Style::SingleAnimationRange&) const final;

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -242,7 +242,7 @@ bool JSDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* le
         // FIXME: scopedChild/scopedChildCount and RemoteFrame need to work together well. We're using using child/childCount until then.
         if (is<LocalFrame>(frame)) {
             if (index < frame->tree().scopedChildCount()) {
-                if (auto* scopedChild = frame->tree().scopedChild(index)) {
+                if (RefPtr scopedChild = frame->tree().scopedChild(index)) {
                     slot.setValue(thisObject, enumToUnderlyingType(JSC::PropertyAttribute::ReadOnly), toJS(lexicalGlobalObject, scopedChild->window()));
                     return true;
                 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2434,14 +2434,14 @@ bool Document::isBodyPotentiallyScrollable(HTMLBodyElement& body)
         && !body.computedStyle()->isOverflowVisible();
 }
 
-Element* Document::scrollingElementForAPI()
+RefPtr<Element> Document::scrollingElementForAPI()
 {
     if (inQuirksMode())
         updateLayoutIgnorePendingStylesheets();
     return scrollingElement();
 }
 
-Element* Document::scrollingElement()
+RefPtr<Element> Document::scrollingElement()
 {
     // See https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement.
     // The scrollingElement attribute, on getting, must run these steps:
@@ -2450,7 +2450,7 @@ Element* Document::scrollingElement()
         // 1. If the HTML body element exists, and it is not potentially scrollable, return the
         // HTML body element and abort these steps.
         if (RefPtr firstBody = body(); firstBody && !isBodyPotentiallyScrollable(*firstBody))
-            return firstBody.unsafeGet();
+            return firstBody;
 
         // 2. Return null and abort these steps.
         return nullptr;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -577,8 +577,8 @@ public:
     std::optional<BoundaryPoint> caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource);
     RefPtr<CaretPosition> caretPositionFromPoint(double x, double y, CaretPositionFromPointOptions);
 
-    WEBCORE_EXPORT Element* scrollingElementForAPI();
-    WEBCORE_EXPORT Element* scrollingElement();
+    WEBCORE_EXPORT RefPtr<Element> scrollingElementForAPI();
+    WEBCORE_EXPORT RefPtr<Element> scrollingElement();
 
     enum class ReadyState : uint8_t { Loading, Interactive, Complete };
     ReadyState readyState() const { return m_readyState; }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6387,7 +6387,7 @@ TextStream& operator<<(TextStream& ts, ContentRelevancy relevancy)
 // https://html.spec.whatwg.org/#topmost-popover-ancestor
 // Consider both DOM ancestors and popovers where the given popover was invoked from as ancestors.
 // Use top layer positions to disambiguate the topmost one when both exist.
-HTMLElement* Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
+RefPtr<HTMLElement> Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
 {
     // Store positions to avoid having to do O(n) search for every popover invoker.
     HashMap<Ref<const Element>, size_t> topLayerPositions;
@@ -6429,7 +6429,7 @@ HTMLElement* Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
     if (topLayerType == TopLayerElementType::Popover)
         checkAncestor(popoverData()->invoker());
 
-    return topmostAncestor.unsafeGet();
+    return topmostAncestor;
 }
 
 double Element::lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const CSSCalc::RandomCachingKey& key) const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -223,7 +223,7 @@ public:
     inline String attributeTrimmedWithDefaultARIA(const QualifiedName&) const;
 
     enum class TopLayerElementType : bool { Other, Popover };
-    HTMLElement* topmostPopoverAncestor(TopLayerElementType topLayerType);
+    RefPtr<HTMLElement> topmostPopoverAncestor(TopLayerElementType topLayerType);
 
     // https://github.com/w3c/aria/pull/2484
     // These ARIA attributes will become enumerated. Currently, they use [ReflectSetter] with custom getters

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -277,7 +277,7 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
         appendOutputForElement(output, *element);
 }
 
-static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector& firstSelector)
+static Ref<ContainerNode> filterRootById(ContainerNode& rootNode, const CSSSelector& firstSelector)
 {
     if (!rootNode.isConnected())
         return rootNode;
@@ -303,7 +303,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();
                     if (searchRoot && (rootNode.isTreeScope() || searchRoot->isInclusiveDescendantOf(rootNode)))
-                        return *searchRoot.unsafeGet();
+                        return searchRoot.releaseNonNull();
                 }
             }
         }
@@ -575,7 +575,7 @@ bool SelectorDataList::compileSelector(const SelectorData& selectorData)
 template<typename OutputType>
 ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType& output) const
 {
-    ContainerNode* searchRootNode = &rootNode;
+    RefPtr<ContainerNode> searchRootNode = &rootNode;
     switch (m_matchType) {
     case RightMostWithIdMatch:
         {
@@ -622,7 +622,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
 #if ENABLE(CSS_SELECTOR_JIT)
     case CompiledSingleWithRootFilter:
         CompiledSingleWithRootFilterCase:
-        searchRootNode = &filterRootById(*searchRootNode, *m_selectors.first().selector);
+        searchRootNode = filterRootById(*searchRootNode, *m_selectors.first().selector);
         [[fallthrough]];
     case CompiledSingle:
         {
@@ -651,7 +651,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
 
     case SingleSelectorWithRootFilter:
         SingleSelectorWithRootFilterCase:
-        searchRootNode = &filterRootById(*searchRootNode, *m_selectors.first().selector);
+        searchRootNode = filterRootById(*searchRootNode, *m_selectors.first().selector);
         [[fallthrough]];
     case SingleSelector:
         SingleSelectorCase:

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -461,14 +461,14 @@ EditCommandComposition* CompositeEditCommand::composition() const
     return nullptr;
 }
 
-EditCommandComposition& CompositeEditCommand::ensureComposition()
+Ref<EditCommandComposition> CompositeEditCommand::ensureComposition()
 {
-    RefPtr command { this };
+    Ref command { *this };
     while (RefPtr parent = command->parent())
-        command = WTFMove(parent);
+        command = parent.releaseNonNull();
     if (!command->m_composition)
         command->m_composition = EditCommandComposition::create(document(), startingSelection(), endingSelection(), editingAction());
-    return *command->m_composition.unsafeGet();
+    return *command->m_composition;
 }
 
 bool CompositeEditCommand::preservesTypingStyle() const
@@ -509,7 +509,7 @@ void CompositeEditCommand::applyCommandToComposite(Ref<EditCommand>&& command)
     command->doApply();
     if (auto* simpleCommand = dynamicDowncast<SimpleEditCommand>(command.get())) {
         command->setParent(nullptr);
-        ensureComposition().append(simpleCommand);
+        ensureComposition()->append(simpleCommand);
     }
     m_commands.append(WTFMove(command));
 }

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -121,7 +121,7 @@ public:
     bool isFirstCommand(EditCommand* command) { return !m_commands.isEmpty() && m_commands.first() == command; }
     EditCommandComposition* composition() const;
     RefPtr<EditCommandComposition> protectedComposition() const { return composition(); }
-    EditCommandComposition& ensureComposition();
+    Ref<EditCommandComposition> ensureComposition();
 
     virtual bool isTypingCommand() const;
     virtual bool isDictationCommand() const { return false; }

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -382,7 +382,7 @@ std::pair<String, MarkupAccumulator::IsCreatedByURLReplacement> MarkupAccumulato
     return { element.resolveURLStringIfNeeded(urlString, m_resolveURLs), IsCreatedByURLReplacement::No };
 }
 
-const ShadowRoot* MarkupAccumulator::suitableShadowRoot(const Node& node)
+RefPtr<const ShadowRoot> MarkupAccumulator::suitableShadowRoot(const Node& node)
 {
     if (!shouldIncludeShadowRoots())
         return nullptr;
@@ -390,7 +390,7 @@ const ShadowRoot* MarkupAccumulator::suitableShadowRoot(const Node& node)
     RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(node);
     if (!shadowRoot || !includeShadowRoot(*shadowRoot))
         return nullptr;
-    return shadowRoot.unsafeGet();
+    return shadowRoot;
 }
 
 void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespaces)

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -121,7 +121,7 @@ private:
     LocalFrame* frameForAttributeReplacement(const Element&) const;
     Attribute replaceAttributeIfNecessary(const Element&, const Attribute&);
     bool appendURLAttributeForReplacementIfNecessary(StringBuilder&, const Element&, Namespaces*);
-    const ShadowRoot* suitableShadowRoot(const Node&);
+    RefPtr<const ShadowRoot> suitableShadowRoot(const Node&);
     bool shouldExcludeElement(const Element&);
     void appendStartTagWithURLReplacement(StringBuilder&, const Element&, Namespaces*);
 

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -651,11 +651,11 @@ auto VisiblePosition::localCaretRect() const -> LocalCaretRect
         return { };
 
     auto boxAndOffset = inlineBoxAndOffset();
-    CheckedPtr renderer = boxAndOffset.box ? &boxAndOffset.box->renderer() : node->renderer();
+    CheckedPtr renderer = boxAndOffset.box ? const_cast<RenderObject*>(&boxAndOffset.box->renderer()) : node->renderer();
     if (!renderer)
         return { };
 
-    return { computeLocalCaretRect(*renderer, boxAndOffset), const_cast<RenderObject*>(renderer.unsafeGet()) };
+    return { computeLocalCaretRect(*renderer, boxAndOffset), WTFMove(renderer) };
 }
 
 IntRect VisiblePosition::absoluteCaretBounds(bool* insideFixed) const

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -110,7 +110,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
 
     ContainerNode& root = rootNode();
     if (traversalType != CollectionTraversalType::CustomForwardOnly && root.isInTreeScope()) {
-        RefPtr<Element> candidate;
+        WeakPtr<Element, WeakPtrImplWithEventTargetData> candidate;
 
         TreeScope& treeScope = root.treeScope();
         if (treeScope.hasElementWithId(name)) {
@@ -130,7 +130,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
 
         if (candidate && collection().elementMatches(*candidate)) {
             if (traversalType == CollectionTraversalType::ChildrenOnly ? candidate->parentNode() == &root : candidate->isDescendantOf(root))
-                return candidate.unsafeGet();
+                return candidate.get();
         }
     }
 

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -82,7 +82,7 @@ public:
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
 
-    CanvasRenderingContext* getContext(const String&);
+    RefPtr<CanvasRenderingContext> getContext(const String&);
 
     static bool is2dType(const String&);
     CanvasRenderingContext2D* createContext2d(const String&, CanvasRenderingContext2DSettings&&);
@@ -92,7 +92,7 @@ public:
     static bool isWebGLType(const String&);
     static WebGLVersion toWebGLVersion(const String&);
     WebGLRenderingContextBase* createContextWebGL(WebGLVersion type, WebGLContextAttributes&& = { });
-    WebGLRenderingContextBase* getContextWebGL(WebGLVersion type, WebGLContextAttributes&& = { });
+    RefPtr<WebGLRenderingContextBase> getContextWebGL(WebGLVersion type, WebGLContextAttributes&& = { });
 #endif
 
     static bool isBitmapRendererType(const String&);

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -97,7 +97,8 @@ HTMLElement* HTMLFormControlsCollection::customElementAfter(Element* current) co
         if (element->asFormListedElement()->isEnumeratable()) {
             m_cachedElement = element.get();
             m_cachedElementOffsetInArray = i;
-            return element.unsafeGet();
+            ASSERT(element == elements[i].get());
+            return elements[i].get();
         }
     }
     return nullptr;

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
@@ -59,8 +59,10 @@ void ArchiveResourceCollection::addResource(Ref<ArchiveResource>&& resource)
 
 ArchiveResource* ArchiveResourceCollection::archiveResourceForURL(const URL& url)
 {
-    if (RefPtr resource = m_subresources.get(url.string()))
-        return resource.unsafeGet();
+    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
+    // as we merely return it right away (rdar://165602290).
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* resource = m_subresources.get(url.string()))
+        return resource;
     if (!url.protocolIs("https"_s))
         return nullptr;
     URL httpURL = url;

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -288,11 +288,10 @@ Image* CachedImage::imageForRenderer(const RenderObject* renderer)
         return &Image::nullImage();
 
     if (m_image->drawsSVGImage()) {
-        RefPtr image = m_svgImageCache->imageForRenderer(renderer);
-        if (image != &Image::nullImage())
-            return image.unsafeGet();
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* image = m_svgImageCache->imageForRenderer(renderer); image != &Image::nullImage())
+            return image;
     }
-    return m_image.unsafeGet();
+    return m_image.get();
 }
 
 void CachedImage::setContainerContextForClient(const CachedImageClient& client, const LayoutSize& containerSize, float containerZoom, const URL& imageURL)

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -131,7 +131,7 @@ int MathMLSelectElement::getSelectedActionChildAndIndex(Element*& selectedChild)
     return i;
 }
 
-Element* MathMLSelectElement::getSelectedActionChild()
+RefPtr<Element> MathMLSelectElement::getSelectedActionChild()
 {
     ASSERT(hasTagName(mactionTag));
 
@@ -154,10 +154,10 @@ Element* MathMLSelectElement::getSelectedActionChild()
         child = selectedChild;
     }
 
-    return child.unsafeGet();
+    return child;
 }
 
-Element* MathMLSelectElement::getSelectedSemanticsChild()
+RefPtr<Element> MathMLSelectElement::getSelectedSemanticsChild()
 {
     ASSERT(hasTagName(semanticsTag));
 
@@ -170,7 +170,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
         child = child->nextElementSibling();
     } else if (!downcast<MathMLElement>(*child).isSemanticAnnotation()) {
         // The first child is a presentation MathML but not an annotation, so we can just display it.
-        return child.unsafeGet();
+        return child;
     }
     // Otherwise, the first child is an <annotation> or <annotation-xml> element. This is invalid, but some people use this syntax so we take care of this case too and start the search from this first child.
 
@@ -183,7 +183,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             if (child->hasAttributeWithoutSynchronization(MathMLNames::srcAttr))
                 continue;
             // Otherwise, we assume it is a text annotation that can always be displayed and we stop here.
-            return child.unsafeGet();
+            return child;
         }
 
         if (child->hasTagName(MathMLNames::annotation_xmlTag)) {
@@ -193,7 +193,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             // If the <annotation-xml> element has an encoding attribute describing presentation MathML, SVG or HTML we assume the content can be displayed and we stop here.
             auto& value = child->attributeWithoutSynchronization(MathMLNames::encodingAttr);
             if (isMathMLEncoding(value) || isSVGEncoding(value) || isHTMLEncoding(value))
-                return child.unsafeGet();
+                return child;
         }
     }
 
@@ -206,7 +206,7 @@ void MathMLSelectElement::updateSelectedChild()
     if (document().settings().coreMathMLEnabled())
         return;
 
-    auto* newSelectedChild = hasTagName(mactionTag) ? getSelectedActionChild() : getSelectedSemanticsChild();
+    RefPtr newSelectedChild = hasTagName(mactionTag) ? getSelectedActionChild() : getSelectedSemanticsChild();
 
     if (m_selectedChild == newSelectedChild)
         return;

--- a/Source/WebCore/mathml/MathMLSelectElement.h
+++ b/Source/WebCore/mathml/MathMLSelectElement.h
@@ -54,8 +54,8 @@ private:
 
     void toggle();
     int getSelectedActionChildAndIndex(Element*& selectedChild);
-    Element* getSelectedActionChild();
-    Element* getSelectedSemanticsChild();
+    RefPtr<Element> getSelectedActionChild();
+    RefPtr<Element> getSelectedSemanticsChild();
 
     void updateSelectedChild() final;
     RefPtr<Element> m_selectedChild;

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -154,7 +154,7 @@ void AutoscrollController::updateAutoscrollRenderer()
 void AutoscrollController::updateDragAndDrop(Node* dropTargetNode, const IntPoint& eventPosition, MonotonicTime eventTime)
 {
     IntSize offset;
-    auto findDragAndDropScroller = [&]() -> RenderBox* {
+    auto findDragAndDropScroller = [&]() -> CheckedPtr<RenderBox> {
         if (!dropTargetNode)
             return nullptr;
 
@@ -170,7 +170,7 @@ void AutoscrollController::updateDragAndDrop(Node* dropTargetNode, const IntPoin
         if (offset.isZero())
             return nullptr;
 
-        return scrollable.unsafeGet();
+        return scrollable;
     };
     
     CheckedPtr scrollable = findDragAndDropScroller();

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -828,7 +828,7 @@ static inline size_t indexOf(DebugPageOverlays::RegionType regionType)
     return static_cast<size_t>(regionType);
 }
 
-RegionOverlay& DebugPageOverlays::ensureRegionOverlayForPage(Page& page, RegionType regionType)
+Ref<RegionOverlay> DebugPageOverlays::ensureRegionOverlayForPage(Page& page, RegionType regionType)
 {
     auto it = m_pageRegionOverlays.find(page);
     if (it != m_pageRegionOverlays.end()) {
@@ -839,16 +839,16 @@ RegionOverlay& DebugPageOverlays::ensureRegionOverlayForPage(Page& page, RegionT
     }
 
     Vector<RefPtr<RegionOverlay>> visualizers(NumberOfRegionTypes);
-    auto visualizer = RegionOverlay::create(page, regionType);
+    Ref visualizer = RegionOverlay::create(page, regionType);
     visualizers[indexOf(regionType)] = visualizer.copyRef();
     m_pageRegionOverlays.add(page, WTFMove(visualizers));
-    return visualizer.unsafeGet();
+    return visualizer;
 }
 
 void DebugPageOverlays::showRegionOverlay(Page& page, RegionType regionType)
 {
-    auto& visualizer = ensureRegionOverlayForPage(page, regionType);
-    page.pageOverlayController().installPageOverlay(visualizer.overlay(), PageOverlay::FadeMode::DoNotFade);
+    Ref visualizer = ensureRegionOverlayForPage(page, regionType);
+    page.pageOverlayController().installPageOverlay(visualizer->overlay(), PageOverlay::FadeMode::DoNotFade);
 }
 
 void DebugPageOverlays::hideRegionOverlay(Page& page, RegionType regionType)

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -76,7 +76,7 @@ private:
     bool shouldPaintOverlayIntoLayer(Page&, RegionType) const;
 
     RegionOverlay* regionOverlayForPage(Page&, RegionType) const;
-    RegionOverlay& ensureRegionOverlayForPage(Page&, RegionType);
+    Ref<RegionOverlay> ensureRegionOverlayForPage(Page&, RegionType);
 
     WeakHashMap<Page, Vector<RefPtr<RegionOverlay>>> m_pageRegionOverlays;
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -557,13 +557,13 @@ static inline bool dispatchSelectStart(Node* node)
     return !event->defaultPrevented();
 }
 
-static Node* nodeToSelectOnMouseDownForNode(Node& targetNode)
+static RefPtr<Node> nodeToSelectOnMouseDownForNode(Node& targetNode)
 {
     if (ImageOverlay::isInsideOverlay(targetNode))
         return nullptr;
 
     if (RefPtr rootUserSelectAll = Position::rootUserSelectAllForNode(&targetNode))
-        return rootUserSelectAll.unsafeGet();
+        return rootUserSelectAll;
 
     if (targetNode.shouldSelectOnMouseDown())
         return &targetNode;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -89,14 +89,14 @@ static HTMLElement* invokerForOpenPopover(const Node* candidatePopover)
     return nullptr;
 }
 
-static Element* openPopoverForInvoker(const Node* candidateInvoker)
+static RefPtr<Element> openPopoverForInvoker(const Node* candidateInvoker)
 {
     RefPtr invoker = dynamicDowncast<HTMLElement>(candidateInvoker);
     if (!invoker)
         return nullptr;
     RefPtr popover = invoker->invokedPopover();
     if (popover && popover->isPopoverShowing() && popover->popoverData()->invoker() == invoker)
-        return popover.unsafeGet();
+        return popover;
     return nullptr;
 }
 
@@ -751,7 +751,7 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
             auto candidateInInnerScope = findFocusableElementWithinScope(direction, FocusNavigationScope::scopeOwnedByScopeOwner(*currentElement), nullptr, focusEventData);
             if (candidateInInnerScope.element)
                 return candidateInInnerScope;
-        } else if (auto* popover = openPopoverForInvoker(currentNode)) {
+        } else if (RefPtr popover = openPopoverForInvoker(currentNode)) {
             auto candidateInInnerScope = findFocusableElementWithinScope(direction, FocusNavigationScope::scopeOwnedByScopeOwner(*popover), nullptr, focusEventData);
             if (candidateInInnerScope.element)
                 return candidateInInnerScope;

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -153,7 +153,7 @@ public:
     virtual bool frameCanCreatePaymentSession() const;
     FrameTreeSyncData& frameTreeSyncData() const { return m_frameTreeSyncData.get(); }
     Ref<FrameTreeSyncData> protectedFrameTreeSyncData() const { return m_frameTreeSyncData.get(); }
-    WEBCORE_EXPORT virtual RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const = 0;
+    WEBCORE_EXPORT virtual SecurityOrigin* frameDocumentSecurityOrigin() const = 0;
     WEBCORE_EXPORT virtual String frameURLProtocol() const = 0;
 
     WEBCORE_EXPORT virtual void setPrinting(bool printing, FloatSize pageSize, FloatSize originalPageSize, float maximumShrinkRatio, AdjustViewSize, NotifyUIProcess = NotifyUIProcess::Yes);

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -78,17 +78,17 @@ public:
     Frame* child(unsigned index) const;
     Frame* childBySpecifiedName(const AtomString& name) const;
     Frame* descendantByFrameID(FrameIdentifier) const;
-    WEBCORE_EXPORT Frame* findByUniqueName(const AtomString&, Frame& activeFrame) const;
-    WEBCORE_EXPORT Frame* findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
+    WEBCORE_EXPORT RefPtr<Frame> findByUniqueName(const AtomString&, Frame& activeFrame) const;
+    WEBCORE_EXPORT RefPtr<Frame> findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT Frame& top() const;
     Ref<Frame> protectedTop() const;
     unsigned depth() const;
 
-    WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
-    WEBCORE_EXPORT Frame* scopedChildByUniqueName(const AtomString&) const;
-    Frame* scopedChildBySpecifiedName(const AtomString& name) const;
+    WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;
+    WEBCORE_EXPORT RefPtr<Frame> scopedChildByUniqueName(const AtomString&) const;
+    RefPtr<Frame> scopedChildBySpecifiedName(const AtomString& name) const;
     unsigned scopedChildCount() const;
 
 private:
@@ -96,11 +96,11 @@ private:
     Frame* deepLastChild() const;
     Frame* nextAncestorSibling(const Frame* stayWithin) const;
 
-    Frame* scopedChild(unsigned index, TreeScope*) const;
-    Frame* scopedChild(NOESCAPE const Function<bool(const FrameTree&)>& isMatch, TreeScope*) const;
+    RefPtr<Frame> scopedChild(unsigned index, TreeScope*) const;
+    RefPtr<Frame> scopedChild(NOESCAPE const Function<bool(const FrameTree&)>& isMatch, TreeScope*) const;
     unsigned scopedChildCount(TreeScope*) const;
 
-    template<typename F> Frame* find(const AtomString& name, F&& nameGetter, Frame& activeFrame) const;
+    template<typename F> RefPtr<Frame> find(const AtomString& name, F&& nameGetter, Frame& activeFrame) const;
 
     Ref<Frame> protectedThisFrame() const;
 

--- a/Source/WebCore/page/LargestContentfulPaint.cpp
+++ b/Source/WebCore/page/LargestContentfulPaint.cpp
@@ -115,7 +115,8 @@ Element* LargestContentfulPaint::element() const
     if (!LargestContentfulPaintData::isExposedForPaintTiming(*element))
         return nullptr;
 
-    return element.unsafeGet();
+    ASSERT(m_element == element.get());
+    return m_element.get();
 }
 
 void LargestContentfulPaint::setElement(Element* element)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1678,7 +1678,7 @@ bool LocalFrame::frameCanCreatePaymentSession() const
 #endif
 }
 
-RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
+SecurityOrigin* LocalFrame::frameDocumentSecurityOrigin() const
 {
     if (RefPtr document = this->document())
         return &document->securityOrigin();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -375,7 +375,7 @@ private:
     void changeLocation(FrameLoadRequest&&) final;
     void loadFrameRequest(FrameLoadRequest&&, Event*) final;
     void didFinishLoadInAnotherProcess() final;
-    RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const final;
+    SecurityOrigin* frameDocumentSecurityOrigin() const final;
     String frameURLProtocol() const final;
 
     FrameView* virtualView() const final;

--- a/Source/WebCore/page/PerformanceEventTiming.cpp
+++ b/Source/WebCore/page/PerformanceEventTiming.cpp
@@ -52,20 +52,16 @@ PerformanceEventTiming::PerformanceEventTiming(const PerformanceEventTimingCandi
 
 PerformanceEventTiming::~PerformanceEventTiming() = default;
 
-Node* PerformanceEventTiming::target() const
+RefPtr<Node> PerformanceEventTiming::target() const
 {
-    if (!m_target || !m_target->isNode())
+    RefPtr node = dynamicDowncast<Node>(m_target.get());
+    if (!node || !node->isConnected())
         return nullptr;
 
-    RefPtr<Node> node = downcast<Node>((m_target.get()));
-    if (!node)
+    if (!node->protectedDocument()->isFullyActive())
         return nullptr;
 
-    Ref document = node->document();
-    if (!node->isConnected() || !document->isFullyActive())
-        return nullptr;
-
-    return node.unsafeGet();
+    return node;
 }
 
 PerformanceEntry::Type PerformanceEventTiming::performanceEntryType() const

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -45,7 +45,7 @@ public:
     DOMHighResTimeStamp processingStart() const { return m_processingStart.milliseconds(); }
     DOMHighResTimeStamp processingEnd() const { return m_processingEnd.milliseconds(); }
     bool cancelable() const { return m_cancelable; }
-    Node* target() const;
+    RefPtr<Node> target() const;
     uint64_t interactionId() const;
 
     Type performanceEntryType() const final;

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -61,10 +61,9 @@ PointerCaptureController::PointerCaptureController(Page& page)
 
 Element* PointerCaptureController::pointerCaptureElement(Document* document, PointerID pointerId) const
 {
-    if (auto capturingData = m_activePointerIdsToCapturingData.get(pointerId)) {
-        auto pointerCaptureElement = capturingData->targetOverride;
-        if (pointerCaptureElement && &pointerCaptureElement->document() == document)
-            return pointerCaptureElement.unsafeGet();
+    if (auto* capturingData = m_activePointerIdsToCapturingData.get(pointerId)) {
+        if (capturingData->targetOverride && &capturingData->targetOverride->document() == document)
+            return capturingData->targetOverride.get();
     }
     return nullptr;
 }

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -183,9 +183,9 @@ void RemoteFrame::reportMixedContentViolation(bool blocked, const URL& target) c
     m_client->reportMixedContentViolation(blocked, target);
 }
 
-RefPtr<SecurityOrigin> RemoteFrame::frameDocumentSecurityOrigin() const
+SecurityOrigin* RemoteFrame::frameDocumentSecurityOrigin() const
 {
-    return frameTreeSyncData().frameDocumentSecurityOrigin;
+    return frameTreeSyncData().frameDocumentSecurityOrigin.get();
 }
 
 String RemoteFrame::frameURLProtocol() const
@@ -195,9 +195,8 @@ String RemoteFrame::frameURLProtocol() const
 
 const SecurityOrigin& RemoteFrame::frameDocumentSecurityOriginOrOpaque() const
 {
-    RefPtr securityOrigin = frameDocumentSecurityOrigin();
-    if (securityOrigin)
-        return *securityOrigin.unsafeGet();
+    if (auto* securityOrigin = frameDocumentSecurityOrigin())
+        return *securityOrigin;
     return SecurityOrigin::opaqueOrigin();
 }
 

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -94,7 +94,7 @@ private:
     void didFinishLoadInAnotherProcess() final;
     bool isRootFrame() const final { return false; }
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
-    RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const final;
+    SecurityOrigin* frameDocumentSecurityOrigin() const final;
     String frameURLProtocol() const final;
 
     FrameView* virtualView() const final;

--- a/Source/WebCore/page/UserMessageHandlersNamespace.cpp
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.cpp
@@ -78,7 +78,7 @@ bool UserMessageHandlersNamespace::isSupportedPropertyName(const AtomString&)
     return false;
 }
 
-UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& world, const AtomString& name)
+RefPtr<UserMessageHandler> UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& world, const AtomString& name)
 {
     RefPtr frame = this->frame();
     if (!frame)
@@ -90,7 +90,7 @@ UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& wor
 
     RefPtr handler = m_messageHandlers.get({ name, &world });
     if (handler)
-        return handler.unsafeGet();
+        return handler;
 
     userContentProvider->forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
         if (descriptor.name() != name || &descriptor.world() != &world)
@@ -102,7 +102,7 @@ UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& wor
         handler = addResult.iterator->value.get();
     });
 
-    return handler.unsafeGet();
+    return handler;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserMessageHandlersNamespace.h
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.h
@@ -52,7 +52,7 @@ public:
     virtual ~UserMessageHandlersNamespace();
 
     Vector<AtomString> supportedPropertyNames() const;
-    UserMessageHandler* namedItem(DOMWrapperWorld&, const AtomString&);
+    RefPtr<UserMessageHandler> namedItem(DOMWrapperWorld&, const AtomString&);
     bool isSupportedPropertyName(const AtomString&);
 
     // UserContentProviderInvalidationClient, FrameDestructionObserver.

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -622,8 +622,8 @@ LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(std::option
     if (!page())
         return nullptr;
     for (const auto& rootFrame : page()->rootFrames()) {
-        if (RefPtr frameView = frameViewForScrollingNode(rootFrame.get(), scrollingNodeID))
-            return frameView.unsafeGet();
+        if (auto* frameView = frameViewForScrollingNode(rootFrame.get(), scrollingNodeID))
+            return frameView;
     }
     return nullptr;
 }

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -581,7 +581,7 @@ void WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange
     Ref currentCommand = state->reappliedCommands.takeLast();
 
     // The prior replacement command must be undone in such a way as to not have it be added to the undo stack.
-    currentCommand->ensureComposition().unapply(EditCommandComposition::AddToUndoStack::No);
+    currentCommand->ensureComposition()->unapply(EditCommandComposition::AddToUndoStack::No);
 
     // Now that the prior replacement command is undone, remove and replace it with a fresh command, with the same range.
     // The same range is used since it represents the end of the previous command, and is only updated again when `finished` is `true`,
@@ -665,7 +665,7 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
     Ref currentCommand = state->reappliedCommands.takeLast();
 
     // The prior replacement command must be undone in such a way as to not have it be added to the undo stack
-    currentCommand->ensureComposition().unapply(EditCommandComposition::AddToUndoStack::No);
+    currentCommand->ensureComposition()->unapply(EditCommandComposition::AddToUndoStack::No);
 
     // Now that the prior replacement command is undone, remove and replace it with a fresh command, with the same range.
     // The same range is used since it represents the end of the previous command, and is only updated again when `finished` is `true`,
@@ -1057,7 +1057,7 @@ void WritingToolsController::updateStateForSelectedSuggestionIfNeeded()
 static bool appliedCommandIsWritingToolsCommand(const Vector<Ref<WritingToolsCompositionCommand>>& commands, EditCommandComposition* composition)
 {
     return std::ranges::any_of(commands, [composition](const auto& command) {
-        return &command->ensureComposition() == composition;
+        return command->ensureComposition().ptr() == composition;
     });
 }
 
@@ -1144,7 +1144,7 @@ void WritingToolsController::showOriginalCompositionForSession()
         auto oldSize = stack.size();
 
         // Each call to `unapply` indirectly results in a call to `respondToUnappliedEditing`, which decrements the size of the stack.
-        stack.last()->ensureComposition().unapply();
+        stack.last()->ensureComposition()->unapply();
 
         RELEASE_ASSERT(oldSize > stack.size());
     }
@@ -1166,7 +1166,7 @@ void WritingToolsController::showRewrittenCompositionForSession()
         auto oldSize = stack.size();
 
         // Each call to `reapply` indirectly results in a call to `respondToReappliedEditing`, which decrements the size of the stack.
-        stack.last()->ensureComposition().reapply();
+        stack.last()->ensureComposition()->reapply();
 
         RELEASE_ASSERT(oldSize > stack.size());
     }

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -191,8 +191,7 @@ public:
 #if PLATFORM(COCOA)
     virtual id accessibilityHitTest(const IntPoint&) const { return nil; }
     virtual id accessibilityObject() const { return nil; }
-    NSView* outerView() const;
-    RetainPtr<NSView> protectedOuterView() const;
+    RetainPtr<NSView> outerView() const;
 
     void removeFromSuperview();
 #endif

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -31,6 +31,7 @@
 #include <QuartzCore/CALayer.h>
 #include <WebCore/FloatRect.h>
 #include <pal/spi/cocoa/FoundationSPI.h>
+#include <wtf/RefPtr.h>
 
 OBJC_CLASS AVPlayerController;
 OBJC_CLASS NSDictionary;
@@ -43,7 +44,7 @@ class VideoPresentationModel;
 WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, retain, nullable) NSString *videoGravity;
 @property (nonatomic, getter=isReadyForDisplay) BOOL readyForDisplay;
-@property (nonatomic, assign, nullable) WebCore::VideoPresentationModel* presentationModel;
+@property (nonatomic, assign) RefPtr<WebCore::VideoPresentationModel> presentationModel;
 @property (nonatomic, retain, nonnull) AVPlayerController *playerController;
 @property (nonatomic, retain, nonnull) CALayer *videoSublayer;
 @property (nonatomic, retain, nullable) CALayer *captionsLayer;

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -124,12 +124,12 @@ private:
     [super dealloc];
 }
 
-- (VideoPresentationModel*)presentationModel
+- (RefPtr<VideoPresentationModel>)presentationModel
 {
-    return _presentationModel.get().unsafeGet();
+    return _presentationModel.get();
 }
 
-- (void)setPresentationModel:(VideoPresentationModel*)presentationModel
+- (void)setPresentationModel:(RefPtr<VideoPresentationModel>)presentationModel
 {
     auto model = _presentationModel.get();
     if (model == presentationModel)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY) && HAVE(AVKIT)
 
 #import "WebAVPlayerLayer.h"
+#import <WebCore/VideoPresentationModel.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 
@@ -148,9 +149,9 @@ static WebAVPictureInPicturePlayerLayerView *WebAVPlayerLayerView_pictureInPictu
     if (WebAVPictureInPicturePlayerLayerView *pipView = [playerLayerView valueForKey:pictureInPicturePlayerLayerViewKey])
         return pipView;
 
-    auto pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstance() initWithFrame:CGRectZero]);
+    RetainPtr pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstance() initWithFrame:CGRectZero]);
     [playerLayerView setValue:pipView.get() forKey:pictureInPicturePlayerLayerViewKey];
-    return pipView.unsafeGet();
+    return pipView.autorelease();
 }
 #endif // HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
 

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -123,7 +123,7 @@ size_t DisplayRefreshMonitorManager::findMonitorForDisplayID(PlatformDisplayID d
     });
 }
 
-DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForClient(DisplayRefreshMonitorClient& client)
+RefPtr<DisplayRefreshMonitor> DisplayRefreshMonitorManager::monitorForClient(DisplayRefreshMonitorClient& client)
 {
     if (!client.hasDisplayID())
         return nullptr;
@@ -132,7 +132,7 @@ DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForClient(DisplayRef
     if (monitor)
         monitor->addClient(client);
 
-    return monitor.unsafeGet();
+    return monitor;
 }
 
 DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForDisplayID(PlatformDisplayID displayID) const

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
@@ -61,7 +61,7 @@ private:
 
     size_t findMonitorForDisplayID(PlatformDisplayID) const;
     DisplayRefreshMonitor* monitorForDisplayID(PlatformDisplayID) const;
-    DisplayRefreshMonitor* monitorForClient(DisplayRefreshMonitorClient&);
+    RefPtr<DisplayRefreshMonitor> monitorForClient(DisplayRefreshMonitorClient&);
 
     DisplayRefreshMonitor* ensureMonitorForDisplayID(PlatformDisplayID, DisplayRefreshMonitorFactory*);
 

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -76,9 +76,9 @@ void MediaResourceSniffer::cancel()
     m_content.reset();
 }
 
-MediaResourceSniffer::Promise& MediaResourceSniffer::promise() const
+Ref<MediaResourceSniffer::Promise> MediaResourceSniffer::promise() const
 {
-    return m_producer.promise().unsafeGet();
+    return m_producer.promise();
 }
 
 void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.h
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.h
@@ -42,7 +42,7 @@ public:
     ~MediaResourceSniffer();
 
     using Promise = NativePromise<ContentType, PlatformMediaError>;
-    Promise& promise() const;
+    Ref<Promise> promise() const;
     void cancel();
 
 private:

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -124,8 +124,10 @@ private:
     PathSegment* asSingle() { return std::get_if<PathSegment>(&m_data); }
     const PathSegment* asSingle() const { return std::get_if<PathSegment>(&m_data); }
 
-    RefPtr<PathImpl> asImpl();
-    RefPtr<const PathImpl> asImpl() const;
+    PathImpl* asImpl();
+    const PathImpl* asImpl() const;
+    RefPtr<PathImpl> asProtectedImpl();
+    RefPtr<const PathImpl> asProtectedImpl() const;
 
     std::optional<FloatPoint> initialMoveToPoint() const;
 
@@ -249,7 +251,7 @@ inline FloatPoint Path::currentPoint() const
         FloatPoint lastMoveToPoint;
         return segment->calculateEndPoint({ }, lastMoveToPoint);
     }
-    return asImpl()->currentPoint();
+    return asProtectedImpl()->currentPoint();
 }
 
 inline std::optional<FloatPoint> Path::initialMoveToPoint() const

--- a/Source/WebCore/platform/ios/WidgetIOS.mm
+++ b/Source/WebCore/platform/ios/WidgetIOS.mm
@@ -116,7 +116,7 @@ void Widget::setFrameRect(const IntRect &rect)
     m_frame = rect;
     
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    NSView *v = outerView();
+    RetainPtr v = outerView();
     NSRect f = rect;
     if (!NSEqualRects(f, [v frame])) {
         [v setFrame:f];
@@ -125,9 +125,9 @@ void Widget::setFrameRect(const IntRect &rect)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-NSView* Widget::outerView() const
+RetainPtr<NSView> Widget::outerView() const
 {
-    NSView* view = platformWidget();
+    RetainPtr view = platformWidget();
 
     // If this widget's view is a WebCoreFrameScrollView then we
     // resize its containing view, a WebFrameView.
@@ -144,7 +144,7 @@ void Widget::paint(GraphicsContext& p, const IntRect& r, SecurityOriginPaintPoli
     if (p.paintingDisabled())
         return;
     
-    NSView *view = outerView();
+    RetainPtr view = outerView();
 
     CGContextRef cgContext = p.platformContext();
     CGContextSaveGState(cgContext);
@@ -169,15 +169,15 @@ void Widget::addToSuperview(NSView *view)
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     ASSERT(view);
-    NSView *subview = outerView();
+    RetainPtr subview = outerView();
 
     if (!subview)
         return;
 
-    ASSERT(![view isDescendantOf:subview]);
+    ASSERT(![view isDescendantOf:subview.get()]);
     
     if ([subview superview] != view)
-        [view addSubview:subview];
+        [view addSubview:subview.get()];
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -185,7 +185,7 @@ void Widget::addToSuperview(NSView *view)
 void Widget::removeFromSuperview()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    safeRemoveFromSuperview(outerView());
+    safeRemoveFromSuperview(outerView().get());
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/ios/wak/WAKWindow.mm
+++ b/Source/WebCore/platform/ios/wak/WAKWindow.mm
@@ -613,7 +613,7 @@ static RetainPtr<WebEvent>& currentEvent()
 {
     if (!_tileCache)
         return NULL;
-    return _tileCache->contentReplacementImage().unsafeGet();
+    return _tileCache->contentReplacementImage().autorelease();
 }
 
 - (void)displayRect:(NSRect)rect

--- a/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
@@ -76,7 +76,7 @@
 
 - (NSResponder *)target
 {
-    return _target.get().unsafeGet();
+    return _target.getAutoreleased();
 }
 
 - (void)setTarget:(NSResponder *)target

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -113,7 +113,7 @@ void Widget::show()
     setSelfVisible(true);
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [protectedOuterView() setHidden:NO];
+    [outerView() setHidden:NO];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -125,7 +125,7 @@ void Widget::hide()
     setSelfVisible(false);
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [protectedOuterView() setHidden:YES];
+    [outerView() setHidden:YES];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -135,7 +135,7 @@ IntRect Widget::frameRect() const
         return m_frame;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    return enclosingIntRect([protectedOuterView() frame]);
+    return enclosingIntRect([outerView() frame]);
     END_BLOCK_OBJC_EXCEPTIONS
     
     return m_frame;
@@ -164,7 +164,7 @@ void Widget::setFrameRect(const IntRect& rect)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-NSView *Widget::outerView() const
+RetainPtr<NSView> Widget::outerView() const
 {
     RetainPtr view = platformWidget();
 
@@ -176,12 +176,7 @@ NSView *Widget::outerView() const
         ASSERT(view);
     }
 
-    return view.unsafeGet();
-}
-
-RetainPtr<NSView> Widget::protectedOuterView() const
-{
-    return outerView();
+    return view;
 }
 
 void Widget::paint(GraphicsContext& p, const IntRect& r, SecurityOriginPaintPolicy, RegionContext*)
@@ -271,7 +266,7 @@ void Widget::setIsSelected(bool isSelected)
 void Widget::removeFromSuperview()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    safeRemoveFromSuperview(protectedOuterView().get());
+    safeRemoveFromSuperview(outerView().get());
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -224,12 +224,12 @@ LocalFrame* HitTestResult::frame() const
     return nullptr;
 }
 
-Frame* HitTestResult::targetFrame() const
+RefPtr<Frame> HitTestResult::targetFrame() const
 {
     if (!m_innerURLElement)
         return nullptr;
 
-    auto* frame = m_innerURLElement->document().frame();
+    RefPtr frame = m_innerURLElement->document().frame();
     if (!frame)
         return nullptr;
 

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -106,7 +106,7 @@ public:
     const HitTestLocation& hitTestLocation() const { return m_hitTestLocation; }
 
     WEBCORE_EXPORT LocalFrame* frame() const;
-    WEBCORE_EXPORT Frame* targetFrame() const;
+    WEBCORE_EXPORT RefPtr<Frame> targetFrame() const;
     WEBCORE_EXPORT bool isSelected() const;
     WEBCORE_EXPORT bool allowsFollowingLink() const;
     WEBCORE_EXPORT bool allowsFollowingImageURL() const;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -826,10 +826,10 @@ void RenderBlockFlow::layoutInFlowChildren(RelayoutChildren relayoutChildren, La
         auto applyTextBoxTrimEndIfNeeded = [&] {
             // With block children and blocks-inside-inline, there's no way to tell what the last formatted line is until after we finished laying out the subtree.
             // Dirty the last formatted line (in the last IFC) and issue relayout with forcing trimming the last line if applicable.
-            if (auto* rootForLastFormattedLine = TextBoxTrimmer::lastInlineFormattingContextRootForTrimEnd(*this)) {
+            if (CheckedPtr rootForLastFormattedLine = TextBoxTrimmer::lastInlineFormattingContextRootForTrimEnd(*this)) {
                 ASSERT(rootForLastFormattedLine != this);
                 // FIXME: We should be able to damage the last line only.
-                for (RenderBlock* ancestor = rootForLastFormattedLine; ancestor && ancestor != this; ancestor = ancestor->containingBlock())
+                for (CheckedPtr<RenderBlock> ancestor = rootForLastFormattedLine; ancestor && ancestor != this; ancestor = ancestor->containingBlock())
                     ancestor->setNeedsLayout(MarkOnlyThis);
 
                 auto textBoxTrimmer = TextBoxTrimmer { *this, *rootForLastFormattedLine };

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -749,13 +749,13 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         return ImageDrawResult::DidNothing;
 
     // FIXME: Document when image != img.get().
-    auto* image = imageResource().image().unsafeGet();
+    RefPtr image = imageResource().image();
 
     ImagePaintingOptions options = {
         CompositeOperator::SourceOver,
         decodingModeForImageDraw(*image, paintInfo),
         imageOrientation(),
-        image ? chooseInterpolationQuality(paintInfo.context(), *image, image, LayoutSize(rect.size())) : InterpolationQuality::Default,
+        image ? chooseInterpolationQuality(paintInfo.context(), *image, image.get(), LayoutSize(rect.size())) : InterpolationQuality::Default,
         settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
         settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No,
 #if USE(SKIA)

--- a/Source/WebCore/rendering/TextBoxTrimmer.h
+++ b/Source/WebCore/rendering/TextBoxTrimmer.h
@@ -36,7 +36,7 @@ public:
     TextBoxTrimmer(const RenderBlockFlow& blockContainer, const RenderBlockFlow& lastFormattedLineRoot);
     ~TextBoxTrimmer();
 
-    static RenderBlockFlow* lastInlineFormattingContextRootForTrimEnd(const RenderBlockFlow& blockContainer);
+    static CheckedPtr<RenderBlockFlow> lastInlineFormattingContextRootForTrimEnd(const RenderBlockFlow& blockContainer);
 
 private:
     void adjustTextBoxTrimStatusBeforeLayout(const RenderBlockFlow* lastFormattedLineRoot);

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -108,14 +108,14 @@ const RenderElement* RenderSVGModelObject::pushMappingToContainer(const RenderLa
     ASSERT(style().position() == PositionType::Static);
 
     bool ancestorSkipped;
-    CheckedPtr container = this->container(ancestorToStopAt, ancestorSkipped);
+    WeakPtr container = this->container(ancestorToStopAt, ancestorSkipped);
     if (!container)
         return nullptr;
 
     ASSERT_UNUSED(ancestorSkipped, !ancestorSkipped);
 
-    pushOntoGeometryMap(geometryMap, ancestorToStopAt, container.get(), ancestorSkipped);
-    return container.unsafeGet();
+    pushOntoGeometryMap(geometryMap, ancestorToStopAt, CheckedPtr { container.get() }.get(), ancestorSkipped);
+    return container.get();
 }
 
 LayoutRect RenderSVGModelObject::outlineBoundsForRepaint(const RenderLayerModelObject* repaintContainer, const RenderGeometryMap* geometryMap) const

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -185,7 +185,7 @@ static inline bool isChainableResource(const SVGElement& element, const SVGEleme
     return false;
 }
 
-static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
+static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
 {
     auto paintURL = paint.tryAnyURL();
     if (!paintURL)
@@ -202,7 +202,7 @@ static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(Tre
     if (resourceType != PatternResourceType && resourceType != LinearGradientResourceType && resourceType != RadialGradientResourceType)
         return nullptr;
 
-    return container.unsafeGet();
+    return container;
 }
 
 std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderElement& renderer, const RenderStyle& style)
@@ -282,8 +282,8 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         if (style.hasFill()) {
             bool hasPendingResource = false;
             AtomString id;
-            if (auto* fill = paintingResourceFromSVGPaint(treeScope, style.fill(), id, hasPendingResource))
-                ensureResources(foundResources).setFill(fill);
+            if (CheckedPtr fill = paintingResourceFromSVGPaint(treeScope, style.fill(), id, hasPendingResource))
+                ensureResources(foundResources).setFill(fill.get());
             else if (hasPendingResource)
                 treeScope->addPendingSVGResource(id, element);
         }
@@ -291,8 +291,8 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         if (style.hasStroke()) {
             bool hasPendingResource = false;
             AtomString id;
-            if (auto* stroke = paintingResourceFromSVGPaint(treeScope, style.stroke(), id, hasPendingResource))
-                ensureResources(foundResources).setStroke(stroke);
+            if (CheckedPtr stroke = paintingResourceFromSVGPaint(treeScope, style.stroke(), id, hasPendingResource))
+                ensureResources(foundResources).setStroke(stroke.get());
             else if (hasPendingResource)
                 treeScope->addPendingSVGResource(id, element);
         }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class RenderTreeBuilder::Inline {
     WTF_MAKE_TZONE_ALLOCATED(Inline);
 public:
-    static RenderBoxModelObject& parentCandidateInContinuation(RenderInline& parent, const RenderObject* beforeChild);
+    static CheckedRef<RenderBoxModelObject> parentCandidateInContinuation(RenderInline& parent, const RenderObject* beforeChild);
 
     Inline(RenderTreeBuilder&);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -67,7 +67,7 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
 {
     RenderElement* beforeChildAncestor = &parent;
     if (auto* rubyInline = dynamicDowncast<RenderInline>(parent); rubyInline && rubyInline->continuation())
-        beforeChildAncestor = &RenderTreeBuilder::Inline::parentCandidateInContinuation(*rubyInline, beforeChild);
+        beforeChildAncestor = RenderTreeBuilder::Inline::parentCandidateInContinuation(*rubyInline, beforeChild).ptr();
     else if (auto* rubyBlock = dynamicDowncast<RenderBlock>(parent); rubyBlock && rubyBlock->continuation())
         beforeChildAncestor = RenderTreeBuilder::Block::continuationBefore(*rubyBlock, beforeChild);
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -104,7 +104,7 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     };
 }
 
-const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
+RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
 {
     // "For each element, the query container to be queried is selected from among the element’s
     // ancestor query containers that have a valid container-type for all the container features
@@ -181,7 +181,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
         // https://drafts.csswg.org/css-conditional-5/#container-queries
         for (RefPtr ancestor = originatingElement; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
             if (isContainerForQuery(*ancestor.get(), originatingElement.get()))
-                return ancestor.unsafeGet();
+                return ancestor;
         }
         return nullptr;
     }
@@ -196,7 +196,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
 
     for (RefPtr ancestor = element.parentElementInComposedTree(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
         if (isContainerForQuery(*ancestor.get()))
-            return ancestor.unsafeGet();
+            return ancestor;
     }
     return { };
 }

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -48,7 +48,7 @@ public:
 
     bool evaluate(const CQ::ContainerQuery&) const;
 
-    static const Element* selectContainer(OptionSet<CQ::Axis>, const String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
+    static RefPtr<const Element> selectContainer(OptionSet<CQ::Axis>, const String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
 
 private:
     std::optional<MQ::FeatureEvaluationContext> featureEvaluationContextForQuery(const CQ::ContainerQuery&) const;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -151,16 +151,16 @@ RenderElement* Styleable::renderer() const
             return nullptr;
 
         // Find the right ::view-transition-group().
-        CheckedPtr correctGroup = element.renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameArgument);
+        WeakPtr correctGroup = element.renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameArgument);
         if (!correctGroup)
             return nullptr;
 
         // Return early if we're looking for ::view-transition-group().
         if (pseudoElementIdentifier->type == PseudoElementType::ViewTransitionGroup)
-            return correctGroup.unsafeGet();
+            return correctGroup.get();
 
         // Go through all descendants until we find the relevant pseudo element otherwise.
-        for (auto& descendant : descendantsOfType<RenderBox>(*correctGroup)) {
+        for (auto& descendant : descendantsOfType<RenderBox>(CheckedRef { *correctGroup }.get())) {
             if (descendant.style().pseudoElementType() == pseudoElementIdentifier->type)
                 return &descendant;
         }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -832,7 +832,7 @@ void SVGSVGElement::resumeFromDocumentSuspension()
 
 // getElementById on SVGSVGElement is restricted to only the child subtree defined by the <svg> element.
 // See http://www.w3.org/TR/SVG11/struct.html#InterfaceSVGSVGElement
-Element* SVGSVGElement::getElementById(const AtomString& id)
+RefPtr<Element> SVGSVGElement::getElementById(const AtomString& id)
 {
     if (id.isNull())
         return nullptr;
@@ -847,7 +847,7 @@ Element* SVGSVGElement::getElementById(const AtomString& id)
 
     RefPtr element = treeScope().getElementById(id);
     if (element && element->isDescendantOf(*this))
-        return element.unsafeGet();
+        return element;
     if (treeScope().containsMultipleElementsWithId(id)) {
         for (auto& element : *treeScope().getAllElementsById(id)) {
             if (element->isDescendantOf(*this))

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -69,7 +69,7 @@ public: // DOM
     static Ref<SVGTransform> createSVGTransform();
     static Ref<SVGTransform> createSVGTransformFromMatrix(DOMMatrix2DInit&&);
 
-    Element* getElementById(const AtomString&);
+    RefPtr<Element> getElementById(const AtomString&);
 
     void pauseAnimations();
     void unpauseAnimations();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1738,10 +1738,10 @@ void Internals::setCanShowPlaceholder(Element& element, bool canShowPlaceholder)
         textFormControlElement->setCanShowPlaceholder(canShowPlaceholder);
 }
 
-Element* Internals::insertTextPlaceholder(int width, int height)
+RefPtr<Element> Internals::insertTextPlaceholder(int width, int height)
 {
     RefPtr localFrame = frame();
-    return localFrame ? localFrame->editor().insertTextPlaceholder(IntSize { width, height }).unsafeGet() : nullptr;
+    return localFrame ? localFrame->editor().insertTextPlaceholder(IntSize { width, height }) : nullptr;
 }
 
 void Internals::removeTextPlaceholder(Element& element)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -348,7 +348,7 @@ public:
     String visiblePlaceholder(Element&);
     void setCanShowPlaceholder(Element&, bool);
 
-    Element* insertTextPlaceholder(int width, int height);
+    RefPtr<Element> insertTextPlaceholder(int width, int height);
     void removeTextPlaceholder(Element&);
 
     void selectColorInColorChooser(HTMLInputElement&, const String& colorValue);

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -245,7 +245,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (WebFrame *)_targetWebFrame
 {
-    return kit(dynamicDowncast<LocalFrame>(_result->targetFrame()));
+    return kit(dynamicDowncast<LocalFrame>(_result->targetFrame().get()));
 }
 
 - (NSString *)_titleDisplayString

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2567,7 +2567,7 @@ static NSURL *createUniqueWebDataURL()
     auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return nil;
-    return kit(dynamicDowncast<WebCore::LocalFrame>(coreFrame->tree().findByUniqueName(name, *coreFrame)));
+    return kit(dynamicDowncast<WebCore::LocalFrame>(coreFrame->tree().findByUniqueName(name, *coreFrame).get()));
 }
 
 - (WebFrame *)parentFrame


### PR DESCRIPTION
#### ab15e4ea138a3601fc6346aea7717e7196aefb94
<pre>
Further reduce use of unsafeGet() in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=303447">https://bugs.webkit.org/show_bug.cgi?id=303447</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hasUnignoredChild):
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::previousInPreOrder):
(WebCore::AXCoreObject::nextSiblingIncludingIgnoredOrParent const):
(WebCore::AXCoreObject::parentObjectUnignored const):
(WebCore::AXCoreObject::firstUnignoredChild): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::hasUnignoredChild):
(WebCore::AXCoreObject::firstUnignoredChild): Deleted.
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::shouldIncludeInSnapshot const):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::rolePlatformString):
(WebCore::AXCoreObject::isEmptyGroup):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::bindingsSource const):
(WebCore::ScrollTimeline::source const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::bindingsSource const):
(WebCore::ViewTimeline::source const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::getOwnPropertySlotByIndex):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scrollingElementForAPI):
(WebCore::Document::scrollingElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::filterRootById):
(WebCore::SelectorDataList::execute const):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::ensureComposition):
(WebCore::CompositeEditCommand::applyCommandToComposite):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::suitableShadowRoot):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::localCaretRect const):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_blockLevelElementForNode):
(HTMLConverter::computedAttributesForElement):
(HTMLConverter::aggregatedAttributesForAncestors):
(HTMLConverter::aggregatedAttributesForElementAndItsAncestors):
(HTMLConverter::_processElement):
(HTMLConverter::_processText):
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::traversalType&gt;::namedItem const):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::createContextWebGL):
(WebCore::HTMLCanvasElement::getContextWebGL):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::customElementAfter const):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageForRenderer):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::getSelectedActionChild):
(WebCore::MathMLSelectElement::getSelectedSemanticsChild):
(WebCore::MathMLSelectElement::updateSelectedChild):
* Source/WebCore/mathml/MathMLSelectElement.h:
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::updateDragAndDrop):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::DebugPageOverlays::ensureRegionOverlayForPage):
(WebCore::DebugPageOverlays::showRegionOverlay):
* Source/WebCore/page/DebugPageOverlays.h:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::querySelectorMatchesOneElement):
(WebCore::findOnlyMainElement):
(WebCore::searchForElementContainingText):
(WebCore::elementToAdjust):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::nodeToSelectOnMouseDownForNode):
* Source/WebCore/page/FocusController.cpp:
(WebCore::openPopoverForInvoker):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::scopedChildByUniqueName const):
(WebCore::FrameTree::scopedChildBySpecifiedName const):
(WebCore::FrameTree::find const):
(WebCore::FrameTree::findByUniqueName const):
(WebCore::FrameTree::findBySpecifiedName const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/LargestContentfulPaint.cpp:
(WebCore::LargestContentfulPaint::element const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameDocumentSecurityOrigin const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/PerformanceEventTiming.cpp:
(WebCore::PerformanceEventTiming::target const):
* Source/WebCore/page/PerformanceEventTiming.h:
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerCaptureElement const):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDocumentSecurityOrigin const):
(WebCore::RemoteFrame::frameDocumentSecurityOriginOrOpaque const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
(WebCore::UserMessageHandlersNamespace::namedItem):
* Source/WebCore/page/UserMessageHandlersNamespace.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):
(WebCore::appliedCommandIsWritingToolsCommand):
(WebCore::WritingToolsController::showOriginalCompositionForSession):
(WebCore::WritingToolsController::showRewrittenCompositionForSession):
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer presentationModel]):
(-[WebAVPlayerLayer setPresentationModel:]):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_pictureInPicturePlayerLayerView):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp:
(WebCore::DisplayRefreshMonitorManager::monitorForClient):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h:
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp:
(WebCore::MediaResourceSniffer::promise const):
* Source/WebCore/platform/graphics/MediaResourceSniffer.h:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::ensureImpl):
(WebCore::Path::asImpl):
(WebCore::Path::asImpl const):
(WebCore::Path::asProtectedImpl):
(WebCore::Path::asProtectedImpl const):
(WebCore::Path::applySegments const):
(WebCore::Path::applyElements const):
(WebCore::Path::transform):
(WebCore::Path::singleSegment const):
(WebCore::Path::segmentsIfExists const):
(WebCore::Path::isClosed const):
(WebCore::Path::hasSubpaths const):
(WebCore::Path::fastBoundingRect const):
(WebCore::Path::boundingRect const):
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::currentPoint const):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::readRespectingUTIFidelities):
(WebCore::Pasteboard::readPlatformValuesAsStrings):
(WebCore::Pasteboard::readFilePaths):
* Source/WebCore/platform/ios/WidgetIOS.mm:
(WebCore::Widget::setFrameRect):
(WebCore::Widget::outerView const):
(WebCore::Widget::paint):
(WebCore::Widget::addToSuperview):
(WebCore::Widget::removeFromSuperview):
* Source/WebCore/platform/ios/wak/WAKWindow.mm:
(-[WAKWindow contentReplacementImage]):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screen):
* Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm:
(-[WebCoreFullScreenPlaceholderView target]):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::Widget::show):
(WebCore::Widget::hide):
(WebCore::Widget::frameRect const):
(WebCore::Widget::outerView const):
(WebCore::Widget::removeFromSuperview):
(WebCore::Widget::protectedOuterView const): Deleted.
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::targetFrame const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutInFlowChildren):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/TextBoxTrimmer.cpp:
(WebCore::firstFormattedLineRoot):
(WebCore::lastFormattedLineRoot):
(WebCore::TextBoxTrimmer::lastInlineFormattingContextRootForTrimEnd):
* Source/WebCore/rendering/TextBoxTrimmer.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::pushMappingToContainer const):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::parentCandidateInContinuation):
(WebCore::RenderTreeBuilder::Inline::insertChildToContinuation):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):
* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::renderer const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getElementById):
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::insertTextPlaceholder):
* Source/WebCore/testing/Internals.h:
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(-[WebElementDictionary _targetWebFrame]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame findFrameNamed:]):

Canonical link: <a href="https://commits.webkit.org/304037@main">https://commits.webkit.org/304037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a01ccc81ad91ecb30eabe9ce89874f4200b3d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86210 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09e02de6-b161-4689-a539-365f1945a7e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102587 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69892 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db47c06b-bcfa-45eb-be90-589737721255) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83381 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cdb0dcc-e6cb-48d0-94d8-d171df8749d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2532 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144373 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6328 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110963 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28251 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4765 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60098 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6380 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34807 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->