### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AudioSessionInterruptionObserver

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -190,7 +190,7 @@ class HTMLMediaElement
 public:
     USING_CAN_MAKE_WEAKPTR(SINGLE_ARG(CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>));
 
-    // ActiveDOMObject.
+    // ActiveDOMObject, AudioSessionConfigurationChangeObserver.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
     using HTMLElement::protectedScriptExecutionContext;

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -176,8 +176,8 @@ void AudioSession::beginInterruption()
         return;
     }
     m_isInterrupted = true;
-    for (auto& observer : audioSessionInterruptionObserversSingleton())
-        observer.beginAudioSessionInterruption();
+    for (Ref observer : audioSessionInterruptionObserversSingleton())
+        observer->beginAudioSessionInterruption();
 }
 
 void AudioSession::endInterruption(MayResume mayResume)
@@ -189,14 +189,14 @@ void AudioSession::endInterruption(MayResume mayResume)
     }
     m_isInterrupted = false;
 
-    for (auto& observer : audioSessionInterruptionObserversSingleton())
-        observer.endAudioSessionInterruption(mayResume);
+    for (Ref observer : audioSessionInterruptionObserversSingleton())
+        observer->endAudioSessionInterruption(mayResume);
 }
 
 void AudioSession::activeStateChanged()
 {
-    for (auto& observer : audioSessionInterruptionObserversSingleton())
-        observer.audioSessionActiveStateChanged();
+    for (Ref observer : audioSessionInterruptionObserversSingleton())
+        observer->audioSessionActiveStateChanged();
 }
 
 void AudioSession::setCategory(CategoryType, Mode, RouteSharingPolicy)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -41,13 +41,11 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class AudioSessionInterruptionObserver;
 class AudioSessionRoutingArbitrationClient;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioSessionInterruptionObserver> : std::true_type { };
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioSessionRoutingArbitrationClient> : std::true_type { };
 }
 
@@ -202,7 +200,7 @@ protected:
     bool m_isInterrupted { false };
 };
 
-class AudioSessionInterruptionObserver : public CanMakeWeakPtr<AudioSessionInterruptionObserver> {
+class AudioSessionInterruptionObserver : public AbstractRefCountedAndCanMakeWeakPtr<AudioSessionInterruptionObserver> {
 public:
     virtual ~AudioSessionInterruptionObserver() = default;
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -57,6 +57,9 @@ public:
     bool hasWirelessTargetsAvailable() final;
     bool isMonitoringWirelessTargets() const final;
 
+    void ref() const override { MediaSessionManagerCocoa::ref(); }
+    void deref() const override { MediaSessionManagerCocoa::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(MediaSessionHelperClient);
 
 protected:

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
@@ -36,10 +36,12 @@ namespace WebCore {
 
 class CoreAudioCaptureSourceFactoryIOS final : public CoreAudioCaptureSourceFactory  {
 public:
-    CoreAudioCaptureSourceFactoryIOS();
+    static Ref<CoreAudioCaptureSourceFactoryIOS> create();
     ~CoreAudioCaptureSourceFactoryIOS();
 
 private:
+    CoreAudioCaptureSourceFactoryIOS();
+
     RetainPtr<WebCoreAudioCaptureSourceIOSListener> m_listener;
 };
 

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
@@ -84,6 +84,11 @@ using namespace WebCore;
 
 namespace WebCore {
 
+Ref<CoreAudioCaptureSourceFactoryIOS> CoreAudioCaptureSourceFactoryIOS::create()
+{
+    return adoptRef(*new CoreAudioCaptureSourceFactoryIOS);
+}
+
 CoreAudioCaptureSourceFactoryIOS::CoreAudioCaptureSourceFactoryIOS()
     : m_listener(adoptNS([[WebCoreAudioCaptureSourceIOSListener alloc] initWithCallback:this]))
 {
@@ -97,7 +102,7 @@ CoreAudioCaptureSourceFactoryIOS::~CoreAudioCaptureSourceFactoryIOS()
 
 CoreAudioCaptureSourceFactory& CoreAudioCaptureSourceFactory::singleton()
 {
-    static NeverDestroyed<CoreAudioCaptureSourceFactoryIOS> factory;
+    static NeverDestroyed<Ref<CoreAudioCaptureSourceFactoryIOS>> factory = CoreAudioCaptureSourceFactoryIOS::create();
     return factory.get();
 }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -64,7 +64,7 @@ namespace WebCore {
 #if PLATFORM(MAC)
 CoreAudioCaptureSourceFactory& CoreAudioCaptureSourceFactory::singleton()
 {
-    static NeverDestroyed<CoreAudioCaptureSourceFactory> factory;
+    static NeverDestroyed<Ref<CoreAudioCaptureSourceFactory>> factory = adoptRef(*new CoreAudioCaptureSourceFactory);
     return factory.get();
 }
 #endif

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -141,18 +141,23 @@ public:
     virtual OSStatus produceSpeakerSamples(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) = 0;
 };
 
-class CoreAudioCaptureSourceFactory : public AudioCaptureFactory, public AudioSessionInterruptionObserver {
+class CoreAudioCaptureSourceFactory : public AudioCaptureFactory, public AudioSessionInterruptionObserver, public RefCounted<CoreAudioCaptureSourceFactory> {
 public:
     WEBCORE_EXPORT static CoreAudioCaptureSourceFactory& singleton();
-
-    CoreAudioCaptureSourceFactory();
     ~CoreAudioCaptureSourceFactory();
+
+    // AudioSessionInterruptionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void scheduleReconfiguration();
 
     WEBCORE_EXPORT void registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
+
+protected:
+    CoreAudioCaptureSourceFactory();
 
 private:
     // AudioSessionInterruptionObserver

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -51,6 +51,7 @@ public:
 
     ~RemoteAudioSessionProxyManager();
 
+    // AudioSessionConfigurationChangeObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -69,6 +69,10 @@ public:
 
     void updateShouldRegisterAsSpeakerSamplesProducer();
 
+    // WebCore::AudioSessionInterruptionObserver.
+    void ref() const final { WebCore::AudioMediaStreamTrackRendererInternalUnit::Client::ref(); }
+    void deref() const final { WebCore::AudioMediaStreamTrackRendererInternalUnit::Client::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionInterruptionObserver);
 
 private:


### PR DESCRIPTION
#### 4432300d98109348380e8cc01dc52521864ee738
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AudioSessionInterruptionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=303533">https://bugs.webkit.org/show_bug.cgi?id=303533</a>

Reviewed by Darin Adler.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::beginInterruption):
(WebCore::AudioSession::endInterruption):
(WebCore::AudioSession::activeStateChanged):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(WebCore::CoreAudioCaptureSourceFactoryIOS::create):
(WebCore::CoreAudioCaptureSourceFactory::singleton):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSourceFactory::singleton):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::audioCaptureFactory):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:

Canonical link: <a href="https://commits.webkit.org/304048@main">https://commits.webkit.org/304048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eddaa8b6bd6b1fd50d3152936ca2d3bd9eaea441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134145 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86208 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102584 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69874 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09359056-e4c2-46d2-a38f-90cc399bb79e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83379 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8907c396-0da0-4fab-85b1-4a7b8a095e52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2530 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1540 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144371 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110958 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111201 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4762 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60096 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6378 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->