### PR TITLE
iOS support for extended proofreading.

### DIFF
--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -33,6 +33,7 @@
 
 #include <WebCore/CharacterRange.h>
 #include <WebCore/TextCheckingRequestIdentifier.h>
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Platform.h>
@@ -67,6 +68,14 @@ struct GrammarDetail {
     CharacterRange range;
     Vector<String> guesses;
     String userDescription;
+
+    GrammarDetail isolatedCopy() && {
+        return {
+            range,
+            crossThreadCopy(WTFMove(guesses)),
+            WTFMove(userDescription).isolatedCopy()
+        };
+    }
 };
 
 struct TextCheckingResult {
@@ -74,6 +83,15 @@ struct TextCheckingResult {
     CharacterRange range;
     Vector<GrammarDetail> details;
     String replacement;
+
+    TextCheckingResult isolatedCopy() && {
+        return {
+            type,
+            range,
+            crossThreadCopy(WTFMove(details)),
+            WTFMove(replacement).isolatedCopy()
+        };
+    }
 };
 
 struct TextCheckingGuesses {

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -256,3 +256,10 @@ selectors = [
     { name = "buildMenuOfType:", class = "AVLegibleMediaOptionsMenuController" },
 ]
 requires = ["HAVE_AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER"]
+
+[[temporary-usage]]
+request = "rdar://165789536"
+cleanup = "rdar://165842824"
+selectors = [
+    { name = "requestProofreadingReviewOfString:range:language:options:completionHandler:", class = "UITextChecker" },
+]

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1078,6 +1078,10 @@ extern void _UIApplicationCatalystRequestViewServiceIdiomAndScaleFactor(UIUserIn
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
+@interface UITextChecker (Staging_165842824)
+- (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler;
+@end
+
 #if HAVE(UITOOLTIPINTERACTION)
 @interface NSObject (NSViewDynamicToolTipManager)
 @property (readonly) NSObject *_dynamicToolTipManager;

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -308,8 +308,7 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
 - (NSInteger)requestGrammarCheckingOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *results))completionHandler
 {
-    RetainPtr overrideResult = retainPtr([_results objectForKey:stringToCheck]);
-    if (overrideResult) {
+    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck]) {
         completionHandler(0, overrideResult.get());
         return 0; // Not currently used, so return value doesn't matter. Should be the sequence number.
     }
@@ -319,6 +318,13 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(POST_EDITING_GRAMMAR_CHECKING)
+
+- (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler
+{
+    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck])
+        completionHandler(overrideResult.get());
+    return [super requestProofreadingReviewOfString:stringToCheck range:range language:language options:options completionHandler:completionHandler];
+}
 
 static NSDictionary *swizzledGrammarDetailsForString(id, SEL, NSString *stringToCheck, NSRange range, NSString *language)
 {

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -517,6 +517,10 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionShouldBeginResult) {
 
 // Start of UIKit IPI
 
+@interface UITextChecker (TestingSupport2)
+- (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler;
+@end
+
 @class UITextInputArrowKeyHistory;
 
 @interface UITextAutofillSuggestion ()


### PR DESCRIPTION
#### 43470b73513f66f2a89f973f06d2f531ba7042a7
<pre>
iOS support for extended proofreading.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303555">https://bugs.webkit.org/show_bug.cgi?id=303555</a>
<a href="https://rdar.apple.com/165075819">rdar://165075819</a>

Reviewed by Aditya Keerthi.

Add support for extended proofreading.
Additional fixes for mac based on
feedback on iOS about cross-thread copying.

* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::convertExtendedCheckingResults):
(WebKit::TextChecker::requestExtendedCheckingOfString):
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(-[LayoutTestSpellChecker requestProofreadingReviewOfString:range:language:options:completionHandler:]):
(-[LayoutTestSpellChecker requestGrammarCheckingOfString:range:language:options:completionHandler:]):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Canonical link: <a href="https://commits.webkit.org/304002@main">https://commits.webkit.org/304002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/510d1acc032a0719dbc015035abe96fda2c1883a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141831 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a405802-5b09-4476-82e5-a8c9b118b7fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136119 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1d779bc-c32b-4d9c-90f1-0e8521c3a24d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137196 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5095 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83449 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa5bd6f3-10b4-409a-8d47-7cdd225c21f8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2605 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144477 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4831 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6484 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6323 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->