### PR TITLE
AX: On Cocoa platforms, attributed strings should return a new AXTable attribute

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -42,6 +42,9 @@ accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Fai
 accessibility/text-marker/text-marker-bidi-element-arabic.html [ Failure ]
 accessibility/text-marker/text-marker-bidi-element-hebrew.html [ Failure ]
 
+# Fails because we don't emit a tab between table cells.
+accessibility/mac/attributed-string-for-table.html [ Failure ]
+
 # Failures introduced by ENABLE(AX_THREAD_TEXT_APIS).
 accessibility/content-editable-as-textarea.html [ Failure ]
 accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html [ Failure ]

--- a/LayoutTests/accessibility/mac/attributed-string-for-table-expected.txt
+++ b/LayoutTests/accessibility/mac/attributed-string-for-table-expected.txt
@@ -1,0 +1,26 @@
+This test ensures we return the right attributes for text within tables.
+
+Attributes in range {0, 14}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+AXTable: {present}
+Attributes in range {14, 18}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Cell 1	Cell 2
+Text outside table
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Cell 1	Cell 2
+Text outside table

--- a/LayoutTests/accessibility/mac/attributed-string-for-table.html
+++ b/LayoutTests/accessibility/mac/attributed-string-for-table.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<table style="border-collapse:collapse; border:1px solid #ccc;">
+  <tr>
+    <td style="padding:8px; border:1px solid #ddd;">Cell 1</td>
+    <td style="padding:8px; border:1px solid #ddd;">Cell 2</td>
+  </tr>
+</table>
+
+Text outside table
+
+<script>
+var output = "This test ensures we return the right attributes for text within tables.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var markerRange = webArea.textMarkerRangeForElement(webArea);
+    output += webArea.attributedStringForTextMarkerRange(markerRange);
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -273,6 +273,11 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
 
         if (ancestor->role() == AccessibilityRole::Blockquote)
             ++blockquoteLevel;
+
+        if (ancestor->isExposableTable()) {
+            if (id wrapper = ancestor->wrapper())
+                [string.get() addAttribute:NSAccessibilityTableAttribute value:(__bridge id)adoptCF(NSAccessibilityCreateAXUIElementRef(wrapper)).get() range:range];
+        }
     }
     if (blockquoteLevel)
         [string.get() addAttribute:NSAccessibilityBlockQuoteLevelAttribute value:@(blockquoteLevel) range:range];

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -306,6 +306,7 @@
 #define NSAccessibilityIsSuggestedInsertionAttribute @"AXIsSuggestedInsertion"
 #define NSAccessibilityIsSuggestedDeletionAttribute @"AXIsSuggestedDeletion"
 #define NSAccessibilityIsSuggestionAttribute @"AXIsSuggestion"
+#define NSAccessibilityTableAttribute @"AXTable"
 
 //
 // Notifications

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -32,6 +32,7 @@
 #import "JSBasics.h"
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/JSStringRefCF.h>
+#import <WebCore/CocoaAccessibilityConstants.h>
 #import <WebKit/WebFrame.h>
 #import <WebKit/WebHTMLView.h>
 #import <wtf/RetainPtr.h>
@@ -1961,6 +1962,9 @@ static JSRetainPtr<JSStringRef> createJSStringRef(id string)
             [mutableString appendFormat:@"%@: YES\n", NSAccessibilityStrikethroughTextAttribute];
             appendColorDescription(mutableString, NSAccessibilityStrikethroughColorTextAttribute, attributes);
         }
+
+        if ([attributes objectForKey:NSAccessibilityTableAttribute])
+            [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityTableAttribute];
     };
     [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
     [mutableString appendString:[string string]];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -35,6 +35,7 @@
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/JSObjectRef.h>
 #import <JavaScriptCore/JSStringRefCF.h>
+#import <WebCore/CocoaAccessibilityConstants.h>
 #import <WebCore/DateComponents.h>
 #import <WebKit/WKBundleFrame.h>
 #import <wtf/RetainPtr.h>
@@ -2608,6 +2609,9 @@ static JSRetainPtr<JSStringRef> createJSStringRef(id string, bool includeDidSpel
         id attachment = [attributes objectForKey:NSAccessibilityAttachmentTextAttribute];
         if (attachment)
             [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityAttachmentTextAttribute];
+
+        if ([attributes objectForKey:NSAccessibilityTableAttribute])
+            [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityTableAttribute];
     };
     [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
     [mutableString appendString:[string string]];


### PR DESCRIPTION
#### 6fb775b0f1117b7e96c4b23ed896a34cd39be7f2
<pre>
AX: On Cocoa platforms, attributed strings should return a new AXTable attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=303560">https://bugs.webkit.org/show_bug.cgi?id=303560</a>
<a href="https://rdar.apple.com/164759673">rdar://164759673</a>

Reviewed by Joshua Hoffman.

Accessibility Reader on macOS wants to use this in order to render tables.

Test: accessibility/mac/attributed-string-for-table.html

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/mac/attributed-string-for-table-expected.txt: Added.
* LayoutTests/accessibility/mac/attributed-string-for-table.html: Added.
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::createJSStringRef):

Canonical link: <a href="https://commits.webkit.org/303963@main">https://commits.webkit.org/303963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a20a0e86c68a4846a638642c247a50d78119f23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86151 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/540d5372-2c82-43e3-ba29-191576c99692) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102564 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3ca20607-228c-4124-bcbb-6c3350483c84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137036 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75c18cd0-e229-462f-9830-cdb79d22e51f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2498 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1484 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144315 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110924 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4733 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6322 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34696 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6413 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->