### PR TITLE
[Xcode] Build settings passed to `make` should forward to xcodebuild

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -19,7 +19,51 @@ BUILD_WEBKIT_BASE += --no-use-workspace
 BUILD_GOAL = $(notdir $(CURDIR))
 endif
 
-XCODE_OPTIONS = $(ARGS)
+# These variables control custom behavior in the Makefile. All other variables
+# passed on the command line are forwarded to xcodebuild directly, in the
+# BUILD_SETTING_OVERRIDES assignment below.
+MAKE_ARGS = \
+    ANALYZER_EXEC \
+    ANALYZER_FLAGS \
+    ANALYZER_OUTPUT \
+    ARCHS \
+    ARGS \
+    ASAN \
+    BUILD_WEBKIT_OPTIONS \
+    CC \
+    CODE_COVERAGE \
+    CPLUSPLUS \
+    ENABLE_LLVM_PROFILE_GENERATION \
+    EXPORT_COMPILE_COMMANDS \
+    EXTRA_CFLAGS \
+    GCC_PREPROCESSOR_ADDITIONS \
+    LIBFUZZER \
+    OTHER_CFLAGS \
+    OTHER_LDFLAGS \
+    PATH_TO_SCAN_BUILD \
+    SCHEME \
+    SDKROOT \
+    SDK_VARIANT \
+    TSAN \
+    UBSAN \
+    USE_WORKSPACE \
+    VERBOSITY \
+    WK_LTO_MODE \
+    WK_SANITIZER_COVERAGE \
+    WK_USE_CCACHE \
+    WORKSPACE_PATH \
+    #
+
+BUILD_SETTING_OVERRIDES := $(filter-out $(MAKE_ARGS),$(foreach v,$(.VARIABLES),$(if $(findstring command line,$(origin $v)),$v)))
+
+ifneq (,$(ARGS))
+_ARGS_THAT_COULD_BE_COMMAND_LINE_VARIABLES := $(shell printf '%s\n' $(ARGS) | perl -nE 'say for /\w+=.*/g')
+ifneq (,$(_ARGS_THAT_COULD_BE_COMMAND_LINE_VARIABLES))
+$(warning Passing build settings via ARGS is deprecated. "$(_ARGS_THAT_COULD_BE_COMMAND_LINE_VARIABLES)" can be passed directly on the Make command line.)
+endif
+endif
+
+XCODE_OPTIONS = $(foreach v,$(BUILD_SETTING_OVERRIDES),$v=$($v)) $(ARGS)
 XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
 ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
 	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION


### PR DESCRIPTION
#### 860ff6168af4cfde4af28634134e55af4ac3d706
<pre>
[Xcode] Build settings passed to `make` should forward to xcodebuild
<a href="https://bugs.webkit.org/show_bug.cgi?id=303566">https://bugs.webkit.org/show_bug.cgi?id=303566</a>
<a href="https://rdar.apple.com/problem/165857240">rdar://problem/165857240</a>

We have handwritten Makefile logic to pass specific common build
settings like SDKROOT and ARCHS through to xcodebuild, but passing
arbitrary build settings requires using &quot;ARGS&quot;. Use a bit of Make
metaprogramming to analyze the $(.VARIABLES) which originate from
command-line overrides. Any variables that are not part of a known set
that control Makefile logic should be passed through to xcodebuild.

For example, controlling the macOS deployment target would previously
require an invocation like:

    make debug ARGS=&quot;MACOSX_DEPLOYMENT_TARGET=15.4&quot;  # old way

Now it can be passed more fluently like:

    make debug MACOSX_DEPLOYMENT_TARGET=15.4         # new way

Add a diagnostic which recognizes build-setting-like words in $(ARGS)
and emit a warning to  encourage the new style.

* Makefile.shared:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/860ff6168af4cfde4af28634134e55af4ac3d706

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86131 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69831 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a79f23e2-36b8-454e-8ac2-22d65ffcf8d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6498fd7f-97d4-422b-b11b-a06a1182c4d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2491 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1464 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126146 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114234 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144295 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132583 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111136 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4723 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60020 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6302 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34676 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6148 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43214 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->