### PR TITLE
REGRESSION(301075@main): Address a style error in CachedImageClient.h and add its source file to WebCore.xcodeproj

### DIFF
--- a/Source/WebCore/loader/cache/CachedImageClient.cpp
+++ b/Source/WebCore/loader/cache/CachedImageClient.cpp
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+CachedImageClient::CachedImageClient() = default;
+
 VisibleInViewportState CachedImageClient::imageFrameAvailable(CachedImage& image, ImageAnimatingState, const IntRect* changeRect)
 {
     imageChanged(&image, changeRect);

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -34,7 +34,7 @@ class IntRect;
 
 enum class VisibleInViewportState { Unknown, Yes, No };
 
-class WEBCORE_EXPORT CachedImageClient : public CachedResourceClient {
+class CachedImageClient : public CachedResourceClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CachedImageClient);
 public:
     virtual ~CachedImageClient() = default;
@@ -48,7 +48,7 @@ public:
     virtual bool canDestroyDecodedData() const { return true; }
 
     // Called when a new decoded frame for a large image is available or when an animated image is ready to advance to the next frame.
-    virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
+    WEBCORE_EXPORT virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
     virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
 
     virtual void didRemoveCachedImageClient(CachedImage&) { }
@@ -56,6 +56,9 @@ public:
     virtual void scheduleRenderingUpdateForImage(CachedImage&) { }
 
     virtual bool allowsAnimation() const { return true; }
+
+protected:
+    WEBCORE_EXPORT CachedImageClient();
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 083cd35716ec3a4139fc402a8a733283cc143ff1
<pre>
REGRESSION(301075@main): Address a style error in CachedImageClient.h and add its source file to WebCore.xcodeproj
<a href="https://bugs.webkit.org/show_bug.cgi?id=303498">https://bugs.webkit.org/show_bug.cgi?id=303498</a>
<a href="https://rdar.apple.com/165788371">rdar://165788371</a>

Reviewed by Geoffrey Garen.

CachedImageClient should not be marked WEBCORE_EXPORT. Mark the constructor and
imageFrameAvailable() to be WEBCORE_EXPORT. Also add CachedImageClient.cpp to
WebCore.xcodeproj.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/cache/CachedImageClient.cpp:
* Source/WebCore/loader/cache/CachedImageClient.h:

Canonical link: <a href="https://commits.webkit.org/303881@main">https://commits.webkit.org/303881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f5d83a40f1a2d85f42346875f4e30f744c6f98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09299de7-b42c-452d-a8de-04769dced786) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/996e9c6f-076b-4d76-8ef5-4347148744d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83196 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4724 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2339 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113877 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38098 "Found 1 new test failure: fast/block/basic/015.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144052 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110752 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28145 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116235 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6061 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34520 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69526 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6153 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->