### PR TITLE
[Site Isolation] about:blank should inherit navigator's origin

### DIFF
--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt
@@ -1,0 +1,8 @@
+This test passes if the main page can modify it's child iframe's DOM (once the child iframe has navigated away from a cross-origin site to about:blank).
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Hello from the main page

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// main frame <- this file (hosted at 127.0.0.1)
+//    |
+//    |
+// child frame <- cross origin relative to child frame. opened to:
+//    http://localhost:8000/site-isolation/resources/green-background.html
+
+// Have the main frame navigate a cross-origin child iframe
+// to about:blank. Since the main frame initiated navigation to
+// about:blank, the child iframe inherits its parent's origin.
+// If the child successfully inherited the main frame's origin, the 
+// main frame should be able to modify the child's DOM.
+
+// From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
+// 
+// If url matches about:blank or is about:srcdoc, then:
+//     Set documentState's origin to initiatorOriginSnapshot.
+//     Set documentState's about base URL to initiatorBaseURLSnapshot.
+
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+
+// Once we get back to about:blank, check that we can modify DOM
+loadedAboutBlank = function() {
+  let child = document.getElementById("child");
+  child.onload = null;
+
+  child.contentWindow.document.body.appendChild(
+      child.contentWindow.document.createTextNode('Hello from the main page')
+  );
+
+  if (window.testRunner)
+      testRunner.notifyDone();
+}
+
+loadedCrossOrigin = function() {
+    let child = document.getElementById("child");
+    child.onload = loadedAboutBlank;
+    child.src = 'about:blank';
+};
+
+</script>
+
+<p>This test passes if the main page can modify it's child iframe's DOM (once the child iframe has navigated away from a cross-origin site to about:blank).</p>
+<!-- Navigate to a cross origin url where localhost is cross-origin from 127.0.0.1 (which is where the current document is hosted at) -->
+<iframe id="child" onload="loadedCrossOrigin()" src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe> 
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt
@@ -1,0 +1,15 @@
+This test passes if the child frame can modify the grandchild iframe's DOM (once the grandchild iframe has navigated away from a cross-origin site to about:blank).
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Child iframe
+
+
+
+--------
+Frame: '<!--frame2-->'
+--------
+Hello from your parent

--- a/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<script>
+// main frame <- this file (hosted at 127.0.0.1)
+//    |
+//    |
+// child frame <- cross origin frame opened to:
+//    http://localhost:8000/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
+//    |
+//    |
+// grandchild frame <- cross origin relative to child frame. opened to:
+//    http://127.0.0.1:8000/site-isolation/resources/green-background.html
+
+// Have a child iframe navigate a cross-origin grandchild iframe
+// to about:blank. Since the grandchild iframe's parent initiated navigation
+// to about:blank, the grandchild iframe inherits its parent's origin.
+// If the grandchild successfully inerited the child's origin, the child should be 
+// able to modify the grandchild's DOM.
+
+// From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
+// 
+// If url matches about:blank or is about:srcdoc, then:
+//     Set documentState's origin to initiatorOriginSnapshot.
+//     Set documentState's about base URL to initiatorBaseURLSnapshot.
+
+
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+
+</script>
+<body>
+<p>This test passes if the child frame can modify the grandchild iframe's DOM (once the grandchild iframe has navigated away from a cross-origin site to about:blank).</p>
+<iframe src="http://localhost:8000/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html" style="border:5px solid red;"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+<script>
+
+function loadedAboutBlank() {
+    let grandchild = document.getElementById("grandchild");
+    grandchild.contentWindow.document.body.appendChild(
+        grandchild.contentWindow.document.createTextNode('Hello from your parent')
+    );
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function loadedCrossOrigin()
+{
+    // Once this frame's child loads to a cross site 
+    // origin, then we can attempt to navigate this frame's 
+    // child to about:blank which should make it change origin to
+    // whatever this current frame's origin is. Then, once we share 
+    // origins, we should be able to modify the frame's DOM.
+    let grandchild = document.getElementById("grandchild");
+    grandchild.onload = loadedAboutBlank;
+    grandchild.src = "about:blank";
+}
+</script>
+</head>
+<body>
+<p>Child iframe</p>
+
+<!-- Navigate to a cross origin url (where 127.0.0.1 is cross origin from localhost. keep in mind the current document is opened located at localhost)-->
+<iframe id="grandchild" onload="loadedCrossOrigin()" src="http://127.0.0.1:8000/site-isolation/resources/green-background.html" style="border:5px solid blue;"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling-expected.txt
@@ -1,0 +1,3 @@
+Testing scrolling
+
+scrollY: 2000, works: true

--- a/LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<style>
+body {
+    height: 3000px;
+    margin: 0;
+    padding: 20px;
+    background: repeating-linear-gradient(#ff7e5f, #feb47b 500px);
+}
+</style>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+const fromNavigation = new URLSearchParams(location.search).has('fromNavigation');
+
+// Only set up testRunner if running standalone (not navigated to from another test)
+if (window.testRunner && !fromNavigation) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runScrollTest() {
+    document.getElementById('results').textContent = `eventSender: ${!!window.eventSender}, testRunner: ${!!window.testRunner}`;
+
+    if (!window.eventSender && window.testRunner) {
+        testRunner.notifyDone();
+        return;
+    }
+
+    await UIHelper.mouseWheelScrollAt(100, 100, 0, 0, 0, -200);
+    await UIHelper.waitForScrollCompletion();
+
+    const scrollY = window.scrollY;
+    document.getElementById('results').textContent = `scrollY: ${scrollY}, works: ${scrollY > 0}`;
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.addEventListener('load', runScrollTest);
+</script>
+<body>
+<p>Testing scrolling</p>
+<pre id="results">Running test...</pre>
+</body>

--- a/LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation-expected.txt
@@ -1,0 +1,3 @@
+Testing scrolling
+
+scrollY: 2000, works: true

--- a/LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html
@@ -1,0 +1,17 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// Navigate to cross-origin page where the scroll test will be performed.
+// localhost is treated as cross-origin relative to 127.0.0.1 (which is where the test runner hosts this file)
+window.addEventListener('load', () => {
+    location.href = "http://localhost:8000/site-isolation/scrolling/basic-mouse-wheel-scrolling.html?fromNavigation=1";
+});
+</script>
+<body>
+Navigating to cross-origin page...
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -308,6 +308,8 @@ fast/scrolling/iframe-scrollable-after-back.html [ Skip ]
 fast/scrolling/overflow-scrollable-after-back.html [ Skip ]
 fast/scrolling/programmatic-scroll-to-zero-zero.html [ Skip ]
 http/tests/site-isolation/wheel-event-coordinates.html [ Skip ]
+http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling.html [ Skip ]
+http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html [ Skip ]
 
 # This test requires alpha-channel video support.
 compositing/video/video-background-color.html [ WontFix ]

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
@@ -38,6 +38,11 @@ using SandboxFlags = OptionSet<SandboxFlag>;
 
 namespace WebKit {
 
+enum class CommitTiming : bool {
+    WaitForLoad,
+    Immediately,
+};
+
 struct ProvisionalFrameCreationParameters {
     WebCore::FrameIdentifier frameID;
     std::optional<WebCore::FrameIdentifier> frameIDBeforeProvisionalNavigation;
@@ -46,6 +51,7 @@ struct ProvisionalFrameCreationParameters {
     WebCore::ReferrerPolicy effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };
     WebCore::ScrollbarMode scrollingMode;
     std::optional<WebCore::IntRect> initialRect;
+    CommitTiming commitTiming { CommitTiming::WaitForLoad };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
@@ -28,4 +28,5 @@ struct WebKit::ProvisionalFrameCreationParameters {
     WebCore::ReferrerPolicy effectiveReferrerPolicy;
     WebCore::ScrollbarMode scrollingMode;
     std::optional<WebCore::IntRect> initialRect;
+    WebKit::CommitTiming commitTiming;
 };

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -39,22 +39,15 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalFrameProxy);
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess, CommitTiming commitTiming)
     : m_frame(frame)
     , m_frameProcess(WTF::move(frameProcess))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
 {
     Ref process = this->process();
     process->markProcessAsRecentlyUsed();
-    process->send(Messages::WebFrame::CreateProvisionalFrame(ProvisionalFrameCreationParameters {
-        frame.frameID(),
-        std::nullopt,
-        frame.layerHostingContextIdentifier(),
-        frame.effectiveSandboxFlags(),
-        frame.effectiveReferrerPolicy(),
-        frame.scrollingMode(),
-        frame.remoteFrameRect()
-    }), frame.frameID());
+    auto parameters = frame.provisionalFrameCreationParameters(std::nullopt, frame.layerHostingContextIdentifier(), commitTiming);
+    process->send(Messages::WebFrame::CreateProvisionalFrame(parameters), frame.frameID());
 }
 
 ProvisionalFrameProxy::~ProvisionalFrameProxy()

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -37,11 +37,12 @@ class FrameProcess;
 class VisitedLinkStore;
 class WebFrameProxy;
 class WebProcessProxy;
+enum class CommitTiming : bool;
 
 class ProvisionalFrameProxy : public RefCountedAndCanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
-    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
+    explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&, CommitTiming);
 
     ~ProvisionalFrameProxy();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -298,15 +298,11 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             mainFrame->frameTreeCreationParameters(),
             websitePolicies ? std::optional(websitePolicies->dataForProcess(process)) : std::nullopt
         };
-        creationParameters.provisionalFrameCreationParameters = ProvisionalFrameCreationParameters {
-            m_mainFrame->frameID(),
+        creationParameters.provisionalFrameCreationParameters = mainFrame->provisionalFrameCreationParameters(
             page->mainFrame() && !m_shouldReuseMainFrame ? std::optional(page->mainFrame()->frameID()) : std::nullopt,
             std::nullopt,
-            mainFrame->effectiveSandboxFlags(),
-            mainFrame->effectiveReferrerPolicy(),
-            mainFrame->scrollingMode(),
-            mainFrame->remoteFrameRect()
-        };
+            CommitTiming::WaitForLoad
+        );
     }
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTF::move(creationParameters)), 0);
     if (!preferences->siteIsolationEnabled())

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -39,6 +39,7 @@
 #include "LoadedWebArchive.h"
 #include "MessageSenderInlines.h"
 #include "NetworkProcessMessages.h"
+#include "ProvisionalFrameCreationParameters.h"
 #include "ProvisionalFrameProxy.h"
 #include "ProvisionalPageProxy.h"
 #include "RemotePageProxy.h"
@@ -519,19 +520,23 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&&
 #endif
 }
 
-void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process, API::Navigation& navigation, BrowsingContextGroup& group, CompletionHandler<void(WebCore::PageIdentifier)>&& completionHandler)
+void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process, API::Navigation& navigation, BrowsingContextGroup& group, std::optional<SecurityOriginData> effectiveOrigin, CompletionHandler<void(WebCore::PageIdentifier)>&& completionHandler)
 {
     if (isMainFrame())
         return completionHandler(*webPageIDInCurrentProcess());
 
-    Site navigationSite(navigation.currentRequest().url());
+    Site site = effectiveOrigin ? Site { *effectiveOrigin } : Site { navigation.currentRequest().url() };
     RefPtr page = m_page.get();
     // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
     Site mainFrameSite(page->mainFrame()->url());
     auto mainFrameDomain = mainFrameSite.domain();
 
+    // If we have an effectiveOrigin, it means we are loading about:blank which doesn't have any resources
+    // to load can commit it's provisional frame immediately
+    CommitTiming commitTiming = effectiveOrigin ? CommitTiming::Immediately : CommitTiming::WaitForLoad;
+
     m_provisionalFrame = nullptr;
-    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(navigationSite, mainFrameSite, process, page->protectedPreferences())));
+    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, page->protectedPreferences()), commitTiming));
     page->protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
         completionHandler(pageID);
     });
@@ -947,6 +952,20 @@ void WebFrameProxy::getNodeForSelectorPaths(Vector<HashSet<String>>&& selectors,
         return completion({ });
 
     sendWithAsyncReply(Messages::WebFrame::GetNodeForSelectorPaths(WTF::move(selectors)), WTF::move(completion));
+}
+
+ProvisionalFrameCreationParameters WebFrameProxy::provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier> frameIDBeforeProvisionalNavigation, std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier, CommitTiming commitTiming)
+{
+    return ProvisionalFrameCreationParameters {
+        frameID(),
+        frameIDBeforeProvisionalNavigation,
+        layerHostingContextIdentifier,
+        effectiveSandboxFlags(),
+        effectiveReferrerPolicy(),
+        scrollingMode(),
+        remoteFrameRect(),
+        commitTiming,
+    };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "FrameLoadState.h"
 #include "MessageReceiver.h"
+#include "ProvisionalFrameCreationParameters.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
@@ -214,7 +215,7 @@ public:
     bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
     ProcessID processID() const;
-    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, CompletionHandler<void(WebCore::PageIdentifier)>&&);
+    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(WebCore::PageIdentifier)>&&);
 
     void commitProvisionalFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
 
@@ -302,6 +303,7 @@ public:
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
+    ProvisionalFrameCreationParameters provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::LayerHostingContextIdentifier>, CommitTiming);
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2277,6 +2277,12 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         return { WTF::move(sourceProcess), nullptr, "Process has not yet committed any provisional loads"_s };
     }
 
+    if (siteIsolationEnabled && navigation.currentRequest().url().isAboutBlank()) {
+        RefPtr navigationOriginatorFrame = navigation.originatingFrameInfo() ? WebFrameProxy::webFrame(navigation.originatingFrameInfo()->frameID) : nullptr;
+        if (navigationOriginatorFrame)
+            return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank from a cross site origin. Switching to process that originated navigation."_s };
+    }
+
     // FIXME: We should support process swap when a window has been opened via window.open() without 'noopener'.
     // The issue is that the opener has a handle to the WindowProxy.
     //

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -478,6 +478,9 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
         setLayerHostingContextIdentifier(*parameters.layerHostingContextIdentifier);
     if (parameters.initialRect)
         updateLocalFrameRect(localFrame, *parameters.initialRect);
+
+    if (parameters.commitTiming == CommitTiming::Immediately)
+        commitProvisionalFrame();
 }
 
 void WebFrame::destroyProvisionalFrame()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -7617,6 +7617,122 @@ TEST(SiteIsolation, RequestRectForFoundTextRangeIOS)
 
 #endif
 
+TEST(SiteIsolation, MainPageNavigatesCrossOriginIframeToAboutBlank)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe id='iframe1' src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "<script>alert('loaded iframe1');</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    // Load main page
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+
+    // Wait until cross-origin iframe is loaded
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded iframe1");
+
+    // Before the main page navigates the iframe, check that
+    // the iframe is in a separate process.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s,
+            { { RemoteFrame } }
+        },
+        { RemoteFrame,
+            { { "https://webkit.org"_s } }
+        },
+    });
+
+    // Have the main frame navigate a cross-origin child iframe
+    // to about:blank.
+    // The about:blank iframe should inherit the origin of it's parent,
+    // or it's opener if the parent doesn't exist.
+    // https://dev.w3.org/html5/spec-LC/origin-0.html
+    // https://dev.w3.org/html5/spec-LC/browsers.html#about-blank-origin
+    //
+    // iframe goes from "https://example.com/example" -> "about:blank"
+    // and inherits the origin of the origin which initiated navigation.
+    [webView evaluateJavaScript:
+        @"let iframe1 = document.getElementById('iframe1');"
+        "iframe1.onload = () => { alert('loaded about:blank'); };"
+        "iframe1.src = 'about:blank';"
+    completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded about:blank");
+
+    auto mainFrame = [webView mainFrame];
+    auto childFrame = mainFrame.childFrames.firstObject;
+    pid_t mainFramePid = mainFrame.info._processIdentifier;
+    pid_t childFramePid = childFrame.info._processIdentifier;
+    EXPECT_NE(mainFramePid, 0);
+    EXPECT_NE(childFramePid, 0);
+    EXPECT_EQ(mainFramePid, childFramePid);
+    EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+    EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
+
+    // After navigation, the cross-origin iframe has now become about:blank
+    // and should have the same origin as the main page.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s,
+            { { "https://example.com"_s } }
+        },
+    });
+}
+
+TEST(SiteIsolation, ChildIframeNavigatesCrossOriginGrandchildIframeToAboutBlank)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe id='child' src='https://example.com/child_iframe'></iframe>"_s } },
+        { "/child_iframe"_s, { "<iframe id='grandchild' src='https://webkit.org/grandchild_iframe'></iframe>"_s } },
+        { "/grandchild_iframe"_s, { "<script>alert('loaded webkit.org');</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+
+    // wait for cross-origin grandchild iframe to be loaded
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded webkit.org");
+
+    // ensure that the cross-origin grandchild iframe is in a separate process
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s,
+            { { "https://example.com"_s, { { RemoteFrame } } } }
+        },
+        { RemoteFrame,
+            { { RemoteFrame, { { "https://webkit.org"_s } } } }
+        },
+    });
+
+    // note that this JavaScript gets executed in the context of the
+    // child iframe (which is at example.com).
+    //
+    // The example.com child iframe navigates the webkit.org grandchild iframe.
+    // to about:blank
+    [webView evaluateJavaScript:
+        @"let grandchild = document.getElementById('grandchild');"
+        "grandchild.onload = () => { alert('loaded about:blank'); };"
+        "grandchild.src = 'about:blank';"
+    inFrame:[webView firstChildFrame]
+    completionHandler:nil];
+
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded about:blank");
+
+    auto mainFrame = [webView mainFrame];
+    auto childFrame = mainFrame.childFrames.firstObject;
+    auto grandChildFrame = childFrame.childFrames.firstObject;
+    pid_t childFramePid = childFrame.info._processIdentifier;
+    pid_t grandChildFramePid = grandChildFrame.info._processIdentifier;
+    EXPECT_NE(childFramePid, 0);
+    EXPECT_NE(grandChildFramePid, 0);
+    EXPECT_EQ(childFramePid, grandChildFramePid);
+    EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
+    EXPECT_WK_STREQ(grandChildFrame.info.securityOrigin.host, "example.com");
+
+    // After navigation, the cross-origin iframe has now become about:blank
+    // and should have the same origin as the main page.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s,
+            { { "https://example.com"_s,  { { "https://example.com"_s } } } }
+        },
+    });
+}
+
 TEST(SiteIsolation, BrowsingContextGroupSwitchForIncompatibleCrossOriginOpenerPolicy)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 866e9a21fa2c5cf672e970ca241b6e06b544c67b
<pre>
[Site Isolation] about:blank should inherit navigator&apos;s origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=302102">https://bugs.webkit.org/show_bug.cgi?id=302102</a>
<a href="https://rdar.apple.com/160706600">rdar://160706600</a>

Reviewed by Alex Christensen.

Re-landing #52845 since it was reverted
after breaking scrolling with site isolation.
See <a href="https://bugs.webkit.org/show_bug.cgi?id=303451">https://bugs.webkit.org/show_bug.cgi?id=303451</a>

The issue with scrolling arose because I created a helper method to wrap
the creation of ProvisionalFrameCreationParameters. In one of the calls
of the helper method, I created a ProvisionalFrameCreationParameters where
the layerHostingContextIdentifier field came from WebFrameProxy::layerHostingContextIdentifier().
However, in the original code there was an instance where layerHostingContextIdentifier
was set to std::nullopt. My helper method didn&apos;t account for this use case,
and would always set layerHostingContextIdentifier to WebFrameProxy::layerHostingContextIdentifier().

Now, WebFrameProxy::provisionalFrameCreationParameters will take an additional
argument to specify the layerHostingContextIdentifier.

Also, adding a new test (http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html)
which will navigate the page to a cross-origin site and attempt to scroll.

Original commit message:

        If an iframe is navigated to about:blank, it should inherit the origin
        of whoever initiated the navigation.

        With site isolation, this means that the about:blank iframe needs to
        be in the same process as the navigator. If the iframe was previously
        in a different origin than the navigator, this might require a process
        swap.

        This patch also attempts to perform these loads to about:blank &quot;immediately&quot;
        by committing a provisional frame right after creating one since about:blank
        iframes don&apos;t have any network resources to load.

Tests: http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html
       http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html
       http/tests/site-isolation/scrolling/scroll-down-key.html
       http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-main-page.html: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-child-navigate-to-about-blank-from-cross-origin-initiated-by-parent-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/basic-mouse-wheel-scrolling.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::provisionalFrameCreationParameters):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MainPageNavigatesCrossOriginIframeToAboutBlank)):
(TestWebKitAPI::(SiteIsolation, ChildIframeNavigatesCrossOriginGrandchildIframeToAboutBlank)):

Canonical link: <a href="https://commits.webkit.org/305648@main">https://commits.webkit.org/305648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b5bb6b87c90f9b0dbc40e0fe24633571c911f86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146994 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fd56c2a-ca81-4cab-a39b-7541d017f92c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106296 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f806c8d-a2fb-4515-8bff-e122257fd901) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9024 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87166 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c8daa38-709f-453f-b3b6-c99fb3ee3f8d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6345 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149780 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10924 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114683 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114999 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8902 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65829 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21426 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10973 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->