### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MutationObserverRegistration

### DIFF
--- a/Source/WebCore/dom/MutationObserverRegistration.cpp
+++ b/Source/WebCore/dom/MutationObserverRegistration.cpp
@@ -43,6 +43,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MutationObserverRegistration);
 
+Ref<MutationObserverRegistration> MutationObserverRegistration::create(MutationObserver& observer, Node& node, MutationObserverOptions options, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter)
+{
+    return adoptRef(*new MutationObserverRegistration(observer, node, options, attributeFilter));
+}
+
 MutationObserverRegistration::MutationObserverRegistration(MutationObserver& observer, Node& node, MutationObserverOptions options, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter)
     : m_observer(observer)
     , m_node(node)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -811,7 +811,7 @@ private:
     void trackForDebugging();
     void materializeRareData();
 
-    Vector<std::unique_ptr<MutationObserverRegistration>>* mutationObserverRegistry();
+    Vector<Ref<MutationObserverRegistration>>* mutationObserverRegistry();
     WeakHashSet<MutationObserverRegistration>* transientMutationObserverRegistry();
 
     void adjustStyleValidity(Style::Validity, Style::InvalidationMode);

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -218,7 +218,7 @@ class NodeMutationObserverData {
     WTF_MAKE_TZONE_ALLOCATED(NodeMutationObserverData);
     WTF_MAKE_NONCOPYABLE(NodeMutationObserverData);
 public:
-    Vector<std::unique_ptr<MutationObserverRegistration>> registry;
+    Vector<Ref<MutationObserverRegistration>> registry;
     WeakHashSet<MutationObserverRegistration> transientRegistry;
 
     NodeMutationObserverData() = default;


### PR DESCRIPTION
#### 8d5ed4702934519a24ed204ec01e5f6c305767e5
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MutationObserverRegistration
<a href="https://bugs.webkit.org/show_bug.cgi?id=303529">https://bugs.webkit.org/show_bug.cgi?id=303529</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::disconnect):
(WebCore::MutationObserver::isReachableFromOpaqueRoots const):
(WebCore::MutationObserver::deliver):
* Source/WebCore/dom/MutationObserverRegistration.cpp:
(WebCore::MutationObserverRegistration::create):
* Source/WebCore/dom/MutationObserverRegistration.h:
(WebCore::MutationObserverRegistration::hasTransientRegistrations const): Deleted.
(WebCore::MutationObserverRegistration::isSubtree const): Deleted.
(WebCore::MutationObserverRegistration::observer): Deleted.
(WebCore::MutationObserverRegistration::node): Deleted.
(WebCore::MutationObserverRegistration::deliveryOptions const): Deleted.
(WebCore::MutationObserverRegistration::mutationTypes const): Deleted.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::mutationObserverRegistry):
(WebCore::Node::registeredMutationObservers):
(WebCore::Node::registerMutationObserver):
(WebCore::Node::unregisterMutationObserver):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeRareData.h:

Canonical link: <a href="https://commits.webkit.org/303954@main">https://commits.webkit.org/303954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1339af8c3e5b20fb38ccd3dd60babaa1c08f4a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/406a5805-2425-4f2e-8d6f-faf2dee00c38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70e46c35-999e-43cc-801f-e9804a390f53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137031 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/65170d48-56db-4d0d-9e91-a29b3222f95c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4863 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2494 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1479 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144310 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110925 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4732 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60035 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34692 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6408 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->