### PR TITLE
[iOS26]: 12x fast/viewport/ios tests are constant text failures

### DIFF
--- a/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
@@ -1,17 +1,16 @@
 setViewScale(1.00)
-window size: [810, 1060]
+window size: [768, 1004]
 zoom scale: 1.00
 
 setViewScale(2.00)
-window size: [405, 530]
+window size: [384, 502]
 zoom scale: 2.00
 
 setViewScale(2.50)
-window size: [324, 424]
+window size: [307, 401]
 zoom scale: 2.50
 
 setViewScale(1.00)
-window size: [810, 1060]
+window size: [768, 1004]
 zoom scale: 1.00
-
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
@@ -4,9 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS minScale is 1
-FAIL 800 should be >= document.scrollingElement.scrollWidth. Was 800 (of type number).
+PASS 800 is >= document.scrollingElement.scrollWidth
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
@@ -1,4 +1,3 @@
-window size: [1208, 1581]
-zoom scale: 0.67
-
+window size: [1131, 1479]
+zoom scale: 0.68
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=auto
 
-Window Size: 750 x 1050
+Window Size: 708 x 994
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"768.00000","height":"1004.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=contain
 
-Window Size: 750 x 1050
+Window Size: 708 x 994
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"768.00000","height":"1004.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=cover
 
-Window Size: 810 x 1060
+Window Size: 768 x 1004
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
@@ -3,4 +3,4 @@ Viewport: width=device-width
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
@@ -1,7 +1,7 @@
 Viewport: width=device-width
 
-scale	0.80364
-maxScale	4.01786
-minScale	0.80364
-visibleRect	{"left":"0.00000","top":"0.00000","width":"1007.91510","height":"1319.00000"}
+scale	0.81349
+maxScale	3.80952
+minScale	0.81349
+visibleRect	{"left":"0.00000","top":"0.00000","width":"944.07806","height":"1234.18542"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
 


### PR DESCRIPTION
#### 38dfbded8ab7a803e20923f7abb221368c2d6c0d
<pre>
[iOS26]: 12x fast/viewport/ios tests are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=303410">https://bugs.webkit.org/show_bug.cgi?id=303410</a>
<a href="https://rdar.apple.com/165712922">rdar://165712922</a>

Unreviewed test gardening

Applying new ipad rebaseline in several fast/viewport tests after OS update.

* LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt:

Canonical link: <a href="https://commits.webkit.org/303888@main">https://commits.webkit.org/303888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add7218fbf890f0bade14bcc23248504ffc6732a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85906 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c8c57bf-4d3d-402d-954f-492937577fb3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7880030f-8872-4373-a4ce-a4bdd94ec885) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5ddf889-917f-479e-87ed-2ff280ce059e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4733 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2352 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110955 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4588 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59774 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20691 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6079 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5925 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->