### PR TITLE
[rebaselineserver] Add option to target base directory

### DIFF
--- a/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js
+++ b/Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js
@@ -88,6 +88,11 @@ function main()
         }
     });
 
+    var baseTargetOption = document.createElement('option');
+    baseTargetOption.value = `base`;
+    baseTargetOption.textContent = 'base';
+    $('baseline-target').appendChild(baseTargetOption);
+
     loadText('/platforms.json', function(text) {
         var platforms = JSON.parse(text);
         platforms.platforms.forEach(function(platform) {

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
@@ -67,8 +67,12 @@ def _rebaseline_test(test_file, baseline_target, baseline_move_to, test_config, 
     filesystem = test_config.filesystem
     scm = test_config.scm
     layout_tests_directory = test_config.layout_tests_directory
-    target_expectations_directory = filesystem.join(
-        layout_tests_directory, 'platform', baseline_target, test_directory)
+    target_expectations_directory = ''
+    if baseline_target == 'base':
+        target_expectations_directory = filesystem.join(layout_tests_directory, test_directory)
+    else:
+        target_expectations_directory = filesystem.join(
+            layout_tests_directory, 'platform', baseline_target, test_directory)
     test_results_directory = test_config.filesystem.join(
         test_config.results_directory, test_directory)
 


### PR DESCRIPTION
#### 0e83b2c30a0bea7c4066c981a53b46b6870be51a
<pre>
[rebaselineserver] Add option to target base directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=303530">https://bugs.webkit.org/show_bug.cgi?id=303530</a>
<a href="https://rdar.apple.com/165825714">rdar://165825714</a>

Reviewed by Alan Baradlay.

Sometimes it useful to target the base directory rather than platform directories.

* Tools/Scripts/webkitpy/tool/servers/data/rebaselineserver/main.js:

Add &apos;base&apos; option to the target menu.

* Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py:
(_rebaseline_test):

Target &apos;base&apos; rebaselines to the top level directory.

Canonical link: <a href="https://commits.webkit.org/304224@main">https://commits.webkit.org/304224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87cbe0d644fd6b4b07ffc39e1c1ebcc7665b43a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86001 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26958e35-9a94-41f4-88ac-efa0f3d48ec4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102457 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69765 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120077 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83256 "Found 6 new API test failures: TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest, TestWebKit:WebKit.OnDeviceChangeCrash, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames, WPE/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c005351-c6cb-41d7-8ce6-66fb0ece0370) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133289 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2406 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/902 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110823 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111031 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4642 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116334 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59868 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34592 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6019 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->