### PR TITLE
Copy Link With Highlight copies the URL with a useless ('/') title

### DIFF
--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -419,8 +419,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagCopyLinkWithHighlight:
         if (RefPtr page = frame->page()) {
             auto url = page->fragmentDirectiveURLForSelectedText();
-            if (url.isValid())
-                frame->editor().copyURL(url, { });
+            if (url.isValid()) {
+                auto selectedRange = frame->selection().selection().toNormalizedRange();
+                frame->editor().copyURL(url, selectedRange ? plainText(*selectedRange) : nullString());
+            }
         }
         break;
     case ContextMenuItemTagGoBack:

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -220,7 +220,9 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     RetainPtr title = pasteboardURL.title.createNSString();
     if (![title length]) {
         title = [[nsURL path] lastPathComponent];
-        if (![title length])
+        // Very short titles are not useful, and we commonly get a "/" as the last path component.
+        // Fall back to the full URL in this case.
+        if ([title length] <= 1)
             title = userVisibleString;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyURL.mm
@@ -44,21 +44,6 @@
 - (void)paste:(id)sender;
 @end
 
-#if PLATFORM(MAC)
-NSString *readURLFromPasteboard()
-{
-    if (NSURL *url = [NSURL URLFromPasteboard:[NSPasteboard generalPasteboard]])
-        return url.absoluteString;
-    NSURL *url = [NSURL URLWithString:[[NSPasteboard generalPasteboard] stringForType:NSURLPboardType]];
-    return url.absoluteString;
-}
-#else
-NSString *readURLFromPasteboard()
-{
-    return [UIPasteboard generalPasteboard].URL.absoluteString;
-}
-#endif
-
 TEST(CopyURL, ValidURL)
 {
     auto webView = createWebViewWithCustomPasteboardDataEnabled();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.h
@@ -29,3 +29,8 @@
 OBJC_CLASS TestWKWebView;
 
 RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataEnabled(bool colorFilterEnabled = false);
+
+NSString *readURLFromPasteboard();
+NSString *readTitleFromPasteboard();
+
+void clearPasteboard();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm
@@ -51,3 +51,44 @@ RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataEnabled(bool color
     WKPreferencesSetCustomPasteboardDataEnabled(preferences, true);
     return webView;
 }
+
+#if PLATFORM(MAC)
+NSString *readURLFromPasteboard()
+{
+    if (NSURL *url = [NSURL URLFromPasteboard:NSPasteboard.generalPasteboard])
+        return url.absoluteString;
+    NSURL *url = [NSURL URLWithString:[NSPasteboard.generalPasteboard stringForType:NSURLPboardType]];
+    return url.absoluteString;
+}
+
+NSString *readTitleFromPasteboard()
+{
+    NSArray *urlsAndTitles = [NSPasteboard.generalPasteboard propertyListForType:@"WebURLsWithTitlesPboardType"];
+    if (!urlsAndTitles || ![urlsAndTitles isKindOfClass:[NSArray class]] || urlsAndTitles.count != 2)
+        return nil;
+    NSArray *titles = urlsAndTitles.lastObject;
+    if (!titles || ![titles isKindOfClass:[NSArray class]] || titles.count != 1)
+        return nil;
+    return titles.firstObject;
+}
+
+void clearPasteboard()
+{
+    [NSPasteboard.generalPasteboard clearContents];
+}
+#else
+NSString *readURLFromPasteboard()
+{
+    return UIPasteboard.generalPasteboard.URL.absoluteString;
+}
+
+NSString *readTitleFromPasteboard()
+{
+    return UIPasteboard.generalPasteboard.URL._title;
+}
+
+void clearPasteboard()
+{
+    UIPasteboard.generalPasteboard.items = @[];
+}
+#endif

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -32,6 +32,7 @@
 #import <wtf/text/WTFString.h>
 #endif
 
+@class _WKContextMenuElementInfo;
 @class _WKFrameTreeNode;
 @class _WKJSHandle;
 @class _WKProcessPoolConfiguration;
@@ -265,6 +266,17 @@ class Color;
 - (WKFrameInfo *)secondChildFrame;
 - (void)evaluateJavaScript:(NSString *)string inFrame:(WKFrameInfo *)frame completionHandler:(void(^)(id, NSError *))completionHandler;
 - (WKFindResult *)findStringAndWait:(NSString *)string withConfiguration:(WKFindConfiguration *)configuration;
+@end
+
+#if PLATFORM(MAC)
+using MenuItemFilter = BOOL(^)(NSMenuItem *);
+#endif
+
+@interface TestWKWebView (ContextMenu)
+#if PLATFORM(MAC)
+- (void)rightClick:(NSPoint)clickLocation andSelectItemMatching:(MenuItemFilter)filter;
+- (_WKContextMenuElementInfo *)rightClickAtPointAndWaitForContextMenu:(NSPoint)clickLocation;
+#endif
 @end
 
 #endif // __cplusplus


### PR DESCRIPTION
#### 099965ad5853b105e0140df560a99906d5a2b8f1
<pre>
Copy Link With Highlight copies the URL with a useless (&apos;/&apos;) title
<a href="https://bugs.webkit.org/show_bug.cgi?id=303497">https://bugs.webkit.org/show_bug.cgi?id=303497</a>
<a href="https://rdar.apple.com/144782871">rdar://144782871</a>

Reviewed by Aditya Keerthi.

Text fragment URLs are currently generated with a null title, which then
results in pasteboard code inferring the title from the URL. However,
for URLs with an empty path, we infer the title &quot;/&quot;.

Fix this two ways: pass the selection as the title for text fragment URLs,
and also avoid ever inferring a single-character title from the URL when a title is not provided.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm
       Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
Try to include the selection as the title of the generated text fragment URL.

* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeURLForTypes):
Avoid inferring single-character titles from URL paths, they are common
(because of single-slash last path components), but out of context (when pasted
into TextEdit or Notes or wherever) are very mysterious.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyURL.mm:
(readURLFromPasteboard): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm:
(readURLFromPasteboard):
(readTitleFromPasteboard):
(clearPasteboard):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm:
(TestWebKitAPI::createWebViewForFragmentDirectiveGenerationWithHTML):
(TestWebKitAPI::TEST(FragmentDirectiveGeneration, GenerateFragment)):
(TestWebKitAPI::TEST(FragmentDirectiveGeneration, VerifyFragmentRanges)):
(TestWebKitAPI::TEST(FragmentDirectiveGeneration, IncludesSelectionAsURLTitle)):
Add a test ensuring that &quot;Copy Link With Highlight&quot; includes the selection as the URL&apos;s title.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, CopyLinkIncludesTitle)):
(TestWebKitAPI::TEST(ContextMenuTests, CopyLinkUsesFullURLAsTitleForLinkWithShortPath)):
(TestWebKitAPI::TEST(ContextMenuTests, CopyLinkUsesPathComponentAsTitleForLinkWithPath)):
Add a test ensuring that &quot;Copy Link&quot; includes the full URL as the title for a link with a single-character
path, and includes the last path component in other cases.

(itemMatchingFilter): Deleted.
(-[TestWKWebView rightClick:andSelectItemMatching:]): Deleted.
(-[TestWKWebView rightClickAtPointAndWaitForContextMenu:]): Deleted.
Hoist these useful utilities into shared places.

Canonical link: <a href="https://commits.webkit.org/303887@main">https://commits.webkit.org/303887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d02a4cca66db47f553db404a6265d036765c1be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/85925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c59d19f-4ca2-4d5a-a689-31433829275a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/85925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c4eed5a-1938-4b99-8766-3b3e99779461) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136812 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120041 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83202 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8dce4031-8993-48c5-a429-1e6f6e8043a9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2362 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144088 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110771 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110972 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4598 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6098 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->