### PR TITLE
The page load activity is only taken on the main frame WebProcess

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -296,7 +296,6 @@ private:
     } m_historyDelegateMethods;
 
 #if USE(RUNNINGBOARD)
-    RefPtr<ProcessThrottler::BackgroundActivity> m_networkActivity;
     RunLoop::Timer m_releaseNetworkActivityTimer;
 #endif
 };

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -104,6 +104,9 @@ void RemotePageProxy::injectPageIntoNewProcess()
         m_process->setRunningBoardThrottlingEnabled();
 #endif
 
+    if (page->hasValidNetworkActivity())
+        m_processActivityState->takeNetworkActivity();
+
     Ref drawingArea = *page->drawingArea();
     m_drawingArea = RemotePageDrawingAreaProxy::create(drawingArea.get(), m_process);
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -606,6 +606,14 @@ void WebPageProxy::takeMutedCaptureAssertion()
     });
 }
 
+void WebPageProxy::takeNetworkActivity()
+{
+    m_mainFrameProcessActivityState->takeNetworkActivity();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+        remotePageProxy.processActivityState().takeNetworkActivity();
+    });
+}
+
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
 void WebPageProxy::takeAccessibilityActivityWhenInWindow()
 {
@@ -669,6 +677,14 @@ void WebPageProxy::dropMutedCaptureAssertion()
     });
 }
 
+void WebPageProxy::dropNetworkActivity()
+{
+    m_mainFrameProcessActivityState->dropNetworkActivity();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+        remotePageProxy.processActivityState().dropNetworkActivity();
+    });
+}
+
 bool WebPageProxy::hasValidVisibleActivity() const
 {
     bool hasValidVisibleActivity = m_mainFrameProcessActivityState->hasValidVisibleActivity();
@@ -703,6 +719,15 @@ bool WebPageProxy::hasValidMutedCaptureAssertion() const
         hasValidMutedCaptureAssertion &= remotePageProxy.processActivityState().hasValidMutedCaptureAssertion();
     });
     return hasValidMutedCaptureAssertion;
+}
+
+bool WebPageProxy::hasValidNetworkActivity() const
+{
+    bool hasValidNetworkActivity = m_mainFrameProcessActivityState->hasValidNetworkActivity();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+        hasValidNetworkActivity &= remotePageProxy.processActivityState().hasValidNetworkActivity();
+    });
+    return hasValidNetworkActivity;
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2871,6 +2871,10 @@ public:
 
     void networkRequestsInProgressDidChange();
 
+    void takeNetworkActivity();
+    void dropNetworkActivity();
+    bool hasValidNetworkActivity() const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -27,6 +27,7 @@
 #include "WebProcessActivityState.h"
 
 #include "APIPageConfiguration.h"
+#include "Logging.h"
 #include "RemotePageProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
@@ -104,6 +105,12 @@ void WebProcessActivityState::takeMutedCaptureAssertion()
     });
 }
 
+void WebProcessActivityState::takeNetworkActivity()
+{
+    RELEASE_LOG(Process, "Taking network activity on WebProcess with PID %d", protectedProcess()->processID());
+    m_networkActivity = protectedProcess()->protectedThrottler()->backgroundActivity("Page Load"_s);
+}
+
 void WebProcessActivityState::reset()
 {
     m_isVisibleActivity = nullptr;
@@ -116,6 +123,7 @@ void WebProcessActivityState::reset()
 #if PLATFORM(IOS_FAMILY)
     m_openingAppLinkActivity = nullptr;
 #endif
+    m_networkActivity = nullptr;
 }
 
 void WebProcessActivityState::dropVisibleActivity()
@@ -144,6 +152,12 @@ void WebProcessActivityState::dropMutedCaptureAssertion()
     m_isMutedCaptureAssertion = nullptr;
 }
 
+void WebProcessActivityState::dropNetworkActivity()
+{
+    RELEASE_LOG(Process, "Dropping network activity on WebProcess with PID %d", protectedProcess()->processID());
+    m_networkActivity = nullptr;
+}
+
 bool WebProcessActivityState::hasValidVisibleActivity() const
 {
     return m_isVisibleActivity && m_isVisibleActivity->isValid();
@@ -157,6 +171,11 @@ bool WebProcessActivityState::hasValidAudibleActivity() const
 bool WebProcessActivityState::hasValidCapturingActivity() const
 {
     return m_isCapturingActivity && m_isCapturingActivity->isValid();
+}
+
+bool WebProcessActivityState::hasValidNetworkActivity() const
+{
+    return m_networkActivity && m_networkActivity->isValid();
 }
 
 bool WebProcessActivityState::hasValidMutedCaptureAssertion() const

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -46,17 +46,20 @@ public:
     void takeAudibleActivity();
     void takeCapturingActivity();
     void takeMutedCaptureAssertion();
+    void takeNetworkActivity();
 
     void reset();
     void dropVisibleActivity();
     void dropAudibleActivity();
     void dropCapturingActivity();
     void dropMutedCaptureAssertion();
+    void dropNetworkActivity();
 
     bool hasValidVisibleActivity() const;
     bool hasValidAudibleActivity() const;
     bool hasValidCapturingActivity() const;
     bool hasValidMutedCaptureAssertion() const;
+    bool hasValidNetworkActivity() const;
 
 #if PLATFORM(IOS_FAMILY)
     void takeOpeningAppLinkActivity();
@@ -91,6 +94,8 @@ private:
 #if PLATFORM(IOS_FAMILY)
     RefPtr<ProcessThrottlerActivity> m_openingAppLinkActivity;
 #endif
+    RefPtr<ProcessThrottlerActivity> m_networkActivity;
+
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 44309b26d25492c0a42cee0fc77d0cf06c235919
<pre>
The page load activity is only taken on the main frame WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=303595">https://bugs.webkit.org/show_bug.cgi?id=303595</a>
<a href="https://rdar.apple.com/165884028">rdar://165884028</a>

Reviewed by Sihui Liu.

The page load activity is only taken on the main frame WebProcess. It should also be taken on all iframe WebContent processes.
This patch moves the network activity member of NavigationState to the WebProcessActivityState class, which is used by both
WebPageProxy and RemotePageProxy. A new iframe WebContent process will have a page load activity taken if the main frame
WebContent process already has one.

* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::releaseNetworkActivity):
(WebKit::NavigationState::didChangeIsLoading):
(WebKit::NavigationState::didSwapWebProcesses):
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::expectedThrottleState):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeNetworkActivity):
(WebKit::WebPageProxy::dropNetworkActivity):
(WebKit::WebPageProxy::hasValidNetworkActivity const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::takeNetworkActivity):
(WebKit::WebProcessActivityState::dropNetworkActivity):
(WebKit::WebProcessActivityState::hasValidNetworkActivity const):
* Source/WebKit/UIProcess/WebProcessActivityState.h:

Canonical link: <a href="https://commits.webkit.org/304007@main">https://commits.webkit.org/304007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10c6594a9413a0f33c00c4b3f9bf1238a7e4a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141835 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6628 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137201 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5094 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83455 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aeaedf36-72da-415a-9d64-c480c9a2fb46) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144481 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6436 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39055 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111041 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111290 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4836 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116608 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60225 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34820 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6327 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->