### PR TITLE
Hovering Caption Style Menu items does not change preview

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 }
 
+- (void)setPreviewProfileID:(nullable NSString *)profileID;
+
 @property (nonatomic, copy, nullable) NSString *savedActiveProfileID;
 @property (nonatomic, strong) PlatformMenu *menu;
 #if !TARGET_OS_OSX && !TARGET_OS_WATCH

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -89,38 +89,13 @@ using namespace WTF;
 
 - (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID
 {
-    dispatch_async(mainDispatchQueueSingleton(), ^{
-        [self findAndDismissContextMenus];
-    });
+    [self setPreviewProfileID:profileID];
 }
 
-- (void)findAndDismissContextMenus
+- (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController
 {
-    UIApplication *app = [UIApplication sharedApplication];
-
-    for (UIScene *scene in app.connectedScenes) {
-        if ([scene isKindOfClass:[UIWindowScene class]]) {
-            UIWindowScene *windowScene = (UIWindowScene *)scene;
-            for (UIWindow *window in windowScene.windows)
-                [self searchForContextMenuInteractionsInView:window];
-        }
-    }
+    [self setPreviewProfileID:nil];
 }
-
-- (void)searchForContextMenuInteractionsInView:(UIView *)view
-{
-    for (id<UIInteraction> interaction in view.interactions) {
-        if ([interaction isKindOfClass:[UIContextMenuInteraction class]]) {
-            RetainPtr<UIContextMenuInteraction> contextInteraction = interaction;
-            [contextInteraction dismissMenu];
-            break;
-        }
-    }
-
-    for (UIView *subview in view.subviews)
-        [self searchForContextMenuInteractionsInView:subview];
-}
-
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
@@ -71,7 +71,7 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
     if (AVKitLibrary() && getAVLegibleMediaOptionsMenuControllerClassSingleton())
         return [[_WKCaptionStyleMenuControllerAVKit alloc] init];
 #endif
-    return [[super alloc] init];
+    return [[[super alloc] init] autorelease];
 }
 
 - (instancetype)init
@@ -238,6 +238,18 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
     [self notifyMenuDidClose];
 }
 #endif // USE(UICONTEXTMENU)
+
+#pragma mark - Internal
+- (void)setPreviewProfileID:(NSString *)profileID
+{
+    if (profileID) {
+        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(profileID));
+        return;
+    }
+
+    if (self.savedActiveProfileID && self.savedActiveProfileID.length > 0)
+        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(self.savedActiveProfileID));
+}
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
@@ -82,7 +82,6 @@ using namespace WTF;
 - (void)rebuildMenu
 {
     self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
-    [self.menu setDelegate:self];
 }
 
 - (BOOL)isAncestorOf:(NSMenu *)menu
@@ -108,24 +107,12 @@ using namespace WTF;
 
 - (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID
 {
-    dispatch_async(mainDispatchQueueSingleton(), ^{
-        [self findAndDismissPopoverMenus];
-    });
+    [self setPreviewProfileID:profileID];
 }
 
-- (void)findAndDismissPopoverMenus
+- (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController
 {
-    NSApplication *app = [NSApplication sharedApplication];
-
-    for (NSWindow *window in app.windows)
-        [self searchForMenuInteractionsInWindow:window];
-}
-
-- (void)searchForMenuInteractionsInWindow:(NSWindow *)window
-{
-    NSMenu *mainMenu = [NSApp mainMenu];
-    if (mainMenu)
-        [mainMenu cancelTracking];
+    [self setPreviewProfileID:nil];
 }
 
 #pragma mark - NSMenuDelegate

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
@@ -152,8 +152,16 @@ using namespace WTF;
 - (void)profileMenuItemHighlighted:(NSMenuItem *)item
 {
     NSString *nsProfileID = (NSString *)item.representedObject;
-    if ([nsProfileID isKindOfClass:NSString.class]) {
-        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(nsProfileID));
+    if (nsProfileID && ![nsProfileID isKindOfClass:NSString.class])
+        return;
+
+    [self setPreviewProfileID:nsProfileID];
+}
+
+- (void)setPreviewProfileID:(NSString *)profileID
+{
+    if (profileID) {
+        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(profileID));
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -261,7 +261,8 @@ public:
 
         [ensureController().contextMenuInteraction _presentMenuAtLocation:CGPointMake(0, 0)];
 
-        function(ensureMenu());
+        RetainPtr menu = ensureMenu();
+        function(menu.get());
 
         [ensureController().contextMenuInteraction dismissMenu];
 #else


### PR DESCRIPTION
#### 935b9fc3fbdfbc87248e69f14ecf4f21fbfacb7c
<pre>
Hovering Caption Style Menu items does not change preview
<a href="https://rdar.apple.com/165741968">rdar://165741968</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303455">https://bugs.webkit.org/show_bug.cgi?id=303455</a>

Reviewed by Eric Carlson.

The -legibleMenuController:didRequestCaptionPreviewForProfileID: delegate callback was not being
called on macOS because we reset the NSMenu&apos;s delegate to ourselves after creation; this overrides
AVKit&apos;s own delegate, and subsequently, their own delegate methods were not called when menu items
are hovered.

Take this opportunity to refactor the base classes of WKCaptionStyleMenuController so that behavior
when hovering can be shared between the base class and the AVKit subclass. And add support for
additional delegate callbacks like -_WKCaptionStyleMenuControllerInternal.

* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h:
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit legibleMenuController:didRequestCaptionPreviewForProfileID:]):
(-[_WKCaptionStyleMenuControllerAVKit legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:]):
(-[_WKCaptionStyleMenuControllerAVKit findAndDismissContextMenus]): Deleted.
(-[_WKCaptionStyleMenuControllerAVKit searchForContextMenuInteractionsInView:]): Deleted.
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
(+[WKCaptionStyleMenuController menuController]):
(-[WKCaptionStyleMenuController setPreviewProfileID:]):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm:
(-[_WKCaptionStyleMenuControllerAVKitMac rebuildMenu]):
(-[_WKCaptionStyleMenuControllerAVKitMac legibleMenuController:didRequestCaptionPreviewForProfileID:]):
(-[_WKCaptionStyleMenuControllerAVKitMac legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:]):
(-[_WKCaptionStyleMenuControllerAVKitMac findAndDismissPopoverMenus]): Deleted.
(-[_WKCaptionStyleMenuControllerAVKitMac searchForMenuInteractionsInWindow:]): Deleted.
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm:
(-[WKCaptionStyleMenuController profileMenuItemHighlighted:]):
(-[WKCaptionStyleMenuController setPreviewProfileID:]):

Canonical link: <a href="https://commits.webkit.org/303868@main">https://commits.webkit.org/303868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0971f0ec277c4e672631a49097d7ef6f9c10a0a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141385 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/39cf1d9c-ab16-4db4-ab2a-656c7e580481) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83156 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/509c469e-83d9-44cb-9839-0a10cfed36c8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2324 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144031 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110733 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4565 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59736 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6040 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34499 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->