### PR TITLE
[WKCI][build.webkit.org] Drop the custom step for running API tests on GTK and WPE and use the general one

### DIFF
--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -109,7 +109,7 @@ class TestFactory(Factory):
             self.addStep(ExtractTestResults())
             self.addStep(SetPermissions())
 
-        if platform.startswith(('win', 'mac', 'ios-simulator')) and self.LayoutTestClass != RunWorldLeaksTests:
+        if platform.startswith(('win', 'mac', 'ios-simulator', 'gtk', 'wpe')) and self.LayoutTestClass != RunWorldLeaksTests:
             self.addStep(RunAPITests())
 
         if platform.startswith('mac'):
@@ -122,11 +122,6 @@ class TestFactory(Factory):
 
         if platform.startswith(('mac', 'ios-simulator', 'visionos-simulator')):
             self.addStep(TriggerCrashLogSubmission())
-
-        if platform.startswith("gtk"):
-            self.addStep(RunGtkAPITests())
-        if platform == "wpe":
-            self.addStep(RunWPEAPITests())
 
 
 class BuildAndTestFactory(TestFactory):
@@ -279,12 +274,7 @@ class TestLayoutAndAPIOnlyFactory(Factory):
         self.addStep(UploadTestResults())
         self.addStep(ExtractTestResults())
         self.addStep(SetPermissions())
-        if platform.startswith("gtk"):
-            self.addStep(RunGtkAPITests())
-        elif platform == "wpe":
-            self.addStep(RunWPEAPITests())
-        else:
-            self.addStep(RunAPITests())
+        self.addStep(RunAPITests())
 
 
 class TestWebKit1Factory(TestFactory):

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1219,11 +1219,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
-            'builtins-generator-tests',
-            'API-tests'
+            'builtins-generator-tests'
         ],
         'GTK-Linux-64-bit-Release-JS-Tests': [
             'configure-build',
@@ -1285,11 +1285,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
-            'builtins-generator-tests',
-            'API-tests'
+            'builtins-generator-tests'
         ],
         'GTK-Linux-64-bit-Debug-JS-Tests': [
             'configure-build',
@@ -1423,11 +1423,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
             'builtins-generator-tests',
-            'API-tests',
             'archive-built-product',
             'upload-built-product'
         ],
@@ -1603,11 +1603,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
-            'builtins-generator-tests',
-            'API-tests',
+            'builtins-generator-tests'
         ],
         'WPE-Linux-64-bit-Release-JS-Tests': [
             'configure-build',
@@ -1669,11 +1669,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
-            'builtins-generator-tests',
-            'API-tests',
+            'builtins-generator-tests'
         ],
         'WPE-Linux-64-bit-Debug-JS-Tests': [
             'configure-build',
@@ -1868,11 +1868,11 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
+            'run-api-tests',
             'webkitpy-test',
             'webkitperl-test',
             'bindings-generation-tests',
             'builtins-generator-tests',
-            'API-tests',
             'archive-built-product',
             'upload-built-product'
         ],
@@ -1908,7 +1908,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'upload',
             'extract-test-results',
             'set-permissions',
-            'API-tests'
+            'run-api-tests'
         ],
     }
 


### PR DESCRIPTION
#### d5aea46c648789471e0f3cd4448d51cf49cff0f6
<pre>
[WKCI][build.webkit.org] Drop the custom step for running API tests on GTK and WPE and use the general one
<a href="https://bugs.webkit.org/show_bug.cgi?id=303557">https://bugs.webkit.org/show_bug.cgi?id=303557</a>

Reviewed by Aakash Jain.

GTK and WPE ports use a custom step for running the API tests on the config
of build.webkit.org, but not on the one of ews-build.webkit.org.

This patch drops the custom RunGLibAPITests() step and makes the GTK and WPE
ports use the generic RunAPITests() one instead.

Thanks to this the GTK and WPE runners will now generate the json with the
results, and the result summary string in case of failure should work now.
This was broken on the RunGLibAPITests() removed due to that step using
the legacy getText2() method instead of getResultSummary()

Also the custom high timeout on the step is removed, because since 303319@main
the tool filter-test-logs outputs each 5 minutes a summary of the number of
lines filtered, so it is not longer needed to rise the buildbot step timeouts
to avoid issues with the &quot;timeout-without-output&quot; timer.

* Tools/CISupport/build-webkit-org/factories.py:
(TestFactory.__init__):
(TestLayoutAndAPIOnlyFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(RunAPITests):
(RunAPITests.__init__):
(RunAPITests.run):
(RunMVTTests.getResultSummary):
(RunGLibAPITests): Deleted.
(RunGLibAPITests.run): Deleted.
(RunGLibAPITests.getText): Deleted.
(RunGLibAPITests.getText2): Deleted.
(RunGtkAPITests): Deleted.
(RunWPEAPITests): Deleted.
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/303928@main">https://commits.webkit.org/303928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f6610ad48ee623931196e4713c27364ca21883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45214 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135880 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/38270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6191 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/38847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/110877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/133438 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111090 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/116406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/59961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20708 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6243 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->