### PR TITLE
Cache nested inline blocks by storing them in RenderBlockFlowRareData

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -146,25 +146,21 @@ CheckedRef<Layout::ElementBox> BoxTreeUpdater::build()
 
 void BoxTreeUpdater::tearDown()
 {
-    if (m_document->renderTreeBeingDestroyed())
+    if (m_document->renderTreeBeingDestroyed()) {
+        if (auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(m_rootRenderer))
+            renderBlockFlow->clearNestedInlineBlocks();
         return rootLayoutBox().destroyChildren();
-
-    Vector<CheckedRef<Layout::Box>> boxesToDetach;
-    for (auto& constLayoutBox : formattingContextBoxes(rootLayoutBox())) {
-        auto& layoutBox = const_cast<Layout::Box&>(constLayoutBox);
-        auto* renderer = layoutBox.rendererForIntegration();
-        if (!renderer)
-            continue;
-
-        auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(*renderer);
-        auto isLFCInlineBlock = renderBlockFlow && renderBlockFlow->inlineLayout();
-        if (isLFCInlineBlock)
-            boxesToDetach.append(layoutBox);
     }
-
-    for (auto& toDetach : boxesToDetach) {
-        auto detachedBox = toDetach->removeFromParent();
-        initialContainingBlock().appendChild(WTFMove(detachedBox));
+    auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(m_rootRenderer);
+    if (renderBlockFlow && renderBlockFlow->hasRareBlockFlowData()) {
+        auto* cachedNestedInlineBlocks = renderBlockFlow->nestedInlineBlocks();
+        if (cachedNestedInlineBlocks && !cachedNestedInlineBlocks->isEmpty()) {
+            for (auto& toDetach : *cachedNestedInlineBlocks) {
+                auto detachedBox = toDetach->removeFromParent();
+                initialContainingBlock().appendChild(WTFMove(detachedBox));
+            }
+            renderBlockFlow->clearNestedInlineBlocks();
+        }
     }
 
     if (&rootLayoutBox().parent() == &initialContainingBlock())
@@ -314,7 +310,10 @@ void BoxTreeUpdater::buildTreeForInlineContent()
                 return existingChildBox->removeFromParent();
             return createLayoutBox(childRenderer);
         };
-        insertChild(childLayoutBox(), childRenderer, childRenderer.previousSibling());
+        auto childBox = childLayoutBox();
+        if (is<RenderBlockFlow>(childRenderer))
+            downcast<RenderBlockFlow>(m_rootRenderer).addNestedInlineBlock(childBox.get());
+        insertChild(WTFMove(childBox), childRenderer, childRenderer.previousSibling());
     }
 }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4180,6 +4180,24 @@ RenderBlockFlowRareData& RenderBlockFlow::ensureRareBlockFlowData()
     return *m_rareBlockFlowData;
 }
 
+void RenderBlockFlow::addNestedInlineBlock(CheckedRef<Layout::Box>&& box)
+{
+    ensureRareBlockFlowData().m_nestedInlineBlocks.append(WTFMove(box));
+}
+
+void RenderBlockFlow::clearNestedInlineBlocks()
+{
+    if (hasRareBlockFlowData())
+        m_rareBlockFlowData->m_nestedInlineBlocks.clear();
+}
+
+Vector<CheckedRef<Layout::Box>>* RenderBlockFlow::nestedInlineBlocks() const
+{
+    if (!hasRareBlockFlowData())
+        return nullptr;
+    return &m_rareBlockFlowData->m_nestedInlineBlocks;
+}
+
 void RenderBlockFlow::materializeRareBlockFlowData()
 {
     ASSERT(!hasRareBlockFlowData());

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -116,6 +116,8 @@ public:
 
     SingleThreadWeakPtr<RenderMultiColumnFlow> m_multiColumnFlow;
 
+    Vector<CheckedRef<Layout::Box>> m_nestedInlineBlocks;
+
     bool m_didBreakAtLineToAvoidWidow : 1;
 };
 
@@ -562,6 +564,10 @@ public:
     RenderBlockFlowRareData* rareBlockFlowData() const { ASSERT_WITH_SECURITY_IMPLICATION(hasRareBlockFlowData()); return m_rareBlockFlowData.get(); }
     RenderBlockFlowRareData& ensureRareBlockFlowData();
     void materializeRareBlockFlowData();
+
+    void addNestedInlineBlock(CheckedRef<Layout::Box>&&);
+    void clearNestedInlineBlocks();
+    Vector<CheckedRef<Layout::Box>>* nestedInlineBlocks() const;
 
 #if ENABLE(TEXT_AUTOSIZING)
     void adjustComputedFontSizes(float size, float visibleWidth);


### PR DESCRIPTION
#### 47676de83f359dae011d1a625eef7cda4e3402bb
<pre>
Cache nested inline blocks by storing them in RenderBlockFlowRareData
<a href="https://rdar.apple.com/165795813">rdar://165795813</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303505">https://bugs.webkit.org/show_bug.cgi?id=303505</a>

Reviewed by NOBODY (OOPS!).

During BoxTree tearDown, avoid iterating over
formattingContextBoxes() to find inlineBlocks by
instead tracking and storing all inline blocks that get inserted into the Boxtree.
This list avoids having to unconditionally search formattingContextBoxes() even if there
are no inline blocks in the boxTree. In SP3, inline child blocks are found only 0.4% of all calls to tearDown. 
This is a performance improvement.

No new tests (OOPS!).
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::tearDown):
(WebCore::LayoutIntegration::BoxTreeUpdater::buildTreeForInlineContent):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::addNestedInlineBlock):
(WebCore::RenderBlockFlow::clearNestedInlineBlocks):
(WebCore::RenderBlockFlow::nestedInlineBlocks const):
* Source/WebCore/rendering/RenderBlockFlow.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47676de83f359dae011d1a625eef7cda4e3402bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc45349b-ca6a-4d2a-88ab-4928cf5a1bd0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103670 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71638 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84542 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3632 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3978 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146118 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112029 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112404 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5879 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117909 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7762 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36023 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->