### PR TITLE
Refactoring text zoom : apply text zoom to font-relative units during length resolution

### DIFF
--- a/LayoutTests/fast/text/letter-spacing-em-text-zoom-expected.html
+++ b/LayoutTests/fast/text/letter-spacing-em-text-zoom-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+body {
+    font-family: Ahem;
+}
+.test-expected {
+    font-size: 32px;
+    letter-spacing: 3.2px;
+    margin-bottom: 2px;
+}
+</style>
+</head>
+<body>
+<div class="test-expected">
+    <div>The quick brown fox</div>
+</div>
+<div class="test-expected">
+    <div>The quick brown fox</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/letter-spacing-em-text-zoom.html
+++ b/LayoutTests/fast/text/letter-spacing-em-text-zoom.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<script>
+if (window.internals)
+    internals.setTextZoomFactor(2.0);
+</script>
+<style>
+body {
+    font-family: Ahem;
+}
+.test-em {
+    font-size: 16px;
+    letter-spacing: 0.1em;
+    margin-bottom: 2px;
+}
+.test-percent {
+    font-size: 16px;
+    letter-spacing: 10%;
+    margin-bottom: 2px;
+}
+</style>
+</head>
+<body>
+<div class="test-em">
+    <div>The quick brown fox</div>
+</div>
+<div class="test-percent">
+    <div>The quick brown fox</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/margin-em-text-zoom-expected.html
+++ b/LayoutTests/fast/text/margin-em-text-zoom-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+    font-size: 32px;
+    border: 2px solid black;
+    margin: 2px;
+}
+.test-expected {
+    margin: 64px;
+    background: lightblue;
+    border: 2px dashed blue;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="test-expected">Box with 2em margin</div>
+</div>
+<div class="container">
+    <div class="test-expected">Box with 2rem margin</div>
+</div>
+<div class="container">
+    <div class="test-expected">Box with 64px margin</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/margin-em-text-zoom.html
+++ b/LayoutTests/fast/text/margin-em-text-zoom.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    internals.setTextZoomFactor(2.0);
+</script>
+<style>
+.container {
+    font-size: 16px;
+    border: 2px solid black;
+    margin: 2px;
+}
+.test-em {
+    margin: 2em;
+    background: lightblue;
+    border: 2px dashed blue;
+}
+.test-rem {
+    margin: 2rem;
+    background: lightblue;
+    border: 2px dashed blue;
+}
+.test-expected {
+    margin: 64px;
+    background: lightblue;
+    border: 2px dashed blue;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="test-em">Box with 2em margin</div>
+</div>
+<div class="container">
+    <div class="test-rem">Box with 2rem margin</div>
+</div>
+<div class="container">
+    <div class="test-rem">Box with 64px margin</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/word-spacing-em-text-zoom-expected.html
+++ b/LayoutTests/fast/text/word-spacing-em-text-zoom-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+body {
+    font-family: Ahem;
+}
+.test-em {
+    font-size: 32px;
+    word-spacing: 16px;
+    margin-bottom: 2px;
+}
+.test-percent {
+    font-size: 32px;
+    word-spacing: 16px;
+    margin-bottom: 2px;
+}
+</style>
+</head>
+<body>
+<div class="test-em">
+    <div>xx xxx xxxx</div>
+</div>
+<div class="test-percent">
+    <div>xx xxx xxxx</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/word-spacing-em-text-zoom.html
+++ b/LayoutTests/fast/text/word-spacing-em-text-zoom.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<script>
+if (window.internals)
+    internals.setTextZoomFactor(2.0);
+</script>
+<style>
+body {
+    font-family: Ahem;
+}
+.test-em {
+    font-size: 16px;
+    word-spacing: 0.5em;
+    margin-bottom: 2px;
+}
+.test-percent {
+    font-size: 16px;
+    word-spacing: 50%;
+    margin-bottom: 2px;
+}
+</style>
+</head>
+<body>
+<div class="test-em">
+    <div>xx xxx xxxx</div>
+</div>
+<div class="test-percent">
+    <div>xx xxx xxxx</div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/style/values/box/StyleMargin.cpp
+++ b/Source/WebCore/style/values/box/StyleMargin.cpp
@@ -62,10 +62,9 @@ auto CSSValueConversion<MarginEdge>::operator()(BuilderState& state, const CSSPr
         : cssToLengthConversionDataWithTextZoomFactorIfNeeded(state, primitiveValue.isFontIndependentLength());
 
     if (primitiveValue.isLength()) {
-        auto textZoom = (evaluationTimeZoomEnabled(state) && !primitiveValue.isFontIndependentLength()) ? conversionData.zoom() : 1.0f;
         return MarginEdge {
             typename MarginEdge::Fixed {
-                CSS::clampToRange<MarginEdge::Fixed::range, float>(primitiveValue.resolveAsLength(conversionData) * textZoom, minValueForCssLength, maxValueForCssLength),
+                CSS::clampToRange<MarginEdge::Fixed::range, float>(primitiveValue.resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
             },
             primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM
         };

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -70,19 +70,9 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
 
     if (primitiveValue.isLength() || primitiveValue.isCalculatedPercentageWithLength()) {
         double fixedValue = 0;
-        if (primitiveValue.isLength()) {
-            auto lengthUnit = CSS::toLengthUnit(primitiveValue.primitiveType());
+        if (primitiveValue.isLength())
             fixedValue = primitiveValue.resolveAsLength(conversionData);
-
-            // Apply text zoom to font-relative units when evaluationTimeZoomEnabled.
-            // This matches the behavior of percentage-based line-height (see primitiveValue.isPercentage() case below).
-            // When evaluationTimeZoomEnabled is true, computedSizeForRangeZoomOption returns
-            // the unzoomed font size, so we need to multiply by text zoom for font-relative units.
-            if (lengthUnit && CSS::isFontOrRootFontRelativeLength(*lengthUnit)) {
-                auto textZoom = evaluationTimeZoomEnabled(state) ? conversionData.zoom() : 1.0f;
-                fixedValue *= textZoom;
-            }
-        } else
+        else
             fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()), zoomFactor());
 
         if (multiplier != 1.0f)

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
@@ -39,7 +39,7 @@ auto CSSValueConversion<LetterSpacing>::operator()(BuilderState& state, const CS
         auto zoom = state.zoomWithTextZoomFactor();
         if (zoom == state.cssToLengthConversionData().zoom())
             return state.cssToLengthConversionData();
-        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom);
+        return state.cssToLengthConversionData().copyWithAdjustedZoom(zoom, LetterSpacing::Fixed::range.zoomOptions);
     };
 
     RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);


### PR DESCRIPTION
#### 4fa13fd953bf5c72e00e755955a75784d4483dbc
<pre>
Refactoring text zoom : apply text zoom to font-relative units during length resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=303672">https://bugs.webkit.org/show_bug.cgi?id=303672</a>

Reviewed by Brent Fulgham.

Previously, text zoom multiplication for em-based and other font-relative units
was handled individually per property (line-height, word-spacing, letter-spacing, margin).
This approach was error-prone and incomplete, as it required each property to
remember to multiply by text zoom when evaluationTimeZoomEnabled is true.

This patch centralizes text zoom application for all font-relative units
(em, rem, ex, rex, ch, rch, cap, rcap, ic, ric) computeNonCalcLengthDouble.

The fix applies when:
1. evaluationTimeZoomEnabled is true
2. rangeZoomOption is Unzoomed
3. The unit is font-relative

We explicitly use BuilderState::zoomWithTextZoomFactor() instead of
conversionData.zoom() to guarantee only text zoom is applied, not page zoom
or other zoom mechanisms. When evaluationTimeZoomEnabled is true,
zoomWithTextZoomFactor() returns (1.0f * textZoomFactor), ensuring independence
from page zoom.

Tests: fast/text/letter-spacing-em-text-zoom.html
       fast/text/margin-em-text-zoom.html
       fast/text/word-spacing-em-text-zoom.html

* LayoutTests/fast/text/letter-spacing-em-text-zoom-expected.html: Added.
* LayoutTests/fast/text/letter-spacing-em-text-zoom.html: Added.
* LayoutTests/fast/text/margin-em-text-zoom-expected.html: Added.
* LayoutTests/fast/text/margin-em-text-zoom.html: Added.
* LayoutTests/fast/text/word-spacing-em-text-zoom-expected.html: Added.
* LayoutTests/fast/text/word-spacing-em-text-zoom.html: Added.
* Source/WebCore/style/values/box/StyleMargin.cpp:
(WebCore::Style::CSSValueConversion&lt;MarginEdge&gt;::operator):
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::CSSValueConversion&lt;LineHeight&gt;::operator):
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::adjustZoomStateForFontRelativeUnitsIfNeeded):
(WebCore::Style::computeNonCalcLengthDouble):
* Source/WebCore/style/values/text/StyleLetterSpacing.cpp:
(WebCore::Style::CSSValueConversion&lt;LetterSpacing&gt;::operator):
 Fixed missing rangeZoomOptions parameter

Canonical link: <a href="https://commits.webkit.org/304138@main">https://commits.webkit.org/304138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff044227b56797f43c29847b65f7a4ea87f91960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142203 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/297273ba-e8cd-4c80-8641-83485214e5db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6987 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b1c93ba-f6cc-4b5d-84b5-4110f0cb0630) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/12086263-7f97-4925-b9ff-07d84e1a2507) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2793 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144897 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6808 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39436 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28309 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5118 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116988 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35179 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70440 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->