### PR TITLE
[blocks-in-inline] Wrong render tree shape after block switches to absolute positioning

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-rebuild-root-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-rebuild-root-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="http://wpt.live/fonts/ahem.css" />
+<style>
+  body {
+    font: 100px/1 Ahem;
+    color: red;
+  }
+  .abs {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<body>
+    <span id="span" style="position: relative;">
+      <div id="absdiv" class="abs" ></div>
+      x
+    </span>
+</body>
+<script>
+  document.body.offsetHeight;
+  document.getElementById("absdiv").style.position = "absolute";
+</script>

--- a/LayoutTests/fast/inline/blocks-in-inline-rebuild-root.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-rebuild-root.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="http://wpt.live/fonts/ahem.css" />
+<style>
+  body {
+    font: 100px/1 Ahem;
+    color: red;
+  }
+  .abs {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<body>
+    <span id="span" style="position: relative;">
+      <div id="absdiv" class="abs" ></div>
+      x
+    </span>
+</body>
+<script>
+  document.body.offsetHeight;
+  document.getElementById("absdiv").style.position = "absolute";
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -151,7 +151,8 @@ void RenderTreeUpdater::updateRebuildRoots()
         auto* renderingAncestor = findRenderingAncestor(root);
         if (!renderingAncestor)
             return nullptr;
-        auto isInsideContinuation = root.renderer() && root.renderer()->parent()->isContinuation();
+        auto* rootRenderer = root.renderer();
+        auto isInsideContinuation = rootRenderer && rootRenderer->parent()->isContinuation();
         auto isInsideAnonymousFlexItemWithSiblings = [&] {
             if (!is<RenderFlexibleBox>(renderingAncestor->renderer()))
                 return false;
@@ -162,7 +163,12 @@ void RenderTreeUpdater::updateRebuildRoots()
                 return true;
             return false;
         };
-        if (isInsideContinuation || isInsideAnonymousFlexItemWithSiblings() || RenderTreeBuilder::isRebuildRootForChildren(*renderingAncestor->renderer()))
+        auto isBlockInInline = [&] {
+            if (!is<RenderInline>(renderingAncestor->renderer()))
+                return false;
+            return rootRenderer && rootRenderer->isInFlow() && !rootRenderer->isInline();
+        };
+        if (isInsideContinuation || isInsideAnonymousFlexItemWithSiblings() || isBlockInInline() || RenderTreeBuilder::isRebuildRootForChildren(*renderingAncestor->renderer()))
             return renderingAncestor;
         return nullptr;
     };


### PR DESCRIPTION
#### fa39bffc16abdf6fd8ea7e1d2c9d25fdad75aa78
<pre>
[blocks-in-inline] Wrong render tree shape after block switches to absolute positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=303476">https://bugs.webkit.org/show_bug.cgi?id=303476</a>
<a href="https://rdar.apple.com/165763630">rdar://165763630</a>

Reviewed by Alan Baradlay.

Seen in LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild.html

Test: fast/inline/blocks-in-inline-rebuild-root.html
* LayoutTests/fast/inline/blocks-in-inline-rebuild-root-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-rebuild-root.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRebuildRoots):

Adjust render tree rebuild root for block-in-inline when positioning state changes similar to continuations.

Canonical link: <a href="https://commits.webkit.org/303838@main">https://commits.webkit.org/303838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f72d4119298df14b49253980eddfb0cdfa1de100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141336 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/848ed647-8a01-45a5-8bfb-082d36727c2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102318 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e29650cf-eef8-4111-8b52-5d60ed57fbbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136708 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83121 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/83a196b3-643d-4261-b65b-5f45ac6127af) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143984 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38614 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4534 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59689 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5993 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->