### PR TITLE
Enforce that container CFTypes can't be sent from WebContent

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -96,8 +96,6 @@
 # The AliasParam handling either shows the whole type if it's on one line or just the OTD if it's a multiline variant
 [Legacy] AliasParam FileSystem::Salt std::array<uint8_t, 8>
 [Legacy] AliasParam WebCore::GraphicsContextGL::ExternalSyncSource std::tuple<MachSendRight, uint64_t>
-[Legacy] AliasParam WebKit::CFObjectValue Variant<std::nullptr_t, WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL, WebKit::CoreIPCSecCertificate, WebKit::CoreIPCSecTrust, WebKit::CoreIPCCGColorSpace, WebCore::Color, WebKit::CoreIPCSecAccessControl>
-[Legacy] AliasParam WebKit::CoreIPCCFDictionary::KeyType Variant<WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL>
 [Legacy] AliasParam WebKit::CoreIPCNSURLRequestData::BodyParts Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>
 [Legacy] AliasParam WebKit::CoreIPCSecTrustData::ExceptionType Vector<std::pair<WebKit::CoreIPCString, Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, bool>>>
 [NeedsReview] AliasParam WebKit::CoreIPCSecTrustData::RevocationInfoSubDictValue Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, WebKit::CoreIPCDate, bool>
@@ -115,7 +113,6 @@
 [Legacy] AliasParam WebKit::ImageBufferBackendHandle Variant<WebCore::ShareableBitmapHandle, MachSendRight>
 [Legacy] AliasParam WebKit::ObjectValue WebKit::CoreIPCData
 [Legacy] AliasParam WebCore::SharedMemory::Handle WebCore::SharedMemoryHandle
-[Legacy] AliasParam WebKit::PlistValue Variant<WebKit::CoreIPCPlistArray, WebKit::CoreIPCPlistDictionary, WebKit::CoreIPCString, WebKit::CoreIPCNumber, WebKit::CoreIPCDate, WebKit::CoreIPCData>
 [Legacy] AliasParam WebKit::SharedVideoFrame::Buffer Variant<std::nullptr_t, WebKit::RemoteVideoFrameReadReference, MachSendRight, WebCore::IntSize>
 
 # [UnsafeWrapper] in single line format as they are all unique types
@@ -362,13 +359,6 @@
     [NotSentFromWebContent] MessageParam VideoPresentationManager.SetVideoLayerFrameFenced sendRightAnnotated
 }
 
-[UnsafeWrapper] RetainPtr<CFDictionaryRef> {
-    [Legacy] StructureParam WebKit::CoreIPCError.userInfo()
-    [Legacy] StructureParam WebKit::NetworkSessionCreationParameters.proxyConfiguration
-    [Legacy] StructureParam WebKit::SecItemRequestData.m_attributesToMatch
-    [Legacy] StructureParam WebKit::SecItemRequestData.m_queryDictionary
-}
-
 [UnsafeWrapper] RetainPtr<CFDataRef> {
     [Legacy] StructureParam WebCore::FontPlatformSerializedAttributes.matrix
 }
@@ -543,6 +533,19 @@
 }
 
 [Legacy] StructureParam WebCore::AccessibilityRemoteToken.bytes Vector<uint8_t>
+
+# Deprecated CFTypes Which Should Not Be Sent From WebContent
+[NotSentFromWebContent] AliasParam WebKit::CFObjectValue Variant<std::nullptr_t, WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL, WebKit::CoreIPCSecCertificate, WebKit::CoreIPCSecTrust, WebKit::CoreIPCCGColorSpace, WebCore::Color, WebKit::CoreIPCSecAccessControl>
+[NotSentFromWebContent] AliasParam WebKit::CoreIPCCFDictionary::KeyType Variant<WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL>
+[UnsafeWrapper] RetainPtr<CFDictionaryRef> {
+    [NotSentFromWebContent] StructureParam WebKit::NetworkSessionCreationParameters.proxyConfiguration
+    [NotSentFromWebContent] StructureParam WebKit::SecItemRequestData.m_attributesToMatch
+    [NotSentFromWebContent] StructureParam WebKit::SecItemRequestData.m_queryDictionary
+}
+[NotSentFromWebContent] AliasParam WebKit::PlistValue Variant<WebKit::CoreIPCPlistArray, WebKit::CoreIPCPlistDictionary, WebKit::CoreIPCString, WebKit::CoreIPCNumber, WebKit::CoreIPCDate, WebKit::CoreIPCData>
+[UnsafeWrapper] std::optional<WebKit::CoreIPCPlistDictionary> {
+    [NotSentFromWebContent] StructureParam WebKit::CoreIPCNSURLRequestData.protocolProperties
+}
 
 # GTK Specific
 [Legacy] StructureParam sk_sp<SkColorSpace>.dataReference() std::span<const uint8_t>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm
@@ -38,6 +38,7 @@
 #import "CoreIPCSecTrust.h"
 #import "CoreIPCTypes.h"
 #import "StreamConnectionEncoder.h"
+#import <wtf/RuntimeApplicationChecks.h>
 
 namespace WebKit {
 
@@ -83,7 +84,10 @@ static CFObjectValue variantFromCFType(CFTypeRef cfType)
 }
 
 CoreIPCCFType::CoreIPCCFType(CFTypeRef cfType)
-    : m_object(makeUniqueRefWithoutFastMallocCheck<CFObjectValue>(variantFromCFType(cfType))) { }
+    : m_object(makeUniqueRefWithoutFastMallocCheck<CFObjectValue>(variantFromCFType(cfType)))
+{
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+}
 
 CoreIPCCFType::CoreIPCCFType(CoreIPCCFType&&) = default;
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -30,6 +30,7 @@
 #if PLATFORM(COCOA)
 
 #import "CoreIPCTypes.h"
+#import <wtf/RuntimeApplicationChecks.h>
 
 namespace WebKit {
 
@@ -37,6 +38,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCDictionary);
 
 CoreIPCDictionary::CoreIPCDictionary(NSDictionary *dictionary)
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+
     m_keyValuePairs.reserveInitialCapacity(dictionary.count);
 
     for (id key in dictionary) {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
@@ -34,12 +34,15 @@
 #import "CoreIPCPlistDictionary.h"
 #import "CoreIPCPlistObject.h"
 #import "CoreIPCString.h"
+#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 
 CoreIPCPlistArray::CoreIPCPlistArray(NSArray *array)
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+
     for (id value in array) {
         if (!CoreIPCPlistObject::isPlistType(value))
             continue;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
@@ -35,6 +35,7 @@
 #import "CoreIPCPlistObject.h"
 #import "CoreIPCString.h"
 #import <wtf/Assertions.h>
+#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -43,6 +44,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCPlistDictionary);
 
 CoreIPCPlistDictionary::CoreIPCPlistDictionary(NSDictionary *dictionary)
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+
     m_keyValuePairs.reserveInitialCapacity(dictionary.count);
 
     for (id key in dictionary) {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
@@ -36,6 +36,7 @@
 #import "CoreIPCPlistDictionary.h"
 #import "CoreIPCString.h"
 #import "GeneratedWebKitSecureCoding.h"
+#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
@@ -75,6 +76,7 @@ static PlistValue valueFromID(id object)
 CoreIPCPlistObject::CoreIPCPlistObject(id object)
     : m_value(makeUniqueRefWithoutFastMallocCheck<PlistValue>(valueFromID(object)))
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
 }
 
 CoreIPCPlistObject::CoreIPCPlistObject(UniqueRef<PlistValue>&& value)

--- a/Source/WebKit/Shared/cf/CoreIPCCFArray.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCCFArray.mm
@@ -30,6 +30,7 @@
 
 #import "CoreIPCCFType.h"
 #import "CoreIPCTypes.h"
+#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cf/VectorCF.h>
 
 namespace WebKit {
@@ -43,6 +44,8 @@ CoreIPCCFArray::CoreIPCCFArray(CoreIPCCFArray&&) = default;
 
 CoreIPCCFArray::CoreIPCCFArray(CFArrayRef array)
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+
     CFIndex count = array ? CFArrayGetCount(array) : 0;
     for (CFIndex i = 0; i < count; i++) {
         RetainPtr element = CFArrayGetValueAtIndex(array, i);

--- a/Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm
@@ -34,6 +34,7 @@
 #import "CoreIPCCFType.h"
 #import "CoreIPCCFURL.h"
 #import "CoreIPCTypes.h"
+#import <wtf/RuntimeApplicationChecks.h>
 #include <optional>
 
 namespace WebKit {
@@ -106,6 +107,8 @@ CoreIPCCFDictionary::~CoreIPCCFDictionary() = default;
 
 CoreIPCCFDictionary::CoreIPCCFDictionary(CFDictionaryRef dictionary)
 {
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
+
     if (!dictionary)
         return;
     m_vector = makeUnique<KeyValueVector>();


### PR DESCRIPTION
#### 61dbd4377d0f805b200d42553f0661f46f60eb16
<pre>
Enforce that container CFTypes can&apos;t be sent from WebContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=303473">https://bugs.webkit.org/show_bug.cgi?id=303473</a>
<a href="https://rdar.apple.com/165756991">rdar://165756991</a>

Reviewed by NOBODY (OOPS!).

Enforces that CFDictionary, CFArray and similar wrappers (like CFType)
can&apos;t be dispatched from the WebContent process.

* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm:
(WebKit::CoreIPCCFType::CoreIPCCFType):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
* Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm:
(WebKit::CoreIPCPlistArray::CoreIPCPlistArray):
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm:
(WebKit::CoreIPCPlistDictionary::CoreIPCPlistDictionary):
* Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm:
(WebKit::CoreIPCPlistObject::CoreIPCPlistObject):
* Source/WebKit/Shared/cf/CoreIPCCFArray.mm:
(WebKit::CoreIPCCFArray::CoreIPCCFArray):
* Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm:
(WebKit::CoreIPCCFDictionary::CoreIPCCFDictionary):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61dbd4377d0f805b200d42553f0661f46f60eb16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99773 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/249f0707-b13d-4833-8dce-5c0389b51832) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80533 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b874f79c-a03b-4ac1-a9fd-b052f85fb3f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93479 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7573012-81b7-45bf-9404-05f16670caf9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145654 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14235 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12198 "1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2441 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123804 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157316 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120639 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120937 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74615 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8001 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18172 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->