### PR TITLE
Crash in RTCEncodedStreamProducer::writeFrame, m_transformBackend nullptr

### DIFF
--- a/LayoutTests/http/wpt/webrtc/unset-transform-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/unset-transform-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Validate unsetting a sender transform
+PASS Validate unsetting a receiver transform
+

--- a/LayoutTests/http/wpt/webrtc/unset-transform.html
+++ b/LayoutTests/http/wpt/webrtc/unset-transform.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay playsInline></video>
+        <script src="routines.js"></script>
+        <script>
+function waitForMessage(port, data)
+{
+    let lastData;
+    let gotMessage;
+    const promise = new Promise((resolve, reject) => {
+        gotMessage = resolve;
+        setTimeout(() => { reject("did not get " + data + ", got: '" + lastData + "'") }, 5000);
+    });
+    port.onmessage = event => {
+       lastData = event.data;
+       if (event.data === data)
+           gotMessage();
+    };
+    return promise;
+}
+
+let senderTransform, receiverTransform;
+let stream;
+let worker;
+let senderChannel, receiverChannel;
+
+async function doSetup(test, isSenderTransform)
+{
+    worker = new Worker('unset-transform.js');
+    const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
+    assert_equals(data, "registered");
+
+    const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
+
+    senderChannel = new MessageChannel;
+    receiverChannel = new MessageChannel;
+    let sender, receiver;
+    senderTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'sender', port:senderChannel.port2}, [senderChannel.port2]);
+    receiverTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'receiver', port:receiverChannel.port2}, [receiverChannel.port2]);
+    senderTransform.port = senderChannel.port1;
+    receiverTransform.port = receiverChannel.port1;
+
+    promise1 = waitForMessage(senderTransform.port, "started video sender");
+    promise2 = waitForMessage(receiverTransform.port, "started video receiver");
+
+    let pc1, pc2;
+    stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            if (isSenderTransform)
+                sender.transform = senderTransform;
+            pc1 = firstConnection;
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                receiver = trackEvent.receiver;
+                if (!isSenderTransform)
+                    receiver.transform = receiverTransform;
+                resolve(trackEvent.streams[0]);
+            };
+            pc2 = secondConnection;
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+
+    await promise1;
+    await promise2;
+
+    await video.play();
+    return [pc1, pc2];
+}
+
+promise_test(async (test) => {
+    const [pc1, pc2 ] = await doSetup(test, true);
+
+    senderTransform.port.postMessage("delayWrite");
+    await waitForMessage(senderTransform.port, "delaying");
+
+    pc1.getSenders()[0].transform = null;
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+
+    pc1.close();
+    pc2.close();
+}, "Validate unsetting a sender transform");
+
+promise_test(async (test) => {
+    const [pc1, pc2 ] = await doSetup(test, false);
+    await new Promise(resolve => test.step_timeout(resolve, 1000));
+
+    receiverTransform.port.postMessage("delayWrite");
+    await waitForMessage(receiverTransform.port, "delaying");
+
+    pc2.getReceivers()[0].transform = null;
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+
+    pc1.close();
+    pc2.close();
+}, "Validate unsetting a receiver transform");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/http/wpt/webrtc/unset-transform.js
+++ b/LayoutTests/http/wpt/webrtc/unset-transform.js
@@ -1,0 +1,49 @@
+class MockRTCRtpTransformer {
+    constructor(transformer) {
+        this.delayWrite = false;
+        this.context = transformer;
+        this.context.options.port.onmessage = (event) => {
+            if (event.data === "delayWrite")
+                this.delayWrite = true;
+        };
+        this.start();
+    }
+    start()
+    {
+        this.reader = this.context.readable.getReader();
+        this.writer = this.context.writable.getWriter();
+        this.process();
+        this.context.options.port.postMessage("started " + this.context.options.mediaType + " " + this.context.options.side);
+    }
+
+    process()
+    {
+        this.reader.read().then(async chunk => {
+            if (chunk.done)
+                return;
+
+            const shouldDelay = this.delayWrite;
+            if (shouldDelay) {
+                this.context.options.port.postMessage("delaying");
+                await new Promise(resolve => setTimeout(resolve, 500));
+            }
+
+            try {
+                this.writer.write(chunk.value);
+            } catch (e) {
+            }
+
+            if (shouldDelay)
+                this.delayWrite = false;
+
+            this.process();
+        });
+    }
+};
+
+
+onrtctransform = (event) => {
+    new MockRTCRtpTransformer(event.transformer);
+};
+
+self.postMessage("registered");

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2598,6 +2598,7 @@ webrtc/video-sframe.html [ Skip ]
 webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
 webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
 http/wpt/webrtc/video-script-transform-simulcast.html [ Skip ]
+http/wpt/webrtc/unset-transform.html [ Failure ]
 
 # GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented and also hitting srtpenc errors.
 webkit.org/b/235885 webrtc/video-addTransceiver.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -139,6 +139,10 @@ void RTCEncodedStreamProducer::enqueueFrame(Ref<RTCRtpTransformableFrame>&& fram
 
 ExceptionOr<void> RTCEncodedStreamProducer::writeFrame(ScriptExecutionContext& context, JSC::JSValue value)
 {
+    RefPtr transformBackend = m_transformBackend;
+    if (!transformBackend)
+        return { };
+
     auto* globalObject = context.globalObject();
     if (!globalObject)
         return { };
@@ -159,7 +163,7 @@ ExceptionOr<void> RTCEncodedStreamProducer::writeFrame(ScriptExecutionContext& c
 
     // If no data, skip the frame since there is nothing to packetize or decode.
     if (rtcFrame->data().data())
-        Ref { *m_transformBackend }->processTransformedFrame(rtcFrame.get());
+        transformBackend->processTransformedFrame(rtcFrame.get());
 
     return { };
 }


### PR DESCRIPTION
#### 8b20220f4c45b7051687abb7d332136bd0534d05
<pre>
Crash in RTCEncodedStreamProducer::writeFrame, m_transformBackend nullptr
<a href="https://rdar.apple.com/165687266">rdar://165687266</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303383">https://bugs.webkit.org/show_bug.cgi?id=303383</a>

Reviewed by Kimmo Kinnunen.

There is a race condition with RTCEncodedStreamProducer when unsetting transforms between writing a frame and clearing the transform.
We add a nullptr check to prevent this race.

Test: http/wpt/webrtc/unset-transform.html
Canonical link: <a href="https://commits.webkit.org/303908@main">https://commits.webkit.org/303908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4df33610df67761e99bc653dbb171758622cd23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141546 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eda9fa40-8623-4f86-9d65-e36b7c98e6ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102481 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/157d4878-1b9f-4e99-87a0-a110a9b27489) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136913 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83278 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4941aac0-cdc6-48ff-9801-09d1e45af7ba) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144191 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6147 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110843 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28164 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4660 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59900 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6199 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69663 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->