### PR TITLE
Adopt LIFETIME_BOUND in UniqueRef.h

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -77,13 +77,13 @@ public:
         ASSERT(m_ref);
     }
 
-    T* ptr() const RETURNS_NONNULL { ASSERT(m_ref); return m_ref.get(); }
-    T& get() const { ASSERT(m_ref); return *m_ref; }
+    T* ptr() const LIFETIME_BOUND RETURNS_NONNULL { ASSERT(m_ref); return m_ref.get(); }
+    T& get() const LIFETIME_BOUND { ASSERT(m_ref); return *m_ref; }
 
-    T* operator&() const { ASSERT(m_ref); return m_ref.get(); }
-    T* operator->() const { ASSERT(m_ref); return m_ref.get(); }
+    T* operator&() const LIFETIME_BOUND { ASSERT(m_ref); return m_ref.get(); }
+    T* operator->() const LIFETIME_BOUND { ASSERT(m_ref); return m_ref.get(); }
 
-    operator T&() const { ASSERT(m_ref); return *m_ref; }
+    operator T&() const LIFETIME_BOUND { ASSERT(m_ref); return *m_ref; }
 
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }
 
@@ -108,7 +108,7 @@ template<typename T>
 struct GetPtrHelper<UniqueRef<T>> {
     using PtrType = T*;
     using UnderlyingType = T;
-    static T* getPtr(const UniqueRef<T>& p) { return const_cast<T*>(p.ptr()); }
+    static T* getPtr(const UniqueRef<T>& p LIFETIME_BOUND) { return const_cast<T*>(p.ptr()); }
 };
 
 template<typename T>


### PR DESCRIPTION
#### c4595104d58acc4a9cbdadcf468104b2ad0844ee
<pre>
Adopt LIFETIME_BOUND in UniqueRef.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=303616">https://bugs.webkit.org/show_bug.cgi?id=303616</a>

Reviewed by David Kilzer.

* Source/WTF/wtf/UniqueRef.h:
(WTF::GetPtrHelper&lt;UniqueRef&lt;T&gt;&gt;::getPtr):
(WTF::UniqueRef::get const): Deleted.
(WTF::UniqueRef::operator&amp; const): Deleted.
(WTF::UniqueRef::operator-&gt; const): Deleted.
(WTF::UniqueRef::operator T&amp; const): Deleted.

Canonical link: <a href="https://commits.webkit.org/304050@main">https://commits.webkit.org/304050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0655056bef1d5d0fba2898beb2a9c8ce4a45f065

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86386 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102727 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83518 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5065 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2686 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126453 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144623 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132907 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6543 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4899 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6595 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34922 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165838 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70166 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->