### PR TITLE
Synchronise WebSocket WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.js
@@ -11,6 +11,7 @@ async_test(t => {
 // list of bad ports according to
 // https://fetch.spec.whatwg.org/#port-blocking
 [
+  0,
   1,    // tcpmux
   7,    // echo
   9,    // discard
@@ -49,6 +50,7 @@ async_test(t => {
   137,  // netbios-ns
   139,  // netbios-ssn
   143,  // imap2
+  161,  // snmp
   179,  // bgp
   389,  // ldap
   427,  // afp (alternate)
@@ -80,6 +82,8 @@ async_test(t => {
   3659, // apple-sasl
   4045, // lockd
   4190, // sieve
+  5060, // sip
+  5061, // sips
   6000, // x11
   6566, // sane-port
   6665, // irc (alternate)

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_default-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Basic check
+PASS WebSocket blocked port test 0
 PASS WebSocket blocked port test 1
 PASS WebSocket blocked port test 7
 PASS WebSocket blocked port test 9
@@ -38,6 +39,7 @@ PASS WebSocket blocked port test 135
 PASS WebSocket blocked port test 137
 PASS WebSocket blocked port test 139
 PASS WebSocket blocked port test 143
+PASS WebSocket blocked port test 161
 PASS WebSocket blocked port test 179
 PASS WebSocket blocked port test 389
 PASS WebSocket blocked port test 427
@@ -69,6 +71,8 @@ PASS WebSocket blocked port test 2049
 PASS WebSocket blocked port test 3659
 PASS WebSocket blocked port test 4045
 PASS WebSocket blocked port test 4190
+PASS WebSocket blocked port test 5060
+PASS WebSocket blocked port test 5061
 PASS WebSocket blocked port test 6000
 PASS WebSocket blocked port test 6566
 PASS WebSocket blocked port test 6665

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_wss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_wss-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Basic check
+PASS WebSocket blocked port test 0
 PASS WebSocket blocked port test 1
 PASS WebSocket blocked port test 7
 PASS WebSocket blocked port test 9
@@ -38,6 +39,7 @@ PASS WebSocket blocked port test 135
 PASS WebSocket blocked port test 137
 PASS WebSocket blocked port test 139
 PASS WebSocket blocked port test 143
+PASS WebSocket blocked port test 161
 PASS WebSocket blocked port test 179
 PASS WebSocket blocked port test 389
 PASS WebSocket blocked port test 427
@@ -69,6 +71,8 @@ PASS WebSocket blocked port test 2049
 PASS WebSocket blocked port test 3659
 PASS WebSocket blocked port test 4045
 PASS WebSocket blocked port test 4190
+PASS WebSocket blocked port test 5060
+PASS WebSocket blocked port test 5061
 PASS WebSocket blocked port test 6000
 PASS WebSocket blocked port test 6566
 PASS WebSocket blocked port test 6665

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_default-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Basic check
+PASS WebSocket blocked port test 0
 PASS WebSocket blocked port test 1
 PASS WebSocket blocked port test 7
 PASS WebSocket blocked port test 9
@@ -38,6 +39,7 @@ PASS WebSocket blocked port test 135
 PASS WebSocket blocked port test 137
 PASS WebSocket blocked port test 139
 PASS WebSocket blocked port test 143
+PASS WebSocket blocked port test 161
 PASS WebSocket blocked port test 179
 PASS WebSocket blocked port test 389
 PASS WebSocket blocked port test 427
@@ -69,6 +71,8 @@ PASS WebSocket blocked port test 2049
 PASS WebSocket blocked port test 3659
 PASS WebSocket blocked port test 4045
 PASS WebSocket blocked port test 4190
+PASS WebSocket blocked port test 5060
+PASS WebSocket blocked port test 5061
 PASS WebSocket blocked port test 6000
 PASS WebSocket blocked port test 6566
 PASS WebSocket blocked port test 6665

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_wss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_wss-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Basic check
+PASS WebSocket blocked port test 0
 PASS WebSocket blocked port test 1
 PASS WebSocket blocked port test 7
 PASS WebSocket blocked port test 9
@@ -38,6 +39,7 @@ PASS WebSocket blocked port test 135
 PASS WebSocket blocked port test 137
 PASS WebSocket blocked port test 139
 PASS WebSocket blocked port test 143
+PASS WebSocket blocked port test 161
 PASS WebSocket blocked port test 179
 PASS WebSocket blocked port test 389
 PASS WebSocket blocked port test 427
@@ -69,6 +71,8 @@ PASS WebSocket blocked port test 2049
 PASS WebSocket blocked port test 3659
 PASS WebSocket blocked port test 4045
 PASS WebSocket blocked port test 4190
+PASS WebSocket blocked port test 5060
+PASS WebSocket blocked port test 5061
 PASS WebSocket blocked port test 6000
 PASS WebSocket blocked port test 6566
 PASS WebSocket blocked port test 6665

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: websockets
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Testing BFCache support for a page with an open WebSocket connection, but close it in pagehide. assert_false: WebSocket should not have error expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.js
@@ -1,0 +1,28 @@
+// META: title=Testing BFCache support for a page with an open WebSocket connection, but close it in pagehide.
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/utils.js
+// META: script=/html/browsers/browsing-the-web/back-forward-cache/resources/rc-helper.js
+// META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+// META: script=/websockets/constants.sub.js
+// META: script=resources/websockets-test-helpers.sub.js
+
+'use strict';
+
+promise_test(async t => {
+  const rcHelper = new RemoteContextHelper();
+    // Open a window with noopener so that BFCache will work.
+  const rc1 = await rcHelper.addWindow(
+      /*config=*/ null, /*options=*/ { features: 'noopener' });
+
+  await openWebSocketAndCloseItInPageHide(rc1);
+
+  // The page should be eligible for BFCache because the WebSocket connection will be closed in `pagehide`.
+  // `pagehide` is dispatched before BFCache
+  await assertBFCacheEligibility(rc1, /*shouldRestoreFromBFCache=*/ true);
+
+  // Read WebSocket event flags
+  const { wsError, wsClose } = await readWebSocketCloseAndErrorFlags(rc1);
+
+  assert_false(wsError, 'WebSocket should not have error');
+  assert_true(wsClose, 'WebSocket should have been closed via pagehide');
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set-expected.txt
@@ -1,0 +1,5 @@
+WebSocket - Set Cross-origin cookie
+
+
+FAIL Cookie should be set assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Include credentials in cross-origin websocket requests</title>
+<meta name=author title="Domenico Rizzo" href="mailto:domenico.rizzo@gmail.com">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/websockets/constants.sub.js"></script>
+
+<h1>WebSocket - Set Cross-origin cookie</h1>
+<div id=log></div>
+<script>
+    var resp_test = async_test('Cookie should be set')
+
+    resp_test.step(function() {
+        var ws = new WebSocket(SCHEME_CROSSDOMAIN_PORT + "/set-cookie?cookie_test");
+        ws.onerror = resp_test.step_func_done(function () {
+            assert_unreached("ws no error");
+        });
+        ws.onclose = resp_test.step_func_done(function () {
+            assert_unreached("'close' should not fire before 'open'.");
+        });
+        ws.onopen = resp_test.step_func(function (e) {
+            ws.onclose = null;
+            ws.close();
+
+            var ws2 = new WebSocket(SCHEME_CROSSDOMAIN_PORT + "/echo-cookie");
+            ws2.onerror = resp_test.step_func_done(function () {
+                assert_unreached("ws2 no error");
+            });
+            ws2.onclose = resp_test.step_func_done(function () {
+                assert_unreached("'close' should not fire before 'open'.");
+            });
+            ws2.onmessage = resp_test.step_func_done(function (e) {
+                ws2.onclose = null;
+                ws2.close();
+                assert_true(/ws_test_cookie_test=test/.test(e.data));
+            });
+        });
+    })
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/w3c-import.log
@@ -21,4 +21,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/005.html
 /LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/006.html
 /LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/007.html
+/LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set.html
 /LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/third-party-cookie-accepted.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/msg_channel_wsh.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/msg_channel_wsh.py
@@ -150,8 +150,8 @@ def run_read(request, uuid, queue):
      close - Close the reader queue
 
     In addition there's a thread that listens for messages on the
-    socket itself. Typically this socket shouldn't recieve any
-    messages, but it can recieve an explicit "close" message,
+    socket itself. Typically this socket shouldn't receive any
+    messages, but it can receive an explicit "close" message,
     indicating the socket should be disconnected.
     """
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Websockets - Received 301 code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>WebSockets: 301 Code Failed</title>
+<meta name=author title="Domenico Rizzo" href="mailto:domenico.rizzo@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../constants.sub.js"></script>
+<div id="log"></div>
+<script>
+async_test(function(t) {
+    t.step(function() {
+        const ws = new WebSocket(new URL("resources/redirect_response.py", location.href));
+
+        ws.onopen = t.step_func(function() {
+            assert_unreached("onopen");
+        });
+
+        ws.onerror = t.step_func(function() {
+            assert_true(true)
+            t.done()
+        });
+      });
+}, 'Websockets - Received 301 code');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/redirect_response.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/redirect_response.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    headers = [('Location', '/echo')]
+    return (301, "moved"), headers, ''

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/redirect_response.py

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/w3c-import.log
@@ -20,3 +20,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/003.html
 /LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/005.html
 /LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/006.html
+/LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code.html

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/resources/websockets-test-helpers.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/resources/websockets-test-helpers.sub.js
@@ -23,3 +23,36 @@ async function openThenCloseWebSocket(remoteContextHelper) {
   }, [SCHEME_DOMAIN_PORT]);
   assert_equals(return_value, 42);
 }
+
+// Opens a new WebSocket connection and close it in pagehide event listener.
+async function openWebSocketAndCloseItInPageHide(remoteContextHelper) {
+  window.wsErrorOccurred = false;
+  window.wsCloseOccurred = false;
+
+  let return_value = await remoteContextHelper.executeScript((domain) => {
+    return new Promise((resolve) => {
+      var testWebSocket = new WebSocket(domain + '/echo');
+      testWebSocket.onopen = () => {
+        // Close WebSocket during pagehide (BFCache entry)
+        window.addEventListener(
+          'pagehide',
+          () => testWebSocket.close()
+        );
+        resolve(42);
+      };
+      testWebSocket.onerror = () => { window.wsErrorOccurred = true; };
+      testWebSocket.onclose = () => { window.wsCloseOccurred = true; };
+    });
+  }, [SCHEME_DOMAIN_PORT]);
+  assert_equals(return_value, 42);
+}
+
+// Reads wsErrorOccurred and wsCloseOccurred from the remote context.
+async function readWebSocketCloseAndErrorFlags(remoteContext) {
+  return await remoteContext.executeScript(() => {
+    return {
+      wsError: window.wsErrorOccurred === true,
+      wsClose: window.wsCloseOccurred === true
+    };
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/w3c-import.log
@@ -75,8 +75,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/websockets/Send-paired-surrogates.any.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/Send-unicode-data.any.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/Send-unpaired-surrogates.any.js
+/LayoutTests/imported/w3c/web-platform-tests/websockets/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window.js
+/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection.window.js
 /LayoutTests/imported/w3c/web-platform-tests/websockets/basic-auth.any.js


### PR DESCRIPTION
#### 0ba170ca10920fb7c8f6ee62f83d0fb1dd0f4709
<pre>
Synchronise WebSocket WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=303534">https://bugs.webkit.org/show_bug.cgi?id=303534</a>

Reviewed by Fujii Hironori.

Updating to the newest WebSocket WPT tests.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8934df5fa015dc3b57a9b284c51a947db73d53f9">https://github.com/web-platform-tests/wpt/commit/8934df5fa015dc3b57a9b284c51a947db73d53f9</a>

* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.js:
* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker_wss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-blocked-port.any_wss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.js: Added.
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/cross-origin-cookie-set.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/cookies/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/msg_channel_wsh.py:
(run_read):
* LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/received-301-code.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/redirect_response.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/resources/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/websockets/opening-handshake/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/websockets/resources/websockets-test-helpers.sub.js:
(async openWebSocketAndCloseItInPageHide):
(async readWebSocketCloseAndErrorFlags):
* LayoutTests/imported/w3c/web-platform-tests/websockets/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/303977@main">https://commits.webkit.org/303977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8ba52f5c4cf36a86c5dd3afc2a14e1fa08a0d76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45442 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6599 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120307 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1620 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144451 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39026 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111266 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28205 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/4807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116579 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6459 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->