### PR TITLE
[webkitscmpy] Capture scm logging during tests

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
@@ -169,7 +169,7 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual('a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd', local.Git(self.path).commit().hash)
 
     def test_checkout_ambiguous_remote(self):
-        with mocks.remote.GitHub() as remote, mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn():
+        with OutputCapture(), mocks.remote.GitHub() as remote, mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn():
             repo.edit_config('remote.webkit.url', 'https://github.com/WebKit/WebKit')
             repo.edit_config('remote.webkit-integration.url', 'https://github.com/WebKit/WebKit')
             repo.commits['remotes/webkit-integration/eng/example'] = [

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -531,7 +531,7 @@ CommitDate: {time_c}
             )
 
     def test_diff_identifier(self):
-        with mocks.local.Git(self.path):
+        with mocks.local.Git(self.path), OutputCapture():
             repo = local.Git(self.path)
             self.assertEqual(
                 ['--- a/ChangeLog', '+++ b/ChangeLog', '@@ -1,0 +1,0 @@', '+8th commit'],
@@ -620,7 +620,7 @@ CommitDate: {time_c}
             )
 
     def test_last_commits_on(self):
-        with mocks.local.Git(self.path):
+        with mocks.local.Git(self.path), OutputCapture():
             git = local.Git(self.path)
             commits = git.last_commits_on('README.md', count=5)
 


### PR DESCRIPTION
#### 6698ac78afde97e17941190b59ede5d479b006ef
<pre>
[webkitscmpy] Capture scm logging during tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=303643">https://bugs.webkit.org/show_bug.cgi?id=303643</a>
<a href="https://rdar.apple.com/165929138">rdar://165929138</a>

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/304108@main">https://commits.webkit.org/304108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8efad252440212339adc16dce4838d06a0fdcaa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86318 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3c64c4b-6e66-4859-ad21-8d989ee2393c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69935 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/081c3a61-fe7f-4964-8c02-c46743b77b79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83467 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0607a89f-4286-4660-a016-5032d247ca57) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133623 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2619 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114202 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144501 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111057 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/133702 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111308 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4848 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116625 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20781 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34839 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->