### PR TITLE
[WPE] WPE Platform: synthetic clicks generated for unhandled touch events are firing two pointer events

### DIFF
--- a/Source/WebKit/Shared/NativeWebTouchEvent.h
+++ b/Source/WebKit/Shared/NativeWebTouchEvent.h
@@ -43,6 +43,7 @@
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include <wpe/GRefPtrWPE.h>
 typedef struct _WPEEvent WPEEvent;
 #endif
 
@@ -64,12 +65,15 @@ public:
     NativeWebTouchEvent(GdkEvent*, Vector<WebPlatformTouchPoint>&&);
     NativeWebTouchEvent(const NativeWebTouchEvent&);
     const GdkEvent* nativeEvent() const { return m_nativeEvent.get(); }
-#elif USE(LIBWPE)
+#elif PLATFORM(WPE)
+#if USE(LIBWPE)
     NativeWebTouchEvent(struct wpe_input_touch_event*, float deviceScaleFactor);
     bool isNativeWebTouchEvent() const final { return true; }
     const struct wpe_input_touch_event_raw* nativeFallbackTouchPoint() const { return &m_fallbackTouchPoint; }
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#endif
+#if ENABLE(WPE_PLATFORM)
     NativeWebTouchEvent(WPEEvent*, Vector<WebPlatformTouchPoint>&&);
+    WPEEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #endif
 #elif PLATFORM(WIN)
     NativeWebTouchEvent();
@@ -86,8 +90,13 @@ private:
     GRefPtr<GdkEvent> m_nativeEvent;
 #elif PLATFORM(GTK)
     GUniquePtr<GdkEvent> m_nativeEvent;
-#elif USE(LIBWPE)
+#elif PLATFORM(WPE)
+#if USE(LIBWPE)
     struct wpe_input_touch_event_raw m_fallbackTouchPoint;
+#endif
+#if ENABLE(WPE_PLATFORM)
+    GRefPtr<WPEEvent> m_nativeEvent;
+#endif
 #endif
 };
 

--- a/Source/WebKit/Shared/wpe/NativeWebTouchEventWPE.cpp
+++ b/Source/WebKit/Shared/wpe/NativeWebTouchEventWPE.cpp
@@ -34,6 +34,7 @@ namespace WebKit {
 
 NativeWebTouchEvent::NativeWebTouchEvent(WPEEvent* event, Vector<WebPlatformTouchPoint>&& touchPoints)
     : WebTouchEvent(WebEventFactory::createWebTouchEvent(event, WTFMove(touchPoints)))
+    , m_nativeEvent(event)
 {
 }
 

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -133,16 +133,21 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
     auto button = WebMouseEventButton::None;
     auto position = positionFromEvent(event);
     unsigned clickCount = 0;
+    auto syntheticClickType = WebMouseEventSyntheticClickType::NoTap;
 
     switch (wpe_event_get_event_type(event)) {
     case WPE_EVENT_POINTER_DOWN:
         type = WebEventType::MouseDown;
         button = buttonForWPEButton(wpe_event_pointer_button_get_button(event));
         clickCount = wpe_event_pointer_button_get_press_count(event);
+        if (wpe_event_get_input_source(event) == WPE_INPUT_SOURCE_TOUCHSCREEN)
+            syntheticClickType = WebMouseEventSyntheticClickType::OneFingerTap;
         break;
     case WPE_EVENT_POINTER_UP:
         type = WebEventType::MouseUp;
         button = buttonForWPEButton(wpe_event_pointer_button_get_button(event));
+        if (wpe_event_get_input_source(event) == WPE_INPUT_SOURCE_TOUCHSCREEN)
+            syntheticClickType = WebMouseEventSyntheticClickType::OneFingerTap;
         break;
     case WPE_EVENT_POINTER_MOVE:
     case WPE_EVENT_POINTER_ENTER:
@@ -163,7 +168,9 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
         movementDelta.x(),
         movementDelta.y(),
         0 /* deltaZ */,
-        clickCount);
+        clickCount,
+        0 /* force */,
+        syntheticClickType);
 }
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event)

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -246,8 +246,11 @@ void PageClientImpl::doneWithTouchEvent(const WebTouchEvent& touchEvent, bool wa
     }
 
 #if ENABLE(WPE_PLATFORM)
-    if (m_view.wpeView())
+    if (m_view.wpeView()) {
+        if (touchEvent.isNativeWebTouchEvent())
+            static_cast<WKWPE::ViewPlatform&>(m_view).handleGesture(static_cast<const NativeWebTouchEvent&>(touchEvent).nativeEvent());
         return;
+    }
 #endif
 
     const struct wpe_input_touch_event_raw* touchPoint = touchEvent.isNativeWebTouchEvent() ? static_cast<const NativeWebTouchEvent&>(touchEvent).nativeFallbackTouchPoint() : nullptr;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -411,7 +411,6 @@ gboolean ViewPlatform::handleEvent(WPEEvent* event)
         m_touchEvents.set(wpe_event_touch_get_sequence_id(event), event);
         page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, touchPointsForEvent(event)));
 #endif
-        handleGesture(event);
         return TRUE;
     case WPE_EVENT_TOUCH_UP:
     case WPE_EVENT_TOUCH_CANCEL: {
@@ -421,7 +420,6 @@ gboolean ViewPlatform::handleEvent(WPEEvent* event)
         m_touchEvents.remove(wpe_event_touch_get_sequence_id(event));
         page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, WTFMove(points)));
 #endif
-        handleGesture(event);
         return TRUE;
     }
     case WPE_EVENT_TOUCH_MOVE:
@@ -429,7 +427,6 @@ gboolean ViewPlatform::handleEvent(WPEEvent* event)
         m_touchEvents.set(wpe_event_touch_get_sequence_id(event), event);
         page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, touchPointsForEvent(event)));
 #endif
-        handleGesture(event);
         return TRUE;
     };
     return FALSE;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -70,6 +70,8 @@ public:
     void updateAcceleratedSurface(uint64_t);
     WebKit::RendererBufferDescription renderBufferDescription() const;
 
+    void handleGesture(WPEEvent*);
+
 private:
     ViewPlatform(WPEDisplay*, const API::PageConfiguration&);
 
@@ -94,7 +96,6 @@ private:
     void dispatchPendingNextPresentationUpdateCallbacks();
 
     gboolean handleEvent(WPEEvent*);
-    void handleGesture(WPEEvent*);
 
     GRefPtr<WPEView> m_wpeView;
     RefPtr<WebKit::AcceleratedBackingStore> m_backingStore;


### PR DESCRIPTION
#### 21e718c506bcf8bb3b91621e65c4088fcdcbe4d5
<pre>
[WPE] WPE Platform: synthetic clicks generated for unhandled touch events are firing two pointer events
<a href="https://bugs.webkit.org/show_bug.cgi?id=303531">https://bugs.webkit.org/show_bug.cgi?id=303531</a>

Reviewed by Adrian Perez de Castro.

There are two problems:

  - We should synthesize clicks for taps only when the touch events were not handled.
    So, instead of calling handleGesture right after the touch event is
    passed to the page, we now do it from PageClientImpl::doneWithTouchEvent()
    when wasEventHandled is false.
  - We should notify the web process that synthetic mouse events are a simulated tap.
    When creating the WebMouse Event we check if the input source is
    WPE_INPUT_SOURCE_TOUCHSCREEN to pass WebMouseEventSyntheticClickType::OneFingerTap
    to the constructor.

Canonical link: <a href="https://commits.webkit.org/304226@main">https://commits.webkit.org/304226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7abdfab036270acb2f055edf7248e8aabd945290

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142455 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7210 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5476 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3084 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3051 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7040 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39686 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111845 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5312 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60959 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7089 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70661 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->