### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AVContentKeySessionDelegateClient

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -424,7 +424,7 @@ bool CDMPrivateFairPlayStreaming::distinctiveIdentifiersAreUniquePerOriginAndCle
 RefPtr<CDMInstance> CDMPrivateFairPlayStreaming::createInstance()
 {
 #if HAVE(AVCONTENTKEYSESSION)
-    auto instance = adoptRef(new CDMInstanceFairPlayStreamingAVFObjC(*this));
+    auto instance = CDMInstanceFairPlayStreamingAVFObjC::create(*this);
 #if !RELEASE_LOG_DISABLED
     instance->setLogIdentifier(m_logIdentifier);
 #endif


### PR DESCRIPTION
#### 4faeba9d349f06e6de1b3fc80937efdef5664180
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AVContentKeySessionDelegateClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303600">https://bugs.webkit.org/show_bug.cgi?id=303600</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::createInstance):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:didProvideContentKeyRequest:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:didProvideRenewingContentKeyRequest:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:didProvidePersistableContentKeyRequest:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:didProvideContentKeyRequests:forInitializationData:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:contentKeyRequest:didFailWithError:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:contentKeyRequestDidSucceed:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:shouldRetryContentKeyRequest:reason:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySessionContentProtectionSessionIdentifierDidChange:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:contentProtectionSessionIdentifierDidChangeForReportGroup:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:externalProtectionStatusDidChangeForContentKey:]):
(-[WebCoreFPSContentKeySessionDelegate contentKeySession:externalProtectionStatusDidChangeForContentKeyRequest:]):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::create):

Canonical link: <a href="https://commits.webkit.org/304047@main">https://commits.webkit.org/304047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/366c17b00bd15d89a2c4adcc7388f5d0d9cb0932

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86233 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7eb232e-0913-403e-a760-33d91ad70c7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102596 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69891 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a839641b-60b4-476e-9779-f14c83fa85ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83390 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/02120336-7377-4d04-aca4-8a95f4078ad9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2542 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144394 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6349 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110971 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28259 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4772 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60120 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6401 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->