### PR TITLE
[BFCache][WebSocket] don't dispatch error if websocket is closed in pagehide

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing BFCache support for a page with an open WebSocket connection, but close it in pagehide. assert_false: WebSocket should not have error expected false got true
+PASS Testing BFCache support for a page with an open WebSocket connection, but close it in pagehide.
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -501,7 +501,7 @@ void WebSocket::contextDestroyed()
 void WebSocket::suspend(ReasonForSuspension reason)
 {
     RefPtr channel = m_channel;
-    if (!channel)
+    if (!channel || m_state == CLOSING || m_state == CLOSED)
         return;
 
     if (reason == ReasonForSuspension::BackForwardCache) {


### PR DESCRIPTION
#### 4028de758439cb29e65eb20ccc822a032816f326
<pre>
[BFCache][WebSocket] don&apos;t dispatch error if websocket is closed in pagehide
<a href="https://bugs.webkit.org/show_bug.cgi?id=303619">https://bugs.webkit.org/show_bug.cgi?id=303619</a>

Reviewed by Alexey Proskuryakov.

When the WebSocket is suspending and it was closed, or it is in the
middle of closing, it does not need to be closed separately (and dispatch
the error event).

There is already WPT test for that case. Now the test passes.

* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::suspend):

Canonical link: <a href="https://commits.webkit.org/304082@main">https://commits.webkit.org/304082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/780833a78c240d9b08bbd782ccabfe10a64474a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102648 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83441 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2594 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/1634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4822 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60208 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6473 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34805 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69939 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->