### PR TITLE
[WPE][GTK] Fix typo in ThreadedCompositor.cpp, rename to didCompositeRenderingUpdateFunction

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -120,7 +120,7 @@ void ThreadedCompositor::invalidate()
     {
         Locker locker { m_state.lock };
         m_renderTimer.stop();
-        m_state.didCompositeRenderinUpdateFunction = nullptr;
+        m_state.didCompositeRenderingUpdateFunction = nullptr;
         m_state.state = State::Idle;
     }
 
@@ -333,7 +333,7 @@ void ThreadedCompositor::renderLayerTree()
                 reasons.remove(CompositionReason::RenderingUpdate);
                 m_state.reasons.add(CompositionReason::RenderingUpdate);
             } else
-                shouldNotifiyDidComposite = !!m_state.didCompositeRenderinUpdateFunction;
+                shouldNotifiyDidComposite = !!m_state.didCompositeRenderingUpdateFunction;
         }
 
         ASSERT(m_state.state == State::Scheduled);
@@ -395,8 +395,8 @@ void ThreadedCompositor::requestCompositionForRenderingUpdate(Function<void()>&&
     ASSERT(RunLoop::isMain());
     Locker locker { m_state.lock };
     m_state.reasons.add(CompositionReason::RenderingUpdate);
-    ASSERT(!m_state.didCompositeRenderinUpdateFunction);
-    m_state.didCompositeRenderinUpdateFunction = WTFMove(didCompositeFunction);
+    ASSERT(!m_state.didCompositeRenderingUpdateFunction);
+    m_state.didCompositeRenderingUpdateFunction = WTFMove(didCompositeFunction);
     if (m_sceneState->pendingTiles())
         m_state.isWaitingForTiles = true;
     scheduleUpdateLocked();
@@ -467,7 +467,7 @@ void ThreadedCompositor::didCompositeRunLoopObserverFired()
     Function<void()> didCompositeFunction;
     {
         Locker locker { m_state.lock };
-        didCompositeFunction = std::exchange(m_state.didCompositeRenderinUpdateFunction, nullptr);
+        didCompositeFunction = std::exchange(m_state.didCompositeRenderingUpdateFunction, nullptr);
     }
     if (didCompositeFunction)
         didCompositeFunction();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -133,7 +133,7 @@ private:
         State state WTF_GUARDED_BY_LOCK(lock) { State::Idle };
         bool isWaitingForTiles WTF_GUARDED_BY_LOCK(lock) { false };
         OptionSet<WebCore::CompositionReason> reasons WTF_GUARDED_BY_LOCK(lock);
-        Function<void()> didCompositeRenderinUpdateFunction WTF_GUARDED_BY_LOCK(lock);
+        Function<void()> didCompositeRenderingUpdateFunction WTF_GUARDED_BY_LOCK(lock);
     } m_state;
 
     struct {


### PR DESCRIPTION
#### 88ede940ca7149a5ea1799dbfa2f0572310e38c2
<pre>
[WPE][GTK] Fix typo in ThreadedCompositor.cpp, rename to didCompositeRenderingUpdateFunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=303493">https://bugs.webkit.org/show_bug.cgi?id=303493</a>

Reviewed by Nikolas Zimmermann.

This is just a rename to fix a typo in the function name.

No new tests needed.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestCompositionForRenderingUpdate):
(WebKit::ThreadedCompositor::didCompositeRunLoopObserverFired):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/303894@main">https://commits.webkit.org/303894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24ea672b6ba4b88a6d238b1cc96d811787e34e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85868 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102358 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2327 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113856 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4564 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59737 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6041 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69505 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->