### PR TITLE
Properly handle speculationrules script element removal.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/mutate-rules.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/mutate-rules.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Removing the <script type=speculationrules> must cancel the prefetch assert_equals: expected (undefined) undefined but got (string) "prefetch"
+PASS Removing the <script type=speculationrules> must cancel the prefetch
 PASS Removing a rule from the <script type=speculationrules> must not cancel the prefetch
 PASS Adding a rule to the <script type=speculationrules> must not prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
@@ -3,5 +3,5 @@ PASS Sec-Speculation-Tags: deduped and sorted tags
 PASS Sec-Speculation-Tags: deduped and sorted tags within rules
 PASS Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets
 PASS Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets
-FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "\"abc\", \"def\", \"ghi\", \"jkl\""
+PASS Sec-Speculation-Tags: removed ruleset
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -979,13 +979,13 @@ void ScriptController::registerImportMap(const ScriptSourceCode& sourceCode, con
         globalObject->importMap().mergeExistingAndNewImportMaps(WTFMove(newImportMap.value()), reporter);
 }
 
-bool ScriptController::registerSpeculationRules(const ScriptSourceCode& sourceCode, const URL& baseURL)
+bool ScriptController::registerSpeculationRules(Node& sourceNode, const ScriptSourceCode& sourceCode, const URL& baseURL)
 {
     RefPtr document = m_frame->document();
     if (!document || !document->settings().speculationRulesPrefetchEnabled())
         return false;
 
-    return document->speculationRules()->parseSpeculationRules(sourceCode.source(), baseURL, document->url());
+    return document->speculationRules()->parseSpeculationRules(sourceNode, sourceCode.source(), baseURL, document->url());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -59,6 +59,7 @@ namespace WebCore {
 
 class CachedScriptFetcher;
 class HTMLDocument;
+class Node;
 class HTMLPlugInElement;
 class LoadableModuleScript;
 class LocalFrame;
@@ -176,7 +177,7 @@ public:
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
 
     void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
-    bool registerSpeculationRules(const ScriptSourceCode&, const URL& baseURL);
+    bool registerSpeculationRules(Node&, const ScriptSourceCode&, const URL& baseURL);
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4890,17 +4890,19 @@ void Document::processSpeculationRules()
 
     HashMap<URL, PrefetchCandidate> urlGroups;
 
-    for (const auto& rule : speculationRules()->prefetchRules()) {
-        for (const auto& url : rule.urls) {
-            auto& group = urlGroups.ensure(url, [] {
-                return PrefetchCandidate { };
-            }).iterator->value;
+    for (auto [node, rules] : speculationRules()->prefetchRules()) {
+        for (const auto& rule : rules) {
+            for (const auto& url : rule.urls) {
+                auto& group = urlGroups.ensure(url, [] {
+                    return PrefetchCandidate { };
+                }).iterator->value;
 
-            group.tagSets.append(rule.tags);
+                group.tagSets.append(rule.tags);
 
-            // Use the first referrer policy encountered for each URL
-            if (!group.referrerPolicy)
-                group.referrerPolicy = rule.referrerPolicy;
+                // Use the first referrer policy encountered for each URL
+                if (!group.referrerPolicy)
+                    group.referrerPolicy = rule.referrerPolicy;
+            }
         }
     }
 

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -137,7 +137,8 @@ void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const Ne
         ScriptSourceCode sourceCode(speculationRulesText, JSC::SourceTaintedOrigin::Untainted, URL(m_url), TextPosition(), JSC::SourceProviderSourceType::Program);
         // 5. Let ruleSet be the result of parsing a speculation rule set string given bodyText, document, and response's URL. If this throws an exception, then abort these steps.
         // 6. Append ruleSet to document's speculation rule sets.
-        if (frame->checkedScript()->registerSpeculationRules(sourceCode, m_url)) {
+        // Header-based rules use the Document as the source node.
+        if (frame->checkedScript()->registerSpeculationRules(*document, sourceCode, m_url)) {
             // 7. Consider speculative loads for document.
             document->considerSpeculationRules();
         }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -59,6 +59,7 @@ public:
     void executeModuleScript(LoadableModuleScript&);
     void registerImportMap(const ScriptSourceCode&);
     void registerSpeculationRules(const ScriptSourceCode&);
+    void unregisterSpeculationRules();
 
     void executePendingScript(PendingScript&);
 

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -78,6 +78,7 @@ void HTMLScriptElement::removedFromAncestor(RemovalType type, ContainerNode& con
 {
     HTMLElement::removedFromAncestor(type, container);
     unblockRendering();
+    unregisterSpeculationRules();
 }
 
 void HTMLScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -175,6 +175,20 @@ void DocumentPrefetcher::notifyFinished(CachedResource& resource, const NetworkL
         resource.removeClient(*this);
 }
 
+void DocumentPrefetcher::removePrefetch(const URL& url)
+{
+    auto it = m_prefetchedData.find(url);
+    if (it == m_prefetchedData.end())
+        return;
+
+    if (auto& resource = it->value.resource) {
+        if (resource->hasClient(*this))
+            resource->removeClient(*this);
+        MemoryCache::singleton().remove(*resource);
+    }
+    m_prefetchedData.remove(it);
+}
+
 bool DocumentPrefetcher::wasPrefetched(const URL& url) const
 {
     return m_prefetchedData.contains(url);

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -58,6 +58,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     void prefetch(const URL&, const Vector<String>& tags, std::optional<ReferrerPolicy>, bool lowPriority = false);
+    void removePrefetch(const URL&);
     bool wasPrefetched(const URL&) const;
     Box<NetworkLoadMetrics> takePrefetchedNetworkLoadMetrics(const URL&);
 

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -25,16 +25,19 @@
 
 #pragma once
 
+#include <WebCore/EventTarget.h>
 #include <wtf/Box.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/Variant.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class Node;
 enum class ReferrerPolicy : uint8_t;
 
 // https://wicg.github.io/nav-speculation/speculation-rules.html
@@ -100,14 +103,17 @@ public:
     static Ref<SpeculationRules> create();
 
     // https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
-    WEBCORE_EXPORT bool parseSpeculationRules(const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
+    WEBCORE_EXPORT bool parseSpeculationRules(Node& sourceNode, const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
 
-    const Vector<Rule>& prefetchRules() const;
+    // https://html.spec.whatwg.org/multipage/webappapis.html#unregister-speculation-rules
+    Vector<URL> unregisterSpeculationRules(Node& sourceNode);
+
+    const WeakHashMap<Node, Vector<Rule>, WeakPtrImplWithEventTargetData>& prefetchRules() const { return m_prefetchRulesByNode; }
 
 private:
     SpeculationRules() = default;
 
-    Vector<Rule> m_prefetchRules;
+    WeakHashMap<Node, Vector<Rule>, WeakPtrImplWithEventTargetData> m_prefetchRulesByNode;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c843c2aa8e00388e2e0f86accedc3b6ea0f76e9f
<pre>
Properly handle speculationrules script element removal.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303548">https://bugs.webkit.org/show_bug.cgi?id=303548</a>

Reviewed by Alex Christensen.

Currently when a speculationrules script element is removed, its parsed rules are still processed in the next microtask checkpoint.
This PR changes that and removeis the rules of such scripts, ensuring that no prefetch would happen if the removal happens within a microtask of the script&apos;s addition.

No new tests, but this progresses existing tests.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/mutate-rules.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt: Progression.
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::registerSpeculationRules): Pass an element.
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processSpeculationRules): Pass a callback to process each rule.
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
(WebCore::LoadableSpeculationRules::notifyFinished): Pass a nullptr instead of an element.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::registerSpeculationRules): Pass an element.
(WebCore::ScriptElement::unregisterSpeculationRules): Remove the speculation rules associated with an element.
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::SpeculationRulesMatcher::hasMatchingRule): Pass a callback to process each rule.
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::removedFromAncestor): Call unregisterSpeculationRules.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::removePrefetch): Remove a prefetched URL from cache.
* Source/WebCore/loader/DocumentPrefetcher.h:
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::SpeculationRules::parseSpeculationRules): Add rule to a container associated with its element.
(WebCore::SpeculationRules::unregisterSpeculationRules): Remove element-associated rules.
(WebCore::SpeculationRules::prefetchRules const): Deleted.
* Source/WebCore/loader/SpeculationRules.h:
(WebCore::SpeculationRules::prefetchRules const): Getter.

Canonical link: <a href="https://commits.webkit.org/304255@main">https://commits.webkit.org/304255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a5f41084a7bc1ad8367157909b13239d58c56d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86799 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103113 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70406 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5474 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3083 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111494 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5308 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7088 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35408 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70660 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->