### PR TITLE
[GFC] Implement logic to support track sizing with min-content as track sizing functions.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -66,7 +66,7 @@ private:
 
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
-    static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridFormattingContext::GridLayoutConstraints&);
+    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridFormattingContext::GridLayoutConstraints&) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const UsedTrackSizes&) const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+namespace WTF {
+template <typename T>
+class Range;
+}
+
 namespace WebCore {
 
 class LayoutUnit;
@@ -47,6 +52,7 @@ using GridCell = Vector<UnplacedGridItem, 1>;
 using GridItemRects = Vector<GridItemRect>;
 using GridMatrix = Vector<Vector<GridCell>>;
 using PlacedGridItems = Vector<PlacedGridItem>;
+using PlacedGridItemSpanList = Vector<WTF::Range<size_t>>;
 using TrackSizes = Vector<LayoutUnit>;
 using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
 using UnsizedTracks = Vector<UnsizedTrack>;

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -32,9 +32,11 @@ namespace WebCore {
 
 namespace Layout {
 
+class IntegrationUtils;
+
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const IntegrationUtils&);
 
 private:
 


### PR DESCRIPTION
#### ea5f8d15a93d7a62da8be51cd7d68ce4ee862386
<pre>
[GFC] Implement logic to support track sizing with min-content as track sizing functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303597">https://bugs.webkit.org/show_bug.cgi?id=303597</a>
<a href="https://rdar.apple.com/165062010">rdar://165062010</a>

Reviewed by Brandon Stewart.

This patch builds upon the track sizing algorithm to start considering
min-content as a track sizing function for the columns.
<a href="https://drafts.csswg.org/css-grid-1/#algo-track-sizing">https://drafts.csswg.org/css-grid-1/#algo-track-sizing</a>

We have already added logic in regards to making sure the base size and
growth limits for these tracks are set properly so we do not need to add
any extra work for that step here so most of the new code here focuses
on step two of the track sizing algorithm (resolve intrinsic track sizes):
<a href="https://drafts.csswg.org/css-grid-1/#algo-content">https://drafts.csswg.org/css-grid-1/#algo-content</a>

The general idea is that we will loop over the tracks that are
intrinsically sized, get the items that are completely contained within
that track, get the item&apos;s min-content contribution, and update the base
size and growth limit if needed.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
In order to perform the track sizing algorithm properly, we will need
to know which tracks a grid item spans. In addition to passing in the
PlacedGridItems to the track sizing function, I have decided to also
create and pass in a SpanList that holds a Range corresponding to the
tracks the associated grid item spans. Each index in the SpanList maps
to an entry in the grid item list, so a span at index 1 is associated
with the grid item at index 1.

(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::singleSpanningItemsWithinTrack):
Helper function that is used to collect the items corresponding with the
&quot;consider the items in it with a span of 1,&quot; portion of the spec. This
takes in the SpanList and returns the indexes of the grid items that
have a span of one. I prefer this instead of passing in the grid items,
iterating over them, and constructing another list of grid items as a
result. Here we are working with simple structures that contain just the
information we need to perform the task instead of a list of items that
contain more information than necessary.

(WebCore::Layout::tracksWithIntrinsicSizingFunction):
Helper function that is used to collect the tracks corresponding with
the &quot;For each track with an intrinsic track sizing function and not a
flexible sizing function&quot; portion of the spec. Same reasoning as above
for the overall structure.

(WebCore::Layout::minContentContributions):
Stub for a helper function that will be used to get the min-content
contributions of the grid items. This will get filled in with whatever
API we end up coming up with to get these sizes.

(WebCore::Layout::resolveIntrinsicTrackSizes):
This is basically just the spec as written in 11.5.2 so there should
hopefully be no surprises here!

Canonical link: <a href="https://commits.webkit.org/306091@main">https://commits.webkit.org/306091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00a70698c9e75d6045ba342d957100b8fddfbeb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84835de6-1ea2-44d9-8fb0-8b4b9d8cc9a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6acd7f56-2ff2-477c-b890-a16ebcfbc476) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88444 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a320f00-fe74-4414-b6f1-681fe16cc962) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7436 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8674 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151180 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115791 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11134 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12350 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1504 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->