### PR TITLE
Improve HTMLTreeBuilder for table markup

### DIFF
--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -479,6 +479,23 @@ bool HTMLElementStack::inTableScope(ElementName targetElement) const
     return inScopeCommon<isTableScopeMarker>(m_top.get(), targetElement);
 }
 
+bool HTMLElementStack::hasAnyInTableScope(std::initializer_list<ElementName> targetElements) const
+{
+    for (auto* record = m_top.get(); record; record = record->next()) {
+        auto& item = record->stackItem();
+
+        for (auto targetElement : targetElements) {
+            if (item.elementName() == targetElement)
+                return true;
+        }
+
+        if (isTableScopeMarker(item))
+            return false;
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 bool HTMLElementStack::inButtonScope(ElementName targetElement) const
 {
     return inScopeCommon<isButtonScopeMarker>(m_top.get(), targetElement);

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -128,6 +128,7 @@ public:
     bool inScope(ElementName) const;
     bool inListItemScope(ElementName) const;
     bool inTableScope(ElementName) const;
+    bool hasAnyInTableScope(std::initializer_list<ElementName> targetElements) const;
     bool inButtonScope(ElementName) const;
     bool inSelectScope(ElementName) const;
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1294,8 +1294,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         case TagName::tbody:
         case TagName::tfoot:
         case TagName::thead:
-            // FIXME: This is slow.
-            if (!m_tree.openElements().inTableScope(HTML::tbody) && !m_tree.openElements().inTableScope(HTML::thead) && !m_tree.openElements().inTableScope(HTML::tfoot)) {
+            if (!m_tree.openElements().hasAnyInTableScope({ HTML::tbody, HTML::thead, HTML::tfoot })) {
                 ASSERT(isParsingFragmentOrTemplateContents());
                 parseError(token);
                 return;
@@ -1349,8 +1348,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         case TagName::tbody:
         case TagName::tfoot:
         case TagName::thead:
-            // FIXME: This could be more efficient.
-            if (!m_tree.openElements().inTableScope(HTML::td) && !m_tree.openElements().inTableScope(HTML::th)) {
+            if (!m_tree.openElements().hasAnyInTableScope({ HTML::td, HTML::th })) {
                 ASSERT(isParsingFragment());
                 parseError(token);
                 return;
@@ -1831,8 +1829,7 @@ void HTMLTreeBuilder::processEndTagForInTableBody(AtomHTMLToken&& token)
         m_insertionMode = InsertionMode::InTable;
         return;
     case TagName::table:
-        // FIXME: This is slow.
-        if (!m_tree.openElements().inTableScope(HTML::tbody) && !m_tree.openElements().inTableScope(HTML::thead) && !m_tree.openElements().inTableScope(HTML::tfoot)) {
+        if (!m_tree.openElements().hasAnyInTableScope({ HTML::tbody, HTML::thead, HTML::tfoot })) {
             ASSERT(isParsingFragmentOrTemplateContents());
             parseError(token);
             return;


### PR DESCRIPTION
#### 43e0c05a7650d6eaaf70bd81209b8f638417472c
<pre>
Improve HTMLTreeBuilder for table markup
<a href="https://bugs.webkit.org/show_bug.cgi?id=303546">https://bugs.webkit.org/show_bug.cgi?id=303546</a>
<a href="https://rdar.apple.com/165838124">rdar://165838124</a>

Reviewed by Ryosuke Niwa.

The current code had 3 FIXME pointing at the potential slowness of the
code. This improves and reduces slightly the performance isssue. It&apos;s
probably not a huge improvement. The A/B perf measurement is showing a
bit of improvement.

The code was going a couple through the same list of elements, instead
of doing one pass. This is fixing it.

* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::HTMLElementStack::hasAnyInTableScope const):
* Source/WebCore/html/parser/HTMLElementStack.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processStartTag):
(WebCore::HTMLTreeBuilder::processEndTagForInTableBody):

Canonical link: <a href="https://commits.webkit.org/303950@main">https://commits.webkit.org/303950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a48b32be5ff7267b407d5f70489c3b0ff60ead2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45349 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af3b3be8-e564-455f-99dd-d304b08a725e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136011 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e9a54c2-3063-4190-bf77-9b6b87d8583a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137088 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87923f8f-9c2f-423c-8ec0-1e77669afbde) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144367 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/6322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38944 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111198 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60092 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20718 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/6374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69840 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->