### PR TITLE
[appearance: base] Create a child pseudo render element for the ::checkmark pseudo style

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<style>
+    /* This is supposed to be UA sheet. */
+    input:is([type="radio"], [type="checkbox"]) {
+        margin: 3px 2px;
+        box-sizing: border-box;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        padding: initial;
+        background-color: -internal-auto-base(initial, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
+    }
+
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        height: 100%;
+        width: 100%;
+        display: inline-block;
+        background-color: currentColor;
+    }
+
+    input[type=radio]:checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
+        margin: 10%;
+        height: 80%;
+        width: 80%;
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
+        background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+
+    /* This is the beginning of the author sheet. */
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        width: 50px;
+        height: 50px;
+        color: darkgreen;
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
+    }
+
+    .base input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+    }
+</style>
+<body>
+    <div class="base">
+        <input type="radio" name="auto">
+        <input type="radio" name="auto" checked>
+        <input type="checkbox">
+        <input type="checkbox" checked>
+    </div>
+    <div>
+        <input type="radio" name="base">
+        <input type="radio" name="base" checked>
+        <input type="checkbox">
+        <input type="checkbox" checked>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<style>
+    /* This is supposed to be UA sheet. */
+    input:is([type="radio"], [type="checkbox"]) {
+        margin: 3px 2px;
+        box-sizing: border-box;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        padding: initial;
+        background-color: -internal-auto-base(initial, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
+    }
+
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        height: 100%;
+        width: 100%;
+        display: inline-block;
+        background-color: currentColor;
+    }
+
+    input[type=radio]:checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
+        margin: 10%;
+        height: 80%;
+        width: 80%;
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
+        background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
+        display: none;
+    }
+
+    /* This is the beginning of the author sheet. */
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        width: 50px;
+        height: 50px;
+        color: darkgreen;
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
+    }
+</style>
+<body>
+    <div class="auto-base">
+        <input type="radio" name="auto-base" checked>
+        <input type="radio" name="auto-base">
+        <input type="checkbox" checked>
+        <input type="checkbox">
+    </div>
+    <div class="base-auto">
+        <input type="radio" name="base-auto" checked style="appearance: base;">
+        <input type="radio" name="base-auto" style="appearance: base;">
+        <input type="checkbox" checked style="appearance: base;">
+        <input type="checkbox" style="appearance: base;">
+    </div>
+    <script>
+        const checkables = document.querySelectorAll('input');
+        checkables.forEach(checkable => {
+            if (checkable.style.appearance == 'base')
+                checkable.style.appearance = 'auto';
+            else
+                checkable.style.appearance = 'base';
+            checkable.checked = !checkable.checked;
+        });
+    </script>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial-expected.html
@@ -1,0 +1,93 @@
+<style>
+    .checkable {
+        width: 50px;
+        height: 50px;
+        margin: 2px;
+        display: inline-block;
+        border: 0.3em solid currentColor;
+        background: transparent;
+        font: 11px system-ui;
+        box-sizing: border-box;
+    }
+
+    .radio {
+        border-radius: 100%;
+        position: relative;
+        top: -6px;
+    }
+
+    .checkbox {
+        border-radius: 0.5em;
+    }
+
+    .checkbox .checkmark {
+        height: 100%;
+        width: 100%;
+        position: relative;
+        background-color: currentColor;
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
+    }
+ 
+    .radio .checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
+        margin: 10%;
+        height: 80%;
+        width: 80%;
+    }
+
+    .container {
+        display: inline-block;
+    }
+
+    .enabled .checkable {
+        color: darkblue;
+        margin-top: 3px;
+    }
+
+    .disabled .checkable {
+        color: darkgreen;
+        /*margin-top: 4px;*/
+        border-color: color-mix(in srgb, currentColor 30%, transparent);
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
+    }
+
+    .disabled .checkmark {
+        background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+</style>
+<body>
+    <div class="enabled container">
+        <div class="checkable radio">
+            <div class="checkmark" style="visibility: hidden;"></div>
+        </div>
+        <div class="checkable radio">
+            <div class="checkmark"></div>
+        </div>
+        <div class="checkable checkbox">
+            <div class="checkmark" style="visibility: hidden;"></div>
+        </div>
+        <div class="checkable checkbox">
+            <div class="checkmark"></div>
+        </div>
+    </div>
+    <div class="disabled container">
+        <div class="checkable radio">
+            <div class="checkmark" style="visibility: hidden;"></div>
+        </div>
+        <div class="checkable radio">
+            <div class="checkmark"></div>
+        </div>
+        <div class="checkable checkbox">
+            <div class="checkmark" style="visibility: hidden;"></div>
+        </div>
+        <div class="checkable checkbox">
+            <div class="checkmark"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
@@ -1,0 +1,90 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<style>
+    /* This is supposed to be UA sheet. */
+    input:is([type="radio"], [type="checkbox"]) {
+        margin: 3px 2px;
+        box-sizing: border-box;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        padding: initial;
+        background-color: -internal-auto-base(initial, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
+    }
+
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        height: 100%;
+        width: 100%;
+        display: inline-block;
+        background-color: currentColor;
+    }
+
+    input[type=radio]:checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
+        margin: 10%;
+        height: 80%;
+        width: 80%;
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
+        background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
+        display: none;
+    }
+
+    /* This is the beginning of the author sheet. */
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 50px;
+        height: 50px;
+        font: 11px system-ui;
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
+    }
+
+    .container {
+        display: inline-block;
+    }
+
+    .enabled input:is([type=checkbox]:not([switch]), [type=radio]) {
+        color: darkblue;
+    }
+
+    .disabled input:is([type=checkbox]:not([switch]), [type=radio]) {
+        color: darkgreen;
+    }
+</style>
+<body>
+    <div class="enabled container">
+        <input type="radio" name="enabled">
+        <input type="radio" name="enabled" checked>
+        <input type="checkbox">
+        <input type="checkbox" checked>
+    </div>
+    <div class="disabled container">
+        <input type="radio" name="disabled" disabled>
+        <input type="radio" name="disabled" checked disabled>
+        <input type="checkbox" disabled>
+        <input type="checkbox" checked disabled>
+    </div>
+</body>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1085,6 +1085,8 @@ void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedB
         if (CheckedPtr cache = renderer->document().existingAXObjectCache())
             cache->checkedStateChanged(*this);
     }
+
+    invalidateStyleInternal();
 }
 
 void HTMLInputElement::setIndeterminate(bool newValue)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -997,8 +997,10 @@ void RenderTreeBuilder::updateAfterDescendants(RenderElement& renderer)
         firstLetterBuilder().updateAfterDescendants(*block);
     if (auto* listItem = dynamicDowncast<RenderListItem>(renderer))
         listBuilder().updateItemMarker(*listItem);
-    if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderer))
+    if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderer)) {
         multiColumnBuilder().updateAfterDescendants(*blockFlow);
+        formControlsBuilder().updateAfterDescendants(*blockFlow);
+    }
 }
 
 RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderGrid(RenderGrid& parent, RenderObject& child, WillBeDestroyed willBeDestroyed)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,12 +45,15 @@ public:
     WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
     WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderMenuList& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
+    void updateAfterDescendants(RenderBlockFlow&);
+
 private:
     RenderBlock& findOrCreateParentForChild(RenderButton&);
     RenderBlock& findOrCreateParentForChild(RenderMenuList&);
+
+    void updateCheckmark(RenderBlockFlow&);
 
     RenderTreeBuilder& m_builder;
 };
 
 }
-


### PR DESCRIPTION
#### c3100e0d365f2da44633b72b58bd637df7a0c534
<pre>
[appearance: base] Create a child pseudo render element for the ::checkmark pseudo style
<a href="https://bugs.webkit.org/show_bug.cgi?id=303606">https://bugs.webkit.org/show_bug.cgi?id=303606</a>
<a href="https://rdar.apple.com/165893004">rdar://165893004</a>

Reviewed by Antti Koivisto.

A child checkmark box will be created for ::checkmark pseudo style. It will be
created only if the appearance is `base` and the ::checkmark is not styled with
`display: none;` or `display: contents;`.

This checkmark box will be removed from the parent renderer when the appearance is
not `base` or ::checkmark is styled with `display: none;` or `display: contents;`.

The UA style sheet will have a rule to set ::checkmark style with `display: none;`
when it is unchecked. For now this rule will be added in the test style sheet.

Tests: fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
       fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html

* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html: Added.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setChecked):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::updateCheckmark):
(WebCore::RenderTreeBuilder::FormControls::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h:

Canonical link: <a href="https://commits.webkit.org/304390@main">https://commits.webkit.org/304390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ecd082c425ca0beb92aaaab1a229fce3663db33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143139 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c5e03c7-c12c-46f4-a8e5-3775cdd6d346) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137315 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8461 "Hash 1ecd082c for PR 54904 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7671 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca6d261c-28f3-4342-92ec-14eb6aceb8b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138392 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/8461 "Hash 1ecd082c for PR 54904 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dfd2f26b-ba12-41ba-a10c-a8b4d8a5d733) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/8461 "Hash 1ecd082c for PR 54904 does not build (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3750 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/8461 "Hash 1ecd082c for PR 54904 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145894 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7507 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/40159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5698 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20884 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7561 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7309 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/71108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7410 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->