### PR TITLE
Make the latest version of WebKit working on QNX

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
+++ b/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
@@ -37,6 +37,8 @@
 #include <mach-o/dyld.h>
 #include <uuid/uuid.h>
 #include <wtf/spi/darwin/dyldSPI.h>
+#elif OS(QNX)
+#include <sys/link.h>
 #else
 #include <link.h>
 #endif
@@ -66,7 +68,7 @@ uint32_t computeJSCBytecodeCacheVersion()
         }
         cacheVersion.construct(0);
         dataLogLnIf(JSCBytecodeCacheVersionInternal::verbose, "Failed to get UUID for JavaScriptCore framework");
-#elif OS(UNIX) && !PLATFORM(PLAYSTATION) && !OS(HAIKU)
+#elif OS(UNIX) && !PLATFORM(PLAYSTATION) && !OS(HAIKU) && !OS(QNX)
         auto result = ([&] -> std::optional<uint32_t> {
             Dl_info info { };
             if (!dladdr(jsFunctionAddr, &info))

--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -165,6 +165,16 @@ static inline void*& stackPointerImpl(mcontext_t& machineContext)
 #error Unknown Architecture
 #endif
 
+#elif OS(QNX)
+
+#if CPU(X86_64)
+    return reinterpret_cast<void*&>((uintptr_t&) machineContext.cpu.rsp);
+#elif CPU(ARM64)
+    return reinterpret_cast<void*&>((uintptr_t&) machineContext.cpu.gpr[AARCH64_REG_SP]);
+#else
+#error Unknown Architecture
+#endif
+
 #elif OS(NETBSD)
 
 #if CPU(X86_64)

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -39,7 +39,7 @@ class Structure;
 
 #if defined(STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB) && STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB > 0
 constexpr uintptr_t structureHeapAddressSize = STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB * MB;
-#elif PLATFORM(PLAYSTATION)
+#elif PLATFORM(PLAYSTATION) || OS(QNX)
 constexpr uintptr_t structureHeapAddressSize = 128 * MB;
 #elif (PLATFORM(IOS_FAMILY) && !CPU(ARM64E)) || PLATFORM(WATCHOS) || PLATFORM(APPLETV)
 constexpr uintptr_t structureHeapAddressSize = 512 * MB;

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -34,6 +34,8 @@
 #include <sys/sysctl.h>
 #elif OS(LINUX) || OS(AIX) || OS(OPENBSD) || OS(NETBSD) || OS(FREEBSD) || OS(HAIKU)
 #include <unistd.h>
+#elif OS(QNX)
+#include <sys/syspage.h>
 #elif OS(WINDOWS)
 #include <windows.h>
 #endif
@@ -70,6 +72,9 @@ int numberOfProcessorCores()
     long sysconfResult = sysconf(_SC_NPROCESSORS_ONLN);
 
     s_numberOfCores = sysconfResult < 0 ? defaultIfUnavailable : static_cast<int>(sysconfResult);
+#elif OS(QNX)
+    int numCpuQNX = _syspage_ptr->num_cpu;
+    s_numberOfCores = numCpuQNX < 0 ? defaultIfUnavailable : numCpuQNX;
 #elif OS(WINDOWS)
     UNUSED_PARAM(defaultIfUnavailable);
     SYSTEM_INFO sysInfo;

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -66,7 +66,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 
         unix/MemoryPressureHandlerUnix.cpp
     )
-elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "QNX")
     list(APPEND WTF_SOURCES
         generic/MemoryFootprintGeneric.cpp
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -208,7 +208,7 @@
 #define HAVE_MADV_FREE_REUSE 1
 #endif
 
-#if OS(DARWIN) || OS(HAIKU)
+#if OS(DARWIN) || OS(HAIKU) || OS(QNX)
 #define HAVE_MADV_DONTNEED 1
 #endif
 
@@ -408,7 +408,7 @@
 #define HAVE_URL_FORMATTING 1
 #endif
 
-#if !OS(WINDOWS)
+#if !OS(WINDOWS) && !OS(QNX)
 #define HAVE_STACK_BOUNDS_FOR_NEW_THREAD 1
 #endif
 

--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -81,6 +81,18 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return newThreadStackBounds(pthread_self());
 }
 
+#elif OS(QNX)
+
+StackBounds StackBounds::currentThreadStackBoundsInternal()
+{
+    struct _thread_local_storage* tls = __tls();
+    void* bound = tls->__stackaddr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    void* origin = static_cast<char*>(bound) + tls->__stacksize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return StackBounds { origin, bound };
+}
+
 #elif OS(UNIX) || OS(HAIKU)
 
 #if OS(OPENBSD)
@@ -92,18 +104,6 @@ StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
     void* origin = stack.ss_sp;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void* bound = static_cast<char*>(origin) - stack.ss_size;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    return StackBounds { origin, bound };
-}
-
-#elif OS(QNX)
-
-StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
-{
-    struct _thread_local_storage* tls = __tls();
-    void* bound = tls->__stackaddr;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    void* origin = static_cast<char*>(bound) + tls->__stacksize;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return StackBounds { origin, bound };
 }

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -76,6 +76,19 @@ CString currentExecutablePath()
 {
     return { };
 }
+#elif OS(QNX)
+#include <fcntl.h>
+
+CString currentExecutablePath()
+{
+    static char readBuffer[PATH_MAX];
+    int selfFd = open("/proc/self/exefile", O_RDONLY);
+    ssize_t result = read(selfFd, readBuffer, sizeof(readBuffer));
+    close(selfFd);
+    if (result == -1)
+        return { };
+    return CString(unsafeMakeSpan(readBuffer, static_cast<size_t>(result)));
+}
 #elif OS(UNIX)
 CString currentExecutablePath()
 {

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -221,7 +221,7 @@ void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bo
 
 void OSAllocator::commit(void* address, size_t bytes, bool writable, bool executable)
 {
-#if OS(LINUX) || OS(HAIKU)
+#if OS(LINUX) || OS(HAIKU) || OS(QNX)
     UNUSED_PARAM(writable);
     UNUSED_PARAM(executable);
     while (madvise(address, bytes, MADV_WILLNEED) == -1 && errno == EAGAIN) { }


### PR DESCRIPTION
#### f0d351dc818c8328bee171398eab709d0c81cb29
<pre>
Make the latest version of WebKit working on QNX
<a href="https://bugs.webkit.org/show_bug.cgi?id=303626">https://bugs.webkit.org/show_bug.cgi?id=303626</a>

Reviewed by Justin Michaud.

- MemoryPressureHandlerUnix.cpp is now included in CMake for QNX
- Stack bounds for each JIT instance was not correctly set, __tls() only return thread infomation for the calling thread rather than a newly spawned thread
- currentExecutablePath() is now implemented for QNX
- stackPointer() is now implemented for QNX
- structureHeapAddressSize is now set to 128M for QNX. QNX does not allowed lazy allocation of memory, mapping 4G will ends up with allocating 4G
- Fix some headers includes
- numberOfProcessorCores() is now implemented for QNX

(computeJSCBytecodeCacheVersion()):
* Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp:
(static inline void*&amp; stackPointerImpl()):
* Source/JavaScriptCore/runtime/MachineContext.h:
(structureHeapAddressSize):
* Source/JavaScriptCore/runtime/StructureID.h:
(WTF::numberOfProcessorCores()):
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::StackBounds::currentThreadStackBoundsInternal()):
* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/StackBounds.cpp:
(WTF::currentExecutablePath()):
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::OSAllocator::commit(...)):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
* Source/WTF/wtf/PlatformGTK.cmake:

Canonical link: <a href="https://commits.webkit.org/304481@main">https://commits.webkit.org/304481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b6ae3fd958c3cae80b4dc85eefcabdd9621219

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87308 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6015 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3623 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3966 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127635 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146106 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134126 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40351 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6471 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5873 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117895 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61668 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36005 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166958 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71303 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43586 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->