### PR TITLE
Fix the Catalyst build after recent changes in UIFoundation (rdar://164301290)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -204,7 +204,7 @@ typedef NS_ENUM(NSInteger, _UIDataOwner) {
 + (UIColor *)tableCellDefaultSelectionTintColor;
 @end
 
-#if __has_include(<UIFoundation/NSTextTable.h>)
+#if __has_include(<UIFoundation/NSTextTable.h>) && (!PLATFORM(MACCATALYST) || __has_include(<UIKit/NSTextTable.h>))
 #import <UIFoundation/NSTextTable.h>
 #else
 

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -619,7 +619,7 @@ inline static ParagraphStyle extractParagraphStyle(NSParagraphStyle *style, Tabl
                     [nsTable borderColorForEdge:NSRectEdgeMaxY]
                 },
                 tableID,
-                [nsTable numberOfColumns],
+                static_cast<uint64_t>([nsTable numberOfColumns]),
                 extractTextTableLayoutAlgorithm([nsTable layoutAlgorithm]),
                 !![nsTable collapsesBorders],
                 !![nsTable hidesEmptyCells],

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -2017,7 +2017,7 @@ void HTMLConverter::_exitElement(Element& element, NSInteger depth, NSUInteger s
         NSTextTableBlock *block;
         NSMutableArray *rowArray = [_textTableRowArrays lastObject], *previousRowArray;
         NSUInteger i, count;
-        NSInteger numberOfColumns = [table numberOfColumns];
+        auto numberOfColumns = [table numberOfColumns];
         NSInteger openColumn;
         NSInteger rowNumber = [[_textTableRows lastObject] integerValue];
         do {
@@ -2027,8 +2027,11 @@ void HTMLConverter::_exitElement(Element& element, NSInteger depth, NSUInteger s
             count = [previousRowArray count];
             for (i = 0; i < count; i++) {
                 block = [previousRowArray objectAtIndex:i];
-                if ([block startingColumn] + [block columnSpan] > numberOfColumns) numberOfColumns = [block startingColumn] + [block columnSpan];
-                if ([block startingRow] + [block rowSpan] > rowNumber) [rowArray addObject:block];
+                if ([block startingColumn] + [block columnSpan] > static_cast<NSInteger>(numberOfColumns))
+                    numberOfColumns = [block startingColumn] + [block columnSpan];
+
+                if ([block startingRow] + [block rowSpan] > rowNumber)
+                    [rowArray addObject:block];
             }
             count = [rowArray count];
             openColumn = 0;
@@ -2036,8 +2039,8 @@ void HTMLConverter::_exitElement(Element& element, NSInteger depth, NSUInteger s
                 block = [rowArray objectAtIndex:i];
                 if (openColumn >= [block startingColumn] && openColumn < [block startingColumn] + [block columnSpan]) openColumn = [block startingColumn] + [block columnSpan];
             }
-        } while (openColumn >= numberOfColumns);
-        if ((NSUInteger)numberOfColumns > [table numberOfColumns])
+        } while (openColumn >= static_cast<NSInteger>(numberOfColumns));
+        if (numberOfColumns > [table numberOfColumns])
             [table setNumberOfColumns:numberOfColumns];
         [_textTableRows removeLastObject];
         [_textTableRows addObject:[NSNumber numberWithInteger:rowNumber]];


### PR DESCRIPTION
#### ea64ba9374c3931b19539a2aebd47b59c1781453
<pre>
Fix the Catalyst build after recent changes in UIFoundation (<a href="https://rdar.apple.com/164301290">rdar://164301290</a>)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303488">https://bugs.webkit.org/show_bug.cgi?id=303488</a>
<a href="https://rdar.apple.com/165774936">rdar://165774936</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Fix the build after the changes in <a href="https://rdar.apple.com/164301290">rdar://164301290</a>; we avoid importing `&lt;UIFoundation/NSTextTable.h&gt;`
on Catalyst, since the header does not declare `NSTextBlock` when `TARGET_OS_MACCATALYST` is defined
(so we need to fall back on forward declarations).

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::extractParagraphStyle):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_exitElement):

Canonical link: <a href="https://commits.webkit.org/303862@main">https://commits.webkit.org/303862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f045f7153aa1e9234c8c5bc707a517ec41063c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141383 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b257b64d-4ef8-4705-b992-a4fed6976305) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41c4d723-6413-47a6-9063-3dd70f9b0d85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136753 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff08b6a5-46f5-4ac5-891a-f534c0d5fa77) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2321 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38652 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6069 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/5119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4562 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116209 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6038 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/5884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69502 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->