### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for LibWebRTCRtpSenderBackend

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -55,19 +55,19 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RTCRtpSender);
 
-Ref<RTCRtpSender> RTCRtpSender::create(RTCPeerConnection& connection, Ref<MediaStreamTrack>&& track, std::unique_ptr<RTCRtpSenderBackend>&& backend)
+Ref<RTCRtpSender> RTCRtpSender::create(RTCPeerConnection& connection, Ref<MediaStreamTrack>&& track, Ref<RTCRtpSenderBackend>&& backend)
 {
     auto sender = adoptRef(*new RTCRtpSender(connection, String(track->kind()), WTFMove(backend)));
     sender->setTrack(WTFMove(track));
     return sender;
 }
 
-Ref<RTCRtpSender> RTCRtpSender::create(RTCPeerConnection& connection, String&& trackKind, std::unique_ptr<RTCRtpSenderBackend>&& backend)
+Ref<RTCRtpSender> RTCRtpSender::create(RTCPeerConnection& connection, String&& trackKind, Ref<RTCRtpSenderBackend>&& backend)
 {
     return adoptRef(*new RTCRtpSender(connection, WTFMove(trackKind), WTFMove(backend)));
 }
 
-RTCRtpSender::RTCRtpSender(RTCPeerConnection& connection, String&& trackKind, std::unique_ptr<RTCRtpSenderBackend>&& backend)
+RTCRtpSender::RTCRtpSender(RTCPeerConnection& connection, String&& trackKind, Ref<RTCRtpSenderBackend>&& backend)
     : m_trackKind(WTFMove(trackKind))
     , m_backend(WTFMove(backend))
     , m_connection(connection)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -60,8 +60,8 @@ class RTCRtpSender final : public RefCounted<RTCRtpSender>
     {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCRtpSender);
 public:
-    static Ref<RTCRtpSender> create(RTCPeerConnection&, Ref<MediaStreamTrack>&&, std::unique_ptr<RTCRtpSenderBackend>&&);
-    static Ref<RTCRtpSender> create(RTCPeerConnection&, String&& trackKind, std::unique_ptr<RTCRtpSenderBackend>&&);
+    static Ref<RTCRtpSender> create(RTCPeerConnection&, Ref<MediaStreamTrack>&&, Ref<RTCRtpSenderBackend>&&);
+    static Ref<RTCRtpSender> create(RTCPeerConnection&, String&& trackKind, Ref<RTCRtpSenderBackend>&&);
     virtual ~RTCRtpSender();
 
     static std::optional<RTCRtpCapabilities> getCapabilities(ScriptExecutionContext&, const String& kind);
@@ -102,7 +102,7 @@ public:
     ExceptionOr<RTCEncodedStreams> createEncodedStreams(ScriptExecutionContext&);
 
 private:
-    RTCRtpSender(RTCPeerConnection&, String&& trackKind, std::unique_ptr<RTCRtpSenderBackend>&&);
+    RTCRtpSender(RTCPeerConnection&, String&& trackKind, Ref<RTCRtpSenderBackend>&&);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
@@ -115,7 +115,7 @@ private:
     RefPtr<RTCDtlsTransport> m_transport;
     String m_trackId;
     String m_trackKind;
-    std::unique_ptr<RTCRtpSenderBackend> m_backend;
+    RefPtr<RTCRtpSenderBackend> m_backend;
     WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
     RefPtr<RTCDTMFSender> m_dtmfSender;
     std::unique_ptr<RTCRtpTransform> m_transform;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSenderBackend.h
@@ -26,6 +26,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 
@@ -42,7 +43,7 @@ struct RTCRtpSendParameters;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class RTCRtpSenderBackend {
+class RTCRtpSenderBackend : public AbstractRefCounted {
 public:
     virtual ~RTCRtpSenderBackend() = default;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
@@ -87,7 +87,7 @@ void RTCRtpTransform::attachToSender(RTCRtpSender& sender, RTCRtpTransform* prev
 
     if (previousTransform)
         m_backend = previousTransform->takeBackend();
-    else if (auto* backend = sender.backend())
+    else if (RefPtr backend = sender.backend())
         m_backend = backend->rtcRtpTransformBackend();
 
     if (!m_backend)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1234,7 +1234,7 @@ std::optional<bool> GStreamerMediaEndpoint::isIceGatheringComplete(const String&
     return true;
 }
 
-ExceptionOr<std::unique_ptr<GStreamerRtpSenderBackend>> GStreamerMediaEndpoint::addTrack(MediaStreamTrack& track, const FixedVector<String>& mediaStreamIds)
+ExceptionOr<RefPtr<GStreamerRtpSenderBackend>> GStreamerMediaEndpoint::addTrack(MediaStreamTrack& track, const FixedVector<String>& mediaStreamIds)
 {
     GStreamerRtpSenderBackend::Source source;
     auto mediaStreamId = mediaStreamIds.isEmpty() ? "-"_s : mediaStreamIds[0];

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -88,13 +88,13 @@ public:
 
     void configureSource(RealtimeOutgoingMediaSourceGStreamer&, GUniquePtr<GstStructure>&&);
 
-    ExceptionOr<std::unique_ptr<GStreamerRtpSenderBackend>> addTrack(MediaStreamTrack&, const FixedVector<String>&);
+    ExceptionOr<RefPtr<GStreamerRtpSenderBackend>> addTrack(MediaStreamTrack&, const FixedVector<String>&);
     void removeTrack(GStreamerRtpSenderBackend&);
 
     void recycleTransceiverForSenderTrack(GStreamerRtpTransceiverBackend*, MediaStreamTrack&, const FixedVector<String>&);
 
     struct Backends {
-        std::unique_ptr<GStreamerRtpSenderBackend> senderBackend;
+        RefPtr<GStreamerRtpSenderBackend> senderBackend;
         std::unique_ptr<GStreamerRtpReceiverBackend> receiverBackend;
         std::unique_ptr<GStreamerRtpTransceiverBackend> transceiverBackend;
     };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -362,7 +362,7 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
     auto transceiverBackend = m_endpoint->transceiverBackendFromSender(*senderBackend);
 
     Ref peerConnection = m_peerConnection.get();
-    auto newSender = RTCRtpSender::create(peerConnection, track, WTFMove(senderBackend));
+    auto newSender = RTCRtpSender::create(peerConnection, track, senderBackend.releaseNonNull());
     newSender->setMediaStreamIds(mediaStreamIds);
     auto receiver = createReceiver(transceiverBackend->createReceiverBackend(), track.kind(), track.id());
     auto transceiver = RTCRtpTransceiver::create(newSender.copyRef(), WTFMove(receiver), WTFMove(transceiverBackend));
@@ -381,7 +381,7 @@ ExceptionOr<Ref<RTCRtpTransceiver>> GStreamerPeerConnectionBackend::addTransceiv
     GST_DEBUG_OBJECT(m_endpoint->pipeline(), "Creating new transceiver.");
     auto backends = result.releaseReturnValue();
     Ref peerConnection = m_peerConnection.get();
-    auto sender = RTCRtpSender::create(peerConnection, WTFMove(trackOrKind), WTFMove(backends.senderBackend));
+    auto sender = RTCRtpSender::create(peerConnection, WTFMove(trackOrKind), backends.senderBackend.releaseNonNull());
     auto receiver = createReceiver(WTFMove(backends.receiverBackend), sender->trackKind(), sender->trackId());
     auto transceiver = RTCRtpTransceiver::create(WTFMove(sender), WTFMove(receiver), WTFMove(backends.transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -50,6 +50,16 @@ static void ensureDebugCategoryIsRegistered()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GStreamerRtpSenderBackend);
 
+Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
+{
+    return adoptRef(*new GStreamerRtpSenderBackend(WTFMove(backend), WTFMove(rtcSender)));
+}
+
+Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
+{
+    return adoptRef(*new GStreamerRtpSenderBackend(WTFMove(backend), WTFMove(rtcSender), WTFMove(source), WTFMove(initData)));
+}
+
 GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
     : m_peerConnectionBackend(WTFMove(backend))
     , m_rtcSender(WTFMove(rtcSender))

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -66,11 +66,11 @@ std::unique_ptr<GStreamerRtpReceiverBackend> GStreamerRtpTransceiverBackend::cre
     return WTF::makeUnique<GStreamerRtpReceiverBackend>(GRefPtr(m_rtcTransceiver));
 }
 
-std::unique_ptr<GStreamerRtpSenderBackend> GStreamerRtpTransceiverBackend::createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GStreamerRtpSenderBackend::Source&& source, GUniquePtr<GstStructure>&& initData)
+Ref<GStreamerRtpSenderBackend> GStreamerRtpTransceiverBackend::createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GStreamerRtpSenderBackend::Source&& source, GUniquePtr<GstStructure>&& initData)
 {
     GRefPtr<GstWebRTCRTPSender> sender;
     g_object_get(m_rtcTransceiver.get(), "sender", &sender.outPtr(), nullptr);
-    return WTF::makeUnique<GStreamerRtpSenderBackend>(WTFMove(backend), WTFMove(sender), WTFMove(source), WTFMove(initData));
+    return GStreamerRtpSenderBackend::create(WTFMove(backend), WTFMove(sender), WTFMove(source), WTFMove(initData));
 }
 
 RTCRtpTransceiverDirection GStreamerRtpTransceiverBackend::direction() const

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
@@ -37,7 +37,7 @@ public:
     GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTCRTPTransceiver>&&);
 
     std::unique_ptr<GStreamerRtpReceiverBackend> createReceiverBackend();
-    std::unique_ptr<GStreamerRtpSenderBackend> createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GStreamerRtpSenderBackend::Source&&, GUniquePtr<GstStructure>&&);
+    Ref<GStreamerRtpSenderBackend> createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GStreamerRtpSenderBackend::Source&&, GUniquePtr<GstStructure>&&);
 
     GstWebRTCRTPTransceiver* rtcTransceiver() { return m_rtcTransceiver.get(); }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -107,7 +107,7 @@ public:
     void removeTrack(LibWebRTCRtpSenderBackend&);
 
     struct Backends {
-        std::unique_ptr<LibWebRTCRtpSenderBackend> senderBackend;
+        RefPtr<LibWebRTCRtpSenderBackend> senderBackend;
         std::unique_ptr<LibWebRTCRtpReceiverBackend> receiverBackend;
         std::unique_ptr<LibWebRTCRtpTransceiverBackend> transceiverBackend;
     };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -208,6 +208,11 @@ static inline LibWebRTCRtpSenderBackend& backendFromRTPSender(RTCRtpSender& send
     return static_cast<LibWebRTCRtpSenderBackend&>(*sender.backend());
 }
 
+static inline Ref<LibWebRTCRtpSenderBackend> protectedBackendFromRTPSender(RTCRtpSender& sender)
+{
+    return backendFromRTPSender(sender);
+}
+
 void LibWebRTCPeerConnectionBackend::getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise)
 {
     webrtc::RtpSenderInterface* rtcSender = sender.backend() ? backendFromRTPSender(sender).rtcSender() : nullptr;
@@ -316,24 +321,24 @@ static inline RefPtr<RTCRtpSender> findExistingSender(const Vector<RefPtr<RTCRtp
 
 ExceptionOr<Ref<RTCRtpSender>> LibWebRTCPeerConnectionBackend::addTrack(MediaStreamTrack& track, FixedVector<String>&& mediaStreamIds)
 {
-    auto senderBackend = makeUnique<LibWebRTCRtpSenderBackend>(*this, nullptr);
-    if (!m_endpoint->addTrack(*senderBackend, track, mediaStreamIds))
+    Ref senderBackend = LibWebRTCRtpSenderBackend::create(*this, nullptr);
+    if (!m_endpoint->addTrack(senderBackend, track, mediaStreamIds))
         return Exception { ExceptionCode::TypeError, "Unable to add track"_s };
 
     Ref peerConnection = m_peerConnection.get();
-    if (auto sender = findExistingSender(peerConnection->currentTransceivers(), *senderBackend)) {
-        backendFromRTPSender(*sender).takeSource(*senderBackend);
+    if (RefPtr sender = findExistingSender(peerConnection->currentTransceivers(), senderBackend)) {
+        protectedBackendFromRTPSender(*sender)->takeSource(senderBackend);
         sender->setTrack(track);
         sender->setMediaStreamIds(mediaStreamIds);
         return sender.releaseNonNull();
     }
 
-    auto transceiverBackend = m_endpoint->transceiverBackendFromSender(*senderBackend);
+    auto transceiverBackend = m_endpoint->transceiverBackendFromSender(senderBackend);
 
-    auto sender = RTCRtpSender::create(peerConnection, track, WTFMove(senderBackend));
+    Ref sender = RTCRtpSender::create(peerConnection, track, WTFMove(senderBackend));
     sender->setMediaStreamIds(mediaStreamIds);
-    auto receiver = createReceiver(transceiverBackend->createReceiverBackend());
-    auto transceiver = RTCRtpTransceiver::create(sender.copyRef(), WTFMove(receiver), WTFMove(transceiverBackend));
+    Ref receiver = createReceiver(transceiverBackend->createReceiverBackend());
+    Ref transceiver = RTCRtpTransceiver::create(sender.copyRef(), WTFMove(receiver), WTFMove(transceiverBackend));
     peerConnection->addInternalTransceiver(WTFMove(transceiver));
     return sender;
 }
@@ -347,7 +352,7 @@ ExceptionOr<Ref<RTCRtpTransceiver>> LibWebRTCPeerConnectionBackend::addTransceiv
 
     auto backends = result.releaseReturnValue();
     Ref peerConnection = m_peerConnection.get();
-    auto sender = RTCRtpSender::create(peerConnection, std::forward<T>(trackOrKind), WTFMove(backends.senderBackend));
+    Ref sender = RTCRtpSender::create(peerConnection, std::forward<T>(trackOrKind), backends.senderBackend.releaseNonNull());
     auto receiver = createReceiver(WTFMove(backends.receiverBackend));
     auto transceiver = RTCRtpTransceiver::create(WTFMove(sender), WTFMove(receiver), WTFMove(backends.transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());
@@ -401,14 +406,14 @@ void LibWebRTCPeerConnectionBackend::collectTransceivers()
 void LibWebRTCPeerConnectionBackend::removeTrack(RTCRtpSender& sender)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "Removing "_s, sender.trackKind(), " track with ID "_s, sender.trackId());
-    m_endpoint->removeTrack(backendFromRTPSender(sender));
+    m_endpoint->removeTrack(protectedBackendFromRTPSender(sender));
 }
 
 void LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources()
 {
     for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
         if (!transceiver->sender().isStopped()) {
-            if (auto* videoSource = backendFromRTPSender(transceiver->sender()).videoSource())
+            if (auto* videoSource = protectedBackendFromRTPSender(transceiver->sender())->videoSource())
                 videoSource->applyRotation();
         }
     }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -44,9 +44,9 @@ std::unique_ptr<LibWebRTCRtpReceiverBackend> LibWebRTCRtpTransceiverBackend::cre
     return makeUnique<LibWebRTCRtpReceiverBackend>(toRef(m_rtcTransceiver->receiver()));
 }
 
-std::unique_ptr<LibWebRTCRtpSenderBackend> LibWebRTCRtpTransceiverBackend::createSenderBackend(LibWebRTCPeerConnectionBackend& backend, LibWebRTCRtpSenderBackend::Source&& source)
+Ref<LibWebRTCRtpSenderBackend> LibWebRTCRtpTransceiverBackend::createSenderBackend(LibWebRTCPeerConnectionBackend& backend, LibWebRTCRtpSenderBackend::Source&& source)
 {
-    return makeUnique<LibWebRTCRtpSenderBackend>(backend, toRefPtr(m_rtcTransceiver->sender()), WTFMove(source));
+    return LibWebRTCRtpSenderBackend::create(backend, toRefPtr(m_rtcTransceiver->sender()), WTFMove(source));
 }
 
 RTCRtpTransceiverDirection LibWebRTCRtpTransceiverBackend::direction() const

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
@@ -45,7 +45,7 @@ public:
     }
 
     std::unique_ptr<LibWebRTCRtpReceiverBackend> createReceiverBackend();
-    std::unique_ptr<LibWebRTCRtpSenderBackend> createSenderBackend(LibWebRTCPeerConnectionBackend&, LibWebRTCRtpSenderBackend::Source&&);
+    Ref<LibWebRTCRtpSenderBackend> createSenderBackend(LibWebRTCPeerConnectionBackend&, LibWebRTCRtpSenderBackend::Source&&);
 
     webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.ptr(); }
 


### PR DESCRIPTION
#### d6106fc6631fab689a9efa3980a9e622e7ffee67
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for LibWebRTCRtpSenderBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=303523">https://bugs.webkit.org/show_bug.cgi?id=303523</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp:
(WebCore::RTCRtpSender::create):
(WebCore::RTCRtpSender::RTCRtpSender):
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/RTCRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp:
(WebCore::RTCRtpTransform::attachToSender):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::addTrack):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::addTrack):
(WebCore::GStreamerPeerConnectionBackend::addTransceiverFromTrackOrKind):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::create):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::createSenderBackend):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::protectedBackendFromRTPSender):
(WebCore::LibWebRTCPeerConnectionBackend::addTrack):
(WebCore::LibWebRTCPeerConnectionBackend::addTransceiverFromTrackOrKind):
(WebCore::LibWebRTCPeerConnectionBackend::removeTrack):
(WebCore::LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::LibWebRTCRtpSenderBackend::create):
(WebCore::LibWebRTCRtpSenderBackend::startSource):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp:
(WebCore::LibWebRTCRtpTransceiverBackend::createSenderBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h:

Canonical link: <a href="https://commits.webkit.org/303939@main">https://commits.webkit.org/303939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ecfb42308bfa86b5f01e0514c097e43e7e30e85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b01ae6e3-a6e0-403e-bac1-190e9d9cde97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102449 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/112534f1-84dd-4466-9a9d-05ba65c1bdc7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83248 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20e9adbd-a6e7-457a-9efc-bafe556e0b6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2399 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110816 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28179 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4632 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59861 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34583 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69630 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->