### PR TITLE
REGRESSION(299621@main): [MacOS Debug] ASSERTION FAILED: m_gamepads[platformGamepad.index] in 'gamepad/gamepad-visibility-1.html' is failing

### DIFF
--- a/LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt
+++ b/LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt
@@ -1,0 +1,4 @@
+Connect: 0
+Disconnect: 0
+barrier
+

--- a/LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html
+++ b/LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html
@@ -1,0 +1,42 @@
+<body>
+<div id="logger"></div>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+function log(msg) {
+    logger.innerHTML += msg + "<br>";
+}
+function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function runTest() {
+    testRunner.setMockGamepadDetails(0, "Test0", "", 2, 2, false, /*was connected*/ true);
+    let connected = new Promise(resolve => {
+        window.ongamepadconnected = (event) => {
+            log(`Connect: ${event.gamepad.index}`);
+            resolve();
+        };
+    });
+    let disconnected = new Promise(resolve => {
+        window.ongamepaddisconnected = (event) => {
+            log(`Disconnect: ${event.gamepad.index}`);
+            resolve();
+        };
+    });
+    testRunner.connectMockGamepad(0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    await connected;
+    testRunner.disconnectMockGamepad(0);
+    await disconnected;
+    log("barrier"); // No Connect:/Disconnect: after barrier.
+    testRunner.connectMockGamepad(0);
+    // This is being tested: at the time of writing, this would assert because
+    // the "[[exposed]]" state of a particular gamepad was being tracked per
+    // navigator, and only once.
+    testRunner.disconnectMockGamepad(0);
+    await timeout(200);
+    testRunner.notifyDone();
+}
+runTest();
+</script>
+</body>

--- a/LayoutTests/gamepad/gamepad-polling-access-expected.txt
+++ b/LayoutTests/gamepad/gamepad-polling-access-expected.txt
@@ -384,185 +384,185 @@ Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
 Disconnecting gamepads in reverse order, making sure gamepads array remains as expected
 Disconnecting gamepad:
-ongamepaddisconnected event fired (19).
+ongamepaddisconnected event fired (20).
 Name: 19
 Index: 19
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (19).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (20).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (18).
+ongamepaddisconnected event fired (19).
 Name: 18
 Index: 18
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (18).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (19).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (17).
+ongamepaddisconnected event fired (18).
 Name: 17
 Index: 17
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (17).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (18).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (16).
+ongamepaddisconnected event fired (17).
 Name: 16
 Index: 16
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (16).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (17).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (15).
+ongamepaddisconnected event fired (16).
 Name: 15
 Index: 15
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (15).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (16).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (14).
+ongamepaddisconnected event fired (15).
 Name: 14
 Index: 14
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (14).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (15).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (13).
+ongamepaddisconnected event fired (14).
 Name: 13
 Index: 13
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (13).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (14).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (12).
+ongamepaddisconnected event fired (13).
 Name: 12
 Index: 12
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (12).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (13).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (11).
+ongamepaddisconnected event fired (12).
 Name: 11
 Index: 11
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (11).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (12).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (10).
+ongamepaddisconnected event fired (11).
 Name: 10
 Index: 10
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (10).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (11).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (9).
+ongamepaddisconnected event fired (10).
 Name: 9
 Index: 9
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (9).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (10).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (8).
+ongamepaddisconnected event fired (9).
 Name: 8
 Index: 8
 Mapping:
 Axes: 0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (8).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (9).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (7).
+ongamepaddisconnected event fired (8).
 Name: 7
 Index: 7
 Mapping:
 Axes: 0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (7).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (8).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (6).
+ongamepaddisconnected event fired (7).
 Name: 6
 Index: 6
 Mapping:
 Axes: 0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (6).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (7).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (5).
+ongamepaddisconnected event fired (6).
 Name: 5
 Index: 5
 Mapping:
 Axes: 0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (5).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (6).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (4).
+ongamepaddisconnected event fired (5).
 Name: 4
 Index: 4
 Mapping:
 Axes: 0,0,0,0
 Buttons: false-0 false-0 false-0 false-0
-gamepaddisconnected event fired (4).
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (5).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (3).
+ongamepaddisconnected event fired (4).
 Name: 3
 Index: 3
 Mapping:
 Axes: 0,0,0
 Buttons: false-0 false-0 false-0
-gamepaddisconnected event fired (3).
-[object Gamepad],[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (4).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (2).
+ongamepaddisconnected event fired (3).
 Name: 2
 Index: 2
 Mapping:
 Axes: 0,0
 Buttons: false-0 false-0
-gamepaddisconnected event fired (2).
-[object Gamepad],[object Gamepad]
+gamepaddisconnected event fired (3).
+[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (1).
+ongamepaddisconnected event fired (2).
 Name: 1
 Index: 1
 Mapping:
 Axes: 0
 Buttons: false-0
-gamepaddisconnected event fired (1).
-[object Gamepad]
+gamepaddisconnected event fired (2).
+[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-ongamepaddisconnected event fired (0).
+ongamepaddisconnected event fired (1).
 Name: 0
 Index: 0
 Mapping:
 Axes:
 Buttons:
-gamepaddisconnected event fired (0).
-
+gamepaddisconnected event fired (1).
+[object Gamepad]
 Checking non-zero'ed details for a gamepad
 Name: Awesome Joystick 5000
 Index: 10
@@ -577,11 +577,11 @@ Axes: 0.7,-0.9,1,-1
 Buttons: true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1
 gamepadconnected event fired (1).
 Disconnecting final gamepad
-ongamepaddisconnected event fired (0).
+ongamepaddisconnected event fired (1).
 Name: Awesome Joystick 5000
 Index: 10
 Mapping: standard
 Axes: 0.7,-0.9,1,-1
 Buttons: true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1
-gamepaddisconnected event fired (0).
+gamepaddisconnected event fired (1).
 

--- a/LayoutTests/gamepad/gamepad-visibility-poll-expected.txt
+++ b/LayoutTests/gamepad/gamepad-visibility-poll-expected.txt
@@ -1,0 +1,14 @@
+empty getGamepads()
+after button interaction
+gamepadsSeen[0]: index: 0, connected: true
+gamepadsSeen[1]: index: 1, connected: true
+after disconnecting 0
+gamepadsSeen[0]: index: 0, connected: false
+gamepadsSeen[1]: index: 1, connected: true
+getGamepads()[0]: null
+getGamepads()[1]: index: 1, connected: true
+after disconnecting 1
+gamepadsSeen[0]: index: 0, connected: false
+gamepadsSeen[1]: index: 1, connected: false
+empty getGamepads()
+

--- a/LayoutTests/gamepad/gamepad-visibility-poll.html
+++ b/LayoutTests/gamepad/gamepad-visibility-poll.html
@@ -1,0 +1,89 @@
+<body>
+<div id="logger"></div>
+<script>
+function log(msg) {
+    logger.innerHTML += msg + "<br>";
+}
+function timeout(ms) {
+    return new Promise((resolve, reject) => setTimeout(resolve, ms));
+}
+function logGamepads(name, gamepads) {
+    function logGamepad(gamepad) {
+        if (gamepad)
+            return `index: ${gamepad.index}, connected: ${gamepad.connected}`;
+        return gamepad === null ? "null" : typeof gamepad;
+    }
+    if (!gamepads.length)
+        log(`empty ${name}`);
+    else
+        gamepads.forEach((gamepad, i) => log(`${name}[${i}]: ${logGamepad(gamepad)}`));
+}
+// Tests gamepad visibility when the page doesn't register any event listeners, just 
+// uses Navigator.getGamepads().
+async function runTest() {
+    // Race condition in UIGamepadProvider: if it misses the mock gamepad connections
+    // because the page is not yet monitoring, it fails to monitor the gamepad altogether.
+    navigator.getGamepads();
+    await timeout(200);
+
+    testRunner.setMockGamepadDetails(0, "Test0", "", 2, 2, false, /*was connected*/ true);
+    testRunner.setMockGamepadDetails(1, "Test1", "", 2, 2, false, /*was connected*/ true);
+    testRunner.connectMockGamepad(0);
+    testRunner.connectMockGamepad(1);
+    // Poll gamepads, they should not be visible.
+    for (let i = 0; i < 20; ++i) {
+        if (navigator.getGamepads().filter(x => x).length)
+            break;
+        await timeout(100);
+    }
+    logGamepads("getGamepads()", navigator.getGamepads());
+
+    // After button interaction, both should appear.
+    log('after button interaction'); 
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    for (let i = 0; i < 200; ++i) {
+        if (navigator.getGamepads().filter(x => x).length)
+            break;
+        await timeout(100);
+    }
+    let gamepadsSeen = navigator.getGamepads();
+    logGamepads("gamepadsSeen", gamepadsSeen)
+
+    // After disconnecting 0, 0 should disappear and seenGamepads[0].connected == false.
+    testRunner.disconnectMockGamepad(0);
+    log('after disconnecting 0');
+    for (let i = 0; i < 200; ++i) {
+        if (!navigator.getGamepads()[0])
+            break;
+        await timeout(100);
+    }
+    logGamepads("gamepadsSeen", gamepadsSeen)
+    logGamepads("getGamepads()", navigator.getGamepads());
+
+    // After disconnecting 1, 1 should disappear and seenGamepads[1].connected == false.
+    // and getGamepads() should not return null entries.
+    testRunner.disconnectMockGamepad(1);
+    log('after disconnecting 1');
+    for (let i = 0; i < 200; ++i) {
+        if (!navigator.getGamepads().length)
+            break;
+        await timeout(100);
+    }
+    logGamepads("gamepadsSeen", gamepadsSeen)
+    logGamepads("getGamepads()", navigator.getGamepads());
+}
+
+async function test() {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    try {
+        await runTest();
+    } catch (e) {
+        log(`exception: ${e}`);
+    } finally {
+        testRunner.notifyDone();
+    }
+}
+test();
+</script>
+</body>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2441,8 +2441,6 @@ webkit.org/b/298042 http/tests/security/clipboard/copy-paste-html-cross-origin-i
 
 webkit.org/b/298402 inspector/worker/dom-debugger-event-after-terminate-crash.html [ Pass Crash ]
 
-webkit.org/b/298476 gamepad/gamepad-visibility-1.html [ Crash ]
-
 webkit.org/b/280234 imported/w3c/web-platform-tests/html/dom/idlharness.https.html? [ Skip ]
 
 webkit.org/b/299131 [ Release ] inspector/unit-tests/target-manager.html [ Pass Crash ]

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -47,11 +47,6 @@
 
 namespace WebCore {
 
-static NavigatorGamepad& navigatorGamepadFromDOMWindow(LocalDOMWindow& window)
-{
-    return NavigatorGamepad::from(window.protectedNavigator().get());
-}
-
 GamepadManager& GamepadManager::singleton()
 {
     static NeverDestroyed<GamepadManager> sharedManager;
@@ -59,244 +54,135 @@ GamepadManager& GamepadManager::singleton()
 }
 
 GamepadManager::GamepadManager()
-    : m_isMonitoringGamepads(false)
 {
 }
 
-#if PLATFORM(VISION)
-void GamepadManager::findUnquarantinedNavigatorsAndWindows(WeakHashSet<Navigator>& navigators, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>& windows)
+void GamepadManager::platformGamepadConnected(PlatformGamepad&, EventMakesGamepadsVisible eventVisibility)
 {
-    for (auto& navigator : m_navigators) {
-        if (!m_gamepadQuarantinedNavigators.contains(navigator))
-            navigators.add(navigator);
-    }
-    for (auto& window : m_domWindows) {
-        if (!m_gamepadQuarantinedDOMWindows.contains(window))
-            windows.add(window);
-    }
-}
-#endif
-
-void GamepadManager::platformGamepadConnected(PlatformGamepad& platformGamepad, EventMakesGamepadsVisible eventVisibility)
-{
-    if (eventVisibility == EventMakesGamepadsVisible::No)
-        return;
-
-    // Notify blind Navigators and Windows about all gamepads except for this one.
-    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
-        if (!gamepad || gamepad == &platformGamepad)
-            continue;
-
-        makeGamepadVisible(*gamepad, m_gamepadBlindNavigators, m_gamepadBlindDOMWindows);
-    }
-
-    m_gamepadBlindNavigators.clear();
-    m_gamepadBlindDOMWindows.clear();
-
-#if PLATFORM(VISION)
-    // Notify everyone not in the quarantined list of this new gamepad.
-    WeakHashSet<Navigator> navigators;
-    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> windows;
-    findUnquarantinedNavigatorsAndWindows(navigators, windows);
-    makeGamepadVisible(platformGamepad, navigators, windows);
-#else
-    // Notify everyone of this new gamepad.
-    makeGamepadVisible(platformGamepad, m_navigators, m_domWindows);
-#endif
+    m_hasPendingConnections = true;
+    if (eventVisibility == EventMakesGamepadsVisible::Yes)
+        makeGamepadsVisible();
 }
 
 void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepad)
 {
-    WeakHashSet<Navigator> notifiedNavigators;
-
-    // Handle the disconnect for all DOMWindows with event listeners and their Navigators.
     for (auto& window : copyToVectorOf<WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData>>(m_domWindows)) {
         // Event dispatch might have made this window go away.
         if (!window)
             continue;
-
-        // This LocalDOMWindow's Navigator might not be accessible. e.g. The LocalDOMWindow might be in the back/forward cache.
-        // If this happens the LocalDOMWindow will not get this gamepaddisconnected event.
         Ref navigator = window->navigator();
-
-        // If this Navigator hasn't seen gamepads yet then its Window should not get the disconnect event.
-        if (m_gamepadBlindNavigators.contains(navigator.get()))
-            continue;
-#if PLATFORM(VISION)
-        if (m_gamepadQuarantinedNavigators.contains(navigator.get()))
-            continue;
-#endif
-
         auto& navigatorGamepad = NavigatorGamepad::from(navigator);
-
-        Ref gamepad = navigatorGamepad.gamepadFromPlatformGamepad(platformGamepad);
-
-        navigatorGamepad.gamepadDisconnected(platformGamepad);
-        notifiedNavigators.add(navigator.get());
-
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, gamepad.get()), window->protectedDocument().get());
+        RefPtr gamepad = navigatorGamepad.gamepadIfExists(platformGamepad);
+        if (!gamepad)
+            continue;
+        gamepad->setConnected(false);
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, *gamepad), window->protectedDocument().get());
+        navigatorGamepad.removeGamepadIfExists(platformGamepad);
     }
-
-    // Notify all the Navigators that haven't already been notified.
     for (Ref navigator : m_navigators) {
-        if (!notifiedNavigators.contains(navigator.get()))
-            NavigatorGamepad::from(navigator).gamepadDisconnected(platformGamepad);
+        auto& navigatorGamepad = NavigatorGamepad::from(navigator);
+        RefPtr gamepad = navigatorGamepad.gamepadIfExists(platformGamepad);
+        if (!gamepad)
+            continue;
+        gamepad->setConnected(false);
+        navigatorGamepad.removeGamepadIfExists(platformGamepad);
     }
 }
 
 void GamepadManager::platformGamepadInputActivity(EventMakesGamepadsVisible eventVisibility)
 {
-    if (eventVisibility == EventMakesGamepadsVisible::No)
-        return;
-
-    if (m_gamepadBlindNavigators.isEmptyIgnoringNullReferences() && m_gamepadBlindDOMWindows.isEmptyIgnoringNullReferences())
-        return;
-
-    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
-        if (gamepad)
-            makeGamepadVisible(*gamepad, m_gamepadBlindNavigators, m_gamepadBlindDOMWindows);
-    }
-
-    m_gamepadBlindNavigators.clear();
-    m_gamepadBlindDOMWindows.clear();
+    if (eventVisibility == EventMakesGamepadsVisible::Yes)
+        makeGamepadsVisible();
 }
 
-void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, WeakHashSet<Navigator>& navigatorSet, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>& domWindowSet)
+void GamepadManager::makeGamepadsVisible()
 {
-    LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - New gamepad '%s' is visible", (unsigned)getpid(), platformGamepad.id().utf8().data());
-
-    if (navigatorSet.isEmptyIgnoringNullReferences() && domWindowSet.isEmptyIgnoringNullReferences())
+    if (!m_hasPendingConnections)
         return;
+    m_hasPendingConnections = false;
 
-    for (Ref navigator : navigatorSet)
-        NavigatorGamepad::from(navigator).gamepadConnected(platformGamepad);
-
+    // Copy the Vector to avoid possible event dispatch changing the list.
+    auto platformGamepads = copyToVectorOf<WeakPtr<PlatformGamepad>>(GamepadProvider::singleton().platformGamepads());
+    if (platformGamepads.isEmpty())
+        return;
     for (auto& window : copyToVectorOf<WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData>>(m_domWindows)) {
         // Event dispatch might have made this window go away.
         if (!window)
             continue;
-
-        // This LocalDOMWindow's Navigator might not be accessible. e.g. The LocalDOMWindow might be in the back/forward cache.
-        // If this happens the LocalDOMWindow will not get this gamepadconnected event.
-        // The new gamepad will still be visibile to it once it is restored from the back/forward cache.
-        NavigatorGamepad& navigator = navigatorGamepadFromDOMWindow(*window);
-
-        Ref gamepad = navigator.gamepadFromPlatformGamepad(platformGamepad);
-        RefPtr document = navigator.navigator().document();
-
-        LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - Dispatching gamepadconnected event for gamepad '%s'", (unsigned)getpid(), platformGamepad.id().utf8().data());
-        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, gamepad.get()), window->protectedDocument().get());
+        Ref navigator = window->navigator();
+#if PLATFORM(VISION)
+        if (RefPtr page = navigator->page(); page && !page->gamepadAccessGranted())
+            continue;
+#endif
+        NavigatorGamepad& navigatorGamepad = NavigatorGamepad::from(navigator);
+        RefPtr document = navigator->document();
+        for (auto& platformGamepad : platformGamepads) {
+            if (!platformGamepad)
+                continue;
+            // As per spec, if the gamepad is [[exposed]], do not post events.
+            if (navigatorGamepad.gamepadIfExists(*platformGamepad.get()))
+                continue;
+            // As per spec, set [[exposed]] to true.
+            Ref gamepad = navigatorGamepad.ensureGamepad(*platformGamepad.get());
+            LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - Dispatching gamepadconnected event for gamepad '%s'", (unsigned)getpid(), platformGamepad->id().utf8().data());
+            UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
+            window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, gamepad.get()), window->protectedDocument().get());
+        }
+    }
+    for (Ref navigator : m_navigators) {
+#if PLATFORM(VISION)
+        if (RefPtr page = navigator->page(); page && !page->gamepadAccessGranted())
+            continue;
+#endif
+        auto& navigatorGamepad = NavigatorGamepad::from(navigator);
+        for (auto& platformGamepad : platformGamepads) {
+            if (!platformGamepad)
+                continue;
+            // As per spec, set [[exposed]] to true.
+            navigatorGamepad.ensureGamepad(*platformGamepad.get());
+        }
     }
 }
 
 void GamepadManager::registerNavigator(Navigator& navigator)
 {
     LOG(Gamepad, "(%u) GamepadManager registering Navigator %p", (unsigned)getpid(), &navigator);
-
     ASSERT(!m_navigators.contains(navigator));
     m_navigators.add(navigator);
-
-#if PLATFORM(VISION)
-    RefPtr page = navigator.page();
-    if (page && page->gamepadAccessGranted())
-        m_gamepadBlindNavigators.add(navigator);
-    else
-        m_gamepadQuarantinedNavigators.add(navigator);
-#else
-    m_gamepadBlindNavigators.add(navigator);
-#endif
-
     maybeStartMonitoringGamepads();
 }
 
 void GamepadManager::unregisterNavigator(Navigator& navigator)
 {
     LOG(Gamepad, "(%u) GamepadManager unregistering Navigator %p", (unsigned)getpid(), &navigator);
-
     ASSERT(m_navigators.contains(navigator));
     m_navigators.remove(navigator);
-    m_gamepadBlindNavigators.remove(navigator);
-
-#if PLATFORM(VISION)
-    m_gamepadQuarantinedNavigators.remove(navigator);
-#endif
-
     maybeStopMonitoringGamepads();
 }
 
 void GamepadManager::registerDOMWindow(LocalDOMWindow& window)
 {
     LOG(Gamepad, "(%u) GamepadManager registering LocalDOMWindow %p", (unsigned)getpid(), &window);
-
+    // Anytime we register a LocalDOMWindow, we should make sure its NavigatorGamepad is constructed.
+    NavigatorGamepad::from(window.protectedNavigator());
     ASSERT(!m_domWindows.contains(window));
     m_domWindows.add(window);
-
-    // Anytime we register a LocalDOMWindow, we should make sure its NavigatorGamepad is constructed.
-    Ref navigator = navigatorGamepadFromDOMWindow(window).navigator();
-    if (m_navigators.contains(navigator.get())) {
-        // If this LocalDOMWindow's NavigatorGamepad was already registered but was still blind,
-        // then this LocalDOMWindow should be blind.
-        if (m_gamepadBlindNavigators.contains(navigator.get()))
-            m_gamepadBlindDOMWindows.add(window);
-#if PLATFORM(VISION)
-        else if (m_gamepadQuarantinedNavigators.contains(navigator.get()))
-            m_gamepadQuarantinedDOMWindows.add(window);
-#endif
-
-        maybeStartMonitoringGamepads();
-    }
+    maybeStartMonitoringGamepads();
 }
 
 void GamepadManager::unregisterDOMWindow(LocalDOMWindow& window)
 {
     LOG(Gamepad, "(%u) GamepadManager unregistering LocalDOMWindow %p", (unsigned)getpid(), &window);
-
     ASSERT(m_domWindows.contains(window));
     m_domWindows.remove(window);
-    m_gamepadBlindDOMWindows.remove(window);
-
-#if PLATFORM(VISION)
-    m_gamepadQuarantinedDOMWindows.remove(window);
-#endif
-
     maybeStopMonitoringGamepads();
 }
 
 #if PLATFORM(VISION)
-void GamepadManager::updateQuarantineStatus()
+void GamepadManager::didUpdateGamepadAccess()
 {
-    if (m_gamepadQuarantinedNavigators.isEmptyIgnoringNullReferences() && m_gamepadQuarantinedDOMWindows.isEmptyIgnoringNullReferences())
-        return;
-
-    WeakHashSet<Navigator> navigators;
-    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> windows;
-    for (auto& navigator : m_gamepadQuarantinedNavigators) {
-        RefPtr page = navigator.page();
-        if (page && page->gamepadAccessGranted()) {
-            LOG(Gamepad, "(%u) GamepadManager found navigator %p to release from quarantine", (unsigned)getpid(), &navigator);
-            navigators.add(navigator);
-        }
-    }
-    for (auto& window : m_gamepadQuarantinedDOMWindows) {
-        RefPtr page = window.page();
-        if (page && page->gamepadAccessGranted()) {
-            LOG(Gamepad, "(%u) GamepadManager found window %p to release from quarantine", (unsigned)getpid(), &window);
-            windows.add(window);
-        }
-    }
-
-    if (navigators.isEmptyIgnoringNullReferences() && windows.isEmptyIgnoringNullReferences())
-        return;
-
-    for (auto& navigator : navigators) {
-        m_gamepadBlindNavigators.add(navigator);
-        m_gamepadQuarantinedNavigators.remove(navigator);
-    }
-    for (auto& window : windows) {
-        m_gamepadBlindDOMWindows.add(window);
-        m_gamepadQuarantinedDOMWindows.remove(window);
-    }
+    m_hasPendingConnections = true;
+    makeGamepadsVisible();
 }
 #endif // PLATFORM(VISION)
 

--- a/Source/WebCore/Modules/gamepad/GamepadManager.h
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.h
@@ -60,33 +60,22 @@ public:
     void unregisterDOMWindow(LocalDOMWindow&);
 
 #if PLATFORM(VISION)
-    void updateQuarantineStatus();
+    void didUpdateGamepadAccess();
 #endif
 
 private:
     GamepadManager();
 
-    void makeGamepadVisible(PlatformGamepad&, WeakHashSet<Navigator>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
+    void makeGamepadsVisible();
     void dispatchGamepadEvent(const AtomString& eventName, PlatformGamepad&);
 
     void maybeStartMonitoringGamepads();
     void maybeStopMonitoringGamepads();
 
-#if PLATFORM(VISION)
-    void findUnquarantinedNavigatorsAndWindows(WeakHashSet<Navigator>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
-#endif
-
-    bool m_isMonitoringGamepads;
-
     WeakHashSet<Navigator> m_navigators;
-    WeakHashSet<Navigator> m_gamepadBlindNavigators;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_domWindows;
-    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadBlindDOMWindows;
-
-#if PLATFORM(VISION)
-    WeakHashSet<Navigator> m_gamepadQuarantinedNavigators;
-    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadQuarantinedDOMWindows;
-#endif
+    bool m_isMonitoringGamepads { false };
+    bool m_hasPendingConnections { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -70,13 +70,33 @@ NavigatorGamepad& NavigatorGamepad::from(Navigator& navigator)
     return *supplement;
 }
 
-Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platformGamepad)
+Ref<Gamepad> NavigatorGamepad::ensureGamepad(const PlatformGamepad& platformGamepad)
 {
     unsigned index = platformGamepad.index();
-    if (index >= m_gamepads.size() || !m_gamepads[index])
-        return Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
-
+    if (index >= m_gamepads.size())
+        m_gamepads.resize(index + 1);
+    if (!m_gamepads[index])
+        m_gamepads[index] = Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
     return *m_gamepads[index];
+}
+
+RefPtr<Gamepad> NavigatorGamepad::gamepadIfExists(const PlatformGamepad& platformGamepad) const
+{
+    unsigned index = platformGamepad.index();
+    if (index >= m_gamepads.size())
+        return nullptr;
+    return m_gamepads[index];
+}
+
+void NavigatorGamepad::removeGamepadIfExists(const PlatformGamepad& platformGamepad)
+{
+    auto index = platformGamepad.index();
+    if (index >= m_gamepads.size())
+        return;
+    m_gamepads[index] = nullptr;
+    // The spec says no null entries at the end of the getGamepads() list.
+    while (!m_gamepads.isEmpty() && !m_gamepads.last())
+        m_gamepads.removeLast();
 }
 
 ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Navigator& navigator)
@@ -127,72 +147,18 @@ const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
         if (RefPtr page = frame->page())
             page->gamepadsRecentlyAccessed();
     }
-
-    if (m_gamepads.isEmpty())
-        return m_gamepads;
-
     auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
-
-    for (unsigned i = 0; i < platformGamepads.size(); ++i) {
-        if (!platformGamepads[i]) {
-            ASSERT(!m_gamepads[i]);
+    for (unsigned i = 0; i < m_gamepads.size(); ++i) {
+        if (!m_gamepads[i])
+            continue;
+        if (i >= platformGamepads.size() || !platformGamepads[i]) {
+            // Disconnected gamepads are specified to exist in getGamepads() during gamepaddisconnected event.
             continue;
         }
         Ref { *m_gamepads[i] }->updateFromPlatformGamepad(*platformGamepads[i]);
     }
 
     return m_gamepads;
-}
-
-void NavigatorGamepad::gamepadsBecameVisible()
-{
-    auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
-    m_gamepads.resize(platformGamepads.size());
-
-    for (unsigned i = 0; i < platformGamepads.size(); ++i) {
-        if (!platformGamepads[i])
-            continue;
-
-        m_gamepads[i] = Gamepad::create(m_navigator->protectedDocument().get(), *platformGamepads[i]);
-    }
-}
-
-void NavigatorGamepad::gamepadConnected(PlatformGamepad& platformGamepad)
-{
-    // If this is the first gamepad this Navigator object has seen, then all gamepads just became visible.
-    if (m_gamepads.isEmpty()) {
-        gamepadsBecameVisible();
-        return;
-    }
-
-    unsigned index = platformGamepad.index();
-    ASSERT(GamepadProvider::singleton().platformGamepads()[index] == &platformGamepad);
-
-    // The new index should already fit in the existing array, or should be exactly one past-the-end of the existing array.
-    ASSERT(index <= m_gamepads.size());
-
-    if (index < m_gamepads.size())
-        m_gamepads[index] = Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
-    else if (index == m_gamepads.size())
-        m_gamepads.append(Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad));
-}
-
-void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
-{
-    // If this Navigator hasn't seen any gamepads yet its Vector will still be empty.
-    if (!m_gamepads.size())
-        return;
-
-    ASSERT(platformGamepad.index() < m_gamepads.size());
-    ASSERT(m_gamepads[platformGamepad.index()]);
-
-    m_gamepads[platformGamepad.index()] = nullptr;
-}
-
-RefPtr<Page> NavigatorGamepad::protectedPage() const
-{
-    RefPtr frame = m_navigator->frame();
-    return frame ? frame->protectedPage() : nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -59,15 +59,12 @@ public:
     // Null checking each entry is necessary.
     static ExceptionOr<const Vector<RefPtr<Gamepad>>&> getGamepads(Navigator&);
 
-    void gamepadConnected(PlatformGamepad&);
-    void gamepadDisconnected(PlatformGamepad&);
-
-    Ref<Gamepad> gamepadFromPlatformGamepad(PlatformGamepad&);
+    Ref<Gamepad> ensureGamepad(const PlatformGamepad&);
+    RefPtr<Gamepad> gamepadIfExists(const PlatformGamepad&) const;
+    void removeGamepadIfExists(const PlatformGamepad&);
 
     WEBCORE_EXPORT static void setGamepadsRecentlyAccessedThreshold(Seconds);
     static Seconds gamepadsRecentlyAccessedThreshold();
-
-    RefPtr<Page> protectedPage() const;
 
 private:
     static ASCIILiteral supplementName() { return "NavigatorGamepad"_s; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5613,7 +5613,7 @@ void Page::allowGamepadAccess()
         return;
 
     m_gamepadAccessGranted = true;
-    GamepadManager::singleton().updateQuarantineStatus();
+    GamepadManager::singleton().didUpdateGamepadAccess();
 }
 
 void Page::initializeGamepadAccessForPageLoad()


### PR DESCRIPTION
#### 1b7f230c1a6e01d76f98af8b9e0dc5f077e8da3f
<pre>
REGRESSION(<a href="https://commits.webkit.org/299621@main">299621@main</a>): [MacOS Debug] ASSERTION FAILED: m_gamepads[platformGamepad.index] in &apos;gamepad/gamepad-visibility-1.html&apos; is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=298476">https://bugs.webkit.org/show_bug.cgi?id=298476</a>
<a href="https://rdar.apple.com/159970513">rdar://159970513</a>

Reviewed by NOBODY (OOPS!).

Test runs such as following would fail:
run-webkit-tests --iterations 100 --no-build --verbose  --details \
 --debug-rwt-logging --no-retry --no-show-results --debug \
 --exit-after-n-failures=1 gamepad/gamepad-vibrationActuator-type.html \
 gamepad/gamepad-visibility-1.html

Running gamepad/gamepad-visibility-1.html would result frequently in
crash of the subsequent test, making it harder to analyze test failures.

GamepadManager would try to implement the feature where gamepad
connection info is not exposed to the page unless the gamepad is
interacted with. It would assert when running tests, loading two pages
at the same time.

The first web view would see mock gamepad connect, use, disconnect.
Then other web view would invoke connect, disconnect.
The other web view would survive the disconnect, as it would be stored
in &quot;blind&quot; list. The first web view would be moved off of the &quot;blind
list&quot;, and would assert on seeing disconnect without connect. Connects
are no-op due to the above exposure filtering.

Fix by removing complex list handling related to the &quot;blind&quot;
window/navigator concept. Also remove list handling related to vision
os &quot;guarantine&quot; feature.

Instead, implement [[exposed]] property as designed in the spec:
When it&apos;s time to expose the Gamepad, create it to NavigatorGamepad.

To be able to implement consistent code, fix existing bugs:
 - Disconnected Gamepad instances were left in &quot;connected&quot; state. Mark
   them disconnected before dispatching the disconnect event.
 - Navigator.getGamepads() list would end in null values. It
   is specified to end in a populated value or be empty.
 - The disconnected gamepad should remain in Navigator.getGamepads()
   for the duration of the gamepaddisconnected event.

Tests: gamepad/gamepad-connect-disconnect-invisible.html
       gamepad/gamepad-visibility-poll.html

Tests: gamepad/gamepad-connect-disconnect-invisible.html
       gamepad/gamepad-visibility-poll.html
* LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt: Added.
* LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html: Added.
* LayoutTests/gamepad/gamepad-polling-access-expected.txt:
* LayoutTests/gamepad/gamepad-visibility-poll-expected.txt: Added.
* LayoutTests/gamepad/gamepad-visibility-poll.html: Added.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::GamepadManager):
(WebCore::GamepadManager::platformGamepadConnected):
(WebCore::GamepadManager::platformGamepadDisconnected):
(WebCore::GamepadManager::platformGamepadInputActivity):
(WebCore::GamepadManager::makeGamepadsVisible):
(WebCore::GamepadManager::registerNavigator):
(WebCore::GamepadManager::unregisterNavigator):
(WebCore::GamepadManager::registerDOMWindow):
(WebCore::GamepadManager::unregisterDOMWindow):
(WebCore::GamepadManager::didUpdateGamepadAccess):
(WebCore::navigatorGamepadFromDOMWindow): Deleted.
(WebCore::GamepadManager::findUnquarantinedNavigatorsAndWindows): Deleted.
(WebCore::GamepadManager::makeGamepadVisible): Deleted.
(WebCore::GamepadManager::updateQuarantineStatus): Deleted.
* Source/WebCore/Modules/gamepad/GamepadManager.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::ensureGamepad):
(WebCore::NavigatorGamepad::gamepadIfExists const):
(WebCore::NavigatorGamepad::removeGamepadIfExists):
(WebCore::NavigatorGamepad::gamepads):
(WebCore::NavigatorGamepad::gamepadFromPlatformGamepad):
(WebCore::NavigatorGamepad::gamepadsBecameVisible): Deleted.
(WebCore::NavigatorGamepad::gamepadConnected): Deleted.
(WebCore::NavigatorGamepad::gamepadDisconnected): Deleted.
(WebCore::NavigatorGamepad::protectedPage const): Deleted.
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::allowGamepadAccess):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::setUseGPUProcess):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getVideoFrameBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b7f230c1a6e01d76f98af8b9e0dc5f077e8da3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cedb727f-e34e-408c-8bda-1545a752fe47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69928 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83411 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1de07d68-1f76-4331-96e4-336e20cb23b5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2568 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1592 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111000 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111242 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4790 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60148 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34767 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6518 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->