### PR TITLE
Subtitle Previews are not visible if there is not an enabled TextTrack

### DIFF
--- a/LayoutTests/media/track/text-track-caption-style-menu-expected.txt
+++ b/LayoutTests/media/track/text-track-caption-style-menu-expected.txt
@@ -15,5 +15,18 @@ Pretend to hide the subtitle style menu:
 RUN(internals.hideCaptionDisplaySettingsPreviewForMediaElement(video))
 EXPECTED (allCueElements().length == '1') OK
 EXPECTED (firstCueElement().textContent == 'Lorem') OK
+
+Disable the text track:
+RUN(video.textTracks[0].mode = "disabled")
+EXPECTED (allCueElements().length == '0') OK
+
+Pretend to show the subtitle style menu:
+RUN(internals.showCaptionDisplaySettingsPreviewForMediaElement(video))
+EXPECTED (allCueElements().length == '1') OK
+EXPECTED (firstCueElement().textContent == 'This is a preview') OK
+
+Pretend to hide the subtitle style menu:
+RUN(internals.hideCaptionDisplaySettingsPreviewForMediaElement(video))
+EXPECTED (allCueElements().length == '0') OK
 END OF TEST
 

--- a/LayoutTests/media/track/text-track-caption-style-menu.html
+++ b/LayoutTests/media/track/text-track-caption-style-menu.html
@@ -20,13 +20,13 @@
             video.src = findMediaFile('video', '../content/test') + '#t=0.5';
 
             run('video.textTracks[0].mode = "showing"');
-            await testExpectedEventually('allCueElements().length', 1);
+            await testExpectedEventually('allCueElements().length', 1, '==', 500);
             testExpected('firstCueElement().textContent', 'Lorem');
 
             consoleWrite('');
             consoleWrite('Pretend to show the subtitle style menu:');
             run('internals.showCaptionDisplaySettingsPreviewForMediaElement(video)');
-            await testExpectedEventually('allCueElements().length', 1);
+            await testExpectedEventually('allCueElements().length', 1, '==', 500);
             testExpected('firstCueElement().textContent', 'This is a preview');
 
             consoleWrite('');
@@ -36,8 +36,24 @@
             consoleWrite('');
             consoleWrite('Pretend to hide the subtitle style menu:');
             run('internals.hideCaptionDisplaySettingsPreviewForMediaElement(video)');
-            await testExpectedEventually('allCueElements().length', 1);
+            await testExpectedEventually('allCueElements().length', 1, '==', 500);
             testExpected('firstCueElement().textContent', 'Lorem');
+
+            consoleWrite('');
+            consoleWrite('Disable the text track:');
+            run('video.textTracks[0].mode = "disabled"');
+            await testExpectedEventually('allCueElements().length', 0, '==', 500);
+
+            consoleWrite('');
+            consoleWrite('Pretend to show the subtitle style menu:');
+            run('internals.showCaptionDisplaySettingsPreviewForMediaElement(video)');
+            await testExpectedEventually('allCueElements().length', 1, '==', 500);
+            testExpected('firstCueElement().textContent', 'This is a preview');
+
+            consoleWrite('');
+            consoleWrite('Pretend to hide the subtitle style menu:');
+            run('internals.hideCaptionDisplaySettingsPreviewForMediaElement(video)');
+            await testExpectedEventually('allCueElements().length', 0, '==', 500);
         }
 
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -104,7 +104,7 @@ static bool compareCueIntervalForDisplay(const CueInterval& one, const CueInterv
 void MediaControlTextTrackContainerElement::updateDisplay()
 {
     RefPtr mediaElement = m_mediaElement.get();
-    if (mediaElement && !mediaElement->closedCaptionsVisible())
+    if (mediaElement && !mediaElement->closedCaptionsVisible() && !m_shouldShowCaptionPreviewCue)
         removeChildren();
 
     // 1. If the media element is an audio element, or is another playback
@@ -180,7 +180,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
     // so that the newest captions appear at the bottom.
     std::ranges::sort(activeCues, &compareCueIntervalForDisplay);
 
-    if (mediaElement->closedCaptionsVisible()) {
+    if (mediaElement->closedCaptionsVisible() || m_shouldShowCaptionPreviewCue) {
         // 10. For each text track cue in cues that has not yet had
         // corresponding CSS boxes added to output, in text track cue order, run the
         // following substeps:


### PR DESCRIPTION
#### 5b1d2f13b22fcaa97c290d6ab6730c3e38c29318
<pre>
Subtitle Previews are not visible if there is not an enabled TextTrack
<a href="https://rdar.apple.com/165805195">rdar://165805195</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303512">https://bugs.webkit.org/show_bug.cgi?id=303512</a>

Reviewed by Eric Carlson.

MediaControlTextTrackContainerElement will check the HTMLMediaElement to see if
captions are visible before adding cues to the render tree; it should also check
whether caption previews are enabled.

* LayoutTests/media/track/text-track-caption-style-menu-expected.txt:
* LayoutTests/media/track/text-track-caption-style-menu.html:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):

Canonical link: <a href="https://commits.webkit.org/303916@main">https://commits.webkit.org/303916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/201bac2bf8aa8b15dc66846130302b56aee839f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85966 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f4728e8-17c9-4163-8c33-06c89e4665dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102429 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b725793-a673-4170-8fd7-40cee7a0ba8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a6551b1a-61b3-49f4-8a8c-689fb62c3dbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2385 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4620 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59833 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6138 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34562 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5984 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->