### PR TITLE
[Xcode] Build failure due to missing xcfilelist paths should include those paths in the log

### DIFF
--- a/Tools/Scripts/webkitpy/generate_xcfilelists_lib/application.py
+++ b/Tools/Scripts/webkitpy/generate_xcfilelists_lib/application.py
@@ -380,6 +380,25 @@ specified on the command-line:
         for line in message:
             self._log_results(line)
 
+        self._log_results("")
+        self._log_results("Changes made to .xcfilelist files:")
+        for generator in generators:
+            if not generator.has_action():
+                continue
+            self._log_results("  {}/{}/{}:".format(*generator.triple))
+
+            # Show added lines for each type of xcfilelist
+            for lines, name in ((generator.added_lines_input_derived, 'DerivedSources-input.xcfilelist'),
+                                (generator.added_lines_output_derived, 'DerivedSources-output.xcfilelist'),
+                                (generator.added_lines_input_unified, 'UnifiedSources-input.xcfilelist'),
+                                (generator.added_lines_output_unified, 'UnifiedSources-output.xcfilelist')):
+                if not lines:
+                    continue
+                self._log_results("    {} - Added {} lines:".format(name, len(lines)))
+                for line in sorted(lines):
+                    self._log_results("      + {}".format(line))
+
+
     @util.LogEntryExit
     def _report_remediation_steps(self, generators):
         message = textwrap.wrap("One or more \".xcfilelist\" files are out of date. Regenerate them by running the following commands:", 90)


### PR DESCRIPTION
#### a9e6b0b4ae14e4d6e410f1c1a63bd87b18956488
<pre>
[Xcode] Build failure due to missing xcfilelist paths should include those paths in the log
<a href="https://bugs.webkit.org/show_bug.cgi?id=303506">https://bugs.webkit.org/show_bug.cgi?id=303506</a>
<a href="https://rdar.apple.com/161824896">rdar://161824896</a>

Reviewed by Alexey Proskuryakov.

This is useful for observing an xcfilelist build failure in CI. Since
the dirtied working directory might be lost by the time we notice the
failure, the paths to commit have been lost, and it takes longer to fix
the broken build.

For example, after manually deleting the *.sb files from WebKit&apos;s
DerivedSources-output.xcfilelist:

    ### Generating .xcfilelists for WebKit/macosx/Debug
    ### Merging .xcfilelists for WebKit/macosx/Debug

    &quot;.xcfilelist&quot; files tell the build system what files are consumed and produced by the &quot;Run
    Script&quot; build phases in Xcode. At least one of these .xcfilelist files was out of date and
    has been updated. You now need to restart your build.

    Changes made to .xcfilelist files:
      WebKit/macosx/Debug:
        DerivedSources-output.xcfilelist - Added 9 lines:
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.GPU.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.GPUProcess.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.NetworkProcess.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.Networking.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.WebContent.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.adattributiond.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.webpushd.mac.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.webpushd.sb
          + $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebProcess.sb

* Tools/Scripts/webkitpy/generate_xcfilelists_lib/application.py:

Canonical link: <a href="https://commits.webkit.org/303921@main">https://commits.webkit.org/303921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a96f0e1bedeaf8b9115aaeed560669da216b379d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85926 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cf5cc75a-faff-464e-baf1-d49d0d9930ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c1e8581-6561-4367-9bf9-b338457d4368) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83203 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/71c893aa-072f-43b4-bed8-7aba3e73d172) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133215 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2364 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144089 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110775 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4599 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116264 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34539 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5945 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->