### PR TITLE
Do not start same-site navigations in a new process

### DIFF
--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
@@ -17,11 +17,8 @@ onload = function() {
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
             if (window.testRunner) {
-                if (testRunner.isWebKit2) {
-                    shouldBe("testRunner.windowCount()", "2");
-                } else {
-                    shouldBe("testRunner.windowCount()", "3");
-                }
+                // Same-site noopener popups now share a process, so all 3 windows are counted.
+                shouldBe("testRunner.windowCount()", "3");
             }
             finishJSTest();
         }

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS w is null
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
@@ -17,11 +17,8 @@ onload = function() {
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
             if (window.testRunner) {
-                if (testRunner.isWebKit2) {
-                    shouldBe("testRunner.windowCount()", "2");
-                } else {
-                    shouldBe("testRunner.windowCount()", "3");
-                }
+                // Same-site noopener popups now share a process, so all 3 windows are counted.
+                shouldBe("testRunner.windowCount()", "3");
             }
             finishJSTest();
         }

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html
@@ -16,11 +16,8 @@ onload = function() {
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
             if (window.testRunner) {
-                if (testRunner.isWebKit2) {
-                    shouldBe("testRunner.windowCount()", "2");
-                } else {
-                    shouldBe("testRunner.windowCount()", "3");
-                }
+                // Same-site noopener popups now share a process, so all 3 windows are counted.
+                shouldBe("testRunner.windowCount()", "3");
             }
             finishJSTest();
         }

--- a/LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cross-site window.open with noopener respects noopener semantics
+

--- a/LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process.html
+++ b/LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process.html
@@ -1,0 +1,58 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// This test verifies that cross-site window.open with noopener uses a different process.
+// Since we can't directly communicate with a cross-site noopener window, we verify this
+// by checking that:
+// 1. The window.open returns null (noopener behavior)
+// 2. A subsequent window.open to the same target name creates a NEW window (not reusing)
+// 3. The window count increases appropriately
+
+promise_test(async (t) => {
+    if (!window.testRunner) {
+        assert_unreached("This test requires testRunner");
+        return;
+    }
+
+    const initialWindowCount = testRunner.windowCount();
+
+    // Open a cross-site window with noopener (localhost vs 127.0.0.1)
+    const openedWindow = window.open(
+        "http://localhost:8000/site-isolation/resources/simple-page.html",
+        "crossSiteNoopener",
+        "noopener"
+    );
+
+    // With noopener, openedWindow should be null
+    assert_equals(openedWindow, null, "window.open with noopener should return null");
+
+    // Wait a bit for the window to open
+    await new Promise(resolve => t.step_timeout(resolve, 500));
+
+    // The window count should have increased by 1
+    // Note: Cross-site noopener windows are in a different process, so they may not
+    // be counted in windowCount() depending on implementation. The key is that
+    // the window was opened and noopener semantics were respected.
+    const afterOpenCount = testRunner.windowCount();
+    assert_true(afterOpenCount >= initialWindowCount, 
+        "Window count should not decrease after opening a window");
+
+    // Try to target the same window name - should create a new window since noopener
+    // windows are not targetable
+    const secondWindow = window.open("about:blank", "crossSiteNoopener");
+    assert_not_equals(secondWindow, null, "Second window.open should return a window handle");
+    assert_equals(secondWindow.location.href, "about:blank", "Second window should be about:blank");
+
+    t.add_cleanup(() => { if (secondWindow) secondWindow.close(); });
+
+}, "Cross-site window.open with noopener respects noopener semantics");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cross-site window.open uses a different process
+

--- a/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html
+++ b/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (t) => {
+    if (!window.internals) {
+        assert_unreached("This test requires internals API");
+        return;
+    }
+
+    const openerPID = internals.processIdentifier;
+
+    // Open a cross-site window (localhost vs 127.0.0.1 are different sites)
+    const openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-process-id.html");
+    t.add_cleanup(() => { if (openedWindow) openedWindow.close(); });
+
+    const event = await new Promise((resolve, reject) => {
+        const timeout = t.step_timeout(() => reject(new Error("Timeout waiting for message")), 5000);
+        window.addEventListener("message", (e) => {
+            clearTimeout(timeout);
+            resolve(e);
+        }, { once: true });
+    });
+
+    assert_equals(event.data.type, "processId", "Should receive processId message");
+    const openedPID = event.data.pid;
+
+    assert_not_equals(openerPID, openedPID, "Cross-site window.open should use a different process");
+}, "Cross-site window.open uses a different process");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/report-process-id-via-broadcast.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-process-id-via-broadcast.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals) {
+    const params = new URLSearchParams(window.location.search);
+    const channelName = params.get("channel");
+    if (channelName) {
+        const bc = new BroadcastChannel(channelName);
+        bc.postMessage({ type: "processId", pid: internals.processIdentifier });
+        bc.close();
+    }
+}
+</script>
+</head>
+<body>
+This page reports its process ID via BroadcastChannel.
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/resources/report-process-id.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-process-id.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.opener && window.internals) {
+    window.opener.postMessage({ type: "processId", pid: internals.processIdentifier }, "*");
+}
+</script>
+</head>
+<body>
+This page reports its process ID to its opener.
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/resources/simple-page.html
+++ b/LayoutTests/http/tests/site-isolation/resources/simple-page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Simple Page</title>
+</head>
+<body>
+This is a simple page.
+</body>
+</html>
+

--- a/LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Same-site window.open with noopener uses the same process
+

--- a/LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process.html
+++ b/LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// This test verifies that same-site window.open with noopener shares the same process.
+// We use BroadcastChannel to communicate since noopener prevents direct communication.
+
+promise_test(async (t) => {
+    if (!window.internals) {
+        assert_unreached("This test requires internals API");
+        return;
+    }
+
+    const openerPID = internals.processIdentifier;
+    const channelName = "same-site-noopener-test-" + Math.random();
+
+    // Create a BroadcastChannel to receive the process ID from the opened window
+    const bc = new BroadcastChannel(channelName);
+    t.add_cleanup(() => bc.close());
+
+    const messagePromise = new Promise((resolve, reject) => {
+        const timeout = t.step_timeout(() => reject(new Error("Timeout waiting for message")), 5000);
+        bc.onmessage = (e) => {
+            clearTimeout(timeout);
+            resolve(e.data);
+        };
+    });
+
+    // Open a same-site window with noopener
+    // The URL includes the channel name so the opened page knows which channel to use
+    const openedWindow = window.open(
+        "/site-isolation/resources/report-process-id-via-broadcast.html?channel=" + encodeURIComponent(channelName),
+        "_blank",
+        "noopener"
+    );
+
+    // With noopener, openedWindow should be null
+    assert_equals(openedWindow, null, "window.open with noopener should return null");
+
+    const data = await messagePromise;
+
+    assert_equals(data.type, "processId", "Should receive processId message");
+    const openedPID = data.pid;
+
+    assert_equals(openerPID, openedPID, "Same-site window.open with noopener should use the same process");
+}, "Same-site window.open with noopener uses the same process");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
-CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2aa4c567-6ca0-45a6-96d8-6846ef6822c6 due to access control checks.
-CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
-CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=11e644f8-fb6a-4c3c-9266-91c4978d8e0b due to access control checks.
-CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
 FAIL: Timed out waiting for notifyDone to be called
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
@@ -1,4 +1,4 @@
 
 PASS <a>
-FAIL <a target="blank"> assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS <a target="blank">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
@@ -1,4 +1,4 @@
 
 PASS window.open()
-FAIL window.open(noopener) assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS window.open(noopener)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9242,8 +9242,10 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         configuration->setOpenedSite(site);
     } else {
         configuration->setOpenerInfo(std::nullopt);
-        configuration->setOpenedSite(WebCore::Site(navigationAction->request().url()));
-        if (openedBlobURL && !protectedPreferences()->siteIsolationEnabled())
+        WebCore::Site openedSite { navigationAction->request().url() };
+        configuration->setOpenedSite(openedSite);
+        WebCore::Site originatingSite { originatingFrameInfo->request().url() };
+        if ((openedBlobURL && !protectedPreferences()->siteIsolationEnabled()) || openedSite == originatingSite)
             configuration->setRelatedPage(*this);
     }
 


### PR DESCRIPTION
#### 9f20aa832a809ab8603f85748c82df2e40179101
<pre>
Do not start same-site navigations in a new process
<a href="https://bugs.webkit.org/show_bug.cgi?id=303637">https://bugs.webkit.org/show_bug.cgi?id=303637</a>

Reviewed by Alex Christensen.

This PR makes sure that same site navigations don&apos;t get allocated into a new process, by setting a related page and then comparing the URL to it.

No new tests, but a few progressions.

* LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt: Expectation change.
* LayoutTests/http/tests/dom/noopener-window-not-targetable.html: Expectation change.
* LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt: Expectation change.
* LayoutTests/http/tests/dom/noopener-window-not-targetable2.html: Expectation change.
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable-expected.txt: Expectation change.
* LayoutTests/http/tests/dom/noreferrer-window-not-targetable.html: Expectation change.
* LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/cross-site-noopener-uses-different-process.html: Added.
* LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-process-id-via-broadcast.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-process-id.html: Added.
* LayoutTests/http/tests/site-isolation/resources/simple-page.html: Added.
* LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/same-site-noopener-uses-same-process.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt: Progression.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage): Set related page to `this` when the navigation is same site.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal): Only create a new process when the navigation is not to the same site.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, CrossOriginButSameSiteWindowOpenNoOpener)): Expectation change.
((ProcessSwap, SameSiteWindowOpenNoOpener)): Expectation change.
((ProcessSwap, SameSiteBlankTargetNoOpener)): Expectation change.
((ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)): Expectation change.
((ProcessSwap, CrossSiteWindowOpenNoOpenerUsesNewProcess)): Test cross-origin opened pages.
((ProcessSwap, CrossSiteLinkTargetBlankNoOpenerUsesNewProcess)): Test cross-origin opened pages.

Canonical link: <a href="https://commits.webkit.org/304218@main">https://commits.webkit.org/304218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1601a5f33a152480c5a91b7f2a464c60c82b6cd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142436 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5460 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3071 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3030 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39667 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5296 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7072 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70644 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->