### PR TITLE
REGRESSION(303655@main): [WebXR Hit Test][OpenXR] Unreviewed build fix for !ENABLE(WEBXR_HIT_TEST)

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 #include "OpenXRHitTestManager.h"
 
-#if ENABLE(WEBXR) && USE(OPENXR)
+#if ENABLE(WEBXR_HIT_TEST) && USE(OPENXR)
 
 #include "OpenXRExtensions.h"
 #include "OpenXRUtils.h"
@@ -71,4 +71,4 @@ Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTes
 
 } // namespace WebKit
 
-#endif // ENABLE(WEBXR) && USE(OPENXR)
+#endif // ENABLE(WEBXR_HIT_TEST) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#if ENABLE(WEBXR) && USE(OPENXR)
+#if ENABLE(WEBXR_HIT_TEST) && USE(OPENXR)
 
 #include <WebCore/PlatformXR.h>
 #include <openxr/openxr.h>
@@ -44,4 +44,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(WEBXR) && USE(OPENXR)
+#endif // ENABLE(WEBXR_HIT_TEST) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -393,8 +393,10 @@ void OpenXRCoordinator::requestHitTestSource(WebPageProxy& page, const PlatformX
 
             auto copiedOptions = makeUniqueRef<PlatformXR::HitTestOptions>(options);
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTFMove(copiedOptions), completionHandler = WTFMove(completionHandler)]() mutable {
+#if ENABLE(WEBXR_HIT_TEST)
                 if (!renderState->hitTestManager)
                     renderState->hitTestManager = makeUnique<OpenXRHitTestManager>(m_session);
+#endif
                 auto addResult = renderState->hitTestSources.add(renderState->nextHitTestSource, WTFMove(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
                 callOnMainRunLoop([source = renderState->nextHitTestSource, completionHandler = WTFMove(completionHandler)] mutable {
@@ -450,8 +452,10 @@ void OpenXRCoordinator::requestTransientInputHitTestSource(WebPageProxy& page, c
 
             auto copiedOptions = makeUniqueRef<PlatformXR::TransientInputHitTestOptions>(options);
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTFMove(copiedOptions), completionHandler = WTFMove(completionHandler)]() mutable {
+#if ENABLE(WEBXR_HIT_TEST)
                 if (!renderState->hitTestManager)
                     renderState->hitTestManager = makeUnique<OpenXRHitTestManager>(m_session);
+#endif
                 auto addResult = renderState->transientInputHitTestSources.add(renderState->nextTransientInputHitTestSource, WTFMove(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
                 callOnMainRunLoop([source = renderState->nextTransientInputHitTestSource, completionHandler = WTFMove(completionHandler)] mutable {


### PR DESCRIPTION
#### a834360626713ddf04272782042d28d623513feb
<pre>
REGRESSION(303655@main): [WebXR Hit Test][OpenXR] Unreviewed build fix for !ENABLE(WEBXR_HIT_TEST)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303081">https://bugs.webkit.org/show_bug.cgi?id=303081</a>

The build without ENABLE_WEBXR_HIT_TEST was broken after 303655@main.

* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):

Canonical link: <a href="https://commits.webkit.org/303978@main">https://commits.webkit.org/303978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5da90545c1684f918e591d12f3f37a9a18cb2ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141801 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6592 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137164 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120301 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/83429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1613 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39023 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111260 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4809 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60176 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20724 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6450 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/34791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69916 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->