### PR TITLE
Unreviewed, reverting 303807@main (0620c5d84798)

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -118,7 +118,6 @@ public:
     }
 
     PtrType autorelease();
-    PtrType getAutoreleased();
 
 #ifdef __OBJC__
     id bridgingAutorelease();
@@ -222,12 +221,6 @@ template<typename T> inline auto RetainPtr<T>::autorelease() -> PtrType
     if (ptr)
         autoreleaseFoundationPtr(ptr);
     return ptr;
-}
-
-template<typename T> inline auto RetainPtr<T>::getAutoreleased() -> PtrType
-{
-    RetainPtr copy { *this };
-    return copy.autorelease();
 }
 
 #ifdef __OBJC__

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1511,8 +1511,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RELEASE_ASSERT(storageSession);
 
     RetainPtr<NSHTTPCookieStorage> cookieStorage;
-    if (RetainPtr storage = storageSession->cookieStorage()) {
-        cookieStorage = adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:storage.get()]);
+    if (CFHTTPCookieStorageRef storage = storageSession->cookieStorage().unsafeGet()) {
+        cookieStorage = adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:storage]);
         configuration.get().HTTPCookieStorage = cookieStorage.get();
     } else
         cookieStorage = storageSession->nsCookieStorage();
@@ -1577,24 +1577,14 @@ void NetworkSessionCocoa::initializeNSURLSessionsInSet(SessionSet& sessionSet, N
 
 SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID)
 {
-    if (webPageProxyID) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
-            return *sessionSet;
-    }
-    return m_defaultSessionSet.get();
+    RefPtr sessionSet = webPageProxyID ? m_perPageSessionSets.get(*webPageProxyID) : nullptr;
+    return sessionSet ? *sessionSet.unsafeGet() : m_defaultSessionSet.get();
 }
 
 const SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID) const
 {
-    if (webPageProxyID) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
-            return *sessionSet;
-    }
-    return m_defaultSessionSet.get();
+    RefPtr sessionSet = webPageProxyID ? m_perPageSessionSets.get(*webPageProxyID) : nullptr;
+    return sessionSet ? *sessionSet.unsafeGet() : m_defaultSessionSet.get();
 }
 
 SessionWrapper& NetworkSessionCocoa::initializeEphemeralStatelessSessionIfNeeded(std::optional<WebPageProxyIdentifier> webPageProxyID, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -116,7 +116,7 @@ static RetainPtr<NSArray<NSHTTPCookie *>> cookiesByCappingExpiry(NSArray<NSHTTPC
 }
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
-static RetainPtr<NSArray<NSHTTPCookie *>> cookiesBySettingPartition(NSArray<NSHTTPCookie *> *cookies, NSString* partition)
+static NSArray<NSHTTPCookie *> *cookiesBySettingPartition(NSArray<NSHTTPCookie *> *cookies, NSString* partition)
 {
     RetainPtr<NSMutableArray> partitionedCookies = [NSMutableArray arrayWithCapacity:cookies.count];
     for (NSHTTPCookie *cookie in cookies) {
@@ -124,7 +124,7 @@ static RetainPtr<NSArray<NSHTTPCookie *>> cookiesBySettingPartition(NSArray<NSHT
         if (partitionedCookie)
             [partitionedCookies addObject:partitionedCookie.get()];
     }
-    return partitionedCookies;
+    return partitionedCookies.unsafeGet();
 }
 #endif
 
@@ -186,7 +186,7 @@ void NetworkTaskCocoa::setCookieTransformForThirdPartyRequest(const WebCore::Res
 
         // FIXME: Consider making these session cookies, as well.
         if (!cookiePartition.isEmpty())
-            cookiesSetInResponse = cookiesBySettingPartition(cookiesSetInResponse, cookiePartition.createNSString().get()).autorelease();
+            cookiesSetInResponse = cookiesBySettingPartition(cookiesSetInResponse, cookiePartition.createNSString().get());
 
         return cookiesSetInResponse;
     }).get();

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1365,11 +1365,11 @@ void Connection::enqueueIncomingMessage(UniqueRef<Decoder> incomingMessage)
     if (!m_syncState)
         return;
     if (isIncomingMessagesThrottlingEnabled()) {
-        dispatcher()->dispatch([protectedThis = Ref { *this }] {
+        dispatcher().dispatch([protectedThis = Ref { *this }] {
             protectedThis->dispatchIncomingMessages();
         });
     } else {
-        dispatcher()->dispatch([protectedThis = Ref { *this }] {
+        dispatcher().dispatch([protectedThis = Ref { *this }] {
             protectedThis->dispatchOneIncomingMessage();
         });
     }
@@ -1510,7 +1510,7 @@ size_t Connection::numberOfMessagesToProcess(size_t totalMessages)
     return std::min(totalMessages, batchSize);
 }
 
-Ref<SerialFunctionDispatcher> Connection::dispatcher()
+SerialFunctionDispatcher& Connection::dispatcher()
 {
     // dispatcher can only be accessed while the connection is valid,
     // and must have the incoming message lock held if not being
@@ -1527,7 +1527,7 @@ Ref<SerialFunctionDispatcher> Connection::dispatcher()
     // Our syncState is specific to the SerialFunctionDispatcher we have been
     // bound to during open(), so we can retrieve the SerialFunctionDispatcher
     // from it (rather than storing another pointer on this class).
-    return dispatcher.releaseNonNull();
+    return *dispatcher.unsafeGet(); // FIXME: This is unsafe. This function should return RefPtr instead.
 }
 
 void Connection::dispatchOneIncomingMessage()
@@ -1580,7 +1580,7 @@ void Connection::dispatchIncomingMessages()
         // Re-schedule ourselves *before* we dispatch the messages because we want to process follow-up messages if the client
         // spins a nested run loop while we're dispatching a message. Note that this means we can re-enter this method.
         if (!m_incomingMessages.isEmpty()) {
-            dispatcher()->dispatch([protectedThis = Ref { *this }] {
+            dispatcher().dispatch([protectedThis = Ref { *this }] {
                 protectedThis->dispatchIncomingMessages();
             });
         }
@@ -1667,7 +1667,7 @@ void Connection::wakeUpRunLoop()
 {
     if (!isValid())
         return;
-    if (dispatcher().ptr() == &RunLoop::mainSingleton())
+    if (&dispatcher() == &RunLoop::mainSingleton())
         RunLoop::mainSingleton().wakeUp();
 }
 
@@ -1683,7 +1683,7 @@ void Connection::dispatchToClientWithIncomingMessagesLock(F&& clientRunLoopTask)
 {
     if (!m_syncState)
         return;
-    dispatcher()->dispatch(WTFMove(clientRunLoopTask));
+    dispatcher().dispatch(WTFMove(clientRunLoopTask));
 }
 
 #if !USE(UNIX_DOMAIN_SOCKETS) && !OS(DARWIN) && !OS(WINDOWS)

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -649,7 +649,7 @@ private:
     bool isThrottlingIncomingMessages() const { return *m_incomingMessagesThrottlingLevel > 0; }
 
     // Only valid between open() and invalidate().
-    Ref<SerialFunctionDispatcher> dispatcher();
+    SerialFunctionDispatcher& dispatcher();
 
     class SyncMessageState;
     RefPtr<SyncMessageState> protectedSyncState() const;

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -56,7 +56,7 @@ WKTypeID WKWebsiteDataStoreGetTypeID()
 
 WKWebsiteDataStoreRef WKWebsiteDataStoreGetDefaultDataStore()
 {
-    return WebKit::toAPI(WebKit::WebsiteDataStore::protectedDefaultDataStore().get());
+    return WebKit::toAPI(WebKit::WebsiteDataStore::defaultDataStore().ptr());
 }
 
 WKWebsiteDataStoreRef WKWebsiteDataStoreCreateNonPersistentDataStore()

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -412,7 +412,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 + (WKWebsiteDataStore *)defaultDataStore
 {
-    return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
+    return wrapper(WebKit::WebsiteDataStore::defaultDataStore()).autorelease();
 }
 
 + (WKWebsiteDataStore *)nonPersistentDataStore
@@ -1130,7 +1130,7 @@ struct WKWebsiteData {
 
 - (id <_WKWebsiteDataStoreDelegate>)_delegate
 {
-    return _delegate.getAutoreleased();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)set_delegate:(id <_WKWebsiteDataStoreDelegate>)delegate

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -669,7 +669,7 @@ void WebAutomationSession::waitForNavigationToCompleteOnFrame(WebFrameProxy& fra
 void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>& map)
 {
     for (auto id : copyToVector(map.keys())) {
-        RefPtr page = WebProcessProxy::webPage(id);
+        auto page = WebProcessProxy::webPage(id);
         auto callback = map.take(id);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
             callback({ });

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -264,8 +264,7 @@ public:
     void invalidate();
 
     bool canEnterVideoFullscreen() const { return !!m_controlsManagerContextId && m_controlsManagerContextIsVideo; }
-    WebCore::PlatformPlaybackSessionInterface* controlsManagerInterface();
-    RefPtr<WebCore::PlatformPlaybackSessionInterface> protectedControlsManagerInterface();
+    RefPtr<WebCore::PlatformPlaybackSessionInterface> controlsManagerInterface();
     void requestControlledElementID();
 
     bool isPaused(PlaybackSessionContextIdentifier) const;
@@ -288,8 +287,7 @@ private:
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
     const ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
     Ref<PlaybackSessionModelContext> ensureModel(PlaybackSessionContextIdentifier);
-    WebCore::PlatformPlaybackSessionInterface& ensureInterface(PlaybackSessionContextIdentifier);
-    Ref<WebCore::PlatformPlaybackSessionInterface> ensureProtectedInterface(PlaybackSessionContextIdentifier);
+    Ref<WebCore::PlatformPlaybackSessionInterface> ensureInterface(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -322,7 +322,7 @@ UIDelegate::UIClient::~UIClient() = default;
 
 id<WKUIDelegatePrivate> UIDelegate::UIClient::uiDelegatePrivate()
 {
-    return m_uiDelegate ? (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.getAutoreleased() : nil;
+    return m_uiDelegate ? (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get().unsafeGet() : nil;
 }
 
 RetainPtr<id<WKUIDelegatePrivate>> UIDelegate::UIClient::protectedUIDelegatePrivate()

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -135,7 +135,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 
 - (id<WKContactPickerDelegate>)delegate
 {
-    return _delegate.getAutoreleased();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKContactPickerDelegate>)delegate

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1549,7 +1549,7 @@ void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, const RefP
         return;
 
     auto rect = textIndicator->textBoundingRectInRootViewCoordinates();
-    convertRectToMainFrameCoordinates(rect, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, textIndicator = WTFMove(textIndicator), lifetime] (std::optional<FloatRect> convertedRect) mutable {
+    convertRectToMainFrameCoordinates(rect, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, textIndicator = WTFMove(textIndicator), lifetime] (std::optional<FloatRect> convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
@@ -1594,7 +1594,7 @@ void WebPageProxy::updateTextIndicatorFromFrame(FrameIdentifier frameID, RefPtr<
         return;
 
     auto rect = textIndicator->textBoundingRectInRootViewCoordinates();
-    convertRectToMainFrameCoordinates(rect, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, textIndicator = WTFMove(textIndicator)] (std::optional<FloatRect> convertedRect) mutable {
+    convertRectToMainFrameCoordinates(rect, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, textIndicator = WTFMove(textIndicator)] (std::optional<FloatRect> convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
@@ -1677,7 +1677,7 @@ bool WebPageProxy::tryToSendCommandToActiveControlledVideo(PlatformMediaSession:
     if (!hasActiveVideoForControlsManager())
         return false;
 
-    WeakPtr model = protectedPlaybackSessionManager()->protectedControlsManagerInterface()->playbackSessionModel();
+    WeakPtr model = protectedPlaybackSessionManager()->controlsManagerInterface()->playbackSessionModel();
     if (!model)
         return false;
 

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -223,7 +223,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 
 - (id<WKDigitalCredentialsPickerDelegate>)delegate
 {
-    return _delegate.getAutoreleased();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<WKDigitalCredentialsPickerDelegate>)delegate

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2376,11 +2376,11 @@ WebsiteDataStore* WebExtensionContext::websiteDataStore(std::optional<PAL::Sessi
     if (!extensionController)
         return nullptr;
 
-    WeakPtr weakDataStore = extensionController->websiteDataStore(sessionID);
-    if (weakDataStore && !weakDataStore->isPersistent() && !hasAccessToPrivateData())
+    RefPtr result = extensionController->websiteDataStore(sessionID);
+    if (result && !result->isPersistent() && !hasAccessToPrivateData())
         return nullptr;
 
-    return weakDataStore.get();
+    return result.unsafeGet();
 }
 
 void WebExtensionContext::cookiesDidChange(API::HTTPCookieStore&)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -58,7 +58,7 @@ WebsiteDataStore& WebExtensionControllerConfiguration::defaultWebsiteDataStore()
 {
     if (m_defaultWebsiteDataStore)
         return *m_defaultWebsiteDataStore;
-    return WebsiteDataStore::defaultDataStore();
+    return WebsiteDataStore::defaultDataStore().unsafeGet();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -859,13 +859,13 @@ void GPUProcessProxy::voiceActivityDetected()
 
 void GPUProcessProxy::startMonitoringCaptureDeviceRotation(PageIdentifier pageID, const String& persistentId)
 {
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
+    if (auto page = WebProcessProxy::webPage(pageID))
         page->startMonitoringCaptureDeviceRotation(persistentId);
 }
 
 void GPUProcessProxy::stopMonitoringCaptureDeviceRotation(PageIdentifier pageID, const String& persistentId)
 {
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
+    if (auto page = WebProcessProxy::webPage(pageID))
         page->stopMonitoringCaptureDeviceRotation(persistentId);
 }
 
@@ -887,7 +887,7 @@ void GPUProcessProxy::microphoneMuteStatusChanged(bool isMuting)
 #if PLATFORM(IOS_FAMILY)
 void GPUProcessProxy::statusBarWasTapped(CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr page = WebProcessProxy::audioCapturingWebPage())
+    if (auto page = WebProcessProxy::audioCapturingWebPage())
         page->statusBarWasTapped();
     // Find the web page capturing audio and put focus on it.
     completionHandler();

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -45,8 +45,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return view.page;
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
-    if (auto* page = WebProcessProxy::webPageWithActiveXRSession())
-        return page;
+    if (auto page = WebProcessProxy::webPageWithActiveXRSession())
+        return page.unsafeGet();
 #endif
 
     return nullptr;

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -249,7 +249,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
         return nil;
 
     if (RefPtr inspectedPage = _inspectedPage.get())
-        return inspectedPage->cocoaView().autorelease();
+        return inspectedPage->cocoaView().unsafeGet();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -559,20 +559,20 @@ void NetworkProcessProxy::negotiatedLegacyTLS(WebPageProxyIdentifier pageID)
 
 void NetworkProcessProxy::didNegotiateModernTLS(WebPageProxyIdentifier pageID, const URL& url)
 {
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
+    if (auto page = WebProcessProxy::webPage(pageID))
         page->didNegotiateModernTLS(url);
 }
 
 void NetworkProcessProxy::didBlockLoadToKnownTracker(WebPageProxyIdentifier pageID, const URL& url)
 {
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
+    if (auto page = WebProcessProxy::webPage(pageID))
         page->didBlockLoadToKnownTracker(url);
 }
 
 void NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation(WebPageProxyIdentifier pageID, WebCore::NavigationIdentifier navigationID, BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, const WebCore::Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&& completionHandler)
 {
     RELEASE_LOG(ProcessSwapping, "%p - NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation: pageID=%" PRIu64 ", navigationID=%" PRIu64 ", browsingContextGroupSwitchDecision=%u, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, this, pageID.toUInt64(), navigationID.toUInt64(), (unsigned)browsingContextGroupSwitchDecision, existingNetworkResourceLoadIdentifierToResume.toUInt64());
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
+    if (auto page = WebProcessProxy::webPage(pageID))
         page->triggerBrowsingContextGroupSwitchForNavigation(navigationID, browsingContextGroupSwitchDecision, responseSite, existingNetworkResourceLoadIdentifierToResume, WTFMove(completionHandler));
     else
         completionHandler(false);
@@ -592,10 +592,13 @@ void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Con
 
 void NetworkProcessProxy::logDiagnosticMessage(WebPageProxyIdentifier pageID, const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
-        page->logDiagnosticMessage(message, description, shouldSample);
+    if (!page)
+        return;
+
+    page->logDiagnosticMessage(message, description, shouldSample);
 }
 
 void NetworkProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
@@ -619,23 +622,29 @@ void NetworkProcessProxy::terminateIdleServiceWorkers(WebCore::ProcessIdentifier
 
 void NetworkProcessProxy::logDiagnosticMessageWithResult(WebPageProxyIdentifier pageID, const String& message, const String& description, uint32_t result, WebCore::ShouldSample shouldSample)
 {
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
-        page->logDiagnosticMessageWithResult(message, description, result, shouldSample);
+    if (!page)
+        return;
+
+    page->logDiagnosticMessageWithResult(message, description, result, shouldSample);
 }
 
 void NetworkProcessProxy::logDiagnosticMessageWithValue(WebPageProxyIdentifier pageID, const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample shouldSample)
 {
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
-        page->logDiagnosticMessageWithValue(message, description, value, significantFigures, shouldSample);
+    if (!page)
+        return;
+
+    page->logDiagnosticMessageWithValue(message, description, value, significantFigures, shouldSample);
 }
 
 void NetworkProcessProxy::resourceLoadDidSendRequest(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceRequest&& request, std::optional<IPC::FormDataReference>&& httpBody)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -649,7 +658,7 @@ void NetworkProcessProxy::resourceLoadDidSendRequest(WebPageProxyIdentifier page
 
 void NetworkProcessProxy::resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -658,7 +667,7 @@ void NetworkProcessProxy::resourceLoadDidPerformHTTPRedirection(WebPageProxyIden
 
 void NetworkProcessProxy::resourceLoadDidReceiveChallenge(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -667,7 +676,7 @@ void NetworkProcessProxy::resourceLoadDidReceiveChallenge(WebPageProxyIdentifier
 
 void NetworkProcessProxy::resourceLoadDidReceiveResponse(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -676,7 +685,7 @@ void NetworkProcessProxy::resourceLoadDidReceiveResponse(WebPageProxyIdentifier 
 
 void NetworkProcessProxy::resourceLoadDidCompleteWithError(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -1025,7 +1034,7 @@ void NetworkProcessProxy::setGrandfathered(PAL::SessionID sessionID, const Regis
 
 void NetworkProcessProxy::requestStorageAccessConfirm(WebPageProxyIdentifier pageID, FrameIdentifier frameID, const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&& organizationStorageAccessPromptQuirk, CompletionHandler<void(bool)>&& completionHandler)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page) {
         completionHandler(false);
         return;
@@ -1199,8 +1208,11 @@ void NetworkProcessProxy::didCommitCrossSiteLoadWithDataTransferFromPrevalentRes
     if (!canSendMessage())
         return;
 
-    if (RefPtr page = WebProcessProxy::webPage(pageID))
-        page->didCommitCrossSiteLoadWithDataTransferFromPrevalentResource();
+    auto page = WebProcessProxy::webPage(pageID);
+    if (!page)
+        return;
+
+    page->didCommitCrossSiteLoadWithDataTransferFromPrevalentResource();
 }
 
 void NetworkProcessProxy::setCrossSiteLoadWithLinkDecorationForTesting(PAL::SessionID sessionID, const RegistrableDomain& fromDomain, const RegistrableDomain& toDomain, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
@@ -1655,7 +1667,7 @@ void NetworkProcessProxy::setWebProcessHasUploads(WebCore::ProcessIdentifier pro
 
 void NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebPageProxyIdentifier pageID, CompletionHandler<void(bool)>&& reply)
 {
-    RefPtr page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return reply(false);
 
@@ -1947,7 +1959,7 @@ void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<Web
 #endif
         // Since this navigation requested that we clear existing navigation snapshots, we shouldn't
         // create a snapshot for this navigation either if it is same-origin.
-        if (RefPtr page = WebProcessProxy::webPage(webPageProxyID)) {
+        if (auto page = WebProcessProxy::webPage(webPageProxyID)) {
             bool isSameOriginNavigation = SecurityOriginData::fromURL(URL(page->pageLoadState().url())) == origin.topOrigin;
             if (isSameOriginNavigation)
                 page->suppressNextAutomaticNavigationSnapshot();
@@ -2002,7 +2014,7 @@ void NetworkProcessProxy::wakeUpWebProcessForIPC(WebCore::ProcessIdentifier proc
 
 void NetworkProcessProxy::reportNetworkIssue(WebPageProxyIdentifier pageIdentifier, const URL& requestURL)
 {
-    if (RefPtr page = WebProcessProxy::webPage(pageIdentifier))
+    if (auto page = WebProcessProxy::webPage(pageIdentifier))
         page->reportNetworkIssue(requestURL);
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -310,14 +310,14 @@ static Class scrollViewScrollIndicatorClassSingleton()
         if ([view isKindOfClass:[WKChildScrollView class]]) {
             if (WebKit::isScrolledBy((WKChildScrollView *)view.get(), viewsAtPoint.last().get())) {
                 LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is child scroll view and scrolled by " << (void*)viewsAtPoint.last().get());
-                return view.autorelease();
+                return view.unsafeGet();
             }
         }
 
         if ([view isKindOfClass:WebKit::scrollViewScrollIndicatorClassSingleton()] && [[view superview] isKindOfClass:WKChildScrollView.class]) {
             if (WebKit::isScrolledBy((WKChildScrollView *)[view superview], viewsAtPoint.last().get())) {
                 LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is the scroll indicator of child scroll view, which is scrolled by " << (void*)viewsAtPoint.last().get());
-                return view.autorelease();
+                return view.unsafeGet();
             }
         }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -179,7 +179,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
 
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {
-            auto& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode.get());
+            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
@@ -194,7 +194,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         };
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
-            auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode.get());
+            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
@@ -218,7 +218,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
             break;
         }
         case ScrollingNodeType::PluginScrolling: {
-            auto& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode.get());
+            ScrollingStatePluginScrollingNode& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode).unsafeGet();
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -84,7 +84,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDisplayLinkClient);
 void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplayID /* displayID */, WebCore::DisplayUpdate /* displayUpdate */, bool /* wantsFullSpeedUpdates */, bool /* anyObserverWantsCallback */)
 {
     RunLoop::mainSingleton().dispatch([pageIdentifier = m_pageIdentifier]() {
-        RefPtr page = WebProcessProxy::webPage(pageIdentifier);
+        auto page = WebProcessProxy::webPage(pageIdentifier);
         if (!page)
             return;
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -814,12 +814,12 @@ void WebFrameProxy::updateOpener(WebCore::FrameIdentifier newOpener)
     m_opener = WebFrameProxy::webFrame(newOpener);
 }
 
-Ref<WebFrameProxy> WebFrameProxy::rootFrame()
+WebFrameProxy& WebFrameProxy::rootFrame()
 {
     Ref rootFrame = *this;
     while (rootFrame->m_parentFrame && rootFrame->m_parentFrame->process().coreProcessIdentifier() == process().coreProcessIdentifier())
         rootFrame = *rootFrame->m_parentFrame;
-    return rootFrame;
+    return rootFrame.unsafeGet();
 }
 
 bool WebFrameProxy::isMainFrame() const

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -210,7 +210,7 @@ public:
     FrameTreeCreationParameters frameTreeCreationParameters() const;
 
     WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
-    Ref<WebFrameProxy> rootFrame();
+    WebFrameProxy& rootFrame();
     WebProcessProxy& process() const;
     Ref<WebProcessProxy> protectedProcess() const;
     void setProcess(FrameProcess&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10561,7 +10561,7 @@ void WebPageProxy::showPopupMenuFromFrame(IPC::Connection& connection, FrameIden
     if (!frame)
         return;
 
-    convertRectToMainFrameCoordinates(rect, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, textDirection, selectedIndex, data, items = WTFMove(items), connection = Ref { connection }] (std::optional<FloatRect> convertedRect) {
+    convertRectToMainFrameCoordinates(rect, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, textDirection, selectedIndex, data, items = WTFMove(items), connection = Ref { connection }] (std::optional<FloatRect> convertedRect) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
@@ -10619,7 +10619,7 @@ void WebPageProxy::showContextMenuFromFrame(FrameInfoData&& frameInfo, ContextMe
         return;
 
     auto menuLocation = contextMenuContextData.menuLocation();
-    convertPointToMainFrameCoordinates(menuLocation, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, contextMenuContextData = WTFMove(contextMenuContextData), userData = WTFMove(userData), frameInfo = WTFMove(frameInfo)] (std::optional<FloatPoint> result) mutable {
+    convertPointToMainFrameCoordinates(menuLocation, frame->rootFrame().frameID(), [weakThis = WeakPtr { *this }, contextMenuContextData = WTFMove(contextMenuContextData), userData = WTFMove(userData), frameInfo = WTFMove(frameInfo)] (std::optional<FloatPoint> result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -13478,7 +13478,7 @@ void WebPageProxy::convertPointToMainFrameCoordinates(WebCore::FloatPoint point,
     if (!parent)
         return completionHandler(point);
 
-    sendWithAsyncReplyToProcessContainingFrame(parent->frameID(), Messages::WebPage::ContentsToRootViewPoint(frame->frameID(), point), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), nextFrameID = parent->rootFrame()->frameID()](FloatPoint convertedPoint) mutable {
+    sendWithAsyncReplyToProcessContainingFrame(parent->frameID(), Messages::WebPage::ContentsToRootViewPoint(frame->frameID(), point), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), nextFrameID = parent->rootFrame().frameID()](FloatPoint convertedPoint) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler(std::nullopt);
@@ -13496,7 +13496,7 @@ void WebPageProxy::convertRectToMainFrameCoordinates(WebCore::FloatRect rect, st
     if (!parent)
         return completionHandler(rect);
 
-    sendWithAsyncReplyToProcessContainingFrame(parent->frameID(), Messages::WebPage::ContentsToRootViewRect(frame->frameID(), rect), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), nextFrameID = parent->rootFrame()->frameID()](FloatRect convertedRect) mutable {
+    sendWithAsyncReplyToProcessContainingFrame(parent->frameID(), Messages::WebPage::ContentsToRootViewRect(frame->frameID(), rect), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), nextFrameID = parent->rootFrame().frameID()](FloatRect convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler(std::nullopt);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1301,7 +1301,7 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
 
     if (usesSingleWebProcess()) {
 #if PLATFORM(COCOA)
-        bool mustMatchDataStore = WebKit::WebsiteDataStore::defaultDataStoreExists() && &websiteDataStore != &WebKit::WebsiteDataStore::defaultDataStore();
+        bool mustMatchDataStore = WebKit::WebsiteDataStore::defaultDataStoreExists() && &websiteDataStore != WebKit::WebsiteDataStore::defaultDataStore().ptr();
 #else
         bool mustMatchDataStore = false;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -746,36 +746,36 @@ void WebProcessProxy::shutDown()
     Ref<WebProcessPool> { processPool() }->disconnectProcess(*this);
 }
 
-WebPageProxy* WebProcessProxy::webPage(WebPageProxyIdentifier pageID)
+RefPtr<WebPageProxy> WebProcessProxy::webPage(WebPageProxyIdentifier pageID)
 {
     return globalPageMap().get(pageID);
 }
 
-WebPageProxy* WebProcessProxy::webPage(PageIdentifier pageID)
+RefPtr<WebPageProxy> WebProcessProxy::webPage(PageIdentifier pageID)
 {
-    for (WeakRef page : globalPageMap().values()) {
+    for (Ref page : globalPages()) {
         if (page->webPageIDInMainFrameProcess() == pageID)
-            return page.ptr();
+            return page;
     }
+
     return nullptr;
 }
 
-WebPageProxy* WebProcessProxy::audioCapturingWebPage()
+RefPtr<WebPageProxy> WebProcessProxy::audioCapturingWebPage()
 {
-    for (WeakRef page : globalPageMap().values()) {
-        if (Ref { page.get() }->hasActiveAudioStream())
+    for (Ref page : globalPages()) {
+        if (page->hasActiveAudioStream())
             return page.ptr();
     }
     return nullptr;
 }
 
 #if ENABLE(WEBXR)
-WebPageProxy* WebProcessProxy::webPageWithActiveXRSession()
+RefPtr<WebPageProxy> WebProcessProxy::webPageWithActiveXRSession()
 {
-    for (WeakRef weakPage : globalPageMap().values()) {
-        Ref page = weakPage.get();
+    for (Ref page : globalPages()) {
         if (page->xrSystem() && page->xrSystem()->hasActiveSession())
-            return weakPage.ptr();
+            return page;
     }
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -247,11 +247,11 @@ public:
 
     static RefPtr<WebProcessProxy> processForIdentifier(WebCore::ProcessIdentifier);
     static Ref<WebProcessProxy> fromConnection(const IPC::Connection&);
-    static WebPageProxy* webPage(WebPageProxyIdentifier);
-    static WebPageProxy* webPage(WebCore::PageIdentifier);
-    static WebPageProxy* audioCapturingWebPage();
+    static RefPtr<WebPageProxy> webPage(WebPageProxyIdentifier);
+    static RefPtr<WebPageProxy> webPage(WebCore::PageIdentifier);
+    static RefPtr<WebPageProxy> audioCapturingWebPage();
 #if ENABLE(WEBXR)
-    static WebPageProxy* webPageWithActiveXRSession();
+    static RefPtr<WebPageProxy> webPageWithActiveXRSession();
 #endif
     Ref<WebPageProxy> createWebPage(PageClient&, Ref<API::PageConfiguration>&&);
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -125,8 +125,7 @@ using RemoveDataTaskCounter = RefCounter<RemoveDataTaskCounterType>;
 
 class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore> {
 public:
-    static WebsiteDataStore& defaultDataStore();
-    static Ref<WebsiteDataStore> protectedDefaultDataStore();
+    static Ref<WebsiteDataStore> defaultDataStore();
     static bool defaultDataStoreExists();
     static void deleteDefaultDataStoreForTesting();
     static RefPtr<WebsiteDataStore> existingDataStoreForIdentifier(const WTF::UUID&);

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -54,7 +54,7 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
     if (m_processPool->sandboxEnabled()) {
         // Prewarmed processes don't have a WebsiteDataStore yet, so use the primary WebsiteDataStore from the WebProcessPool.
         // The process won't be used if current WebsiteDataStore is different than the WebProcessPool primary one.
-        RefPtr dataStore = isPrewarmed() ? &WebsiteDataStore::defaultDataStore() : websiteDataStore();
+        RefPtr dataStore = isPrewarmed() ? WebsiteDataStore::defaultDataStore().ptr() : websiteDataStore();
 
         ASSERT(dataStore);
         launchOptions.extraInitializationData.set("mediaKeysDirectory"_s, dataStore->resolvedDirectories().mediaKeysStorageDirectory);

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -233,7 +233,7 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 {
     for (RetainPtr parent = [self superview]; parent; parent = [parent superview]) {
         if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>(parent.get()))
-            return scrollView.autorelease();
+            return scrollView.unsafeGet();
     }
     return nil;
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12817,12 +12817,12 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (CGImageRef)copySubjectResultForImageContextMenu
 {
-    return valueOrDefault(_imageAnalysisContextMenuActionData).copySubjectResult.getAutoreleased();
+    return valueOrDefault(_imageAnalysisContextMenuActionData).copySubjectResult.unsafeGet();
 }
 
 - (UIMenu *)machineReadableCodeSubMenuForImageContextMenu
 {
-    return valueOrDefault(_imageAnalysisContextMenuActionData).machineReadableCodeMenu.getAutoreleased();
+    return valueOrDefault(_imageAnalysisContextMenuActionData).machineReadableCodeMenu.unsafeGet();
 }
 
 #if USE(QUICK_LOOK)
@@ -14258,7 +14258,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
             if (enclosingView != selectedView && ![enclosingView _wk_isAncestorOf:selectedView])
                 return self;
         }
-        return enclosingView.autorelease();
+        return enclosingView.unsafeGet();
     }();
 
     ASSERT(_cachedSelectionContainerView);

--- a/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
@@ -176,7 +176,7 @@ static UIBezierPath *pathWithRoundedRectInFrame(CGRect rect, CGFloat borderRadiu
 
 - (id <WKFocusedFormControlViewDelegate>)delegate
 {
-    return _delegate.get().getAutoreleased();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id <WKFocusedFormControlViewDelegate>)delegate

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -147,21 +147,17 @@ IntSize PageClientImpl::viewSize()
 
 NSView *PageClientImpl::activeView() const
 {
-    if (CheckedPtr impl = m_impl.get()) {
-        if (RetainPtr thumbnailView = impl->thumbnailView())
-            return thumbnailView.autorelease();
-    }
-    return m_view.getAutoreleased();
+    CheckedPtr impl = m_impl.get();
+    return (impl && impl->thumbnailView()) ? impl->thumbnailView().unsafeGet() : m_view.getAutoreleased();
 }
 
 NSWindow *PageClientImpl::activeWindow() const
 {
-    if (CheckedPtr impl = m_impl.get()) {
-        if (RetainPtr thumbnailView = impl->thumbnailView())
-            return [thumbnailView window];
-        if (impl->targetWindowForMovePreparation())
-            return impl->targetWindowForMovePreparation();
-    }
+    CheckedPtr impl = m_impl.get();
+    if (impl && impl->thumbnailView())
+        return [impl->thumbnailView() window];
+    if (impl && impl->targetWindowForMovePreparation())
+        return impl->targetWindowForMovePreparation();
     return [m_view.get() window];
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3850,7 +3850,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
 id WebViewImpl::accessibilityFocusedUIElement()
 {
     enableAccessibilityIfNecessary();
-    return remoteAccessibilityChildIfNotSuspended().autorelease();
+    return remoteAccessibilityChildIfNotSuspended().unsafeGet();
 }
 
 id WebViewImpl::accessibilityHitTest(CGPoint)
@@ -6635,7 +6635,7 @@ void WebViewImpl::togglePictureInPicture()
 PlatformPlaybackSessionInterface* WebViewImpl::playbackSessionInterface() const
 {
     if (RefPtr manager = m_page->playbackSessionManager())
-        return manager->controlsManagerInterface();
+        return manager->controlsManagerInterface().unsafeGet();
 
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -370,10 +370,8 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);
 
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* axObject = axObjectCache->exportedGetOrCreate(*coreElement))
-            return axObject;
+        if (RefPtr<WebCore::AccessibilityObject> axObject = axObjectCache->exportedGetOrCreate(*coreElement))
+            return axObject.unsafeGet();
     }
 
     errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InternalError);
@@ -668,21 +666,17 @@ static WebCore::Element* containerElementForElement(WebCore::Element& element)
     // §13. Element State.
     // https://w3c.github.io/webdriver/webdriver-spec.html#dfn-container.
     if (is<WebCore::HTMLOptionElement>(element)) {
-        if (auto* parentElement = WebCore::ancestorsOfType<WebCore::HTMLDataListElement>(element).first())
-            return parentElement;
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* parentElement = downcast<WebCore::HTMLOptionElement>(element).ownerSelectElement())
-            return parentElement;
+        if (RefPtr parentElement = WebCore::ancestorsOfType<WebCore::HTMLDataListElement>(element).first())
+            return parentElement.unsafeGet();
+        if (RefPtr parentElement = downcast<WebCore::HTMLOptionElement>(element).ownerSelectElement())
+            return parentElement.unsafeGet();
 
         return nullptr;
     }
 
     if (RefPtr optgroup = dynamicDowncast<WebCore::HTMLOptGroupElement>(element)) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* parentElement = optgroup->ownerSelectElement())
-            return parentElement;
+        if (RefPtr parentElement = optgroup->ownerSelectElement())
+            return parentElement.unsafeGet();
 
         return nullptr;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -58,16 +58,16 @@ IPC::Connection* RemoteWCLayerTreeHostProxy::messageSenderConnection() const
 
 GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()
 {
-    if (!m_gpuProcessConnection.get()) {
-        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection.get();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->connection().send(
             Messages::GPUConnectionToWebProcess::CreateWCLayerTreeHost(wcLayerTreeHostIdentifier(), m_page->nativeWindowHandle(), m_usesOffscreenRendering),
             0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     }
-    ASSERT(m_gpuProcessConnection.get() == &WebProcess::singleton().ensureGPUProcessConnection());
-    return WebProcess::singleton().ensureGPUProcessConnection();
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteWCLayerTreeHostProxy::disconnectGpuProcessIfNeeded()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -89,14 +89,14 @@ void RemoteImageDecoderAVFManager::gpuProcessConnectionDidClose(GPUProcessConnec
 
 GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
 {
-    if (!m_gpuProcessConnection.get()) {
-        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection.get();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName(), *this);
     }
-    ASSERT(m_gpuProcessConnection.get() == &WebProcess::singleton().ensureGPUProcessConnection());
-    return WebProcess::singleton().ensureGPUProcessConnection();
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -275,13 +275,15 @@ void RemoteMediaPlayerManager::setUseGPUProcess(bool useGPUProcess)
 
 GPUProcessConnection& RemoteMediaPlayerManager::gpuProcessConnection()
 {
-    if (!m_gpuProcessConnection.get()) {
-        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection.get();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
         gpuProcessConnection->addClient(*this);
     }
-    ASSERT(m_gpuProcessConnection.get() == &WebProcess::singleton().ensureGPUProcessConnection());
-    return WebProcess::singleton().ensureGPUProcessConnection();
+
+    return *gpuProcessConnection.unsafeGet();
 }
 
 Ref<GPUProcessConnection> RemoteMediaPlayerManager::protectedGPUProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -59,15 +59,15 @@ RemoteRemoteCommandListener::~RemoteRemoteCommandListener()
 
 GPUProcessConnection& RemoteRemoteCommandListener::ensureGPUProcessConnection()
 {
-    if (!m_gpuProcessConnection.get()) {
-        Ref gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        m_gpuProcessConnection = gpuProcessConnection.get();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteRemoteCommandListener::messageReceiverName(), identifier().toUInt64(), *this);
         gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteCommandListener(identifier()), { });
     }
-    ASSERT(m_gpuProcessConnection.get() == &WebProcess::singleton().ensureGPUProcessConnection());
-    return WebProcess::singleton().ensureGPUProcessConnection();
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteRemoteCommandListener::gpuProcessConnectionDidClose(GPUProcessConnection& gpuProcessConnection)

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.h
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.h
@@ -28,14 +28,13 @@
 #include <QuartzCore/CALayer.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/MediaPlayerEnums.h>
-#include <wtf/RefPtr.h>
 
 namespace WebKit {
 class VideoLayerRemoteParent;
 }
 
 @interface WKVideoLayerRemote : CALayer
-@property (nonatomic) RefPtr<WebKit::VideoLayerRemoteParent> parent;
+@property (nonatomic) WebKit::VideoLayerRemoteParent* parent;
 @property (nonatomic) CGRect videoLayerFrame;
 @property (nonatomic) WebCore::MediaPlayerEnums::VideoGravity videoGravity;
 @end

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -83,12 +83,12 @@ static const Seconds PostAnimationDelay { 100_ms };
     [super dealloc];
 }
 
-- (RefPtr<WebKit::VideoLayerRemoteParent>)parent
+- (WebKit::VideoLayerRemoteParent*)parent
 {
-    return _parent.get();
+    return _parent.get().unsafeGet();
 }
 
-- (void)setParent:(RefPtr<WebKit::VideoLayerRemoteParent>)parent
+- (void)setParent:(WebKit::VideoLayerRemoteParent*)parent
 {
     _parent = *parent;
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -53,13 +53,15 @@ ModelProcessModelPlayerManager::~ModelProcessModelPlayerManager() = default;
 
 ModelProcessConnection& ModelProcessModelPlayerManager::modelProcessConnection()
 {
-    if (!m_modelProcessConnection.get()) {
-        Ref modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
-        m_modelProcessConnection = modelProcessConnection.get();
+    RefPtr modelProcessConnection = m_modelProcessConnection.get();
+    if (!modelProcessConnection) {
+        modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
+        m_modelProcessConnection = modelProcessConnection;
+        modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
         modelProcessConnection->addClient(*this);
     }
-    ASSERT(m_modelProcessConnection.get() == &WebProcess::singleton().ensureModelProcessConnection());
-    return WebProcess::singleton().ensureModelProcessConnection();
+
+    return *modelProcessConnection.unsafeGet();
 }
 
 Ref<ModelProcessModelPlayer> ModelProcessModelPlayerManager::createModelProcessModelPlayer(WebPage& page, WebCore::ModelPlayerClient& client)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -148,7 +148,7 @@ static const int defaultScrollMagnitudeThresholdForPageFlip = 20;
             }
         });
     }
-    return protectedSelf->_parent.getAutoreleased();
+    return protectedSelf->_parent.get().unsafeGet();
 }
 
 - (void)setParent:(NSObject *)parent

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -229,7 +229,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             }
         });
     }
-    return protectedSelf->_parent.getAutoreleased();
+    return protectedSelf->_parent.get().unsafeGet();
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1852,16 +1852,14 @@ RefPtr<API::Object> userDataFromJSONData(JSON::Value& value)
         return API::String::create(value.asString());
     case JSON::Value::Type::Object: {
         auto result = API::Dictionary::create();
-        RefPtr jsonObject = value.asObject();
-        for (auto [key, value] : *jsonObject)
+        for (auto [key, value] : *value.asObject().unsafeGet())
             result->add(key, userDataFromJSONData(value));
         return result;
     }
     case JSON::Value::Type::Array: {
         auto array = value.asArray();
         Vector<RefPtr<API::Object>> result;
-        RefPtr jsonArray = value.asArray();
-        for (auto& item : *jsonArray)
+        for (auto& item : *value.asArray().unsafeGet())
             result.append(userDataFromJSONData(item));
         return API::Array::create(WTFMove(result));
     }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -517,7 +517,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         if (properties.animations.size()) {
             [animationGroup setAnimations:createNSArray(properties.animations, [&] (auto& animationProperties) -> CAAnimation * {
                 if (PlatformCAAnimation::isValidKeyPath(properties.keyPath, properties.animationType))
-                    return createAnimation(layer, layerTreeHost, animationProperties).autorelease();
+                    return createAnimation(layer, layerTreeHost, animationProperties).unsafeGet();
                 ASSERT_NOT_REACHED();
                 return nil;
             }).get()];

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -527,12 +527,13 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
 WebCore::LocalFrame* WebFoundTextRangeController::frameForFoundTextRange(const WebFoundTextRange& range) const
 {
-    if (range.frameIdentifier.isEmpty())
-        return protectedWebPage()->protectedCorePage()->localMainFrame();
-
     RefPtr mainFrame = protectedWebPage()->protectedCorePage()->localMainFrame();
     if (!mainFrame)
         return nullptr;
+
+    if (range.frameIdentifier.isEmpty())
+        return mainFrame.unsafeGet();
+
     return dynamicDowncast<WebCore::LocalFrame>(mainFrame->tree().findByUniqueName(AtomString { range.frameIdentifier }, *mainFrame));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1338,14 +1338,14 @@ inline DocumentLoader* WebFrame::policySourceDocumentLoader() const
         return nullptr;
     }
 
-    WeakPtr mainFrameDocumentLoader = mainFrameDocument->loader();
-    if (!mainFrameDocumentLoader)
+    RefPtr policySourceDocumentLoader = mainFrameDocument->loader();
+    if (!policySourceDocumentLoader)
         return nullptr;
 
-    if (Ref { *mainFrameDocumentLoader }->request().url().hasSpecialScheme() && document->url().protocolIsInHTTPFamily())
-        return document->loader();
+    if (!policySourceDocumentLoader->request().url().hasSpecialScheme() && document->url().protocolIsInHTTPFamily())
+        policySourceDocumentLoader = document->loader();
 
-    return mainFrameDocumentLoader.get();
+    return policySourceDocumentLoader.unsafeGet();
 }
 
 OptionSet<WebCore::AdvancedPrivacyProtections> WebFrame::advancedPrivacyProtections() const

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -203,16 +203,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-        return [self accessibilityAttributeParentValue].autorelease();
+        return [self accessibilityAttributeParentValue].unsafeGet();
 
     if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
         return @(screenHeight.load());
 
     if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
-        return [self accessibilityAttributeWindowValue].autorelease();
+        return [self accessibilityAttributeWindowValue].unsafeGet();
 
     if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
-        return [self accessibilityAttributeTopLevelUIElementValue].autorelease();
+        return [self accessibilityAttributeTopLevelUIElementValue].unsafeGet();
 
     return nil;
 }

--- a/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
@@ -35,7 +35,7 @@
 
 - (id<_UIClickInteractionDriverDelegate>)delegate
 {
-    return _delegate.getAutoreleased();
+    return _delegate.get().unsafeGet();
 }
 
 - (void)setDelegate:(id<_UIClickInteractionDriverDelegate>)delegate


### PR DESCRIPTION
#### 8e146faa8074066763bcd64a94d43ad36236e6a3
<pre>
Unreviewed, reverting 303807@main (0620c5d84798)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303479">https://bugs.webkit.org/show_bug.cgi?id=303479</a>
<a href="https://rdar.apple.com/165764960">rdar://165764960</a>

REGRESSION(303807@main): Broke Internal visionOS builds

Reverted change:

    Fix all remaining uses of unsafeGet() in WebKit/
    <a href="https://bugs.webkit.org/show_bug.cgi?id=303359">https://bugs.webkit.org/show_bug.cgi?id=303359</a>
    303807@main (0620c5d84798)

Canonical link: <a href="https://commits.webkit.org/303835@main">https://commits.webkit.org/303835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7bfd04ca67b3e4d4bca12f80a563929a017251e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133764 "49 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141339 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/119919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/83123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125841 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132278 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5943 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/143987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6027 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/5080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/143987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20672 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/5996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/165241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69460 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/165241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/5950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->