### PR TITLE
Scubbing the timeline of a video on target.com registers as a swipe through the gallery instead

### DIFF
--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt
@@ -1,0 +1,12 @@
+Test that scrubbing the timeline does not propagate touch events to parent elements.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS containerReceivedTouchStart is false
+PASS containerReceivedTouchMove is false
+PASS containerReceivedTouchEnd is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../resources/media-controls-utils.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    <script src="../../../video-test.js"></script>
+</head>
+<body>
+    <video id="video" src="../../../content/test.mp4" controls style="width: 400px;"></video>
+    <script>
+        window.jsTestIsAsync = true;
+        
+        description("Test that scrubbing the timeline does not propagate touch events to parent elements.");
+        
+        // Make video globally accessible for testExpectedEventuallySilent
+        window.video = document.getElementById('video');
+        var video = window.video;
+        let containerReceivedTouchStart = false;
+        let containerReceivedTouchMove = false;
+        let containerReceivedTouchEnd = false;
+        
+        video.addEventListener('touchstart', () => { containerReceivedTouchStart = true; }, {once: true});
+        video.addEventListener('touchmove', () => { containerReceivedTouchMove = true; }, {once: true});
+        video.addEventListener('touchend', () => { containerReceivedTouchEnd = true; }, {once: true});
+        
+        video.addEventListener('loadedmetadata', async () => {
+            await testExpectedEventuallySilent("window.internals.shadowRoot(window.video)", null, "!=", 500);
+            
+            const shadowRoot = window.internals.shadowRoot(video);
+            if (!shadowRoot) {
+                testFailed("Could not get shadow root");
+                finishJSTest();
+                return;
+            }
+            
+            const controlsElement = shadowRoot.querySelector('.media-controls');
+            if (!controlsElement) {
+                testFailed("Could not find media controls element");
+                finishJSTest();
+                return;
+            }
+            
+            const rect = controlsElement.getBoundingClientRect();
+            const start = UIHelper.midPointOfRect(rect);
+            
+            await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+                .begin(start.x, start.y)
+                .move(start.x + 50, start.y, 0.5)
+                .end()
+                .takeResult());
+            
+            shouldBeFalse("containerReceivedTouchStart");
+            shouldBeFalse("containerReceivedTouchMove");
+            shouldBeFalse("containerReceivedTouchEnd");
+            
+            video.remove();
+            finishJSTest();
+        });
+    </script>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -426,7 +426,7 @@ class MediaController
             window.removeEventListener("dragstart", this, true);
 
         if (this.host && this.host.inWindowFullscreen) {
-            this._stopPropagationOnClickEvents();
+            this._stopPropagationOnInteractionEvents();
             if (!this.host.supportsRewind)
                 this.controls.rewindButton.dropped = true;
         }
@@ -437,9 +437,9 @@ class MediaController
             this.controls.element.setAttribute('useragentpart', '-webkit-media-controls');
     }
 
-    _stopPropagationOnClickEvents()
+    _stopPropagationOnInteractionEvents()
     {
-        let clickEvents = ["click", "mousedown", "mouseup", "pointerdown", "pointerup"];
+        let clickEvents = ["click", "mousedown", "mouseup", "pointerdown", "pointerup", "touchstart", "touchmove", "touchend"];
         for (let clickEvent of clickEvents) {
             this.controls.element.addEventListener(clickEvent, (event) => {
                 event.stopPropagation();


### PR DESCRIPTION
#### 2c3d7a3c4b3c53f95dca5f2bac11337971529c36
<pre>
Scubbing the timeline of a video on target.com registers as a swipe through the gallery instead
<a href="https://rdar.apple.com/157762977">rdar://157762977</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303570">https://bugs.webkit.org/show_bug.cgi?id=303570</a>

Reviewed by Jer Noble.

Add touchstart, touchmove, and touchend to the list of events that stop propagation on media
controls and ensure the method is called for all controls (not just fullscreen).

Test: media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html

* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt: Added.
* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html: Added.
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):
(MediaController.prototype._stopPropagationOnInteractionEvents):
(MediaController.prototype._stopPropagationOnClickEvents):

Canonical link: <a href="https://commits.webkit.org/303986@main">https://commits.webkit.org/303986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd8b792fc2bf3d5f16761f7390a458bd978d1c2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141783 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/597d7c51-7273-40b1-93b6-5dc7cb999981) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/64a8e4f4-fef2-4e8c-8ea1-d8bba676f2ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83417 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b7b4ef1-3623-409f-acf0-03820f61a2c0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1599 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6384 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111007 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4798 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116564 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60155 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6436 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34783 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6525 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->