### PR TITLE
Fix the Safer CPP build after 303981@main

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/media/sctp/sctp_transport_internal.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/media/sctp/sctp_transport_internal.h
@@ -50,6 +50,8 @@ class SctpTransportInternal {
   // and create a new association? Not clear if this is something we need to
   // support though. See: https://github.com/w3c/webrtc-pc/issues/979
   [[deprecated("Call with SctpOptions")]]
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
   virtual bool Start(int local_sctp_port,
                      int remote_sctp_port,
                      int max_message_size) {
@@ -59,6 +61,7 @@ class SctpTransportInternal {
         .max_message_size = max_message_size,
     });
   }
+#pragma clang diagnostic pop
 
   // NOTE: Initially there was a "Stop" method here, but it was never used, so
   // it was removed.

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_internal.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_internal.h
@@ -130,6 +130,8 @@ class PeerConnectionSdpMethods {
   // `sctp_mid()` if set. Called as part of setting the local description.
   virtual RTCError StartSctpTransport(const SctpOptions& options) = 0;
   [[deprecated("Call with SctpOptions")]]
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
   virtual void StartSctpTransport(int local_port,
                                   int remote_port,
                                   int max_message_size) {
@@ -137,6 +139,7 @@ class PeerConnectionSdpMethods {
                         .remote_port = remote_port,
                         .max_message_size = max_message_size});
   }
+#pragma clang diagnostic pop
 
   // Asynchronously adds a remote candidate on the network thread.
   virtual void AddRemoteCandidate(absl::string_view mid,

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_peer_connection_internal.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_peer_connection_internal.h
@@ -135,11 +135,14 @@ class MockPeerConnectionInternal : public PeerConnectionInternal {
               (StatsObserver*, MediaStreamTrackInterface*, StatsOutputLevel),
               (override));
   MOCK_METHOD(void, GetStats, (RTCStatsCollectorCallback*), (override));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
   MOCK_METHOD(void,
               GetStats,
               (webrtc::scoped_refptr<RtpSenderInterface>,
                webrtc::scoped_refptr<RTCStatsCollectorCallback>),
               (override));
+#pragma clang diagnostic pop
   MOCK_METHOD(void,
               GetStats,
               (webrtc::scoped_refptr<RtpReceiverInterface>,


### PR DESCRIPTION
#### 4ae2ab412bce5d887fe864511e6c6af95649455e
<pre>
Fix the Safer CPP build after 303981@main
<a href="https://rdar.apple.com/165930420">rdar://165930420</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303646">https://bugs.webkit.org/show_bug.cgi?id=303646</a>

Unreviewed build fix.

Suppress &quot;missing-designated-field-initializers&quot; warnings since this is third party code.

* Source/ThirdParty/libwebrtc/Source/webrtc/media/sctp/sctp_transport_internal.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_internal.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_peer_connection_internal.h:

Canonical link: <a href="https://commits.webkit.org/304003@main">https://commits.webkit.org/304003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1b6e7a8c1fefbb55c9c483c9a442b0843e39788

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134283 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/6790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/141860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/141860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/144510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/6461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/144510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/6543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/144510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20735 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/6513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/6586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->