### PR TITLE
[CSS Zoom] line-height should scale font-relative units with text-zoom

### DIFF
--- a/LayoutTests/fast/text/line-height-em-text-zoom-expected.html
+++ b/LayoutTests/fast/text/line-height-em-text-zoom-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.test-pixel {
+    font-size: 32px;
+    line-height: 51.2px;
+}
+</style>
+</head>
+<body>
+<div class="test-pixel">
+    line-height: 1.6em
+    <div>Line 1</div>
+    <div>Line 2</div>
+    <div>Line 3</div>
+</div>
+
+<div class="test-pixel">
+    line-height: 160%
+    <div>Line 1</div>
+    <div>Line 2</div>
+    <div>Line 3</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/line-height-em-text-zoom.html
+++ b/LayoutTests/fast/text/line-height-em-text-zoom.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    internals.setTextZoomFactor(2.0);
+</script>
+<style>
+.test-em {
+    font-size: 16px;
+    line-height: 1.6em;
+}
+.test-percent {
+    font-size: 16px;
+    line-height: 160%;
+}
+</style>
+</head>
+<body>
+<div class="test-em">
+    line-height: 1.6em
+    <div>Line 1</div>
+    <div>Line 2</div>
+    <div>Line 3</div>
+</div>
+
+<div class="test-percent">
+    line-height: 160%
+    <div>Line 1</div>
+    <div>Line 2</div>
+    <div>Line 3</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
#### 473b6eb379d9bd055373cc2fa7a5f5255817b935
<pre>
[CSS Zoom] line-height should scale font-relative units with text-zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=303584">https://bugs.webkit.org/show_bug.cgi?id=303584</a>
<a href="https://rdar.apple.com/165073337">rdar://165073337</a>

Reviewed by Sammy Gill.

As in <a href="https://commits.webkit.org/301757@main">https://commits.webkit.org/301757@main</a> for the percentage case,
text zoom should scale the line-height when the property is set with
a font-relative unit when evaluationTimeZoomEnabled.

This is because, when evaluationTimeZoomEnabled is true,
computedSizeForRangeZoomOption returns the unzoomed font size.

Test: fast/text/line-height-em-text-zoom.html

* LayoutTests/fast/text/line-height-em-text-zoom-expected.html: Added.
* LayoutTests/fast/text/line-height-em-text-zoom.html: Added.
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::CSSValueConversion&lt;LineHeight&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/304012@main">https://commits.webkit.org/304012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ab766cecd92f2df1f368581721befc13060307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86189 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04a4aacb-649c-49d0-8275-0e19e99bdc5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102575 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69863 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49acbbda-e9e5-49f2-8272-e72e3e6f72b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83370 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07617d8b-3238-4f35-9394-0126c0377f49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2519 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1522 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144353 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110944 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28233 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4752 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60078 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6360 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34713 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->