### PR TITLE
[CSS Zoom] Reduce redundant calls to RenderStyle::usedZoomForLength

### DIFF
--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -199,9 +199,9 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
     unsigned tableVerticalBorderSpacing = 0;
     if (CheckedPtr<const RenderStyle> tableStyle = safeStyleFrom(tableElement)) {
         tableBackgroundColor = tableStyle->visitedDependentColor(CSSPropertyBackgroundColor);
-        tableHorizontalBorderSpacing = tableStyle->borderHorizontalSpacing().resolveZoom(tableStyle->usedZoomForLength());
-        tableVerticalBorderSpacing = tableStyle->borderVerticalSpacing().resolveZoom(tableStyle->usedZoomForLength());
-
+        const auto& zoomFactor = tableStyle->usedZoomForLength();
+        tableHorizontalBorderSpacing = tableStyle->borderHorizontalSpacing().resolveZoom(zoomFactor);
+        tableVerticalBorderSpacing = tableStyle->borderVerticalSpacing().resolveZoom(zoomFactor);
     }
 
     unsigned cellCount = 0;

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -340,12 +340,13 @@ VerticalGeometry FormattingGeometry::outOfFlowNonReplacedVerticalGeometry(const 
 
     auto& formattingContext = this->formattingContext();
     auto& style = layoutBox.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto& boxGeometry = formattingContext.geometryForBox(layoutBox);
     auto containingBlockHeight = verticalConstraints.logicalHeight;
     auto containingBlockWidth = horizontalConstraints.logicalWidth;
 
-    auto top = computedValue(style.logicalTop(), containingBlockWidth, style.usedZoomForLength());
-    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, style.usedZoomForLength());
+    auto top = computedValue(style.logicalTop(), containingBlockWidth, zoomFactor);
+    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, zoomFactor);
     auto height = overriddenVerticalValues.height ? overriddenVerticalValues.height.value() : computedHeight(layoutBox, containingBlockHeight);
     auto computedVerticalMargin = FormattingGeometry::computedVerticalMargin(layoutBox, horizontalConstraints);
     UsedVerticalMargin::NonCollapsedValues usedVerticalMargin; 
@@ -460,12 +461,13 @@ HorizontalGeometry FormattingGeometry::outOfFlowNonReplacedHorizontalGeometry(co
 
     auto& formattingContext = this->formattingContext();
     auto& style = layoutBox.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto& boxGeometry = formattingContext.geometryForBox(layoutBox);
     auto containingBlockWidth = horizontalConstraints.logicalWidth;
     auto isLeftToRightDirection = FormattingContext::containingBlock(layoutBox).writingMode().isBidiLTR();
     
-    auto left = computedValue(style.logicalLeft(), containingBlockWidth, style.usedZoomForLength());
-    auto right = computedValue(style.logicalRight(), containingBlockWidth, style.usedZoomForLength());
+    auto left = computedValue(style.logicalLeft(), containingBlockWidth, zoomFactor);
+    auto right = computedValue(style.logicalRight(), containingBlockWidth, zoomFactor);
     auto width = overriddenHorizontalValues.width ? overriddenHorizontalValues.width : computedWidth(layoutBox, containingBlockWidth);
     auto computedHorizontalMargin = FormattingGeometry::computedHorizontalMargin(layoutBox, horizontalConstraints);
     UsedHorizontalMargin usedHorizontalMargin;
@@ -587,12 +589,13 @@ VerticalGeometry FormattingGeometry::outOfFlowReplacedVerticalGeometry(const Ele
 
     auto& formattingContext = this->formattingContext();
     auto& style = replacedBox.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto& boxGeometry = formattingContext.geometryForBox(replacedBox);
     auto containingBlockHeight = verticalConstraints.logicalHeight;
     auto containingBlockWidth = horizontalConstraints.logicalWidth;
 
-    auto top = computedValue(style.logicalTop(), containingBlockWidth, style.usedZoomForLength());
-    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, style.usedZoomForLength());
+    auto top = computedValue(style.logicalTop(), containingBlockWidth, zoomFactor);
+    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, zoomFactor);
     auto height = inlineReplacedContentHeightAndMargin(replacedBox, horizontalConstraints, verticalConstraints, overriddenVerticalValues).contentHeight;
     auto computedVerticalMargin = FormattingGeometry::computedVerticalMargin(replacedBox, horizontalConstraints);
     std::optional<LayoutUnit> usedMarginBefore = computedVerticalMargin.before;
@@ -672,12 +675,13 @@ HorizontalGeometry FormattingGeometry::outOfFlowReplacedHorizontalGeometry(const
 
     auto& formattingContext = this->formattingContext();
     auto& style = replacedBox.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto& boxGeometry = formattingContext.geometryForBox(replacedBox);
     auto containingBlockWidth = horizontalConstraints.logicalWidth;
     auto isLeftToRightDirection = FormattingContext::containingBlock(replacedBox).writingMode().isBidiLTR();
 
-    auto left = computedValue(style.logicalLeft(), containingBlockWidth, style.usedZoomForLength());
-    auto right = computedValue(style.logicalRight(), containingBlockWidth, style.usedZoomForLength());
+    auto left = computedValue(style.logicalLeft(), containingBlockWidth, zoomFactor);
+    auto right = computedValue(style.logicalRight(), containingBlockWidth, zoomFactor);
     auto computedHorizontalMargin = FormattingGeometry::computedHorizontalMargin(replacedBox, horizontalConstraints);
     std::optional<LayoutUnit> usedMarginStart = computedHorizontalMargin.start;
     std::optional<LayoutUnit> usedMarginEnd = computedHorizontalMargin.end;
@@ -1011,10 +1015,11 @@ LayoutSize FormattingGeometry::inFlowPositionedPositionOffset(const Box& layoutB
     // 3. If neither is 'auto', 'bottom' is ignored (i.e., the used value of 'bottom' will be minus the value of 'top').
 
     auto& style = layoutBox.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto containingBlockWidth = horizontalConstraints.logicalWidth;
 
-    auto top = computedValue(style.logicalTop(), containingBlockWidth, style.usedZoomForLength());
-    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, style.usedZoomForLength());
+    auto top = computedValue(style.logicalTop(), containingBlockWidth, zoomFactor);
+    auto bottom = computedValue(style.logicalBottom(), containingBlockWidth, zoomFactor);
 
     if (!top && !bottom) {
         // #1
@@ -1041,8 +1046,8 @@ LayoutSize FormattingGeometry::inFlowPositionedPositionOffset(const Box& layoutB
     //    If the 'direction' property of the containing block is 'ltr', the value of 'left' wins and 'right' becomes -'left'.
     //    If 'direction' of the containing block is 'rtl', 'right' wins and 'left' is ignored.
 
-    auto left = computedValue(style.logicalLeft(), containingBlockWidth, style.usedZoomForLength());
-    auto right = computedValue(style.logicalRight(), containingBlockWidth, style.usedZoomForLength());
+    auto left = computedValue(style.logicalLeft(), containingBlockWidth, zoomFactor);
+    auto right = computedValue(style.logicalRight(), containingBlockWidth, zoomFactor);
 
     if (!left && !right) {
         // #1

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,15 +86,16 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
         for (CheckedPtr flexItem = checkedRoot()->firstInFlowChild(); flexItem; flexItem = flexItem->nextInFlowSibling()) {
             auto& flexItemGeometry = m_globalLayoutState->geometryForBox(*flexItem);
             CheckedRef style = flexItem->style();
+            const auto& flexItemZoomFactor = style->usedZoomForLength();
             auto mainAxis = LogicalFlexItem::MainAxisGeometry { };
             auto crossAxis = LogicalFlexItem::CrossAxisGeometry { };
 
             auto propertyValueForLength = [&](const auto& propertyValue, auto availableSize) -> std::optional<LayoutUnit> {
                 if (auto fixedPropertyValue = propertyValue.tryFixed())
-                    return Style::evaluate<LayoutUnit>(*fixedPropertyValue, style->usedZoomForLength());
+                    return Style::evaluate<LayoutUnit>(*fixedPropertyValue, flexItemZoomFactor);
 
                 if (propertyValue.isSpecified() && availableSize)
-                    return Style::evaluate<LayoutUnit>(propertyValue, *availableSize, style->usedZoomForLength());
+                    return Style::evaluate<LayoutUnit>(propertyValue, *availableSize, flexItemZoomFactor);
                 return { };
             };
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,9 +126,10 @@ static inline bool computeInkOverflowForInlineLevelBox(const RenderStyle& style,
     inflateWithOutline();
 
     auto inflateWithBoxShadow = [&] {
+        const auto& zoomFactor = style.usedZoomForLength();
         // FIXME: Use `Style::shadowOutsetExtent` to get all 4 extents at once after static cast to `int` in `shadowVerticalExtent` is understood.
-        auto [topBoxShadow, bottomBoxShadow] = Style::shadowVerticalExtent(style.boxShadow(), style.usedZoomForLength());
-        auto [leftBoxShadow, rightBoxShadow] = Style::shadowHorizontalExtent(style.boxShadow(), style.usedZoomForLength());
+        auto [topBoxShadow, bottomBoxShadow] = Style::shadowVerticalExtent(style.boxShadow(), zoomFactor);
+        auto [leftBoxShadow, rightBoxShadow] = Style::shadowHorizontalExtent(style.boxShadow(), zoomFactor);
         if (!topBoxShadow && !bottomBoxShadow && !leftBoxShadow && !rightBoxShadow)
             return;
         inkOverflow.inflate(-leftBoxShadow.toFloat(), -topBoxShadow.toFloat(), rightBoxShadow.toFloat(), bottomBoxShadow.toFloat());

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -352,7 +352,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
             }
             auto cellPosition = cell->position();
             auto& cellStyle = cellBox.style();
-            auto usedZoom = cellStyle.usedZoomForLength();
+            const auto& usedZoom = cellStyle.usedZoomForLength();
             // Expand it with border and padding.
             auto horizontalBorderAndPaddingWidth = formattingGeometry.computedCellBorder(*cell).width()
                 + formattingGeometry.fixedValue(cellStyle.paddingLeft(), usedZoom).value_or(0)
@@ -364,7 +364,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
             auto columnIndex = cellPosition.column;
             WTF::switchOn(cellStyle.logicalWidth(),
                 [&](const Style::PreferredSize::Fixed& fixed) {
-                    auto fixedWidth = LayoutUnit { fixed.resolveZoom(cellStyle.usedZoomForLength()) } + horizontalBorderAndPaddingWidth;
+                    auto fixedWidth = LayoutUnit { fixed.resolveZoom(usedZoom) } + horizontalBorderAndPaddingWidth;
                     maximumFixedColumnWidths[columnIndex] = std::max(maximumFixedColumnWidths[columnIndex].value_or(0_lu), fixedWidth);
                     hasColumnWithFixedWidth = true;
                 },

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,8 +43,9 @@ static UniqueRef<TableGrid> ensureTableGrid(const ElementBox& tableBox)
     auto tableGrid = makeUniqueRef<TableGrid>();
     auto& tableStyle = tableBox.style();
     auto shouldApplyBorderSpacing = tableStyle.borderCollapse() == BorderCollapse::Separate;
-    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderHorizontalSpacing().resolveZoom(tableStyle.usedZoomForLength()) : 0 });
-    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderVerticalSpacing().resolveZoom(tableStyle.usedZoomForLength()) : 0 });
+    const auto& zoomFactor = tableStyle.usedZoomForLength();
+    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderHorizontalSpacing().resolveZoom(zoomFactor) : 0 });
+    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderVerticalSpacing().resolveZoom(zoomFactor) : 0 });
 
     auto* firstChild = tableBox.firstChild();
     if (!firstChild) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -230,11 +230,12 @@ Layout::BoxGeometry::HorizontalEdges BoxGeometryUpdater::horizontalLogicalMargin
 Layout::BoxGeometry::VerticalEdges BoxGeometryUpdater::verticalLogicalMargin(const RenderBoxModelObject& renderer, std::optional<LayoutUnit> availableWidth, WritingMode writingMode)
 {
     auto& style = renderer.style();
+    const auto& zoomFactor = style.usedZoomForLength();
     if (writingMode.isHorizontal())
-        return { usedValueOrZero(style.marginTop(), availableWidth, style.usedZoomForLength()), usedValueOrZero(style.marginBottom(), availableWidth, style.usedZoomForLength()) };
+        return { usedValueOrZero(style.marginTop(), availableWidth, zoomFactor), usedValueOrZero(style.marginBottom(), availableWidth, zoomFactor) };
     if (writingMode.isLineOverLeft())
-        return { usedValueOrZero(style.marginLeft(), availableWidth, style.usedZoomForLength()), usedValueOrZero(style.marginRight(), availableWidth, style.usedZoomForLength()) };
-    return { usedValueOrZero(style.marginRight(), availableWidth, style.usedZoomForLength()), usedValueOrZero(style.marginLeft(), availableWidth, style.usedZoomForLength()) };
+        return { usedValueOrZero(style.marginLeft(), availableWidth, zoomFactor), usedValueOrZero(style.marginRight(), availableWidth, zoomFactor) };
+    return { usedValueOrZero(style.marginRight(), availableWidth, zoomFactor), usedValueOrZero(style.marginLeft(), availableWidth, zoomFactor) };
 }
 
 Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxModelObject& renderer, WritingMode writingMode, bool isIntrinsicWidthMode, bool retainBorderStart, bool retainBorderEnd)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 {
     auto& flexContainerRenderer = downcast<RenderFlexibleBox>(*flexContainer.rendererForIntegration());
     auto& flexBoxStyle = flexContainer.style();
+    const auto& flexBoxZoomFactor = flexBoxStyle.usedZoomForLength();
     auto boxSizingIsContentBox = flexBoxStyle.boxSizing() == BoxSizing::ContentBox;
     auto availableLogicalWidth = flexContainerRenderer.contentBoxRect().width();
     // FIXME: Use root's BoxGeometry which first needs to stop flipping for the formatting context.
@@ -73,7 +74,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto widthValue = [&]<typename SizeType> (const SizeType& computedValue) -> std::optional<LayoutUnit> {
         if (auto fixedWidth = computedValue.tryFixed()) {
-            auto value = Style::evaluate<LayoutUnit>(*fixedWidth, flexBoxStyle.usedZoomForLength());
+            auto value = Style::evaluate<LayoutUnit>(*fixedWidth, flexBoxZoomFactor);
             return boxSizingIsContentBox ? value : value - horizontalMarginBorderAndPadding;
         }
         if (auto percentageWidth = computedValue.tryPercentage()) {
@@ -85,7 +86,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto heightValue = [&]<typename SizeType> (const SizeType& computedValue, bool callRendererForPercentValue = false) -> std::optional<LayoutUnit> {
         if (auto fixedHeight = computedValue.tryFixed()) {
-            auto value = Style::evaluate<LayoutUnit>(*fixedHeight, flexBoxStyle.usedZoomForLength());
+            auto value = Style::evaluate<LayoutUnit>(*fixedHeight, flexBoxZoomFactor);
             return boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding;
         }
 

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -174,8 +174,9 @@ void AutoTableLayout::fullRecalc()
             if (!colLogicalWidth.isAuto() && span == 1 && effCol < nEffCols && m_table->spanOfEffCol(effCol) == 1) {
                 m_layoutStruct[effCol].usedZoom = column->style().usedZoom();
                 m_layoutStruct[effCol].logicalWidth = colLogicalWidth;
-                if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength()))
-                    m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength());
+                const auto& zoomFactor = column->style().usedZoomForLength();
+                if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->resolveZoom(zoomFactor))
+                    m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->resolveZoom(zoomFactor);
             }
             currentColumn += span;
         }
@@ -269,13 +270,14 @@ void AutoTableLayout::applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, Lay
 {
     if (auto fixedTableLogicalWidth = m_table->style().logicalWidth().tryFixed(); fixedTableLogicalWidth && fixedTableLogicalWidth->isPositive()) {
         LayoutUnit minContentWidth = minWidth;
-        LayoutUnit tableFixedWidth = m_table->overridingBorderBoxLogicalWidth().value_or(LayoutUnit { fixedTableLogicalWidth->resolveZoom(m_table->style().usedZoomForLength()) });
+        const auto& zoomFactor = m_table->style().usedZoomForLength();
+        LayoutUnit tableFixedWidth = m_table->overridingBorderBoxLogicalWidth().value_or(LayoutUnit { fixedTableLogicalWidth->resolveZoom(zoomFactor) });
         LayoutUnit clampedWidth = std::max(minContentWidth, std::max(minWidth, tableFixedWidth));
         minWidth = clampedWidth;
         maxWidth = clampedWidth;
 
         if (auto fixedMaxWidth = m_table->style().logicalMaxWidth().tryFixed()) {
-            LayoutUnit maxAllowedWidth { fixedMaxWidth->resolveZoom(m_table->style().usedZoomForLength()) };
+            LayoutUnit maxAllowedWidth { fixedMaxWidth->resolveZoom(zoomFactor) };
             minWidth = std::min(minWidth, maxAllowedWidth);
             minWidth = std::max(minWidth, minContentWidth);
             maxWidth = minWidth;

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -221,12 +221,13 @@ inline void LegacyInlineFlowBox::addTextBoxVisualOverflow(LegacyInlineTextBox& t
     // applied to the right, so this is not an issue with left overflow.
     rightGlyphOverflow -= std::min(0, (int)lineStyle.fontCascade().letterSpacing());
 
-    auto [textShadowLogicalTop, textShadowLogicalBottom] = Style::shadowBlockDirectionExtent(lineStyle.textShadow(), writingMode, lineStyle.usedZoomForLength());
+    const auto& zoomFactor = lineStyle.usedZoomForLength();
+    auto [textShadowLogicalTop, textShadowLogicalBottom] = Style::shadowBlockDirectionExtent(lineStyle.textShadow(), writingMode, zoomFactor);
 
     auto childOverflowLogicalTop = std::min<LayoutUnit>(textShadowLogicalTop + topGlyphOverflow, topGlyphOverflow);
     auto childOverflowLogicalBottom = std::max<LayoutUnit>(textShadowLogicalBottom + bottomGlyphOverflow, bottomGlyphOverflow);
 
-    auto [textShadowLogicalLeft, textShadowLogicalRight] = Style::shadowInlineDirectionExtent(lineStyle.textShadow(), writingMode, lineStyle.usedZoomForLength());
+    auto [textShadowLogicalLeft, textShadowLogicalRight] = Style::shadowInlineDirectionExtent(lineStyle.textShadow(), writingMode, zoomFactor);
 
     auto childOverflowLogicalLeft = std::min<LayoutUnit>(textShadowLogicalLeft + leftGlyphOverflow, leftGlyphOverflow);
     auto childOverflowLogicalRight = std::max<LayoutUnit>(textShadowLogicalRight + rightGlyphOverflow, rightGlyphOverflow);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4658,10 +4658,11 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
     auto indentValue = LayoutUnit { };
     if (auto* containingBlock = renderer.containingBlock()) {
         if (auto containingBlockFixedLogicalWidth = containingBlock->style().logicalWidth().tryFixed()) {
-            auto containingBlockFixedLogicalWidthValue = Style::evaluate<LayoutUnit>(*containingBlockFixedLogicalWidth, containingBlock->style().usedZoomForLength());
+            const auto& zoomFactor = containingBlock->style().usedZoomForLength();
+            auto containingBlockFixedLogicalWidthValue = Style::evaluate<LayoutUnit>(*containingBlockFixedLogicalWidth, zoomFactor);
             // At this point of the shrink-to-fit computation, we don't have a used value for the containing block width
             // (that's exactly to what we try to contribute here) unless the computed value is fixed.
-            indentValue = Style::evaluate<LayoutUnit>(style.textIndent().length, containingBlockFixedLogicalWidthValue, containingBlock->style().usedZoomForLength());
+            indentValue = Style::evaluate<LayoutUnit>(style.textIndent().length, containingBlockFixedLogicalWidthValue, zoomFactor);
         }
     }
     return indentValue ? std::make_optional(indentValue) : std::nullopt;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2762,8 +2762,9 @@ void RenderBox::computeLogicalWidth(LogicalExtentComputedValues& computedValues)
     auto& styleToUse = style();
     if (isInline() && is<RenderReplaced>(*this)) {
         // just calculate margins
-        computedValues.m_margins.m_start = Style::evaluateMinimum<LayoutUnit>(styleToUse.marginStart(), containerLogicalWidth, styleToUse.usedZoomForLength());
-        computedValues.m_margins.m_end = Style::evaluateMinimum<LayoutUnit>(styleToUse.marginEnd(), containerLogicalWidth, styleToUse.usedZoomForLength());
+        const auto& zoomFactor = styleToUse.usedZoomForLength();
+        computedValues.m_margins.m_start = Style::evaluateMinimum<LayoutUnit>(styleToUse.marginStart(), containerLogicalWidth, zoomFactor);
+        computedValues.m_margins.m_end = Style::evaluateMinimum<LayoutUnit>(styleToUse.marginEnd(), containerLogicalWidth, zoomFactor);
         if (treatAsReplaced) {
             auto evaluatedWidth = downcast<RenderReplaced>(*this).computeReplacedLogicalWidth();
             auto totalWidth = evaluatedWidth + borderAndPaddingLogicalWidth();
@@ -2792,11 +2793,12 @@ void RenderBox::computeLogicalWidth(LogicalExtentComputedValues& computedValues)
 
     // Margin calculations.
     if (hasPerpendicularContainingBlock || isFloating() || isInline()) {
+        const auto& zoomFactor = styleToUse.usedZoomForLength();
         computedValues.m_margins.m_start = computeOrTrimInlineMargin(containingBlock, Style::MarginTrimSide::BlockStart, [&] {
-            return Style::evaluateMinimum<LayoutUnit>(styleToUse.marginStart(), containerLogicalWidth, styleToUse.usedZoomForLength());
+            return Style::evaluateMinimum<LayoutUnit>(styleToUse.marginStart(), containerLogicalWidth, zoomFactor);
         });
         computedValues.m_margins.m_end = computeOrTrimInlineMargin(containingBlock, Style::MarginTrimSide::BlockEnd, [&] {
-            return Style::evaluateMinimum<LayoutUnit>(styleToUse.marginEnd(), containerLogicalWidth, styleToUse.usedZoomForLength());
+            return Style::evaluateMinimum<LayoutUnit>(styleToUse.marginEnd(), containerLogicalWidth, zoomFactor);
         });
     } else {
         auto containerLogicalWidthForAutoMargins = containerLogicalWidth;
@@ -2851,11 +2853,12 @@ LayoutUnit RenderBox::fillAvailableMeasure(LayoutUnit availableLogicalWidth, Lay
     auto& marginStartLength = style().marginStart();
     auto& marginEndLength = style().marginEnd();
     LayoutUnit availableSizeForResolvingMargin = isOrthogonalElement ? containingBlockLogicalWidthForContent() : availableLogicalWidth;
+    const auto& zoomFactor = style().usedZoomForLength();
     marginStart = computeOrTrimInlineMargin(*container, Style::MarginTrimSide::InlineStart, [&] {
-        return Style::evaluateMinimum<LayoutUnit>(marginStartLength, availableSizeForResolvingMargin, style().usedZoomForLength());
+        return Style::evaluateMinimum<LayoutUnit>(marginStartLength, availableSizeForResolvingMargin, zoomFactor);
     });
     marginEnd = computeOrTrimInlineMargin(*container, Style::MarginTrimSide::InlineEnd, [&] {
-        return Style::evaluateMinimum<LayoutUnit>(marginEndLength, availableSizeForResolvingMargin, style().usedZoomForLength());
+        return Style::evaluateMinimum<LayoutUnit>(marginEndLength, availableSizeForResolvingMargin, zoomFactor);
     });
     return availableLogicalWidth - marginStart - marginEnd;
 }

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -376,12 +376,13 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
     auto& right = style.right();
     auto& top = style.top();
     auto& bottom = style.bottom();
+    const auto& zoomFactor = style.usedZoomForLength();
 
     auto offset = accumulateInFlowPositionOffsets(*this);
     auto topFixed = top.tryFixed();
     auto leftFixed = left.tryFixed();
     if (topFixed && leftFixed && bottom.isAuto() && right.isAuto() && containingBlock->writingMode().isAnyLeftToRight()) {
-        offset.expand(leftFixed->resolveZoom(style.usedZoomForLength()), topFixed->resolveZoom(style.usedZoomForLength()));
+        offset.expand(leftFixed->resolveZoom(zoomFactor), topFixed->resolveZoom(zoomFactor));
         return offset;
     }
 
@@ -404,11 +405,11 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         };
         if (!left.isAuto()) {
             if (!right.isAuto() && !containingBlock->writingMode().isAnyLeftToRight())
-                offset.setWidth(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, style.usedZoomForLength()));
+                offset.setWidth(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, zoomFactor));
             else
-                offset.expand(Style::evaluate<LayoutUnit>(left, !left.isFixed() ? availableWidth() : 0_lu, style.usedZoomForLength()), 0_lu);
+                offset.expand(Style::evaluate<LayoutUnit>(left, !left.isFixed() ? availableWidth() : 0_lu, zoomFactor), 0_lu);
         } else if (!right.isAuto())
-            offset.expand(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, style.usedZoomForLength()), 0_lu);
+            offset.expand(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, zoomFactor), 0_lu);
     }
 
     // If the containing block of a relatively positioned element does not
@@ -439,10 +440,10 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         // FIXME: The computation of the available height is repeated later for "bottom".
         // We could refactor this and move it to some common code for both ifs, however moving it outside of the ifs
         // is not possible as it'd cause performance regressions.
-        offset.expand(0_lu, Style::evaluate<LayoutUnit>(top, !top.isFixed() ? availableHeight() : 0_lu, style.usedZoomForLength()));
+        offset.expand(0_lu, Style::evaluate<LayoutUnit>(top, !top.isFixed() ? availableHeight() : 0_lu, zoomFactor));
     } else if (!bottom.isAuto() && (!bottom.isPercentOrCalculated() || containingBlockHasDefiniteHeight)) {
         // FIXME: Check comment above for "top", it applies here too.
-        offset.expand(0_lu, -Style::evaluate<LayoutUnit>(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, style.usedZoomForLength()));
+        offset.expand(0_lu, -Style::evaluate<LayoutUnit>(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, zoomFactor));
     }
     return offset;
 }
@@ -606,22 +607,22 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     constraints.setStickyBoxRect(stickyBoxRelativeToScrollingAncestor);
 
     if (!style().left().isAuto()) {
-        constraints.setLeftOffset(Style::evaluate<float>(style().left(), constrainingRect.width(), style().usedZoomForLength()));
+        constraints.setLeftOffset(Style::evaluate<float>(style().left(), constrainingRect.width(), zoomFactor));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeLeft);
     }
 
     if (!style().right().isAuto()) {
-        constraints.setRightOffset(Style::evaluate<float>(style().right(), constrainingRect.width(), style().usedZoomForLength()));
+        constraints.setRightOffset(Style::evaluate<float>(style().right(), constrainingRect.width(), zoomFactor));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeRight);
     }
 
     if (!style().top().isAuto()) {
-        constraints.setTopOffset(Style::evaluate<float>(style().top(), constrainingRect.height(), style().usedZoomForLength()));
+        constraints.setTopOffset(Style::evaluate<float>(style().top(), constrainingRect.height(), zoomFactor));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeTop);
     }
 
     if (!style().bottom().isAuto()) {
-        constraints.setBottomOffset(Style::evaluate<float>(style().bottom(), constrainingRect.height(), style().usedZoomForLength()));
+        constraints.setBottomOffset(Style::evaluate<float>(style().bottom(), constrainingRect.height(), zoomFactor));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeBottom);
     }
 }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1501,11 +1501,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
 
     const RenderStyle& outlineStyle = outlineStyleForRepaint();
     auto& style = this->style();
+    const auto& zoomFactor = style.usedZoomForLength();
     auto outlineWidth = LayoutUnit { outlineStyle.outlineSize() };
-    auto insetShadowExtent = Style::shadowInsetExtent(style.boxShadow(), style.usedZoomForLength());
+    auto insetShadowExtent = Style::shadowInsetExtent(style.boxShadow(), zoomFactor);
     auto sizeDelta = LayoutSize { absoluteValue(newOutlineBoundsRect.width() - oldOutlineBoundsRect.width()), absoluteValue(newOutlineBoundsRect.height() - oldOutlineBoundsRect.height()) };
     if (sizeDelta.width()) {
-        auto [shadowLeft, shadowRight] = Style::shadowHorizontalExtent(style.boxShadow(), style.usedZoomForLength());
+        auto [shadowLeft, shadowRight] = Style::shadowHorizontalExtent(style.boxShadow(), zoomFactor);
 
         auto insetExtent = [&] {
             // Inset "content" is inside the border box (e.g. border, negative outline and box shadow).
@@ -1549,7 +1550,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
         }
     }
     if (sizeDelta.height()) {
-        auto [shadowTop, shadowBottom] = Style::shadowVerticalExtent(style.boxShadow(), style.usedZoomForLength());
+        auto [shadowTop, shadowBottom] = Style::shadowVerticalExtent(style.boxShadow(), zoomFactor);
 
         auto insetExtent = [&] {
             // Inset "content" is inside the border box (e.g. border, negative outline and box shadow).

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2013-2014 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
  * Copyright (c) 2020, 2021, 2022 Igalia S.L.
@@ -2970,8 +2970,9 @@ LayoutSize RenderLayer::minimumSizeForResizing(float zoomFactor) const
 {
     // Use the resizer size as the strict minimum size
     auto resizerRect = overflowControlsRects().resizer;
-    auto minWidth = Style::evaluateMinimum<LayoutUnit>(renderer().style().minWidth(), renderer().containingBlock()->width(), renderer().style().usedZoomForLength());
-    auto minHeight = Style::evaluateMinimum<LayoutUnit>(renderer().style().minHeight(), renderer().containingBlock()->height(), renderer().style().usedZoomForLength());
+    const auto& styleZoomFactor = renderer().style().usedZoomForLength();
+    auto minWidth = Style::evaluateMinimum<LayoutUnit>(renderer().style().minWidth(), renderer().containingBlock()->width(), styleZoomFactor);
+    auto minHeight = Style::evaluateMinimum<LayoutUnit>(renderer().style().minHeight(), renderer().containingBlock()->height(), styleZoomFactor);
     minWidth = std::max(LayoutUnit(minWidth / zoomFactor), LayoutUnit(resizerRect.width()));
     minHeight = std::max(LayoutUnit(minHeight / zoomFactor), LayoutUnit(resizerRect.height()));
     return LayoutSize(minWidth, minHeight);

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -614,8 +614,9 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
     LayoutUnit logicalWidth = isOutOfFlowPositioned() ? containingBlock()->clientLogicalWidth() : containingBlock()->contentBoxLogicalWidth();
 
     // This solves above equation for 'width' (== logicalWidth).
-    auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), logicalWidth, style().usedZoomForLength());
-    auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), logicalWidth, style().usedZoomForLength());
+    const auto& zoomFactor = style().usedZoomForLength();
+    auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), logicalWidth, zoomFactor);
+    auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), logicalWidth, zoomFactor);
 
     return std::max(0_lu, (logicalWidth - (marginStart + marginEnd + borderLeft() + borderRight() + paddingLeft() + paddingRight())));
 }

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -116,8 +116,8 @@ void RenderScrollbarPart::computeScrollbarWidth()
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setLeft(Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), 0_lu, style().usedZoomForLength()));
-    m_marginBox.setRight(Style::evaluateMinimum<LayoutUnit>(style().marginRight(), 0_lu, style().usedZoomForLength()));
+    m_marginBox.setLeft(Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), 0_lu, zoomFactor));
+    m_marginBox.setRight(Style::evaluateMinimum<LayoutUnit>(style().marginRight(), 0_lu, zoomFactor));
 }
 
 void RenderScrollbarPart::computeScrollbarHeight()
@@ -131,8 +131,8 @@ void RenderScrollbarPart::computeScrollbarHeight()
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setTop(Style::evaluateMinimum<LayoutUnit>(style().marginTop(), 0_lu, style().usedZoomForLength()));
-    m_marginBox.setBottom(Style::evaluateMinimum<LayoutUnit>(style().marginBottom(), 0_lu, style().usedZoomForLength()));
+    m_marginBox.setTop(Style::evaluateMinimum<LayoutUnit>(style().marginTop(), 0_lu, zoomFactor));
+    m_marginBox.setBottom(Style::evaluateMinimum<LayoutUnit>(style().marginBottom(), 0_lu, zoomFactor));
 }
 
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -158,8 +158,9 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     bool oldFixedTableLayout = oldStyle ? oldStyle->isFixedTableLayout() : false;
 
     // In the collapsed border model, there is no cell spacing.
-    m_hSpacing = collapseBorders() ? 0 : style().borderHorizontalSpacing().resolveZoom(style().usedZoomForLength());
-    m_vSpacing = collapseBorders() ? 0 : style().borderVerticalSpacing().resolveZoom(style().usedZoomForLength());
+    const auto& zoomFactor = style().usedZoomForLength();
+    m_hSpacing = collapseBorders() ? 0 : style().borderHorizontalSpacing().resolveZoom(zoomFactor);
+    m_vSpacing = collapseBorders() ? 0 : style().borderVerticalSpacing().resolveZoom(zoomFactor);
     ASSERT(m_hSpacing >= 0);
     ASSERT(m_vSpacing >= 0);
 
@@ -308,8 +309,9 @@ void RenderTable::updateLogicalWidth()
         setLogicalWidth(convertStyleLogicalWidthToComputedWidth(styleLogicalWidth, containerWidthInInlineDirection));
     else {
         // Subtract out any fixed margins from our available width for auto width tables.
-        auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth, style().usedZoomForLength());
-        auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth,  style().usedZoomForLength());
+        const auto& zoomFactor = style().usedZoomForLength();
+        auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth, zoomFactor);
+        auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth, zoomFactor);
         auto marginTotal = marginStart + marginEnd;
 
         // Subtract out our margins to get the available content width.
@@ -361,8 +363,9 @@ void RenderTable::updateLogicalWidth()
         setMarginStart(marginValues.m_start);
         setMarginEnd(marginValues.m_end);
     } else {
-        setMarginStart(Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth,  style().usedZoomForLength()));
-        setMarginEnd(Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth,  style().usedZoomForLength()));
+        const auto& zoomFactor = style().usedZoomForLength();
+        setMarginStart(Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth, zoomFactor));
+        setMarginEnd(Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth, zoomFactor));
     }
 }
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2016-2017 Google Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
@@ -181,13 +181,13 @@ Style::PreferredSize RenderTableCell::logicalWidthFromColumns(RenderTableCol* fi
     ASSERT(firstColForThisCell && firstColForThisCell == table()->colElement(col()));
     RenderTableCol* tableCol = firstColForThisCell;
 
+    auto& colWidth = tableCol->style().logicalWidth();
+    const auto& tableColZoomFactor = tableCol->style().usedZoomForLength();
+    auto fixedColWidth = colWidth.tryFixed();
+
     unsigned colSpanCount = colSpan();
     LayoutUnit colWidthSum;
     for (unsigned i = 1; i <= colSpanCount; i++) {
-        auto& colWidth = tableCol->style().logicalWidth();
-
-        auto fixedColWidth = colWidth.tryFixed();
-
         // Percentage value should be returned only for colSpan == 1.
         // Otherwise we return original width for the cell.
         if (!fixedColWidth) {
@@ -196,7 +196,7 @@ Style::PreferredSize RenderTableCell::logicalWidthFromColumns(RenderTableCol* fi
             return colWidth;
         }
 
-        colWidthSum += fixedColWidth->resolveZoom(tableCol->style().usedZoomForLength());
+        colWidthSum += fixedColWidth->resolveZoom(tableColZoomFactor);
         tableCol = tableCol->nextColumn();
         // If no next <col> tag found for the span we just return what we have for now.
         if (!tableCol)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -82,7 +82,8 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
             if (auto percentageRowLogicalHeight = row.logicalHeight.tryPercentage(); !percentageRowLogicalHeight || percentageRowLogicalHeight->value < percentageLogicalHeight->value)
                 row.logicalHeight = logicalHeight;
         } else if (auto fixedLogicalHeight = logicalHeight.tryFixed()) {
-            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->resolveZoom(cell->style().usedZoomForLength()) < fixedLogicalHeight->resolveZoom(cell->style().usedZoomForLength())))
+            const auto& zoomFactor = cell->style().usedZoomForLength();
+            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->resolveZoom(zoomFactor) < fixedLogicalHeight->resolveZoom(zoomFactor)))
                 row.logicalHeight = logicalHeight;
         }
     }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -556,8 +556,9 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
 
         auto fixedWidth = thumbStyle.width().tryFixed();
         auto fixedHeight = thumbStyle.height().tryFixed();
-        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->resolveZoom(thumbStyle.usedZoomForLength())) : 0;
-        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->resolveZoom(thumbStyle.usedZoomForLength())) : 0;
+        const auto& zoomFactor = thumbStyle.usedZoomForLength();
+        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->resolveZoom(zoomFactor)) : 0;
+        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->resolveZoom(zoomFactor)) : 0;
 
         thumbSize = { thumbWidth, thumbHeight };
     }

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,12 +41,14 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const RenderStyle&
     if (!lineHeightAsFixed && !lineHeightAsPercentage)
         return false;
 
+    const auto& zoomFactor = style.usedZoomForLength();
+
     auto& maxHeight = style.maxHeight();
     std::optional<float> heightOrMaxHeightAsLength;
     if (auto fixedMaxHeight = maxHeight.tryFixed())
-        heightOrMaxHeightAsLength = fixedMaxHeight->resolveZoom(style.usedZoomForLength());
+        heightOrMaxHeightAsLength = fixedMaxHeight->resolveZoom(zoomFactor);
     else if (auto fixedHeight = style.height().tryFixed(); fixedHeight && (!maxHeight.isSpecified() || maxHeight.isNone()))
-        heightOrMaxHeightAsLength = fixedHeight->resolveZoom(style.usedZoomForLength());
+        heightOrMaxHeightAsLength = fixedHeight->resolveZoom(zoomFactor);
 
     if (!heightOrMaxHeightAsLength)
         return false;
@@ -55,7 +57,7 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const RenderStyle&
     if (heightOrMaxHeight <= 0)
         return false;
 
-    float approximateLineHeight = lineHeightAsPercentage ? lineHeightAsPercentage->value * style.specifiedFontSize() / 100 : lineHeightAsFixed->resolveZoom(style.usedZoomForLength());
+    float approximateLineHeight = lineHeightAsPercentage ? lineHeightAsPercentage->value * style.specifiedFontSize() / 100 : lineHeightAsFixed->resolveZoom(zoomFactor);
     if (approximateLineHeight <= 0)
         return false;
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Adobe Systems Incorporated. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
@@ -552,7 +552,8 @@ bool RenderStyle::isIdempotentTextAutosizingCandidate(AutosizeStatus status) con
                 if (auto fixedHeight = height().tryFixed(); fixedHeight && specifiedLineHeight().isFixed()) {
                     if (auto fixedSpecifiedLineHeight = specifiedLineHeight().tryFixed()) {
                         float specifiedSize = specifiedFontSize();
-                        if (fixedHeight->resolveZoom(usedZoomForLength()) == specifiedSize && fixedSpecifiedLineHeight->resolveZoom(usedZoomForLength()) == specifiedSize)
+                        const auto& zoomFactor = usedZoomForLength();
+                        if (fixedHeight->resolveZoom(zoomFactor) == specifiedSize && fixedSpecifiedLineHeight->resolveZoom(zoomFactor) == specifiedSize)
                             return false;
                     }
                 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1109,7 +1109,8 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
             auto fixedHeight = style.height().tryFixed();
             if (!fixedWidth || !fixedHeight)
                 return { };
-            return std::make_optional(IntSize { static_cast<int>(fixedWidth->resolveZoom(style.usedZoomForLength())), static_cast<int>(fixedHeight->resolveZoom(style.usedZoomForLength())) });
+            const auto& zoomFactor = style.usedZoomForLength();
+            return std::make_optional(IntSize { static_cast<int>(fixedWidth->resolveZoom(zoomFactor)), static_cast<int>(fixedHeight->resolveZoom(zoomFactor)) });
         };
         // SVG content tends to have a fixed size construct. However this is known to be inaccurate in certain cases (box-sizing: border-box) or especially when the parent box is oversized.
         auto candidateSize = IntSize { };

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -257,8 +257,9 @@ void BuilderState::updateFontForSizeChange()
     auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
     auto fontSize = fontCascade.size();
 
-    auto newWordSpacing = evaluate<float>(m_style.computedWordSpacing(), fontSize, m_style.usedZoomForLength());
-    auto newLetterSpacing = evaluate<float>(m_style.computedLetterSpacing(), fontSize, m_style.usedZoomForLength());
+    const auto& zoomFactor = m_style.usedZoomForLength();
+    auto newWordSpacing = evaluate<float>(m_style.computedWordSpacing(), fontSize, zoomFactor);
+    auto newLetterSpacing = evaluate<float>(m_style.computedLetterSpacing(), fontSize, zoomFactor);
 
     if (newWordSpacing != fontCascade.wordSpacing())
         fontCascade.setWordSpacing(newWordSpacing);


### PR DESCRIPTION
#### 05c23c37788485c900bf2a78e7b0e0b31576279f
<pre>
[CSS Zoom] Reduce redundant calls to RenderStyle::usedZoomForLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=303571">https://bugs.webkit.org/show_bug.cgi?id=303571</a>
<a href="https://rdar.apple.com/165863518">rdar://165863518</a>

Reviewed by NOBODY (OOPS!).

This patch addressing an observation @weinig made regarding cases where `usedZoomForLength()`
is called many times, often in succeeding lines. Since the implementation of this method
involves multiple branches, we may get a benefit from only calling it once when we will be
using the same returned value throughout the current method.

Later work will attempt to reduce the cost of that method further, but this is an easy,
small, first step.

* Source/WebCore/accessibility/AXTableHelpers.cpp:
(WebCore::AXTableHelpers::isDataTableWithTraversal):
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::outOfFlowNonReplacedVerticalGeometry const):
(WebCore::Layout::FormattingGeometry::outOfFlowNonReplacedHorizontalGeometry const):
(WebCore::Layout::FormattingGeometry::outOfFlowReplacedVerticalGeometry const):
(WebCore::Layout::FormattingGeometry::outOfFlowReplacedHorizontalGeometry const):
(WebCore::Layout::FormattingGeometry::inFlowPositionedPositionOffset const):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::FlexFormattingContext::convertFlexItemsToLogicalSpace):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::computeInkOverflowForInlineLevelBox):
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
(WebCore::Layout::TableFormattingContext::computedPreferredWidthForColumns):
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
(WebCore::Layout::ensureTableGrid):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::verticalLogicalMargin):
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::constraintsForFlexContent):
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::fullRecalc):
(WebCore::AutoTableLayout::applyPreferredLogicalWidthQuirks const):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addTextBoxVisualOverflow):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::textIndentForBlockContainer):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeLogicalWidth const):
(WebCore::RenderBox::fillAvailableMeasure const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::relativePositionOffset const):
(WebCore::RenderBoxModelObject::computeStickyPositionConstraints const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::minimumSizeForResizing const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::RenderScrollbarPart::computeScrollbarWidth):
(WebCore::RenderScrollbarPart::computeScrollbarHeight):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
(WebCore::RenderTable::updateLogicalWidth):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::logicalWidthFromColumns const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::updateLogicalHeightForCell):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSliderTrackPartForRenderer):
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
(WebCore::AutosizeStatus::probablyContainsASmallFixedNumberOfLines):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::isIdempotentTextAutosizingCandidate const):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::reportVisuallyNonEmptyContent):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForSizeChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05c23c37788485c900bf2a78e7b0e0b31576279f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f5123a6a-e191-4397-92a9-2a3e40fc4a05) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6447 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102543 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69835 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd033a8f-b67c-467e-ae4a-fb91cb8e6da2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83340 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d54ab7c-4fe9-4420-a229-f3652787dee7) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4856 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2488 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1467 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114028 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38303 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144298 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6253 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38881 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110915 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6335 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5285 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111140 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4722 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60023 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6305 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34679 "Found 2 new test failures: fast/table/col-width-span-expand.html imported/w3c/web-platform-tests/css/css-tables/tentative/colspan-redistribution.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6259 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->