### PR TITLE
[GTK][WPE][Skia] Add canvas 2D operation recording for batched replay

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -46,6 +46,7 @@ class Pattern;
 using SkiaImageToFenceMap = HashMap<const SkImage*, std::unique_ptr<GLFence>>;
 
 class WEBCORE_EXPORT GraphicsContextSkia final : public GraphicsContext {
+    friend class ImageBufferSkiaAcceleratedBackend;
 public:
     GraphicsContextSkia(SkCanvas&, RenderingMode, RenderingPurpose, CompletionHandler<void()>&& = nullptr);
     virtual ~GraphicsContextSkia();

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -50,7 +50,7 @@ public:
 protected:
     ImageBufferSkiaSurfaceBackend(const Parameters&, sk_sp<SkSurface>&&, RenderingMode);
 
-    GraphicsContext& context() final { return m_context; }
+    GraphicsContext& context() override { return m_context; }
     unsigned bytesPerRow() const final;
     bool canMapBackingStore() const final;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "SkiaRecordingResult.h"
 
-#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#if USE(SKIA)
 
 namespace WebCore {
 
@@ -62,4 +62,4 @@ void SkiaRecordingResult::waitForFenceIfNeeded(const SkImage& image)
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#if USE(SKIA)
 #include "GraphicsContextSkia.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -67,4 +67,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "SkiaReplayCanvas.h"
 
-#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#if USE(SKIA)
 #include "GLContext.h"
 #include "GLFence.h"
 #include "PlatformDisplay.h"
@@ -273,4 +273,4 @@ void SkiaReplayCanvas::onDrawVerticesObject(const SkVertices* vertices, SkBlendM
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#if USE(SKIA)
 #include "IntSize.h"
 #include "SkiaRecordingResult.h"
 #include <wtf/Assertions.h>
@@ -83,4 +83,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#endif // USE(SKIA)


### PR DESCRIPTION
#### 05c4585aef2819a1881b7d910e70ae55492e0282
<pre>
[GTK][WPE][Skia] Add canvas 2D operation recording for batched replay
<a href="https://bugs.webkit.org/show_bug.cgi?id=303575">https://bugs.webkit.org/show_bug.cgi?id=303575</a>

Reviewed by Carlos Garcia Campos.

Introduce canvas 2D operation recording for GPU-accelerated canvas rendering.
Instead of executing drawing commands immediately, operations are recorded into
an SkPicture and replayed in batch when the canvas contents are actually needed.
This reduces GPU state change overhead for workloads with many small drawing
operations.

When a canvas ImageBuffer is first accessed, we create a recording context backed
by an SkPictureRecorder. All subsequent drawing operations are captured into this
recording rather than being executed on the GPU surface. This continues until a
&quot;materialization point&quot; is reached - a point where the actual pixel contents are
needed. The optimal case is prepareForDisplay(), where the recording is replayed
just before compositing. Other materialization points include createNativeImageReference()
for snapshots, getPixelBuffer()/putPixelBuffer() for CPU access, and flushContext()
for explicit synchronization.

At the materialization point, the recording is finalized and replayed to the GPU
surface. The drawing state (fill/stroke colors, composite modes, transforms, etc.)
is preserved across this transition. After flushing, the canvas switches to direct
rendering mode for all subsequent operations - we don&apos;t restart recording, as the
batching benefit has already been realized for the initial burst of drawing commands.

A SkiaSwitchableCanvas (derived from SkNWayCanvas) serves as the stable canvas
reference held by GraphicsContextSkia, allowing us to transparently redirect
drawing operations from the recording canvas to the surface canvas after flushing.

Cross-thread transfer (e.g., for OffscreenCanvas) is handled by flushing any
pending recording on the source thread before transfer, since Skia surfaces are
not thread-safe. The destination thread simply waits for the GPU fence rather
than recreating the surface. Additionally, when drawing GPU-backed images whose
textures were created in a different GL context, we rewrap them using
SkImages::BorrowTextureFrom() to make them valid for the current context.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::context):
(WebCore::ImageBufferSkiaAcceleratedBackend::ensureCanvasRecordingContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::copyGraphicsState):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushCanvasRecordingContextIfNeeded):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::prepareForDisplay):
(WebCore::ImageBufferSkiaAcceleratedBackend::createNativeImageReference):
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h:

Canonical link: <a href="https://commits.webkit.org/305273@main">https://commits.webkit.org/305273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c6db3fe881a13037e3c89bdc3f08c7f577ff1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105527 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7863 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5617 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113931 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114262 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7802 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10084 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37957 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9815 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->