### PR TITLE
Web Inspector: Pull CSS property keyword completions from the backend instead of hardcoding them

### DIFF
--- a/LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt
+++ b/LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt
@@ -1,4 +1,11 @@
 "background-repeat" is supported
+"background-repeat" has keyword values:
+ - "repeat-x"
+ - "repeat-y"
+ - "repeat"
+ - "space"
+ - "round"
+ - "no-repeat"
 
 "box-sizing" is supported
 "box-sizing" has aliases:
@@ -7,12 +14,49 @@
  - "border-box"
  - "content-box"
 
+"display" is supported
+"display" has keyword values:
+ - "inline"
+ - "block"
+ - "flow"
+ - "flow-root"
+ - "list-item"
+ - "inline-block"
+ - "table"
+ - "inline-table"
+ - "table-row-group"
+ - "table-header-group"
+ - "table-footer-group"
+ - "table-row"
+ - "table-column-group"
+ - "table-column"
+ - "table-cell"
+ - "table-caption"
+ - "flex"
+ - "inline-flex"
+ - "grid"
+ - "inline-grid"
+ - "grid-lanes"
+ - "inline-grid-lanes"
+ - "contents"
+ - "none"
+ - "-webkit-box"
+ - "-webkit-inline-box"
+ - "-webkit-flex"
+ - "-webkit-inline-flex"
+
 "filter" is supported
 "filter" has aliases:
  - "-webkit-filter"
+"filter" has keyword values:
+ - "none"
 
 "font-style" is supported
 "font-style" is inherited
+"font-style" has keyword values:
+ - "normal"
+ - "italic"
+ - "oblique"
 
 "margin" is supported
 "margin" has longhands:
@@ -27,5 +71,6 @@
 "text-transform" is inherited
 "text-transform" has keyword values:
  - "none"
+ - "math-auto"
 
 

--- a/LayoutTests/inspector/css/getSupportedCSSProperties.html
+++ b/LayoutTests/inspector/css/getSupportedCSSProperties.html
@@ -13,6 +13,7 @@ function test()
             const expectedProperties = [
                 "background-repeat",
                 "box-sizing",
+                "display",
                 "filter",
                 "font-style",
                 "margin",

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -483,8 +483,14 @@
                 "inline-flex",
                 "grid",
                 "inline-grid",
-                "grid-lanes",
-                "inline-grid-lanes",
+                {
+                    "value": "grid-lanes",
+                    "settings-flag": "gridLanesEnabled"
+                },
+                {
+                    "value": "inline-grid-lanes",
+                    "settings-flag": "gridLanesEnabled"
+                },
                 {
                     "value": "ruby",
                     "status": "unimplemented"

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -23,6 +23,7 @@
 
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValue.h>
+#include <WebCore/CSSValueKeywords.h>
 #include <WebCore/IsImportant.h>
 #include <WebCore/WritingMode.h>
 #include <wtf/BitSet.h>
@@ -32,6 +33,7 @@ namespace WebCore {
 
 class CSSValueList;
 class Settings;
+struct CSSParserContext;
 
 enum class IsImplicit : bool { No, Yes };
 
@@ -139,6 +141,15 @@ public:
     static bool isSizingProperty(CSSPropertyID);
 
     static bool disablesNativeAppearance(CSSPropertyID);
+
+    // Returns the valid keyword values for a property from CSSProperties.json.
+    // This is used by the Inspector to provide completions for properties
+    // that aren't keyword-fast-path eligible but still have enumerated values.
+    static std::span<const CSSValueID> validKeywordsForProperty(CSSPropertyID);
+
+    // Checks if a keyword is valid for a property, taking settings flags into account.
+    // This is used by the Inspector to filter keywords based on enabled settings.
+    static bool isKeywordValidForPropertyValues(CSSPropertyID, CSSValueID, const CSSParserContext&);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
     static bool isColorProperty(CSSPropertyID propertyId)

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -78,46 +78,52 @@ CSSParserContext::CSSParserContext(const Document& document)
 }
 
 CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBaseURL, ASCIILiteral charset)
-    : baseURL { sheetBaseURL.isNull() ? document.baseURL() : sheetBaseURL }
-    , charset { charset }
-    , mode { document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode }
-    , isHTMLDocument { document.isHTMLDocument() }
-    , hasDocumentSecurityOrigin { sheetBaseURL.isNull() || document.protectedSecurityOrigin()->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton()) }
-    , useSystemAppearance { document.settings().useSystemAppearance() }
-    , counterStyleAtRuleImageSymbolsEnabled { document.settings().cssCounterStyleAtRuleImageSymbolsEnabled() }
-    , springTimingFunctionEnabled { document.settings().springTimingFunctionEnabled() }
+    : CSSParserContext(document.settings())
+{
+    baseURL = sheetBaseURL.isNull() ? document.baseURL() : sheetBaseURL;
+    this->charset = charset;
+    mode = document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode;
+    isHTMLDocument = document.isHTMLDocument();
+    hasDocumentSecurityOrigin = sheetBaseURL.isNull() || document.protectedSecurityOrigin()->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton());
+    webkitMediaTextTrackDisplayQuirkEnabled = document.quirks().needsWebKitMediaTextTrackDisplayQuirk();
+}
+
+CSSParserContext::CSSParserContext(const Settings& settings)
+    : mode { HTMLStandardMode }
+    , useSystemAppearance { settings.useSystemAppearance() }
+    , counterStyleAtRuleImageSymbolsEnabled { settings.cssCounterStyleAtRuleImageSymbolsEnabled() }
+    , springTimingFunctionEnabled { settings.springTimingFunctionEnabled() }
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    , cssTransformStyleSeparatedEnabled { document.settings().cssTransformStyleSeparatedEnabled() }
+    , cssTransformStyleSeparatedEnabled { settings.cssTransformStyleSeparatedEnabled() }
 #endif
-    , gridLanesEnabled { document.settings().gridLanesEnabled() }
-    , cssAppearanceBaseEnabled { document.settings().cssAppearanceBaseEnabled() }
-    , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
-    , cssShapeFunctionEnabled { document.settings().cssShapeFunctionEnabled() }
-    , cssTextDecorationLineErrorValues { document.settings().cssTextDecorationLineErrorValues() }
-    , cssBackgroundClipBorderAreaEnabled  { document.settings().cssBackgroundClipBorderAreaEnabled() }
-    , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
-    , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
-    , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
-    , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
-    , thumbAndTrackPseudoElementsEnabled { document.settings().thumbAndTrackPseudoElementsEnabled() }
+    , gridLanesEnabled { settings.gridLanesEnabled() }
+    , cssAppearanceBaseEnabled { settings.cssAppearanceBaseEnabled() }
+    , cssPaintingAPIEnabled { settings.cssPaintingAPIEnabled() }
+    , cssShapeFunctionEnabled { settings.cssShapeFunctionEnabled() }
+    , cssTextDecorationLineErrorValues { settings.cssTextDecorationLineErrorValues() }
+    , cssBackgroundClipBorderAreaEnabled { settings.cssBackgroundClipBorderAreaEnabled() }
+    , cssWordBreakAutoPhraseEnabled { settings.cssWordBreakAutoPhraseEnabled() }
+    , popoverAttributeEnabled { settings.popoverAttributeEnabled() }
+    , sidewaysWritingModesEnabled { settings.sidewaysWritingModesEnabled() }
+    , cssTextWrapPrettyEnabled { settings.cssTextWrapPrettyEnabled() }
+    , thumbAndTrackPseudoElementsEnabled { settings.thumbAndTrackPseudoElementsEnabled() }
 #if ENABLE(SERVICE_CONTROLS)
-    , imageControlsEnabled { document.settings().imageControlsEnabled() }
+    , imageControlsEnabled { settings.imageControlsEnabled() }
 #endif
-    , colorLayersEnabled { document.settings().cssColorLayersEnabled() }
-    , contrastColorEnabled { document.settings().cssContrastColorEnabled() }
-    , targetTextPseudoElementEnabled { document.settings().targetTextPseudoElementEnabled() }
-    , cssProgressFunctionEnabled { document.settings().cssProgressFunctionEnabled() }
-    , cssRandomFunctionEnabled { document.settings().cssRandomFunctionEnabled() }
-    , cssTreeCountingFunctionsEnabled { document.settings().cssTreeCountingFunctionsEnabled() }
-    , cssURLModifiersEnabled { document.settings().cssURLModifiersEnabled() }
-    , cssURLIntegrityModifierEnabled { document.settings().cssURLIntegrityModifierEnabled() }
-    , cssAxisRelativePositionKeywordsEnabled { document.settings().cssAxisRelativePositionKeywordsEnabled() }
-    , cssDynamicRangeLimitMixEnabled { document.settings().cssDynamicRangeLimitMixEnabled() }
-    , cssConstrainedDynamicRangeLimitEnabled { document.settings().cssConstrainedDynamicRangeLimitEnabled() }
-    , cssTextTransformMathAutoEnabled { document.settings().cssTextTransformMathAutoEnabled() }
-    , cssInternalAutoBaseParsingEnabled { document.settings().cssInternalAutoBaseParsingEnabled() }
-    , webkitMediaTextTrackDisplayQuirkEnabled { document.quirks().needsWebKitMediaTextTrackDisplayQuirk() }
-    , propertySettings { CSSPropertySettings { document.settings() } }
+    , colorLayersEnabled { settings.cssColorLayersEnabled() }
+    , contrastColorEnabled { settings.cssContrastColorEnabled() }
+    , targetTextPseudoElementEnabled { settings.targetTextPseudoElementEnabled() }
+    , cssProgressFunctionEnabled { settings.cssProgressFunctionEnabled() }
+    , cssRandomFunctionEnabled { settings.cssRandomFunctionEnabled() }
+    , cssTreeCountingFunctionsEnabled { settings.cssTreeCountingFunctionsEnabled() }
+    , cssURLModifiersEnabled { settings.cssURLModifiersEnabled() }
+    , cssURLIntegrityModifierEnabled { settings.cssURLIntegrityModifierEnabled() }
+    , cssAxisRelativePositionKeywordsEnabled { settings.cssAxisRelativePositionKeywordsEnabled() }
+    , cssDynamicRangeLimitMixEnabled { settings.cssDynamicRangeLimitMixEnabled() }
+    , cssConstrainedDynamicRangeLimitEnabled { settings.cssConstrainedDynamicRangeLimitEnabled() }
+    , cssTextTransformMathAutoEnabled { settings.cssTextTransformMathAutoEnabled() }
+    , cssInternalAutoBaseParsingEnabled { settings.cssInternalAutoBaseParsingEnabled() }
+    , propertySettings { CSSPropertySettings { settings } }
 {
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class Document;
+class Settings;
 
 struct CSSParserContext {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(CSSParserContext);
@@ -95,6 +96,7 @@ struct CSSParserContext {
     CSSParserContext(CSSParserMode, const URL& baseURL = URL());
     WEBCORE_EXPORT CSSParserContext(const Document&);
     CSSParserContext(const Document&, const URL& baseURL, ASCIILiteral charset = ""_s);
+    CSSParserContext(const Settings&);
 
     void setUASheetMode();
 


### PR DESCRIPTION
#### 68e73e36fe065e4229d37cf0c686e5bd7a64bf53
<pre>
Web Inspector: Pull CSS property keyword completions from the backend instead of hardcoding them
<a href="https://bugs.webkit.org/show_bug.cgi?id=303627">https://bugs.webkit.org/show_bug.cgi?id=303627</a>
<a href="https://rdar.apple.com/problem/165914089">rdar://problem/165914089</a>

Reviewed by Tim Nguyen and Devin Rousso.

The Web Inspector&apos;s CSS autocomplete system previously hardcoded all valid
keyword values for CSS properties in CSSKeywordCompletions.js. This meant
that when new CSS values were added to WebCore, they had to be manually
duplicated in the Inspector frontend, and there was no way to filter values
based on runtime settings (like feature flags).

This change extends getSupportedCSSProperties() to return the valid keyword
values for each property, pulled directly from CSSProperties.json. The
frontend now uses these backend-provided values instead of the hardcoded
ones, ensuring completions stay in sync with WebCore and respect feature
flags.

Key changes:
- Added validKeywordsForProperty() to return keyword values from CSSProperties.json
- Added isKeywordValidForPropertyValues() to filter keywords by settings flags
- Added CSSParserContext(const Settings&amp;) constructor for easy context creation
- Updated getSupportedCSSProperties() to include filtered values in the response
- Added settings-flag to grid-lanes/inline-grid-lanes values in CSSProperties.json

* LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt:
* LayoutTests/inspector/css/getSupportedCSSProperties.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/scripts/process-css-properties.py:
(GenerateCSSPropertyNames._generate_css_property_names_gperf_prelude):
(GenerateCSSPropertyNames):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getSupportedCSSProperties):

Canonical link: <a href="https://commits.webkit.org/304195@main">https://commits.webkit.org/304195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e6cc5e46a546687c8f8ebd4aa37f9eccbf91648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134862 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/55b86ebf-e71c-4d15-a286-a119aabde4c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c87ab974-8edb-4035-96e5-d8dca04b90c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83891 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f73ed9b3-8a8f-4340-928f-1861c86f3d7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3028 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2967 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145072 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39608 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5251 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7012 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35335 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6796 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70590 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 49824 issues") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7032 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->