### PR TITLE
[threaded-animations] add testing functions to inspect remote timelines

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2051,6 +2051,28 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async remoteTimeline(timeline)
+    {
+        if (!this.isWebKit2() || !(timeline instanceof ScrollTimeline))
+            return;
+
+        const scrollingNodeID = window.internals?.scrollingNodeIDForTimeline(timeline);
+        if (!scrollingNodeID[0] || !scrollingNodeID[1])
+            return;
+
+        const identifier = window.internals?.identifierForTimeline(timeline);
+
+        const script = `uiController.uiScriptComplete(uiController.progressBasedTimelinesForScrollingNodeID(${scrollingNodeID[0]}, ${scrollingNodeID[1]}))`;
+        const result = await new Promise(resolve => {
+            testRunner.runUIScript(script, result => resolve(JSON.parse(result)));
+        });
+        const timelines = result.timelines;
+        for (const timeline of timelines) {
+            if (timeline.identifier == identifier)
+                return timeline;
+        }
+    }
+
     static dragFromPointToPoint(fromX, fromY, toX, toY, duration)
     {
         if (!this.isWebKit2() || !this.isIOSFamily()) {

--- a/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A remote timeline gets created, updated and removed during the lifecycle of its associated animation.
+

--- a/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion.html
+++ b/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+.target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const make_target = t => {
+    const target = createDiv(t);
+    target.className = "target";
+    return target;
+};
+
+promise_test(async t => {
+    const source = document.documentElement;
+    const maxScrollTop = source.scrollHeight - window.innerHeight;
+    window.scrollTo(0, maxScrollTop / 2);
+
+    const target = make_target(t);
+    const timeline = new ScrollTimeline({ source });
+    const animation = target.animate({ translate: '100px' }, { timeline });
+    await animationAcceleration(animation);
+    const initialTimeline = await UIHelper.remoteTimeline(timeline);
+    assert_not_equals(initialTimeline, undefined, "Remote timeline was created.");
+
+    document.body.style.height = "3000px";
+    await threadedAnimationsCommit();
+    const updatedTimeline = await UIHelper.remoteTimeline(timeline);
+    assert_not_equals(updatedTimeline.currentTime, initialTimeline.currentTime, "Changing a timeline's source size changes the remote timeline's current time.");
+
+    animation.cancel();
+    await threadedAnimationsCommit();
+    const removedTimeline = await UIHelper.remoteTimeline(timeline);
+    assert_equals(removedTimeline, undefined, "Canceling an animaiton removes its remote timelines.");
+}, "A remote timeline gets created, updated and removed during the lifecycle of its associated animation.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -84,6 +84,7 @@ public:
     virtual bool computeCanBeAccelerated() const { return false; }
     AcceleratedTimeline& acceleratedRepresentation();
     void runPostRenderingUpdateTasks();
+    const TimelineIdentifier& acceleratedTimelineIdentifierForTesting() const { return m_acceleratedTimelineIdentifier; }
 #endif
 
 protected:

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -430,6 +430,15 @@ Ref<AcceleratedTimeline> ScrollTimeline::createAcceleratedRepresentation() const
         data.rangeEnd
     });
 }
+
+std::optional<ScrollingNodeID> ScrollTimeline::scrollingNodeIDForTesting() const
+{
+    if (RefPtr source = this->source()) {
+        if (CheckedPtr sourceScrollableArea = scrollableAreaForSourceRenderer(source->renderer(), source->document()))
+            return sourceScrollableArea->scrollingNodeID();
+    }
+    return std::nullopt;
+}
 #endif
 
 TextStream& operator<<(TextStream& ts, const ScrollTimeline& timeline)

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -84,6 +84,10 @@ public:
         bool isReversed;
     };
 
+#if ENABLE(THREADED_ANIMATIONS)
+    WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeIDForTesting() const;
+#endif
+
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -220,6 +220,7 @@
 #include "ScriptController.h"
 #include "ScriptExecutionContextInlines.h"
 #include "ScriptedAnimationController.h"
+#include "ScrollTimeline.h"
 #include "ScrollToOptions.h"
 #include "ScrollbarsControllerMock.h"
 #include "ScrollingCoordinator.h"
@@ -1436,6 +1437,29 @@ ExceptionOr<void> Internals::resumeAnimations() const
     }
 
     return { };
+}
+
+uint64_t Internals::identifierForTimeline(AnimationTimeline& timeline) const
+{
+#if ENABLE(THREADED_ANIMATIONS)
+    return timeline.acceleratedTimelineIdentifierForTesting().toRawValue();
+#else
+    UNUSED_PARAM(timeline);
+    return 0;
+#endif
+}
+
+Vector<uint64_t> Internals::scrollingNodeIDForTimeline(AnimationTimeline& timeline) const
+{
+#if ENABLE(THREADED_ANIMATIONS)
+    if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(timeline)) {
+        if (auto scrollingNodeID = scrollTimeline->scrollingNodeIDForTesting())
+            return Vector({ scrollingNodeID->object().toUInt64(), scrollingNodeID->processIdentifier().toUInt64() });
+    }
+#else
+    UNUSED_PARAM(timeline);
+#endif
+    return { 0, 0 };
 }
 
 Vector<Internals::AcceleratedAnimation> Internals::acceleratedAnimationsForElement(Element& element)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -129,6 +129,7 @@ class ReadableStream;
 class Range;
 class RenderedDocumentMarker;
 class SVGSVGElement;
+class ScrollTimeline;
 class ScrollableArea;
 class SerializedScriptValue;
 class ServiceWorker;
@@ -331,6 +332,8 @@ public:
         bool isThreaded;
     };
     Vector<AcceleratedAnimation> acceleratedAnimationsForElement(Element&);
+    uint64_t identifierForTimeline(AnimationTimeline&) const;
+    Vector<uint64_t> scrollingNodeIDForTimeline(AnimationTimeline&) const;
     unsigned numberOfAnimationTimelineInvalidations() const;
     double timeToNextAnimationTick(WebAnimation&) const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -564,6 +564,8 @@ enum ContentsFormat {
     readonly attribute double animationsInterval;
 
     // Web Animations testing.
+    unsigned long long identifierForTimeline(AnimationTimeline timeline);
+    sequence<unsigned long long> scrollingNodeIDForTimeline(AnimationTimeline timeline);
     sequence<AcceleratedAnimation> acceleratedAnimationsForElement(Element element);
     unsigned long numberOfAnimationTimelineInvalidations();
     double timeToNextAnimationTick(WebAnimation animation);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -185,6 +185,7 @@ struct WKAppPrivacyReportTestingData {
 
 #if defined(ENABLE_THREADED_ANIMATIONS) && ENABLE_THREADED_ANIMATIONS
 - (NSString *)_animationStackForLayerWithID:(unsigned long long)layerID;
+- (NSString *)_progressBasedTimelinesForScrollingNodeID:(uint64_t)scrollingNodeID processID:(uint64_t)processID;
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp
@@ -46,7 +46,7 @@ Ref<JSON::Object> RemoteAnimationTimeline::toJSONForTesting() const
     Ref object = JSON::Object::create();
     object->setValue("currentTime"_s, WebKit::toJSONForTesting(m_currentTime));
     object->setValue("duration"_s, WebKit::toJSONForTesting(m_duration));
-    object->setString("identifier"_s, m_identifier.loggingString());
+    object->setInteger("identifier"_s, m_identifier.object().toRawValue());
     return object;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
@@ -150,6 +150,18 @@ void RemoteProgressBasedTimelineRegistry::updateTimelinesForNode(const WebCore::
     }
 }
 
+HashSet<Ref<RemoteProgressBasedTimeline>> RemoteProgressBasedTimelineRegistry::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID) const
+{
+    auto processIterator = m_timelines.find(scrollingNodeID.processIdentifier());
+    if (processIterator == m_timelines.end())
+        return { };
+    auto& processTimelines = processIterator->value;
+    auto sourceIterator = processTimelines.find(scrollingNodeID);
+    if (sourceIterator == processTimelines.end())
+        return { };
+    return sourceIterator->value;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -45,6 +45,7 @@ public:
     RemoteProgressBasedTimeline* get(const TimelineID&) const;
     void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
     bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
+    HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 
 private:
     UncheckedKeyHashMap<WebCore::ProcessIdentifier, UncheckedKeyHashMap<WebCore::ScrollingNodeID, HashSet<Ref<RemoteProgressBasedTimeline>>>> m_timelines;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -155,6 +155,7 @@ public:
     virtual RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const { return nullptr; }
     virtual void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) { }
     virtual RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const { return nullptr; }
+    virtual HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const { return { }; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -326,6 +326,13 @@ void RemoteScrollingTree::updateProgressBasedTimelinesForNode(const WebCore::Scr
     if (m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry->updateTimelinesForNode(node);
 }
+
+HashSet<Ref<RemoteProgressBasedTimeline>> RemoteScrollingTree::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID) const
+{
+    if (m_progressBasedTimelineRegistry)
+        return m_progressBasedTimelineRegistry->timelinesForScrollingNodeIDForTesting(scrollingNodeID);
+    return { };
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -96,6 +96,7 @@ public:
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
     bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
+    HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 #endif
 
 protected:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -66,6 +66,7 @@ class DisplayLink;
 class NativeWebWheelEvent;
 #if ENABLE(THREADED_ANIMATIONS)
 class RemoteAnimationTimeline;
+class RemoteProgressBasedTimeline;
 #endif
 class RemoteScrollingCoordinatorProxyMac;
 class RemoteLayerTreeDrawingAreaProxyMac;
@@ -115,6 +116,7 @@ public:
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&);
     void updateAnimations();
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
+    HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID);
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -717,6 +717,13 @@ RefPtr<const RemoteAnimationStack> RemoteLayerTreeEventDispatcher::animationStac
         return it->value.ptr();
     return nullptr;
 }
+
+HashSet<Ref<RemoteProgressBasedTimeline>> RemoteLayerTreeEventDispatcher::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID)
+{
+    if (auto scrollingTree = this->scrollingTree())
+        return scrollingTree->timelinesForScrollingNodeIDForTesting(scrollingNodeID);
+    return { };
+}
 #endif
 
 void RemoteLayerTreeEventDispatcher::windowScreenWillChange()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -78,6 +78,7 @@ private:
     void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const override;
+    HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const override;
 #else
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -302,6 +302,11 @@ RefPtr<const RemoteAnimationStack> RemoteScrollingCoordinatorProxyMac::animation
     m_eventDispatcher->unlockForAnimationChanges();
     return animationStack;
 }
+
+HashSet<Ref<RemoteProgressBasedTimeline>> RemoteScrollingCoordinatorProxyMac::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID) const
+{
+    return m_eventDispatcher->timelinesForScrollingNodeIDForTesting(scrollingNodeID);
+}
 #endif
 
 } // namespace WebKit

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -465,5 +465,6 @@ interface UIScriptController {
 
 #if defined(ENABLE_THREADED_ANIMATIONS) && ENABLE_THREADED_ANIMATIONS
     DOMString animationStackForLayerWithID(unsigned long long layerID);
+    DOMString progressBasedTimelinesForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID);
 #endif
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -475,6 +475,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     // Animations
     virtual JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t) const { notImplemented(); return nullptr; }
+    virtual JSRetainPtr<JSStringRef> progressBasedTimelinesForScrollingNodeID(unsigned long long, unsigned long long) const { notImplemented(); return nullptr; }
 #endif
 
 protected:

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -107,6 +107,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATIONS)
     JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t layerID) const final;
+    JSRetainPtr<JSStringRef> progressBasedTimelinesForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID) const final;
 #endif
 };
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -598,6 +598,11 @@ JSRetainPtr<JSStringRef> UIScriptControllerCocoa::animationStackForLayerWithID(u
 {
     return adopt(JSStringCreateWithCFString((CFStringRef) [webView() _animationStackForLayerWithID:layerID]));
 }
+
+JSRetainPtr<JSStringRef> UIScriptControllerCocoa::progressBasedTimelinesForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID) const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef) [webView() _progressBasedTimelinesForScrollingNodeID:scrollingNodeID processID:processID]));
+}
 #endif
 
 } // namespace WTR


### PR DESCRIPTION
#### 43aa19d3972632d6f3b422fe23779a43be1e22af
<pre>
[threaded-animations] add testing functions to inspect remote timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=303625">https://bugs.webkit.org/show_bug.cgi?id=303625</a>
<a href="https://rdar.apple.com/165912596">rdar://165912596</a>

Reviewed by Anne van Kesteren.

Add two new `internals` functions and a one new `UIScriptController` function to allow the retrieval
of a timeline&apos;s accelerated representation as JSON.

Test: webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion.html

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async remoteTimeline):
* LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-creation-update-and-deletion.html: Added.
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::acceleratedTimelineIdentifierForTesting const):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::scrollingNodeIDForTesting const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::identifierForTimeline const):
(WebCore::Internals::scrollingNodeIDForTimeline const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _progressBasedTimelinesForScrollingNodeID:processID:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.cpp:
(WebKit::RemoteAnimationTimeline::toJSONForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::timelinesForScrollingNodeIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::timelinesForScrollingNodeIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::timelinesForScrollingNodeIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::timelinesForScrollingNodeIDForTesting):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::timelinesForScrollingNodeIDForTesting const):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::progressBasedTimelinesForScrollingNodeID const):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::progressBasedTimelinesForScrollingNodeID const):

Canonical link: <a href="https://commits.webkit.org/303993@main">https://commits.webkit.org/303993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bbfa953af9759f248b3533d6ff79757dacae2bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e519f106-02fc-4ac9-97bd-90b84e5d287b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102652 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5a75579-8a64-4b43-a430-81281ed4eb99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ea6ef7a-06c5-4104-a223-b37ddf7e902b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/4968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1885 "Failed to checkout and rebase branch from PR 54918") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144471 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39048 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111281 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4826 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60214 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6478 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34813 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/69996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->