### PR TITLE
TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenu tests are broken when AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER is available

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -418,12 +418,13 @@ TEST_F(CaptionPreferenceTests, TextEdge)
     EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "stroke-color:black;paint-order:stroke;stroke-linejoin:round;stroke-linecap:round;");
 }
 
+#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenu)
 {
+    MediaAccessibilityShim shim;
+
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
-
-    MediaAccessibilityShim shim;
 
     PlatformMenu *menu = ensureMenu();
 
@@ -462,13 +463,15 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenu)
     EXPECT_WK_STREQ("Profile 3", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 #endif
 }
+#endif
 
+#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenuHighlight)
 {
+    MediaAccessibilityShim shim;
+
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
-
-    MediaAccessibilityShim shim;
 
     showMenuAndThen([&] (PlatformMenu *menu) {
         // TODO: Menu highlighting is currently not supported on IOS_FAMILY
@@ -485,13 +488,15 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenuHighlight)
     // to its previous state.
     EXPECT_WK_STREQ("Profile 1", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 }
+#endif
 
+#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenuSelect)
 {
+    MediaAccessibilityShim shim;
+
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
-
-    MediaAccessibilityShim shim;
 
     showMenuAndThen([&] (PlatformMenu *menu) {
         selectProfileAtIndex(1);
@@ -503,13 +508,15 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenuSelect)
 
     EXPECT_WK_STREQ("Profile 3", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 }
+#endif
 
+#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenuDelegate)
 {
+    MediaAccessibilityShim shim;
+
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
-
-    MediaAccessibilityShim shim;
 
     runAndWaitForCaptionStyleMenuWillOpenCalled([&] {
         runAndWaitForCaptionStyleMenuDidCloseCalled([&] {
@@ -518,6 +525,7 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenuDelegate)
         });
     });
 }
+#endif
 
 #if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && PLATFORM(IOS_FAMILY)
 TEST_F(CaptionPreferenceTests, AVKitMenuControllerIntegration)


### PR DESCRIPTION
#### 4dccb687a437cc70b68cd50c8634f0b01140f779
<pre>
TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenu tests are broken when AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER is available
<a href="https://bugs.webkit.org/show_bug.cgi?id=303495">https://bugs.webkit.org/show_bug.cgi?id=303495</a>
<a href="https://rdar.apple.com/165741859">rdar://165741859</a>

Reviewed by Jer Noble.

Disable CaptionStyleMenu, CaptionStyleMenuDelegate, CaptionStyleMenuHighlight and
CaptionStyleMenuSelect tests when AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER is available.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, CaptionStyleMenu)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, CaptionStyleMenuHighlight)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, CaptionStyleMenuSelect)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, CaptionStyleMenuDelegate)):

Canonical link: <a href="https://commits.webkit.org/303936@main">https://commits.webkit.org/303936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a2508a1440f631b26fde04569a8f3ef89be1f38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86011 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83263 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2412 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6131 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110828 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4647 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116345 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59878 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6183 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34600 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->