### PR TITLE
Add test for extended proofreading.

### DIFF
--- a/LayoutTests/editing/input/cocoa/extended-proofreading-expected.txt
+++ b/LayoutTests/editing/input/cocoa/extended-proofreading-expected.txt
@@ -1,0 +1,7 @@
+PASS internals.hasGrammarMarker(15, 2) became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a test of system.
+
+

--- a/LayoutTests/editing/input/cocoa/extended-proofreading.html
+++ b/LayoutTests/editing/input/cocoa/extended-proofreading.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ExtendedProofreadingEnabled=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div {
+    font-size: 300%;
+}
+</style>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+
+<script>
+jsTestIsAsync = true;
+
+if (window.internals) {
+    internals.setContinuousSpellCheckingEnabled(true);
+}
+
+async function runTest()
+{
+    const target = document.getElementById("target");
+    const misspelledText = "This is a test of system.";
+    
+    await UIHelper.activateElementAndWaitForInputSession(target);
+
+    document.execCommand("insertText", false, misspelledText);
+    document.execCommand("insertText", false, "\n");
+
+    // Move selection start to beginning of content editable or the search for markers will fail.
+
+    const selectionRange = document.createRange();
+    const currentSelection = window.getSelection();
+
+    selectionRange.setStart(target.firstChild, 0);
+    selectionRange.collapse(true);
+
+    currentSelection.removeAllRanges();
+    currentSelection.addRange(selectionRange);
+
+    if (window.testRunner) {
+        await shouldBecomeEqual('internals.hasGrammarMarker(15, 2)', 'true');
+        finishJSTest();
+    }
+}
+</script>
+<body>
+<div contenteditable="true" id="target"></div>
+<script>
+UIHelper.setSpellCheckerResults({
+  "This is a test of system." : [
+    {
+      type: "grammar",
+      from: 15,
+      to : 17,
+      details : [{ from : 0, to : 2 }]
+    }
+  ],
+    "This is a test of system.\n" : [
+    {
+      type: "grammar",
+      from: 15,
+      to : 17,
+      details : [{ from : 0, to : 2 }]
+    }
+  ]
+}).then(runTest);
+</script>
+</body>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -981,6 +981,9 @@ webkit.org/b/158500 storage/indexeddb/database-close-private.html [ Pass Failure
 
 webkit.org/b/128312 media/video-load-preload-metadata.html [ Pass Failure ]
 
+# rdar://problem/166269440
+editing/input/cocoa/extended-proofreading.html [ Skip ]
+
 # rdar://problem/27475162
 compositing/video/poster.html [ Pass ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 513756b52c10e5b18306f758ef0038ff5918ce91
<pre>
Add test for extended proofreading.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303967">https://bugs.webkit.org/show_bug.cgi?id=303967</a>
<a href="https://rdar.apple.com/165892721">rdar://165892721</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

Adding a test. This didn&apos;t work on iOS before because
strings are tokenized differently on mac and iOS and it had a newline in the key.

* LayoutTests/editing/input/cocoa/extended-proofreading-expected.txt: Added.
* LayoutTests/editing/input/cocoa/extended-proofreading.html: Added.
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/304303@main">https://commits.webkit.org/304303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566ec193b66be7b1d2efe1f38540069ed99bfd4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86916 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70482 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84097 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3200 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111625 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5421 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117385 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7237 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35538 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->