### PR TITLE
[blocks-in-inline] Limit behavior where we create empty lines for list markers to quirks mode

### DIFF
--- a/LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line-expected.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE HTML>
+<li id="li" style="border: 1px solid black;"><span><div style="border: 1px solid red;">test</div></span></li>
+

--- a/LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line.html
+++ b/LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line.html
@@ -1,0 +1,3 @@
+<!-- webkit-test-runner [ BlocksInInlineLayoutEnabled=true ] -->
+<!DOCTYPE HTML>
+<li id="li" style="border: 1px solid black;"><span><div style="border: 1px solid red;">test</div></span></li>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -218,9 +218,11 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
         return false;
     }
 
-    auto& rootBox = formattingContext().root();
-    if (rootBox.isAnonymous() || rootBox.isListItem())
-        return false;
+    if (!formattingContext().layoutState().inStandardsMode()) {
+        auto& rootBox = formattingContext().root();
+        if (rootBox.isAnonymous() || rootBox.isListItem())
+            return false;
+    }
 
     for (auto& run : lineContent) {
         if (run.isListMarkerOutside())


### PR DESCRIPTION
#### 7fd7e6f7e795d4850d824dad0d5610abc91a7b66
<pre>
[blocks-in-inline] Limit behavior where we create empty lines for list markers to quirks mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=303550">https://bugs.webkit.org/show_bug.cgi?id=303550</a>
<a href="https://rdar.apple.com/165840871">rdar://165840871</a>

Reviewed by NOBODY (OOPS!).

Test: fast/inline/blocks-in-inline-list-marker-empty-line.html
* LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line-expected.html: Added.
* LayoutTests/fast/inline/blocks-in-inline-list-marker-empty-line.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::shouldCollapseLineBoxHeight const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd7e6f7e795d4850d824dad0d5610abc91a7b66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86047 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6977ee3-9c61-4e51-a46c-d808b3cc295b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6360 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102495 "Found 10 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-testing.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69813 "Found 3 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa5c815d-5fa5-4076-ae9e-bf9664ad19f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136932 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4936 "Found 5 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83293 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4813 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2435 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1380 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113995 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38242 "Found 8 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144210 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6166 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38819 "Found 9 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110859 "Found 10 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-testing.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6248 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5230 "Found 9 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111073 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4676 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6218 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34625 "Found 10 new test failures: editing/execCommand/insert-nested-lists-in-table.html editing/execCommand/insert-nested-lists-with-pre.html editing/execCommand/insert-nested-lists.html fast/lists/list-marker-before-content-table.html fast/lists/ordered-list-with-no-ol-tag.html fast/mediastream/granted-denied-request-management1.html http/tests/lists/list-new-parent-no-sibling-append.html imported/w3c/web-platform-tests/css/css-lists/list-and-writing-mode-001.html imported/w3c/web-platform-tests/editing/other/insert-paragraph-in-void-element.tentative.html imported/w3c/web-platform-tests/editing/run/delete-list-items-in-table-cell.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6309 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->