### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for TrackPrivateBaseClient

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -48,6 +48,10 @@ public:
     }
     virtual ~AudioTrack();
 
+    // AudioTrackPrivateClient.
+    void ref() const final { MediaTrackBase::ref(); }
+    void deref() const final { MediaTrackBase::deref(); }
+
     static const AtomString& descriptionKeyword();
     static const AtomString& mainDescKeyword();
     static const AtomString& translationKeyword();

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -38,6 +38,10 @@ public:
     static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandTextTrack();
 
+    // InbandTextTrackPrivateClient.
+    void ref() const final { TextTrack::ref(); }
+    void deref() const final { TextTrack::deref(); }
+
     bool isClosedCaptions() const override;
     bool isSDH() const override;
     bool containsOnlyForcedSubtitles() const override;

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -51,6 +51,10 @@ public:
     }
     virtual ~VideoTrack();
 
+    // VideoTrackPrivateClient.
+    void ref() const final { MediaTrackBase::ref(); }
+    void deref() const final { MediaTrackBase::deref(); }
+
     static const AtomString& signKeyword();
 
     bool selected() const { return m_selected; }

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -71,8 +71,8 @@ void TrackPrivateBase::notifyClients(Task&& task)
         auto& [dispatcher, weakClient, mainThread] = tuple;
         if (dispatcher) {
             dispatcher->get()([weakClient = WTFMove(weakClient), sharedTask] {
-                if (weakClient)
-                    sharedTask->run(*weakClient);
+                if (RefPtr client = weakClient.get())
+                    sharedTask->run(*client);
             });
         }
     }
@@ -91,8 +91,8 @@ void TrackPrivateBase::notifyMainThreadClient(Task&& task)
         auto& [dispatcher, weakClient, isMainThread] = tuple;
         if (dispatcher && isMainThread) {
             dispatcher->get()([weakClient = WTFMove(weakClient), task = WTFMove(task)] {
-                if (weakClient)
-                    task(*weakClient);
+                if (RefPtr client = weakClient.get())
+                    task(*client);
             });
             break;
         }

--- a/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
@@ -27,23 +27,14 @@
 
 #if ENABLE(VIDEO)
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class TrackPrivateBaseClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TrackPrivateBaseClient> : std::true_type { };
-}
 
 namespace WebCore {
 
 using TrackID = uint64_t;
 
-class TrackPrivateBaseClient : public CanMakeWeakPtr<TrackPrivateBaseClient> {
+class TrackPrivateBaseClient : public AbstractRefCountedAndCanMakeWeakPtr<TrackPrivateBaseClient> {
 public:
     using Task = Function<void()>;
     using Dispatcher = Function<void(Task&&)>;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -59,6 +59,10 @@ public:
 
     virtual ~RemoteAudioTrackProxy();
 
+    // WebCore::AudioTrackPrivateClient.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     WebCore::TrackID id() const { return m_trackPrivate->id(); };
     void setEnabled(bool enabled)
     {

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -59,6 +59,10 @@ public:
 
     virtual ~RemoteTextTrackProxy();
 
+    // WebCore::InbandTextTrackPrivateClient.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     WebCore::TrackID id() const { return m_trackPrivate->id(); }
     void setMode(WebCore::InbandTextTrackPrivate::Mode mode) { m_trackPrivate->setMode(mode); }
     bool operator==(const WebCore::InbandTextTrackPrivate& track) const { return track == m_trackPrivate.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -59,6 +59,10 @@ public:
 
     virtual ~RemoteVideoTrackProxy();
 
+    // WebCore::VideoTrackPrivateClient.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     WebCore::TrackID id() const { return m_trackPrivate->id(); };
     void setSelected(bool selected)
     {


### PR DESCRIPTION
#### b8550b8c29a305b859acd9fecf20397abddbee10
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for TrackPrivateBaseClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303604">https://bugs.webkit.org/show_bug.cgi?id=303604</a>

Reviewed by Darin Adler.

* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::notifyClients):
(WebCore::TrackPrivateBase::notifyMainThreadClient):
* Source/WebCore/platform/graphics/TrackPrivateBaseClient.h:
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:

Canonical link: <a href="https://commits.webkit.org/304049@main">https://commits.webkit.org/304049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/244a38e06963df76c15d39a048e2aba454639a54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86237 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3567172c-36cc-48a5-a193-67631b6efe06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69897 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83393 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2545 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144400 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110975 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111222 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4779 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60126 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6407 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34753 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->