### PR TITLE
Present the immersive model in the client app

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
@@ -1,14 +1,14 @@
 
 PASS Immersive API exists on model and document
 PASS Model immersive request fails without user activation
-FAIL Model enters immersive mode with user activation promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Document.exitImmersive() exits immersive model promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Immersivechange events fire when entering immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Only one model can be immersive at a time promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Exiting immersive model after an immersive update exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Removing immersive model from DOM exits immersive mode promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+PASS Model enters immersive mode with user activation
+PASS Document.exitImmersive() exits immersive model
+PASS Immersivechange events fire when entering immersive
+PASS Only one model can be immersive at a time
+PASS Exiting immersive model after an immersive update exits immersive mode
+FAIL Removing immersive model from DOM exits immersive mode assert_equals: No immersive element after removal expected null but got Element node <model><source src="../resources/cube.usdz"></model>
 PASS Immersiveerror event fires when request fails
-FAIL CSS :immersive pseudo-class matches correctly promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Model is complete once presented as immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
-FAIL Multiple concurrent requestImmersive calls are handled correctly promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+PASS CSS :immersive pseudo-class matches correctly
+PASS Model is complete once presented as immersive
+PASS Multiple concurrent requestImmersive calls are handled correctly
 

--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -61,23 +61,23 @@ promise_test(async t => {
     
     let modelChangeEvents = [];
     let documentChangeEvents = [];
-    
-    model.addEventListener('immersivechange', () => {
-        modelChangeEvents.push(document.immersiveElement);
-    });
-    
-    document.addEventListener('immersivechange', () => {
-        documentChangeEvents.push(document.immersiveElement);
-    });
+    const modelHandler = () => { modelChangeEvents.push(document.immersiveElement); };
+    const documentHandler = () => { documentChangeEvents.push(document.immersiveElement); };
     
     await test_driver.bless("immersive");
+
+    model.addEventListener('immersivechange', modelHandler);
+    document.addEventListener('immersivechange', documentHandler);
+
     await model.requestImmersive();
-    
     await new Promise(resolve => setTimeout(resolve, 100));
+
+    model.removeEventListener('immersivechange', modelHandler);
+    document.removeEventListener('immersivechange', documentHandler);
     
     assert_equals(modelChangeEvents.length, 1, 'Model should fire one immersivechange event');
     assert_equals(modelChangeEvents[0], model, 'Model event should occur when model is immersive');
-    
+
     assert_equals(documentChangeEvents.length, 1, 'Document should fire one immersivechange event');
     assert_equals(documentChangeEvents[0], model, 'Document event should reference model');
 }, 'Immersivechange events fire when entering immersive');
@@ -134,9 +134,8 @@ promise_test(async t => {
     const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
     let errorFired = false;
-    model.addEventListener('immersiveerror', () => {
-        errorFired = true;
-    });
+    const errorHandler = () => { errorFired = true; };
+    model.addEventListener('immersiveerror', errorHandler);
     
     await promise_rejects_js(t, TypeError, 
         model.requestImmersive(),
@@ -144,6 +143,7 @@ promise_test(async t => {
     );
     
     await new Promise(resolve => setTimeout(resolve, 100));
+    model.removeEventListener('immersiveerror', errorHandler);
     
     assert_true(errorFired, 'immersiveerror event should fire on failed request');
 }, 'Immersiveerror event fires when request fails');

--- a/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Hidden inline model should successfully enter immersive promise_test: Unhandled rejection with value: object "TypeError: Not fully implemented, model not displaying in browser."
+PASS Hidden inline model should successfully enter immersive
 

--- a/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html
@@ -21,6 +21,7 @@ promise_test(async t => {
     await model.requestImmersive();
 
     assert_equals(document.immersiveElement, model, 'Hidden model became document\'s immersive element');
+    assert_equals(model.complete, true, 'Model should be complete when immersive');
 }, 'Hidden inline model should successfully enter immersive');
 
 </script>

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -36,6 +36,7 @@
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ImageBufferResourceLimits.h>
 #include <WebCore/InputMode.h>
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/MediaControlsContextMenuItem.h>
 #include <WebCore/PlaybackTargetClientContextIdentifier.h>
 #include <WebCore/PointerCharacteristics.h>
@@ -341,7 +342,9 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    virtual void canEnterImmersiveElement(const Element&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void allowImmersiveElement(const Element&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void presentImmersiveElement(const Element&, const LayerHostingContextIdentifier, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void dismissImmersiveElement(const Element&, CompletionHandler<void()>&& completion) const { completion(); }
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -523,7 +523,9 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-- (void)_canEnterImmersiveElementFromURL:(const URL&)url completion:(CompletionHandler<void(bool)>&&)completion;
+- (void)_allowImmersiveElementFromURL:(const URL&)url completion:(CompletionHandler<void(bool)>&&)completion;
+- (void)_presentImmersiveElement:(const WebCore::LayerHostingContextIdentifier)contextID completion:(CompletionHandler<void(bool)>&&)completion;
+- (void)_dismissImmersiveElement:(CompletionHandler<void()>&&)completion;
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h
@@ -34,7 +34,11 @@ WK_SWIFT_UI_ACTOR
 WK_API_AVAILABLE(visionos(WK_XROS_TBA))
 @protocol _WKImmersiveEnvironmentDelegate <NSObject>
 
-- (void)webView:(WKWebView *)webView canPresentImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool))completion NS_SWIFT_ASYNC_NAME(webView(_:canPresentImmersiveEnvironmentFromURL:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+#if (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool allow))completion NS_SWIFT_ASYNC_NAME(webView(_:allowImmersiveEnvironmentFromURL:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable error))completion NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)(void))completion NS_SWIFT_ASYNC_NAME(webViewDismissImmersiveEnvironment(_:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PageClient.h"
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PlatformTextAlternatives.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakObjCPtr.h>
@@ -78,7 +79,9 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void canEnterImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&&) final;
+    void allowImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&&) const final;
+    void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&) const final;
+    void dismissImmersiveElement(CompletionHandler<void()>&&) const final;
 #endif
 
     void underPageBackgroundColorWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -113,9 +113,19 @@ void PageClientImplCocoa::spatialBackdropSourceDidChange()
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-void PageClientImplCocoa::canEnterImmersiveElementFromURL(const URL& url, CompletionHandler<void(bool)>&& completion)
+void PageClientImplCocoa::allowImmersiveElementFromURL(const URL& url, CompletionHandler<void(bool)>&& completion) const
 {
-    [m_webView _canEnterImmersiveElementFromURL:url completion:WTFMove(completion)];
+    [webView() _allowImmersiveElementFromURL:url completion:WTFMove(completion)];
+}
+
+void PageClientImplCocoa::presentImmersiveElement(const WebCore::LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion) const
+{
+    [webView() _presentImmersiveElement:contextID completion:WTFMove(completion)];
+}
+
+void PageClientImplCocoa::dismissImmersiveElement(CompletionHandler<void()>&& completion) const
+{
+    [webView() _dismissImmersiveElement:WTFMove(completion)];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -47,6 +47,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/InputMode.h>
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/MediaControlsContextMenuItem.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ShareableBitmap.h>
@@ -857,7 +858,9 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    virtual void canEnterImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&& completion) { completion(false); }
+    virtual void allowImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void dismissImmersiveElement(CompletionHandler<void()>&& completion) const { completion(); }
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13499,12 +13499,28 @@ void WebPageProxy::spatialBackdropSourceChanged(std::optional<WebCore::SpatialBa
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-void WebPageProxy::canEnterImmersiveElementFromURL(const URL& url, CompletionHandler<void(bool)>&& completion)
+void WebPageProxy::allowImmersiveElementFromURL(const URL& url, CompletionHandler<void(bool)>&& completion) const
 {
     if (RefPtr pageClient = this->pageClient())
-        pageClient->canEnterImmersiveElementFromURL(url, WTFMove(completion));
+        pageClient->allowImmersiveElementFromURL(url, WTFMove(completion));
     else
         completion(false);
+}
+
+void WebPageProxy::presentImmersiveElement(const WebCore::LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion) const
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->presentImmersiveElement(contextID, WTFMove(completion));
+    else
+        completion(false);
+}
+
+void WebPageProxy::dismissImmersiveElement(CompletionHandler<void()>&& completion) const
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->dismissImmersiveElement(WTFMove(completion));
+    else
+        completion();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -29,6 +29,7 @@
 // Use forward declarations and WebPageProxyInternals.h instead.
 #include "APIObject.h"
 #include "MessageReceiver.h"
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -3066,7 +3067,9 @@ private:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void canEnterImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&&);
+    void allowImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&&) const;
+    void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&) const;
+    void dismissImmersiveElement(CompletionHandler<void()>&&) const;
 #endif
 
     WebCore::Color platformUnderPageBackgroundColor() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -98,7 +98,9 @@ messages -> WebPageProxy {
     SetCanShortCircuitHorizontalWheelEvents(bool canShortCircuitHorizontalWheelEvents)
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    [EnabledBy=ModelElementImmersiveEnabled] CanEnterImmersiveElementFromURL(URL url) -> (bool canEnterImmersive)
+    [EnabledBy=ModelElementImmersiveEnabled] AllowImmersiveElementFromURL(URL url) -> (bool allow)
+    [EnabledBy=ModelElementImmersiveEnabled] PresentImmersiveElement(WebCore::LayerHostingContextIdentifier contextID) -> (bool success)
+    [EnabledBy=ModelElementImmersiveEnabled] DismissImmersiveElement() -> ()
 #endif
 
     DidChangeContentSize(WebCore::IntSize newSize)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1664,12 +1664,28 @@ void WebChromeClient::spatialBackdropSourceChanged() const
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-void WebChromeClient::canEnterImmersiveElement(const Element& element, CompletionHandler<void(bool)>&& completion) const
+void WebChromeClient::allowImmersiveElement(const Element& element, CompletionHandler<void(bool)>&& completion) const
 {
     if (RefPtr page = m_page.get())
-        page->canEnterImmersiveElement(element, WTFMove(completion));
+        page->allowImmersiveElement(element, WTFMove(completion));
     else
         completion(false);
+}
+
+void WebChromeClient::presentImmersiveElement(const Element& element, const LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion) const
+{
+    if (RefPtr page = m_page.get())
+        page->presentImmersiveElement(element, contextID, WTFMove(completion));
+    else
+        completion(false);
+}
+
+void WebChromeClient::dismissImmersiveElement(const Element& element, CompletionHandler<void()>&& completion) const
+{
+    if (RefPtr page = m_page.get())
+        page->dismissImmersiveElement(element, WTFMove(completion));
+    else
+        completion();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -387,7 +387,9 @@ private:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void canEnterImmersiveElement(const WebCore::Element&, CompletionHandler<void(bool)>&&) const final;
+    void allowImmersiveElement(const WebCore::Element&, CompletionHandler<void(bool)>&&) const final;
+    void presentImmersiveElement(const WebCore::Element&, const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&) const final;
+    void dismissImmersiveElement(const WebCore::Element&, CompletionHandler<void()>&&) const final;
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7896,10 +7896,20 @@ void WebPage::spatialBackdropSourceChanged()
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-void WebPage::canEnterImmersiveElement(const Element& element, CompletionHandler<void(bool)>&& completion)
+void WebPage::allowImmersiveElement(const Element& element, CompletionHandler<void(bool)>&& completion)
 {
     auto url = element.document().url();
-    sendWithAsyncReply(Messages::WebPageProxy::CanEnterImmersiveElementFromURL(url), WTFMove(completion));
+    sendWithAsyncReply(Messages::WebPageProxy::AllowImmersiveElementFromURL(url), WTFMove(completion));
+}
+
+void WebPage::presentImmersiveElement(const Element&, const LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::PresentImmersiveElement(contextID), WTFMove(completion));
+}
+
+void WebPage::dismissImmersiveElement(const Element&, CompletionHandler<void()>&& completion)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::DismissImmersiveElement(), WTFMove(completion));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1690,7 +1690,9 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void canEnterImmersiveElement(const WebCore::Element&, CompletionHandler<void(bool)>&&);
+    void allowImmersiveElement(const WebCore::Element&, CompletionHandler<void(bool)>&&);
+    void presentImmersiveElement(const WebCore::Element&, const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&);
+    void dismissImmersiveElement(const WebCore::Element&, CompletionHandler<void()>&&);
 #endif
 
     void flushPendingEditorStateUpdate();

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -708,9 +708,19 @@ static bool isQuickboardViewController(UIViewController *viewController)
 
 #pragma mark - _WKImmersiveEnvironmentDelegate
 
-- (void)webView:(WKWebView *)webView canPresentImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool))completion
+- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool))completion
 {
     completion(self.shouldAcceptImmersiveEnvironmentRequests);
+}
+
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable))completion
+{
+    completion(nil);
+}
+
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)())completion
+{
+    completion();
 }
 
 #endif


### PR DESCRIPTION
#### 0d7a1ea90a00e80f609be99dee6e93c8251f9918
<pre>
Present the immersive model in the client app
<a href="https://bugs.webkit.org/show_bug.cgi?id=303541">https://bugs.webkit.org/show_bug.cgi?id=303541</a>
<a href="https://rdar.apple.com/165833224">rdar://165833224</a>

Reviewed by Etienne Segonzac.

Add WK delegate methods to enable the client to display the remote model inside their Immersive Space.
Plumb the context ID of the remote model up to the UI Process to create the remote environment view.

* LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* LayoutTests/model-element/immersive/model-element-immersive-hidden-inline-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-hidden-inline.html:
Updated test results.

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):
(WebCore::DocumentImmersive::exitImmersive):
Ensure the client has presented/dismissed the immersive environment before completed the immersive enter/exit request.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::allowImmersiveElement const):
(WebCore::ChromeClient::presentImmersiveElement const):
(WebCore::ChromeClient::dismissImmersiveElement const):
(WebCore::ChromeClient::canEnterImmersiveElement const): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _allowImmersiveElementFromURL:completion:]):
(-[WKWebView _presentImmersiveElement:completion:]):
(-[WKWebView _dismissImmersiveElement:]):
(-[WKWebView _canEnterImmersiveElementFromURL:completion:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::allowImmersiveElementFromURL const):
(WebKit::PageClientImplCocoa::presentImmersiveElement const):
(WebKit::PageClientImplCocoa::dismissImmersiveElement const):
(WebKit::PageClientImplCocoa::canEnterImmersiveElementFromURL): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::allowImmersiveElementFromURL const):
(WebKit::PageClient::presentImmersiveElement const):
(WebKit::PageClient::dismissImmersiveElement const):
(WebKit::PageClient::canEnterImmersiveElementFromURL): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::allowImmersiveElementFromURL const):
(WebKit::WebPageProxy::presentImmersiveElement const):
(WebKit::WebPageProxy::dismissImmersiveElement const):
(WebKit::WebPageProxy::canEnterImmersiveElementFromURL): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::allowImmersiveElement const):
(WebKit::WebChromeClient::presentImmersiveElement const):
(WebKit::WebChromeClient::dismissImmersiveElement const):
(WebKit::WebChromeClient::canEnterImmersiveElement const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::allowImmersiveElement):
(WebKit::WebPage::presentImmersiveElement):
(WebKit::WebPage::dismissImmersiveElement):
(WebKit::WebPage::canEnterImmersiveElement): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView webView:allowImmersiveEnvironmentFromURL:completion:]):
(-[TestRunnerWKWebView webView:presentImmersiveEnvironment:completion:]):
(-[TestRunnerWKWebView webView:dismissImmersiveEnvironment:]):
(-[TestRunnerWKWebView webView:canPresentImmersiveEnvironmentFromURL:completion:]): Deleted.
Plumb the present and dismiss signals up to the UI Process.

Canonical link: <a href="https://commits.webkit.org/303987@main">https://commits.webkit.org/303987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cd2253426eba1c11641ccc1a0244a4b4644f91e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141815 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102644 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137179 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83437 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39035 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111274 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4816 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116588 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60200 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6468 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34800 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69934 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->