### PR TITLE
[OpenXR][WebXR Hit Test] xrCreateTrackableTrackerANDROID should be guarded by XR_ANDROID_trackables

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
@@ -94,12 +94,16 @@ bool OpenXRExtensions::loadMethods(XrInstance instance)
         RELEASE_ASSERT(m_methods->xrLocateHandJointsEXT);
     }
 #endif
+#if defined(XR_ANDROID_trackables)
+    if (isExtensionSupported(XR_ANDROID_TRACKABLES_EXTENSION_NAME ""_span)) {
+        xrGetInstanceProcAddr(instance, "xrCreateTrackableTrackerANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateTrackableTrackerANDROID));
+        RELEASE_ASSERT(m_methods->xrCreateTrackableTrackerANDROID);
+    }
+#endif
 #if defined(XR_ANDROID_raycast)
     if (isExtensionSupported(XR_ANDROID_RAYCAST_EXTENSION_NAME ""_span)) {
         xrGetInstanceProcAddr(instance, "xrRaycastANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrRaycastANDROID));
-        xrGetInstanceProcAddr(instance, "xrCreateTrackableTrackerANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateTrackableTrackerANDROID));
         RELEASE_ASSERT(m_methods->xrRaycastANDROID);
-        RELEASE_ASSERT(m_methods->xrCreateTrackableTrackerANDROID);
     }
 #endif
     return true;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -57,9 +57,11 @@ public:
     PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT { nullptr };
     PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT { nullptr };
 #endif
+#if defined(XR_ANDROID_trackables)
+    PFN_xrCreateTrackableTrackerANDROID xrCreateTrackableTrackerANDROID { nullptr };
+#endif
 #if defined(XR_ANDROID_raycast)
     PFN_xrRaycastANDROID xrRaycastANDROID { nullptr };
-    PFN_xrCreateTrackableTrackerANDROID xrCreateTrackableTrackerANDROID { nullptr };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -30,7 +30,7 @@ namespace WebKit {
 OpenXRHitTestManager::OpenXRHitTestManager(XrSession session)
     : m_session(session)
 {
-#if defined(XR_ANDROID_raycast)
+#if defined(XR_ANDROID_trackables)
     auto createInfo = createOpenXRStruct<XrTrackableTrackerCreateInfoANDROID, XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID>();
     createInfo.trackableType = XR_TRACKABLE_TYPE_PLANE_ANDROID;
     CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrCreateTrackableTrackerANDROID(session, &createInfo, &m_trackableTracker));


### PR DESCRIPTION
#### 136f2ea369752e9018e6f6979bb04c57b3affe2f
<pre>
[OpenXR][WebXR Hit Test] xrCreateTrackableTrackerANDROID should be guarded by XR_ANDROID_trackables
<a href="https://bugs.webkit.org/show_bug.cgi?id=303611">https://bugs.webkit.org/show_bug.cgi?id=303611</a>

Reviewed by Dan Glastonbury.

xrCreateTrackableTrackerANDROID should be guarded by XR_ANDROID_trackables, not
by XR_ANDROID_raycast.
&lt;<a href="https://registry.khronos.org/OpenXR/specs/1.1/man/html/xrCreateTrackableTrackerANDROID.html">https://registry.khronos.org/OpenXR/specs/1.1/man/html/xrCreateTrackableTrackerANDROID.html</a>&gt;

* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp:
(WebKit::OpenXRExtensions::loadMethods):
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
(WebKit::OpenXRHitTestManager::OpenXRHitTestManager):

Canonical link: <a href="https://commits.webkit.org/304126@main">https://commits.webkit.org/304126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88274bca2d90cebf03b4b8c8a765e171be1c5990

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4984 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2563 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114191 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144417 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110985 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111234 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4789 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60142 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34765 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69889 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->