### PR TITLE
[check-webkit-style] Diagnose [sdk=] conditionals in xcconfig files

### DIFF
--- a/Configurations/WebKitTargetConditionals.xcconfig
+++ b/Configurations/WebKitTargetConditionals.xcconfig
@@ -24,6 +24,12 @@
 // Use the following helpers to define build settings whose value depends on the target
 // macOS version in a succinct and future-proof way.
 //
+// Prefer these over [sdk=] conditionals in build settings. SDK conditionals
+// test for the SDK version, not deployment target version, so they are not
+// appropriate for controlling features based on platform availability. SDK
+// conditionals also apply to Mac Catalyst and are inherited by embedded
+// platforms in non-obvious ways.
+//
 // Example 1: To give the SMOOTHNESS build setting the value 3 in macOS 10.12 and later and the
 // value 2 in earlier versions, write:
 //

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -40,6 +40,7 @@ from webkitpy.common.system.logutils import configure_logging as _configure_logg
 from webkitpy.port.config import apple_additions
 from webkitpy.style.checkers.basexcconfig import BaseXcconfigChecker
 from webkitpy.style.checkers.common import categories as CommonCategories
+from webkitpy.style.checkers.xcconfig import XcconfigChecker
 from webkitpy.style.checkers.common import CarriageReturnChecker
 from webkitpy.style.checkers.contributors import ContributorsChecker
 from webkitpy.style.checkers.changelog import ChangeLogChecker
@@ -630,6 +631,7 @@ def _all_categories():
     categories = categories.union(PNGChecker.categories)
     categories = categories.union(FeatureDefinesChecker.categories)
     categories = categories.union(BaseXcconfigChecker.categories)
+    categories = categories.union(XcconfigChecker.categories)
     categories = categories.union(XcodeSchemeChecker.categories)
 
     # FIXME: Consider adding all of the pep8 categories.  Since they
@@ -798,9 +800,10 @@ class FileType:
     CMAKE = 11
     FEATUREDEFINES = 12
     BASE_XCCONFIG = 13
-    XCSCHEME = 14
-    SWIFT = 15
-    SPI_ALLOWLIST = 16
+    XCCONFIG = 14
+    XCSCHEME = 15
+    SWIFT = 16
+    SPI_ALLOWLIST = 17
 
 
 class ANSIColor:
@@ -914,6 +917,8 @@ class CheckerDispatcher(object):
             return FileType.BASE_XCCONFIG
         elif os.path.basename(file_path) == "General.xcconfig":  # gtest is different.
             return FileType.BASE_XCCONFIG
+        elif file_extension == "xcconfig":
+            return FileType.XCCONFIG
         elif os.path.basename(file_path).startswith('AllowedSPI') and file_extension == 'toml':
             return FileType.SPI_ALLOWLIST
         else:
@@ -995,6 +1000,8 @@ class CheckerDispatcher(object):
             checker = FeatureDefinesChecker(file_path, handle_style_error)
         elif file_type == FileType.BASE_XCCONFIG:
             checker = BaseXcconfigChecker(file_path, handle_style_error)
+        elif file_type == FileType.XCCONFIG:
+            checker = XcconfigChecker(file_path, handle_style_error)
         elif file_type == FileType.SPI_ALLOWLIST:
             checker = SPIAllowlistChecker(file_path, handle_style_error)
         else:

--- a/Tools/Scripts/webkitpy/style/checkers/xcconfig.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcconfig.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+"""Enforces rules for .xcconfig files."""
+
+
+class XcconfigChecker(object):
+    categories = set([
+        'xcconfig/sdk-conditional-prefer-deployment-target',
+        'xcconfig/sdk-conditional-prefer-wk-platform',
+    ])
+
+    def __init__(self, file_path, handle_style_error):
+        self._file_path = file_path
+        self._handle_style_error = handle_style_error
+
+    def check(self, lines):
+        # Pattern to match any SDK conditional
+        sdk_conditional_pattern = re.compile(r'^\s*([^=]+)\[sdk=([^\]]+)\]\s*=')
+
+        for line_number, line in enumerate(lines, start=1):
+            # Skip comments and empty lines
+            stripped_line = line.strip()
+            if not stripped_line or stripped_line.startswith('//'):
+                continue
+
+            # Check for SDK conditionals
+            match = sdk_conditional_pattern.match(line)
+            if not match:
+                continue
+            sdk_condition = match.group(2)
+
+            if any(c.isdigit() for c in sdk_condition):
+                # Versioned SDK conditional - recommend WebKitTargetConditionals.xcconfig
+                self._handle_style_error(
+                    line_number, 'xcconfig/sdk-conditional-prefer-deployment-target', 3,
+                    ('Prefer deployment-target-based build settings from WebKitTargetConditionals.xcconfig '
+                     'instead of [sdk={}]. SDK conditions apply to older OS versions '
+                     'when back-deploying, so the version number is only valid when checking for behavior in the SDK or toolchain, '
+                     'not controlling a behavior on the target OS.').format(sdk_condition))
+            else:
+                # Unversioned SDK conditional - recommend WK_PLATFORM_NAME
+                self._handle_style_error(
+                    line_number, 'xcconfig/sdk-conditional-prefer-wk-platform', 4,
+                    ('Use $(WK_PLATFORM_NAME) to conditionalize a setting for different platforms instead of [sdk={}]. '
+                     'SDK conditionals are misleading on Catalyst, and are inherited across platforms in some '
+                     'embedded SDKs.').format(sdk_condition))

--- a/Tools/Scripts/webkitpy/style/checkers/xcconfig_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcconfig_unittest.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitpy.style.checkers.xcconfig import XcconfigChecker
+
+
+class XcconfigCheckerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.errors = []
+
+        def handle_style_error(line_number, category, confidence, message):
+            self.errors.append((line_number, category, confidence, message))
+
+        self.checker = XcconfigChecker("fake_path.xcconfig", handle_style_error)
+
+    def test_versioned_sdk_conditional_detected(self):
+        """Test that versioned SDK conditionals are properly detected and flagged."""
+        lines = [
+            'WK_FOO[sdk=macosx26*] = some_value;',
+            'ANOTHER_SETTING[sdk=iphoneos15*] = another_value;',
+            'THIRD_SETTING[sdk=iphonesimulator16.0*] = third_value;'
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 3)
+
+        # Check first error - versioned SDK conditional
+        self.assertEqual(self.errors[0][0], 1)  # Line number
+        self.assertEqual(self.errors[0][1], 'xcconfig/sdk-conditional-prefer-deployment-target')  # Category
+        self.assertIn('macosx26*', self.errors[0][3])  # Message contains sdk condition
+        self.assertIn('WebKitTargetConditionals.xcconfig', self.errors[0][3])
+
+        # Check second error
+        self.assertEqual(self.errors[1][0], 2)
+        self.assertEqual(self.errors[1][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('iphoneos15*', self.errors[1][3])
+
+        # Check third error
+        self.assertEqual(self.errors[2][0], 3)
+        self.assertEqual(self.errors[2][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('iphonesimulator16.0*', self.errors[2][3])
+
+    def test_unversioned_sdk_conditionals_flagged(self):
+        """Test that unversioned SDK conditionals are flagged with WK_PLATFORM_NAME recommendation."""
+        lines = [
+            'PLATFORM_SETTING[sdk=macosx*] = value;',
+            'ANOTHER_PLATFORM[sdk=iphoneos*] = another_value;',
+            'THIRD_PLATFORM[sdk=iphonesimulator*] = third_value;',
+            'FOURTH_PLATFORM[sdk=watchos*] = fourth_value;'
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 4)
+
+        # Check that all are flagged with the WK_PLATFORM_NAME category
+        for i, error in enumerate(self.errors):
+            self.assertEqual(error[0], i + 1)  # Line number
+            self.assertEqual(error[1], 'xcconfig/sdk-conditional-prefer-wk-platform')  # Category
+            self.assertIn('WK_PLATFORM_NAME', error[3])  # Message recommends WK_PLATFORM_NAME
+
+    def test_valid_lines_not_flagged(self):
+        """Test that valid xcconfig lines without SDK conditionals are not flagged."""
+        lines = [
+            '// This is a comment',
+            '',
+            'NORMAL_SETTING = value;',
+            'SETTING_WITH_VARIABLE = $(SOME_VAR);',
+            'WK_FOO = $(WK_FOO$(WK_MACOS_2600));',
+            'WK_FOO_MACOS_SINCE_2600 = some_value;',
+            'WK_PLATFORM_SETTING = $(WK_PLATFORM_SETTING$(WK_PLATFORM_NAME));',
+            '#include "Base.xcconfig"'
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 0)
+
+    def test_mixed_content(self):
+        """Test files with both versioned and unversioned SDK conditionals."""
+        lines = [
+            '// Configuration file',
+            'VALID_SETTING = value;',
+            'UNVERSIONED_SDK[sdk=macosx*] = platform_specific;',  # Should be flagged with wk-platform
+            '',
+            'ANOTHER_VALID = $(SOME_VAR);',
+            'VERSIONED_SDK[sdk=iphoneos15*] = version_specific;',  # Should be flagged with deployment-target
+            '// End of file'
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 2)
+
+        # Check unversioned SDK conditional
+        self.assertEqual(self.errors[0][0], 3)
+        self.assertEqual(self.errors[0][1], 'xcconfig/sdk-conditional-prefer-wk-platform')
+        self.assertIn('macosx*', self.errors[0][3])
+        self.assertIn('WK_PLATFORM_NAME', self.errors[0][3])
+
+        # Check versioned SDK conditional
+        self.assertEqual(self.errors[1][0], 6)
+        self.assertEqual(self.errors[1][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('iphoneos15*', self.errors[1][3])
+        self.assertIn('WebKitTargetConditionals.xcconfig', self.errors[1][3])
+
+    def test_whitespace_handling(self):
+        """Test that various whitespace patterns are handled correctly."""
+        lines = [
+            '   VERSIONED[sdk=macosx26*]   =   value;  ',
+            '\tUNVERSIONED[sdk=iphoneos*]\t=\tvalue;\t',
+            'NO_SPACE[sdk=tvos9*]=value;'
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 3)
+
+        # Check categories are correct
+        self.assertEqual(self.errors[0][1], 'xcconfig/sdk-conditional-prefer-deployment-target')  # versioned
+        self.assertEqual(self.errors[1][1], 'xcconfig/sdk-conditional-prefer-wk-platform')       # unversioned
+        self.assertEqual(self.errors[2][1], 'xcconfig/sdk-conditional-prefer-deployment-target')  # versioned
+
+    def test_complex_setting_names(self):
+        """Test that complex setting names with underscores and prefixes work."""
+        lines = [
+            'WK_COMPLEX_SETTING_NAME[sdk=macosx26*] = value;',         # versioned
+            'OTHER_WEBKIT_FEATURE[sdk=iphoneos16*] = feature_value;',  # versioned
+            'ENABLE_SOMETHING[sdk=watchos9*] = YES;',                  # versioned
+            'UNVERSIONED_COMPLEX[sdk=macosx*] = platform_value;'       # unversioned
+        ]
+        self.checker.check(lines)
+        self.assertEqual(len(self.errors), 4)
+
+        # Check that versioned ones use deployment-target category
+        self.assertEqual(self.errors[0][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('macosx26*', self.errors[0][3])
+
+        self.assertEqual(self.errors[1][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('iphoneos16*', self.errors[1][3])
+
+        self.assertEqual(self.errors[2][1], 'xcconfig/sdk-conditional-prefer-deployment-target')
+        self.assertIn('watchos9*', self.errors[2][3])
+
+        # Check that unversioned one uses wk-platform category
+        self.assertEqual(self.errors[3][1], 'xcconfig/sdk-conditional-prefer-wk-platform')
+        self.assertIn('macosx*', self.errors[3][3])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### fc96dcdf9cce240527a43733feffc72514d69df5
<pre>
[check-webkit-style] Diagnose [sdk=] conditionals in xcconfig files
<a href="https://bugs.webkit.org/show_bug.cgi?id=302366">https://bugs.webkit.org/show_bug.cgi?id=302366</a>
<a href="https://rdar.apple.com/164520074">rdar://164520074</a>

Reviewed by NOBODY (OOPS!).

SDK conditionals are footguns for a variety of reasons:

- On Catalyst, the SDK is &quot;macosx&quot;, even though WebKit&apos;s Catalyst build
  is iOS-like. So conditions that are intended to apply only to AppKit
  macOS builds apply to Catalyst (and we don&apos;t test Catalyst as widely,
  so this can be a source of regressions that slip through EWS).

- On internal SDKs, various embedded platforms inherit from other SDKs.
  e.g. watchOS and tvOS will inherit from `iphoneos` SDK conditionals if
  they are not defined. This is confusing because the public SDKs don&apos;t
  work this way, and a source of breakage that slips through EWS.

- When back-deploying to downlevel OS versions, the SDK version doesn&apos;t
  match the target OS version. So using a conditional like
  [sdk=macosx26*]` to control a feature that ships on 26.x is wrong,
  because it will also be active for back-deployed builds to older
  releases.

We have alternative build settings for these two cases:
$(WK_PLATFORM_NAME) for cases 1 and 2, and the settings from
WebKitTargetConditionals.xcconfig for case 3. Add style rules that
recommend these patterns. For example:

    Source/WebKit/Configurations/WebKit.xcconfig:43: error: [xcconfig/sdk-conditional-prefer-wk-platform] Use $(WK_PLATFORM_NAME) to conditionalize a setting for different platforms instead of [sdk=macosx*]. SDK conditionals are misleading on Catalyst, and are inherited across platforms in some embedded SDKs.
    Source/WebKit/Configurations/WebKit.xcconfig:44: error: [xcconfig/sdk-conditional-prefer-deployment-target] Prefer deployment-target-based build settings from WebKitTargetConditionals.xcconfig instead of [sdk=macosx14*]. SDK conditions apply to older OS versions when back-deploying, so the version number is only valid when checking for behavior in the SDK or toolchain, not controlling a behavior on the target OS.

There are still some valid reasons to use an SDK condition, where this
style check should be ignored, such as:

- Conditionalizing a build setting based on compiler version
- Working around a bug in specific SDKs (e.g. modularizations)

Drafted by Claude.

* Tools/Scripts/webkitpy/style/checker.py:
(_all_categories):
(FileType):
(CheckerDispatcher._file_type):
(CheckerDispatcher._create_checker):
* Tools/Scripts/webkitpy/style/checkers/xcconfig.py: Added.
(XcconfigChecker):
(XcconfigChecker.__init__):
(XcconfigChecker.check):
* Tools/Scripts/webkitpy/style/checkers/xcconfig_unittest.py: Added.
(XcconfigCheckerTest):
(XcconfigCheckerTest.setUp):
(XcconfigCheckerTest.setUp.handle_style_error):
(XcconfigCheckerTest.test_versioned_sdk_conditional_detected):
(XcconfigCheckerTest.test_unversioned_sdk_conditionals_flagged):
(XcconfigCheckerTest.test_valid_lines_not_flagged):
(XcconfigCheckerTest.test_mixed_content):
(XcconfigCheckerTest.test_whitespace_handling):
(XcconfigCheckerTest.test_complex_setting_names):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc96dcdf9cce240527a43733feffc72514d69df5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86363 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102708 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69968 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e47acdb-a651-4acd-b5d8-9ae340f2b15b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83499 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133717 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2665 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114248 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111377 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4878 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6569 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34894 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->