### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for SpeechRecognitionRequest

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognitionRequest.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionRequest.cpp
@@ -31,10 +31,17 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognitionRequest);
 
+Ref<SpeechRecognitionRequest> SpeechRecognitionRequest::create(SpeechRecognitionRequestInfo&& requestInfo)
+{
+    return adoptRef(*new SpeechRecognitionRequest(WTFMove(requestInfo)));
+}
+
 SpeechRecognitionRequest::SpeechRecognitionRequest(SpeechRecognitionRequestInfo&& requestInfo)
     : m_info(WTFMove(requestInfo))
 {
 }
+
+SpeechRecognitionRequest::~SpeechRecognitionRequest() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionRequest.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionRequest.h
@@ -27,23 +27,16 @@
 
 #include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <WebCore/SpeechRecognitionRequestInfo.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-class SpeechRecognitionRequest;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechRecognitionRequest> : std::true_type { };
-}
-
-namespace WebCore {
-
-class SpeechRecognitionRequest : public CanMakeWeakPtr<SpeechRecognitionRequest> {
+class SpeechRecognitionRequest : public RefCountedAndCanMakeWeakPtr<SpeechRecognitionRequest> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SpeechRecognitionRequest, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT explicit SpeechRecognitionRequest(SpeechRecognitionRequestInfo&&);
+    WEBCORE_EXPORT static Ref<SpeechRecognitionRequest> create(SpeechRecognitionRequestInfo&&);
+    WEBCORE_EXPORT ~SpeechRecognitionRequest();
 
     SpeechRecognitionConnectionClientIdentifier clientIdentifier() const { return m_info.clientIdentifier; }
     const String& lang() const { return m_info.lang; }
@@ -54,6 +47,8 @@ public:
     FrameIdentifier mainFrameIdentifier() const { return m_info.mainFrameIdentifier; }
 
 private:
+    explicit SpeechRecognitionRequest(SpeechRecognitionRequestInfo&&);
+
     const SpeechRecognitionRequestInfo m_info;
 };
 

--- a/Source/WebCore/Modules/speech/SpeechRecognizer.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognizer.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognizer);
 
-SpeechRecognizer::SpeechRecognizer(DelegateCallback&& delegateCallback, UniqueRef<SpeechRecognitionRequest>&& request)
+SpeechRecognizer::SpeechRecognizer(DelegateCallback&& delegateCallback, Ref<SpeechRecognitionRequest>&& request)
     : m_delegateCallback(WTFMove(delegateCallback))
     , m_request(WTFMove(request))
 #if HAVE(SPEECHRECOGNIZER)

--- a/Source/WebCore/Modules/speech/SpeechRecognizer.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognizer.h
@@ -48,7 +48,7 @@ class SpeechRecognizer final : public CanMakeWeakPtr<SpeechRecognizer>, public C
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpeechRecognizer);
 public:
     using DelegateCallback = Function<void(const SpeechRecognitionUpdate&)>;
-    WEBCORE_EXPORT explicit SpeechRecognizer(DelegateCallback&&, UniqueRef<SpeechRecognitionRequest>&&);
+    WEBCORE_EXPORT explicit SpeechRecognizer(DelegateCallback&&, Ref<SpeechRecognitionRequest>&&);
     WEBCORE_EXPORT ~SpeechRecognizer();
 
 #if ENABLE(MEDIA_STREAM)
@@ -81,7 +81,7 @@ private:
     void stopRecognition();
 
     DelegateCallback m_delegateCallback;
-    const UniqueRef<SpeechRecognitionRequest> m_request;
+    const Ref<SpeechRecognitionRequest> m_request;
     std::unique_ptr<SpeechRecognitionCaptureSource> m_source;
     State m_state { State::Inactive };
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -153,7 +153,7 @@ void SpeechRecognitionPermissionManager::startProcessingRequest()
 void SpeechRecognitionPermissionManager::continueProcessingRequest()
 {
     ASSERT(!m_requests.isEmpty());
-    auto recognitionRequest = m_requests.first().first->request();
+    RefPtr recognitionRequest = m_requests.first().first->request();
     auto frameInfo = m_requests.first().second;
     if (!recognitionRequest) {
         completeCurrentRequest();

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -83,7 +83,7 @@ private:
         );
 
     void requestPermissionForRequest(WebCore::SpeechRecognitionRequest&, FrameInfoData&&);
-    void handleRequest(UniqueRef<WebCore::SpeechRecognitionRequest>&&);
+    void handleRequest(Ref<WebCore::SpeechRecognitionRequest>&&);
     void sendUpdate(WebCore::SpeechRecognitionConnectionClientIdentifier, WebCore::SpeechRecognitionUpdateType, std::optional<WebCore::SpeechRecognitionError> = std::nullopt, std::optional<Vector<WebCore::SpeechRecognitionResultData>> = std::nullopt);
     void sendUpdate(const WebCore::SpeechRecognitionUpdate&);
 
@@ -98,7 +98,7 @@ private:
 
     WeakPtr<WebProcessProxy> m_process;
     SpeechRecognitionServerIdentifier m_identifier;
-    HashMap<WebCore::SpeechRecognitionConnectionClientIdentifier, std::unique_ptr<WebCore::SpeechRecognitionRequest>> m_requests;
+    HashMap<WebCore::SpeechRecognitionConnectionClientIdentifier, Ref<WebCore::SpeechRecognitionRequest>> m_requests;
     SpeechRecognitionPermissionChecker m_permissionChecker;
     std::unique_ptr<WebCore::SpeechRecognizer> m_recognizer;
     SpeechRecognitionCheckIfMockSpeechRecognitionEnabled m_checkIfMockSpeechRecognitionEnabled;


### PR DESCRIPTION
#### 3049cd9c26475ba8cbdab629bb55f553d839da00
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for SpeechRecognitionRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=303521">https://bugs.webkit.org/show_bug.cgi?id=303521</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/speech/SpeechRecognitionRequest.cpp:
(WebCore::SpeechRecognitionRequest::create):
* Source/WebCore/Modules/speech/SpeechRecognitionRequest.h:
* Source/WebCore/Modules/speech/SpeechRecognizer.cpp:
(WebCore::SpeechRecognizer::SpeechRecognizer):
* Source/WebCore/Modules/speech/SpeechRecognizer.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::continueProcessingRequest):
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::start):
(WebKit::SpeechRecognitionServer::requestPermissionForRequest):
(WebKit::SpeechRecognitionServer::handleRequest):
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:

Canonical link: <a href="https://commits.webkit.org/303946@main">https://commits.webkit.org/303946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1817e962fcf66723b69fae6dee6b91f237e1b4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85973 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56ce4a44-67b8-4c93-994d-292a98d6a2e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69740 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fc4abaed-a67f-4980-803d-8c355501f481) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83238 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e993cb1d-7cd6-4126-b7d1-42b574407e84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2388 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144135 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6093 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110801 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5177 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111009 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4622 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59840 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6145 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34569 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->