### PR TITLE
Switch to WeakPtr for WebPageProxy in TextCheckerCompletion.

### DIFF
--- a/Source/WebKit/UIProcess/TextCheckerCompletion.cpp
+++ b/Source/WebKit/UIProcess/TextCheckerCompletion.cpp
@@ -43,11 +43,6 @@ TextCheckerCompletion::TextCheckerCompletion(TextCheckerRequestID requestID, con
 {
 }
 
-Ref<WebPageProxy> TextCheckerCompletion::protectedPage() const
-{
-    return m_page.get();
-}
-
 const TextCheckingRequestData& TextCheckerCompletion::textCheckingRequestData() const
 {
     return m_requestData;
@@ -55,20 +50,31 @@ const TextCheckingRequestData& TextCheckerCompletion::textCheckingRequestData() 
 
 int64_t TextCheckerCompletion::spellDocumentTag()
 {
-    return protectedPage()->spellDocumentTag();
+    RefPtr page = m_page.get();
+    if (page)
+        return page->spellDocumentTag();
+    return -1;
 }
 
 void TextCheckerCompletion::didFinishCheckingText(const Vector<TextCheckingResult>& result) const
 {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (result.isEmpty())
         didCancelCheckingText();
 
-    protectedPage()->didFinishCheckingText(m_requestID, result);
+    page->didFinishCheckingText(m_requestID, result);
 }
 
 void TextCheckerCompletion::didCancelCheckingText() const
 {
-    protectedPage()->didCancelCheckingText(m_requestID);
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    page->didCancelCheckingText(m_requestID);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/TextCheckerCompletion.h
+++ b/Source/WebKit/UIProcess/TextCheckerCompletion.h
@@ -48,11 +48,9 @@ public:
 private:
     TextCheckerCompletion(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy&);
 
-    Ref<WebPageProxy> protectedPage() const;
-
     const TextCheckerRequestID m_requestID;
     const WebCore::TextCheckingRequestData m_requestData;
-    WeakRef<WebPageProxy> m_page;
+    WeakPtr<WebPageProxy> m_page;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 9dfee2008ef600793cc9bea4c10be3469f6efb75
<pre>
Switch to WeakPtr for WebPageProxy in TextCheckerCompletion.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303569">https://bugs.webkit.org/show_bug.cgi?id=303569</a>
<a href="https://rdar.apple.com/165860363">rdar://165860363</a>

Reviewed by Wenson Hsieh.

When working on 303913@main one of the pieces of feedback
resulted in an empty class that then caused me to try and
use an empty Ref. This caused a crash. While the fix for that
issue was different, it exposed that the relationship between
TextCheckerCompletion and WebPageProxy was incorrect and we should
have an WeakPtr in the case that we&apos;ve lost our WebPageProxy.

* Source/WebKit/UIProcess/TextCheckerCompletion.cpp:
(WebKit::TextCheckerCompletion::protectedPage const):
(WebKit::TextCheckerCompletion::spellDocumentTag):
(WebKit::TextCheckerCompletion::didFinishCheckingText const):
(WebKit::TextCheckerCompletion::didCancelCheckingText const):
* Source/WebKit/UIProcess/TextCheckerCompletion.h:

Canonical link: <a href="https://commits.webkit.org/303964@main">https://commits.webkit.org/303964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/923018cde9c2614897a2a1657f251b0fab633461

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86120 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd229a16-a904-4eb8-98a9-935f456883d6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/349fc7b8-f401-462c-9939-b082af0e284d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83330 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/175f9cdf-8ad5-4012-a792-aa1888bd3017) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2479 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1453 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114021 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144284 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110905 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4717 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60009 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34678 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->