### PR TITLE
Update MetaAllocator::freeFreeSpaceNode() to call the FreeSpaceNode destructor

### DIFF
--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -139,11 +139,19 @@ protected:
 private:
     
     friend class MetaAllocatorHandle;
-    
+
+    DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(MetaAllocatorFreeSpace, WTF_INTERNAL);
+
     class FreeSpaceNode final : public RedBlackTree<FreeSpaceNode, size_t>::ThreadSafeNode {
-        WTF_MAKE_TZONE_ALLOCATED(FreeSpaceNode);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FreeSpaceNode);
     public:
+        void operator delete(void* object) { MetaAllocatorFreeSpaceMalloc::free(object); }
+        void* operator new(size_t size)
+        {
+            ASSERT(sizeof(FreeSpaceNode) == size);
+            return MetaAllocatorFreeSpaceMalloc::malloc(size);
+        }
+
         size_t sizeInBytes()
         {
             return m_end.untaggedPtr<size_t>() - m_start.untaggedPtr<size_t>();


### PR DESCRIPTION
#### 98aa585d7ea2e53740579e88d5a8506c8a4220aa
<pre>
Update MetaAllocator::freeFreeSpaceNode() to call the FreeSpaceNode destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=303519">https://bugs.webkit.org/show_bug.cgi?id=303519</a>

Reviewed by Geoffrey Garen.

Override `operator delete` for FreeSpaceNode to call MetaAllocatorFreeSpaceMalloc::free()
to free the memory and add logic to deal with CheckedPtrs so we can actually guard against
use-after-free. It also makes sure to call the FreeSpaceNode destructor before freeing the
memory since FreeSpaceNode subclasses CanMakeThreadSafeCheckedPtr and it is important for
its destructor to run in order to get security benefits.

Also override `operator new` to call `MetaAllocatorFreeSpaceMalloc::malloc()` from consistency.

Finally, address the crashes found by the steps above.

* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::~MetaAllocator):
(WTF::MetaAllocator::addFreeSpace):
(WTF::MetaAllocator::allocFreeSpaceNode):
(WTF::MetaAllocator::freeFreeSpaceNode):
* Source/WTF/wtf/MetaAllocator.h:

Canonical link: <a href="https://commits.webkit.org/304051@main">https://commits.webkit.org/304051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59eaf6d7d097ccb1ac4280b3809fb2cafaedec1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86394 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d496f80-6e1e-46f2-8137-55fb4bff4068) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c62bfb69-5bd6-49dc-a9b2-0d69d43b4e0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83525 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d0a792a2-e834-4472-8afb-d2a538e37737) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5072 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2692 "Found 1 new API test failure: TestWebKitAPI.FormValidation.PresentingFormValidationUIWithoutViewControllerDoesNotCrash (failure)") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126462 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144632 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132916 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111140 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4901 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6604 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34931 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165848 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70175 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->