### PR TITLE
ImageBitmap with SVG image source does not honor flipY

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
@@ -8,12 +8,12 @@ PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation
 PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
-FAIL createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "flipY", and drawImage on the created ImageBitmap

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
@@ -1,24 +1,24 @@
 
-PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an HTMLVideoElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLVideoElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "none", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 15) expected 255 +/- 10 but got 0
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "none", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "none", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-PASS createImageBitmap from an OffscreenCanvas imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an ImageData imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an ImageBitmap imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an ImageBitmap imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageBitmap imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a Blob imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a Blob imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a Blob imageOrientation: "flipY", and drawImage on the created ImageBitmap
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6902,6 +6902,7 @@ webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/contain-intri
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html [ Failure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html [ Failure ]
 
+
 webkit.org/b/245588 mathml/presentation/mathvariant-inheritance.html [ ImageOnlyFailure ]
 webkit.org/b/245588 mathml/non-core/fenced-mi.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
@@ -1,24 +1,24 @@
 
-PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an HTMLVideoElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLVideoElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "none", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "none", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "none", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from an OffscreenCanvas imageOrientation: "none", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-FAIL createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-PASS createImageBitmap from an ImageData imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from an ImageBitmap imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from an ImageBitmap imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageBitmap imageOrientation: "flipY", and drawImage on the created ImageBitmap
-PASS createImageBitmap from a Blob imageOrientation: "none", and drawImage on the created ImageBitmap
+PASS createImageBitmap from a Blob imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a Blob imageOrientation: "flipY", and drawImage on the created ImageBitmap
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1862,7 +1862,6 @@ webkit.org/b/237172 imported/w3c/web-platform-tests/speech-api/SpeechSynthesis-s
 
 # Note: These tests were previously marked as flaky failures for Big Sur Release WK2 for webkit.org/b/235681, this may need to be re-added once webkit.org/b/248067 is resolved
 webkit.org/b/248067 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html [ Pass Failure ]
-webkit.org/b/248067 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html [ Pass Failure ]
 
 # Plugins
 # FIXME: Remove these tests.


### PR DESCRIPTION
#### b0d65d996b31a2e9f9bb86cc1f7d17179cbb368f
<pre>
ImageBitmap with SVG image source does not honor flipY
<a href="https://bugs.webkit.org/show_bug.cgi?id=231001">https://bugs.webkit.org/show_bug.cgi?id=231001</a>
<a href="https://rdar.apple.com/83959718">rdar://83959718</a>

Reviewed by Nikolas Zimmermann.

SVGImage::draw needs to honor ImagePaintingOptions::orientation() in the
hasPlatformContext() case for ImageBitmap&apos;s flipY handling to work.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::draw):

Canonical link: <a href="https://commits.webkit.org/304137@main">https://commits.webkit.org/304137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402fcdb34e3e86b639b8b791322f49692c4a36ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134691 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7144 "Build is in progress. Recent messages:") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142213 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7746 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad25b119-8b09-4031-baa2-f23da3e2a37e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5438 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83745 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58defcd0-fd35-48fe-a8a0-b89cf79ec4fa) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2803 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144907 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/6818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111631 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/28307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20795 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/6869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->