### PR TITLE
[iOS] Caption Style menu selected item does not update

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -41,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol WKCaptionStyleMenuControllerDelegate <NSObject>
 - (void)captionStyleMenuWillOpen:(PlatformMenu *)menu;
 - (void)captionStyleMenuDidClose:(PlatformMenu *)menu;
+@optional
+- (void)captionStyleMenu:(PlatformMenu *)menu didSelectProfile:(NSString *)profileID;
 @end
 
 WK_EXTERN

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -90,6 +90,10 @@ using namespace WTF;
 - (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID
 {
     [self setPreviewProfileID:profileID];
+    [self rebuildMenu];
+
+    if (auto delegate = self.delegate; delegate && [delegate respondsToSelector:@selector(captionStyleMenu:didSelectProfile:)])
+        [delegate captionStyleMenu:self.menu didSelectProfile:profileID];
 }
 
 - (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController


### PR DESCRIPTION
#### 1e412dbc637a1f6b37bcc3a099b121c3fe7a058d
<pre>
[iOS] Caption Style menu selected item does not update
<a href="https://rdar.apple.com/165893506">rdar://165893506</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303609">https://bugs.webkit.org/show_bug.cgi?id=303609</a>

Reviewed by Eric Carlson.

On iOS, a UIMenu is immutable once it&apos;s presented. To update
the selected state of a menu requires calling -updateVisibleMenu:
and returning a new UIMenu structure.

When a caption profile is selected, iterate over the presented UIMenu
structure and replace the previous captions style menu with a rebuilt
one.

* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant captionStyleMenu:didSelectProfile:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit legibleMenuController:didRequestCaptionPreviewForProfileID:]):

Canonical link: <a href="https://commits.webkit.org/304006@main">https://commits.webkit.org/304006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f5efdcd36812836839ae140f5ded36a93d3793e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86246 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102605 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/053b72c6-bf2b-4460-bb51-69d443b74652) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83399 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2559 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1579 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144411 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4783 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60136 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34760 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->