### PR TITLE
Web process crashes under PDFPluginBase::getByteRanges() during background data preload

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -429,14 +429,16 @@ bool PDFPluginBase::getByteRanges(CFMutableArrayRef dataBuffersArray, std::span<
         RELEASE_ASSERT(range.location >= 0);
         RELEASE_ASSERT(range.length >= 0);
 
-        if (haveStreamedDataForRange(range.location, range.length))
-            return true;
-
         uint64_t rangeLocation = range.location;
         uint64_t rangeLength = range.length;
 
         uint64_t dataLength = CFDataGetLength(m_data.get());
-        if (rangeLocation + rangeLength > dataLength)
+        bool rangeExtentIsSmallerThanBufferSize = isSumSmallerThanOrEqual(rangeLocation, rangeLength, dataLength);
+
+        if (haveStreamedDataForRange(rangeLocation, rangeLength))
+            return rangeExtentIsSmallerThanBufferSize;
+
+        if (!rangeExtentIsSmallerThanBufferSize)
             return false;
 
         return m_validRanges.contains({ rangeLocation, rangeLocation + rangeLength - 1 });


### PR DESCRIPTION
#### 0fc6efb01ba8e276319400fc2831509e2d76cadf
<pre>
Web process crashes under PDFPluginBase::getByteRanges() during background data preload
<a href="https://bugs.webkit.org/show_bug.cgi?id=303543">https://bugs.webkit.org/show_bug.cgi?id=303543</a>
<a href="https://rdar.apple.com/130266446">rdar://130266446</a>

Reviewed by Wenson Hsieh.

The WCP is crashing under PDFPluginBase::getByteRanges() when PDFKit
requests byte ranges during preloading. Code inspection suggests subspan
creation can trigger UB (like crashing) if we integer overflow in the
range validation logic, where range.location + range.length can overflow
and incorrectly pass the bounds check, allowing an OOB read at line 451.

This patch applies the same hardening fix from 297764@main to
getByteRanges(). We adopt isSumSmallerThanOrEqual() to safely validate
range extents. Additionally, even when haveStreamedDataForRange()
returns true, we now verify that the range is within buffer bounds
before attempting to create the subspan.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::getByteRanges const):

Canonical link: <a href="https://commits.webkit.org/303958@main">https://commits.webkit.org/303958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3360ddd0ec7578f8b97efe46ebe161ecd1e4fe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86133 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8edb40a3-77de-48a4-84c6-ea7ba2460bc3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102549 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/102b4a5f-cd48-4768-ba82-993aa981de52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f190edb7-8245-400a-8f1b-ecab41ad9efc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2487 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1466 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114025 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110913 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111137 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4721 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60022 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34677 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->