### PR TITLE
[Site Isolation] Cross-site iframes don't receive DeviceOrientationEvents

### DIFF
--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -63,6 +63,10 @@
 #include "RemotePageVideoPresentationManagerProxy.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+#include "WebDeviceOrientationUpdateProviderProxy.h"
+#endif
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePageProxy);
@@ -85,6 +89,10 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
         m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, page.backForwardList());
 
     m_process->addRemotePageProxy(*this);
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+    m_page->webDeviceOrientationUpdateProviderProxy()->addAsMessageReceiverForProcess(m_process.get(), m_webPageID);
+#endif
 }
 
 void RemotePageProxy::injectPageIntoNewProcess()
@@ -151,6 +159,10 @@ void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTermi
 
 RemotePageProxy::~RemotePageProxy()
 {
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+    m_page->webDeviceOrientationUpdateProviderProxy()->removeAsMessageReceiverForProcess(m_process.get(), m_webPageID);
+#endif
+
     if (RefPtr page = m_page.get())
         page->isNoLongerAssociatedWithRemotePage(*this);
     if (m_drawingArea)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15596,7 +15596,9 @@ void WebPageProxy::willAcquireUniversalFileReadSandboxExtension(WebProcessProxy&
 
 void WebPageProxy::simulateDeviceOrientationChange(double alpha, double beta, double gamma)
 {
-    send(Messages::WebPage::SimulateDeviceOrientationChange(alpha, beta, gamma));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPage::SimulateDeviceOrientationChange(alpha, beta, gamma), pageID);
+    });
 }
 
 #if ENABLE(DATA_DETECTION)
@@ -17401,6 +17403,13 @@ bool shouldShowSwiftDemoLogo()
     RELEASE_ASSERT_NOT_REACHED();
 #endif
 }
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+RefPtr<WebDeviceOrientationUpdateProviderProxy> WebPageProxy::webDeviceOrientationUpdateProviderProxy()
+{
+    return m_webDeviceOrientationUpdateProviderProxy;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2875,6 +2875,10 @@ public:
     void dropNetworkActivity();
     bool hasValidNetworkActivity() const;
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
+    RefPtr<WebDeviceOrientationUpdateProviderProxy> webDeviceOrientationUpdateProviderProxy();
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -29,6 +29,7 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/MotionManagerClient.h>
+#include <WebCore/PageIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -38,6 +39,7 @@ class SecurityOriginData;
 namespace WebKit {
 
 class WebPageProxy;
+class WebProcessProxy;
 struct SharedPreferencesForWebProcess;
 
 class WebDeviceOrientationUpdateProviderProxy final : public WebCore::MotionManagerClient, private IPC::MessageReceiver, public RefCounted<WebDeviceOrientationUpdateProviderProxy>, public CanMakeCheckedPtr<WebDeviceOrientationUpdateProviderProxy> {
@@ -64,6 +66,9 @@ public:
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+
+    void addAsMessageReceiverForProcess(WebProcessProxy&, WebCore::PageIdentifier);
+    void removeAsMessageReceiverForProcess(WebProcessProxy&, WebCore::PageIdentifier);
 
 private:
     explicit WebDeviceOrientationUpdateProviderProxy(WebPageProxy&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8472,8 +8472,14 @@ WebCore::DOMPasteAccessResponse WebPage::requestDOMPasteAccess(DOMPasteAccessCat
 void WebPage::simulateDeviceOrientationChange(double alpha, double beta, double gamma)
 {
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
-    if (RefPtr localTopDocument = this->localTopDocument())
-        localTopDocument->simulateDeviceOrientationChange(alpha, beta, gamma);
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
+        if (!localFrame)
+            continue;
+
+        if (RefPtr document = localFrame->document())
+            document->simulateDeviceOrientationChange(alpha, beta, gamma);
+    }
 #endif
 }
 

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -52,6 +52,10 @@
 @property (nonatomic, copy) void (^insertInputSuggestion)(WKWebView *, UIInputSuggestion *);
 #endif
 
+#if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
+@property (nonatomic, copy) void (^requestDeviceOrientationAndMotionPermissionForOrigin)(WKSecurityOrigin *, WKFrameInfo *, void(^)(WKPermissionDecision));
+#endif
+
 - (NSString *)waitForAlert;
 - (NSString *)waitForConfirm;
 - (NSString *)waitForPromptWithReply:(NSString *)reply;

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -164,6 +164,18 @@
 
 #endif
 
+#if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
+
+- (void)webView:(WKWebView *)webView requestDeviceOrientationAndMotionPermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)requestingFrame decisionHandler:(void (^)(WKPermissionDecision))decisionHandler
+{
+    if (_requestDeviceOrientationAndMotionPermissionForOrigin)
+        _requestDeviceOrientationAndMotionPermissionForOrigin(origin, requestingFrame, decisionHandler);
+    else
+        decisionHandler(WKPermissionDecisionPrompt);
+}
+
+#endif
+
 - (NSString *)waitForAlert
 {
     EXPECT_FALSE(self.runJavaScriptAlertPanelWithMessage);


### PR DESCRIPTION
#### 21b3626e181e759a3202bdc3248cce2549f39acf
<pre>
[Site Isolation] Cross-site iframes don&apos;t receive DeviceOrientationEvents
<a href="https://bugs.webkit.org/show_bug.cgi?id=303618">https://bugs.webkit.org/show_bug.cgi?id=303618</a>
<a href="https://rdar.apple.com/165900470">rdar://165900470</a>

Reviewed by Brady Eidson.

With site isolation on, cross-site iframes don&apos;t receive DeviceOrientationEvents.
There are mulitple problems we must fix to get this working:

1. Not listening for the events:

    Even if the cross-site iframe is granted permission to receive the events
    and has registered an event listener, WebKit still won&apos;t listen for events
    from CoreMotion.

    The Web Process tells the UI Process to listen for events from CoreMotion
    via this call chain:

    1. Event listener is added.
    2. The Web Process sends an IPC to the UI Process in
       WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation()
    3. WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation().
       is called on the UI Process side, and then the UI Process then starts
       listening for events from CoreMotion.

    In the case of the cross-site iframe, the UI Process never received this
    message. This is because, as we see from it&apos;s constructor,
    WebDeviceOrientationUpdateProviderProxy is only set up to receiver messages from
    the main frame&apos;s Web Process.

    To allow WebDeviceOrientationUpdateProviderProxy to receive messages from any
    cross-site Web Process (even those created in the future), we modify
    RemotePageProxy (which is created for every cross-site Web Process) to ensure
    that WebDeviceOrientationUpdateProviderProxy can receive messages from the
    Web Process associated with that RemotePageProxy.

2. Not sending the events

    So now the cross-site iframe&apos;s Web Process is listening for the events, but
    the UI Process is not sending them. We see in
    WebDeviceOrientationUpdateProviderProxy::orientationChanged that the events
    are sent only to the main frame&apos;s Web Process.

    We fix this to ensure that events are sent to all Web Processes.

3. Testing:

    We add a new API test to test this. But testing this required changes as well.
    To simulate a device orientation change, we call _simulateDeviceOrientationChangeWithAlpha
    on the WebView.

    In order for this simulated change to be noticed by the cross-site iframe,
    we must call simulateDeviceOrientationChange() on that iframe&apos;s Document.

    So the first step is ensuring that each Web Process is notified of this change.
    For that, we modify WebPageProxy::simulateDeviceOrientationChange().

    Then, within each Web Process, we must ensure that each LocalFrame&apos;s Document
    is notified of the change (the cross-site iframe will be a LocalFrame in one
    of the WebProcesses). For this, we modify WebPage::simulateDeviceOrientationChange.

    The new API test is SiteIsolation.CrossSiteIFrameCanReceiveDeviceOrientationEvents

* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):

Ensure the associated WebProcess is able to send messages to
WebDeviceOrientationUpdateProviderProxy by adding the Proxy object as a
MessageReceiver.

(WebKit::RemotePageProxy::~RemotePageProxy):

Remove WebDeviceOrientationUpdateProviderProxy as a MessageReceiver of this
WebProcess.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::simulateDeviceOrientationChange):

Send the change to every Web Process (for testing).

(WebKit::WebPageProxy::webDeviceOrientationUpdateProviderProxy):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::addAsMessageReceiverForProcess):
(WebKit::WebDeviceOrientationUpdateProviderProxy::removeAsMessageReceiverForProcess):
(WebKit::WebDeviceOrientationUpdateProviderProxy::orientationChanged):

Send the change to every Web Process.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::simulateDeviceOrientationChange):

Send the change to all LocalFrame&apos;s documents (for testing).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, CrossSiteIFrameCanReceiveDeviceOrientationEvents)):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate webView:requestDeviceOrientationAndMotionPermissionForOrigin:initiatedByFrame:decisionHandler:]):

Canonical link: <a href="https://commits.webkit.org/304018@main">https://commits.webkit.org/304018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd2db8aa227ae9f7ddc3a0f2dc348aaccd0755b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134346 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/6823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136216 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137293 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144569 "Failed to checkout and rebase branch from PR 54913") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/6501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/144569 "Failed to checkout and rebase branch from PR 54913") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/144569 "Failed to checkout and rebase branch from PR 54913") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20740 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/6553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->