### PR TITLE
[WKCI][browserperfdash-benchmark] Pass the build log URL from buildbot to the runner and forward it to the dashboard

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -2479,3 +2479,46 @@ class TestRunTest262Tests(BuildStepMixinAdditions, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS, state_string='test262-test')
         return self.run_step()
+
+
+class TestRunBenchmarkTests(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def test_success(self):
+        self.setup_step(RunBenchmarkTests())
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+        self.setProperty('archive_revision', '12345@main')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=2000,
+                        log_environ=True,
+                        command=['python3', 'Tools/Scripts/browserperfdash-benchmark', '--plans-from-config', '--config-file', '../../browserperfdash-benchmark-config.txt',
+                                 '--browser-version', '12345@main', '--timestamp-from-repo', '.', '--build-log-url', 'http://localhost:8080/#/builders/1/builds/13'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='benchmark tests')
+        return self.run_step()
+
+    def test_failure(self):
+        self.setup_step(RunBenchmarkTests())
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+        self.setProperty('archive_revision', '12345@main')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=2000,
+                        log_environ=True,
+                        command=['python3', 'Tools/Scripts/browserperfdash-benchmark', '--plans-from-config', '--config-file', '../../browserperfdash-benchmark-config.txt',
+                                 '--browser-version', '12345@main', '--timestamp-from-repo', '.', '--build-log-url', 'http://localhost:8080/#/builders/1/builds/13'],
+                        )
+            .exit(7),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Benchmark Tests: 7 unexpected failures')
+        return self.run_step()

--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -53,6 +53,7 @@ def parse_args():
     parser_group_browser_version.add_argument('--query-browser-version', dest='query_browser_version', action='store_true', help='Try to automatically query the browser version.')
     # arguments shared with run-benchmark.
     parser.add_argument('--build-directory', dest='buildDir', help='Path to the browser executable (e.g. WebKitBuild/Release/).')
+    parser.add_argument('--build-log-url', help='Optional: A URL with the build logs of this test run to send to the dashboard.')
     parser.add_argument('--platform', dest='platform', default=None, choices=BrowserDriverFactory.available_platforms())
     parser.add_argument('--browser', dest='browser', default=None, choices=BrowserDriverFactory.available_browsers())
     parser.add_argument('--driver', default=None, choices=benchmark_runner_subclasses.keys(), help='Use the specified benchmark driver. Defaults to %s.' % WebServerBenchmarkRunner.name)
@@ -98,7 +99,8 @@ class BrowserPerfDashRunner(object):
         # - The bot_* data its obtained from the config file
         # - the browser_* data is given at startup time via command-line arguments
         # - The test_* data is generated after each test run.
-        self._result_data = {'bot_id': None,
+        self._result_data = {'build_log_url': args.build_log_url,
+                             'bot_id': None,
                              'bot_password': None,
                              'browser_id': None,
                              'browser_version': None,


### PR DESCRIPTION
#### f36b3a764da0220450b3cc0b2dad96636bdcf334
<pre>
[WKCI][browserperfdash-benchmark] Pass the build log URL from buildbot to the runner and forward it to the dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=303542">https://bugs.webkit.org/show_bug.cgi?id=303542</a>

Reviewed by Nikolas Zimmermann.

Pass the URL of the build log from buildbot to the browserperfdash-benchmark runner,
and forward it as part of the data that the runner send to the performance dashboard.

The idea is that we will use this URL data to show it on the datapoints, so its easier
to open the buildbot logs that generated a given data point on the performance dashboard.

As part of this modernize a bit the builbot RunBenchmarkTests step and fix some issues.
The previous getText2() method was not working to generate the result summary string in
case of failure. Also passing the name of the browser is not longer needed as now that
goes into the configuration file. Also add unit tests.

The timeout of the step is also rised to 2000 because the runners run with an internal
timeout per-test of 1984, so that way we ensure that the runner timeout triggers first.

* Tools/CISupport/build-webkit-org/steps.py:
(RunBenchmarkTests.__init__):
(RunBenchmarkTests.run):
(RunBenchmarkTests.evaluateCommand):
(RunBenchmarkTests.getResultSummary):
(RunBenchmarkTests.getText): Deleted.
(RunBenchmarkTests.getText2): Deleted.
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/303904@main">https://commits.webkit.org/303904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c271d30d41367ac8cf991f8eb00466888fc0f18f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141547 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7009 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6342 "Failed to checkout and rebase branch from PR 54837") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136914 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83279 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133316 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/113966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144192 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38800 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/133395 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6230 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/6342 "Failed to checkout and rebase branch from PR 54837") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111055 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59901 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6200 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->