### PR TITLE
[WebXR Hit Test] imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt
@@ -1,16 +1,8 @@
 
 PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl
 PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl2
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl assert_equals: expected 0 but got 1
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl2 assert_equals: expected 0 but got 1
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl assert_approx_equals: after-move-pose: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: -1.443, y: 1, z: -2.5, w: 1}
- Difference in component x exceeded the given epsilon.
- expected 0 +/- 0.001 but got -1.443
-FAIL Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl2 assert_approx_equals: after-move-pose: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: -1.443, y: 1, z: -2.5, w: 1}
- Difference in component x exceeded the given epsilon.
- expected 0 +/- 0.001 but got -1.443
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl2
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt
@@ -3,24 +3,8 @@ PASS Ensures subscription to hit test works with viewer space - straight ahead -
 PASS Ensures subscription to hit test works with viewer space - straight ahead - plane - webgl2
 PASS Ensures subscription to hit test works with viewer space - straight up - no results - webgl
 PASS Ensures subscription to hit test works with viewer space - straight up - no results - webgl2
-FAIL Ensures subscription to hit test works with local space - webgl assert_approx_equals: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: 0, y: 0, z: -2.5, w: 1}
- Difference in component y exceeded the given epsilon.
- expected 1 +/- 0.001 but got 0
-FAIL Ensures subscription to hit test works with local space - webgl2 assert_approx_equals: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: 0, y: 0, z: -2.5, w: 1}
- Difference in component y exceeded the given epsilon.
- expected 1 +/- 0.001 but got 0
-FAIL Ensures subscription to hit test works with local-floor space - webgl assert_approx_equals: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: 0, y: 0.25, z: -2.5, w: 1}
- Difference in component y exceeded the given epsilon.
- expected 1 +/- 0.001 but got 0.25
-FAIL Ensures subscription to hit test works with local-floor space - webgl2 assert_approx_equals: positions must be equal Point comparison failed.
- p1: {x: 0, y: 1, z: -2.5, w: 1}
- p2: {x: 0, y: 0.25, z: -2.5, w: 1}
- Difference in component y exceeded the given epsilon.
- expected 1 +/- 0.001 but got 0.25
+PASS Ensures subscription to hit test works with local space - webgl
+PASS Ensures subscription to hit test works with local space - webgl2
+PASS Ensures subscription to hit test works with local-floor space - webgl
+PASS Ensures subscription to hit test works with local-floor space - webgl2
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -49,7 +49,7 @@ Ref<WebXRInputSource> WebXRInputSource::create(Document& document, WebXRSession&
 
 WebXRInputSource::WebXRInputSource(Document& document, WebXRSession& session, double timestamp, const PlatformXR::FrameData::InputSource& source)
     : m_session(session)
-    , m_targetRaySpace(WebXRInputSpace::create(document, session, source.pointerOrigin))
+    , m_targetRaySpace(WebXRInputSpace::create(document, session, source.pointerOrigin, source.handle))
     , m_connectTime(timestamp)
 #if ENABLE(GAMEPAD)
     , m_gamepad(Gamepad::create(&document, WebXRGamepad(timestamp, timestamp, source)))
@@ -80,7 +80,7 @@ void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::Inp
         if (m_gripSpace)
             m_gripSpace->setPose(*gripOrigin);
         else if (RefPtr document = downcast<Document>(session->scriptExecutionContext()))
-            m_gripSpace = WebXRInputSpace::create(*document, *session, *gripOrigin);
+            m_gripSpace = WebXRInputSpace::create(*document, *session, *gripOrigin, handle());
     } else
         m_gripSpace = nullptr;
 #if ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
@@ -39,15 +39,16 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRInputSpace);
 
 // WebXRInputSpace
 
-Ref<WebXRInputSpace> WebXRInputSpace::create(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose)
+Ref<WebXRInputSpace> WebXRInputSpace::create(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose, PlatformXR::InputSourceHandle handle)
 {
-    return adoptRef(*new WebXRInputSpace(document, session, pose));
+    return adoptRef(*new WebXRInputSpace(document, session, pose, handle));
 }
 
-WebXRInputSpace::WebXRInputSpace(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose)
+WebXRInputSpace::WebXRInputSpace(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose, PlatformXR::InputSourceHandle handle)
     : WebXRSpace(document, WebXRRigidTransform::create())
     , m_session(session)
     , m_pose(pose)
+    , m_handle(handle)
 {
 }
 
@@ -57,6 +58,13 @@ std::optional<TransformationMatrix> WebXRInputSpace::nativeOrigin() const
 {
     return WebXRFrame::matrixFromPose(m_pose.pose);
 }
+
+#if ENABLE(WEBXR_HIT_TEST)
+std::optional<PlatformXR::NativeOriginInformation> WebXRInputSpace::nativeOriginInformation() const
+{
+    return { PlatformXR::InputSourceSpaceInfo { m_handle, PlatformXR::InputSourceSpaceType::TargetRay } };
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.h
@@ -38,7 +38,7 @@ namespace WebCore {
 class WebXRInputSpace : public RefCounted<WebXRInputSpace>, public WebXRSpace {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRInputSpace);
 public:
-    static Ref<WebXRInputSpace> create(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&);
+    static Ref<WebXRInputSpace> create(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&, PlatformXR::InputSourceHandle);
     virtual ~WebXRInputSpace();
 
     // ContextDestructionObserver.
@@ -49,15 +49,19 @@ public:
     void setPose(const PlatformXR::FrameData::InputSourcePose& pose) { m_pose = pose; }
 
 private:
-    WebXRInputSpace(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&);
+    WebXRInputSpace(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&, PlatformXR::InputSourceHandle);
     WebXRSession* session() const final { return m_session.get(); }
     std::optional<TransformationMatrix> nativeOrigin() const final;
+#if ENABLE(WEBXR_HIT_TEST)
+    std::optional<PlatformXR::NativeOriginInformation> nativeOriginInformation() const final;
+#endif
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
     WeakPtr<WebXRSession> m_session;
     PlatformXR::FrameData::InputSourcePose m_pose;
+    PlatformXR::InputSourceHandle m_handle;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.h
@@ -52,6 +52,9 @@ public:
 
     WebXRSession* session() const final { return m_session.get(); }
     std::optional<TransformationMatrix> nativeOrigin() const override;
+#if ENABLE(WEBXR_HIT_TEST)
+    std::optional<PlatformXR::NativeOriginInformation> nativeOriginInformation() const override { return { m_type }; }
+#endif
     virtual ExceptionOr<Ref<WebXRReferenceSpace>> getOffsetReferenceSpace(const WebXRRigidTransform&);
     XRReferenceSpaceType type() const { return m_type; }
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -784,7 +784,7 @@ void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, Reques
         promise.reject(Exception { ExceptionCode::InvalidStateError });
         return;
     }
-    auto maybeNativeOrigin = init.space->nativeOrigin();
+    auto maybeNativeOrigin = init.space->nativeOriginInformation();
     if (!maybeNativeOrigin) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "Unable to retrieve the native origin from XRSpace"_s });
         return;

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -51,6 +51,9 @@ public:
 
     virtual WebXRSession* session() const = 0;
     virtual std::optional<TransformationMatrix> nativeOrigin() const = 0;
+#if ENABLE(WEBXR_HIT_TEST)
+    virtual std::optional<PlatformXR::NativeOriginInformation> nativeOriginInformation() const { return std::nullopt; }
+#endif
     std::optional<TransformationMatrix> effectiveOrigin() const;
     virtual std::optional<bool> isPositionEmulated() const;
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -296,9 +296,21 @@ struct Ray {
     WebCore::FloatPoint3D direction;
 };
 
+enum class InputSourceSpaceType : uint8_t {
+    TargetRay,
+    Grip,
+};
+
+struct InputSourceSpaceInfo {
+    InputSourceHandle handle;
+    InputSourceSpaceType type;
+};
+
+using NativeOriginInformation = Variant<ReferenceSpaceType, InputSourceSpaceInfo>;
+
 struct HitTestOptions {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(HitTestOptions);
-    WebCore::TransformationMatrix nativeOrigin;
+    NativeOriginInformation nativeOrigin;
     Vector<WebCore::XRHitTestTrackableType> entityTypes;
     Ray offsetRay;
 };

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -22,6 +22,14 @@
 
 #if ENABLE(WEBXR)
 
+enum class PlatformXR::ReferenceSpaceType : uint8_t {
+    Viewer,
+    Local,
+    LocalFloor,
+    BoundedFloor,
+    Unbounded,
+};
+
 enum class PlatformXR::SessionFeature : uint8_t {
     ReferenceSpaceTypeViewer,
     ReferenceSpaceTypeLocal,
@@ -208,8 +216,20 @@ enum class WebCore::XRHitTestTrackableType : uint8_t {
     WebCore::FloatPoint3D direction;
 };
 
+enum class PlatformXR::InputSourceSpaceType : uint8_t {
+    TargetRay,
+    Grip,
+};
+
+[CustomHeader] struct PlatformXR::InputSourceSpaceInfo {
+    PlatformXR::InputSourceHandle handle;
+    PlatformXR::InputSourceSpaceType type;
+};
+
+using PlatformXR::NativeOriginInformation = Variant<PlatformXR::ReferenceSpaceType, PlatformXR::InputSourceSpaceInfo>;
+
 [CustomHeader] struct PlatformXR::HitTestOptions {
-    WebCore::TransformationMatrix nativeOrigin;
+    PlatformXR::NativeOriginInformation nativeOrigin;
     Vector<WebCore::XRHitTestTrackableType> entityTypes;
     PlatformXR::Ray offsetRay;
 };


### PR DESCRIPTION
#### f8e8db847038a190ef76814e16ba9c57ace77e24
<pre>
[WebXR Hit Test] imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=303516">https://bugs.webkit.org/show_bug.cgi?id=303516</a>

Reviewed by Sergio Villar Senin.

Take the space of XRHitTestOptionsInit into account. Hit test should be
performed in the space. Added a new type PlatformXR::NativeOriginInformation
that supports reference spaces and input source spaces at the moment.

Added a new WebXRSpace subclass WebXRHitTestResultSpace in
WebXRHitTestResult.cpp to populate the pose of hit test result.

Tests: imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https.html
       imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_refSpaces.https-expected.txt:
* Source/WebCore/Modules/webxr/WebXRHitTestResult.cpp:
(WebCore::WebXRHitTestResultSpace::WebXRHitTestResultSpace):
(WebCore::WebXRHitTestResult::getPose):
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::WebXRInputSource):
(WebCore::WebXRInputSource::update):
* Source/WebCore/Modules/webxr/WebXRInputSpace.cpp:
(WebCore::WebXRInputSpace::create):
(WebCore::WebXRInputSpace::WebXRInputSpace):
(WebCore::WebXRInputSpace::nativeOriginInformation const):
* Source/WebCore/Modules/webxr/WebXRInputSpace.h:
* Source/WebCore/Modules/webxr/WebXRReferenceSpace.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::requestHitTestSource):
* Source/WebCore/Modules/webxr/WebXRSpace.h:
(WebCore::WebXRSpace::nativeOriginInformation const):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304264@main">https://commits.webkit.org/304264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd5ccd77cea683008185ca78ea96afe0585cc67a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135054 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142561 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8084 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138000 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3157 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145259 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/7136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111935 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20834 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7186 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->