### PR TITLE
[Tools][WPE][GTK][SDK] Build webkit in a common directory at /sdk/webkit when using the SDK

### DIFF
--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -142,13 +142,6 @@ if (DEVELOPER_MODE OR ARM)
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-fno-omit-frame-pointer)
 endif ()
 
-# Record references to files using relative paths instead of absolute.
-# This helps both with reproducible builds and ccache hits.
-# It also breaks debugedit, so limit this to DEVELOPER_MODE.
-if (DEVELOPER_MODE)
-    WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.)
-endif ()
-
 if (COMPILER_IS_GCC_OR_CLANG)
     if (COMPILER_IS_CLANG OR (DEVELOPER_MODE AND NOT ARM))
         # Split debug information in ".debug_types" / ".debug_info" sections - this leads

--- a/Tools/Scripts/browserperfdash-benchmark
+++ b/Tools/Scripts/browserperfdash-benchmark
@@ -27,6 +27,8 @@ import logging
 import sys
 
 from webkitpy.browserperfdash.browserperfdash_runner import main, format_logger
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 _log = logging.getLogger()
 

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -60,6 +60,7 @@ if (shouldBuildForCrossTarget()) {
     my @command = (File::Spec->catfile(sourceDir(), "Tools", "Scripts", "build-webkit"));
     runInFlatpak(@command);
 }
+maybeUseContainerSDKRootDir();
 
 my $originalWorkingDirectory = getcwd();
 chdirWebKit();

--- a/Tools/Scripts/container-sdk-rootdir-wrapper
+++ b/Tools/Scripts/container-sdk-rootdir-wrapper
@@ -1,0 +1,186 @@
+#!/usr/bin/env sh
+#
+# Copyright (C) 2025 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+set -eu
+
+SCRIPTPATH="$(realpath -- "${0}")"
+SCRIPTDIR="$(dirname -- "${SCRIPTPATH}")"
+WEBKITDIR="$(realpath -- "${SCRIPTDIR}/../..")"
+WEBKIT_SOURCE_DIR="${WEBKIT_SOURCE_DIR:-${WEBKITDIR}}"
+WEBKIT_SOURCE_DIR="$(realpath -m -- "${WEBKIT_SOURCE_DIR}")"
+
+help() {
+    cat <<EOF
+Usage: ${0} program-to-execute [arguments...]
+       ${0} --create-symlink
+
+This script is used by the WebKit tooling when running inside the
+webkit-container-sdk for GTK/WPE port development. It enables building
+WebKit and running tests inside a common path at /sdk/webkit.
+
+Options:
+    -h, --help         Show this help message
+    --create-symlink   Create /sdk/webkit as a symlink to ${WEBKIT_SOURCE_DIR}
+                       and exit. Useful for tools not executed through this
+                       wrapper (like gdb) that need to resolve /sdk/webkit paths.
+
+Default behavior:
+    Creates a private mount namespace where /sdk/webkit is a bind-mount
+    to ${WEBKIT_SOURCE_DIR}, then executes the specified program.
+
+Examples:
+    ${0} Tools/Scripts/build-webkit --wpe --release
+    ${0} --create-symlink
+EOF
+    exit 0
+}
+
+error() {
+    printf '%s\n' "${@}" 1>&2
+    exit 1
+}
+
+# If path starts with ${WEBKIT_SOURCE_DIR}, replace that prefix with /sdk/webkit.
+maybe_replace_path_prefix_to_rootsdk() {
+    case "${1}" in
+        "${WEBKIT_SOURCE_DIR}"|"${WEBKIT_SOURCE_DIR}"/*)
+            printf '%s\n' "/sdk/webkit${1#"${WEBKIT_SOURCE_DIR}"}"
+        ;;
+        *)
+            printf '%s\n' "${1}"
+        ;;
+    esac
+}
+
+resolve_relpath_to_abs_if_outside() {
+    abs=$(realpath -m -- "${ORGPWD}/${1}")
+    case "${abs}" in
+        "${WEBKIT_SOURCE_DIR}"|"${WEBKIT_SOURCE_DIR}"/*)
+            # Inside the tree: keep original relative value
+            printf '%s\n' "${1}"
+        ;;
+        *) # relative path outside the tree: make it absolute
+            printf '%s\n' "${abs}"
+        ;;
+    esac
+}
+
+maybe_update_relpath_to_abs_if_outside() {
+    case "${1}" in
+        ""|/*|*://*)
+            # do not touch if is empty or looks like an abs path or a URL
+            printf '%s\n' "${1}"
+        ;;
+        .|..|./*|../*|*/*)
+            resolve_relpath_to_abs_if_outside "${1}"
+        ;;
+        *)
+            if [ -L "${1}" ]; then
+                resolve_relpath_to_abs_if_outside "${1}"
+            else
+                printf '%s\n' "${1}"
+            fi
+        ;;
+    esac
+}
+
+# Convert relative paths to absolute if they point outside ${WEBKIT_SOURCE_DIR}
+args_maybe_update_outside_relpaths() {
+    for arg in "${@}"; do
+        case "${arg}" in
+            --*=*)  # handle arguments like "--option=value"
+                key="${arg%%=*}"
+                val="${arg#*=}"
+                val="$(maybe_update_relpath_to_abs_if_outside "${val}")"
+                arg="${key}=${val}"
+                ;;
+            *)
+                arg="$(maybe_update_relpath_to_abs_if_outside "${arg}")"
+                ;;
+        esac
+        printf "'"
+        printf '%s' "${arg}" | sed "s/'/'\\\\''/g"
+        printf "' "
+    done
+}
+
+[ "$#" -ge 1 ] || help
+[ "${1}" = "--help" ] && help
+[ "${1}" = "-h" ] && help
+
+[ -d "${WEBKIT_SOURCE_DIR}" ] || error "Can't find directory: ${WEBKIT_SOURCE_DIR}"
+[ -d /sdk ] || error "Can't find /sdk directory"
+[ -w /sdk ] || error "Directory /sdk is not writable for user $(whoami)"
+
+case "${WEBKIT_SOURCE_DIR}" in
+  /sdk|/sdk/*) error "${0} should not be invoked with WEBKIT_SOURCE_DIR under /sdk directory" ;;
+esac
+
+if [ "${1}" = "--create-symlink" ]; then
+    [ "$#" -ge 2 ] && error "No extra arguments can be passed with --create-symlink"
+    if [ -L "/sdk/webkit" ]; then
+        CURSYMLINKDEST="$(realpath -m -- /sdk/webkit)"
+        if [ "${CURSYMLINKDEST}" != "${WEBKIT_SOURCE_DIR}" ]; then
+            rm -f "/sdk/webkit"
+            ln -s "${WEBKIT_SOURCE_DIR}" "/sdk/webkit"
+            echo "Symlink at /sdk/webkit changed from ${CURSYMLINKDEST} to ${WEBKIT_SOURCE_DIR}"
+        fi
+    elif ! [ -e "/sdk/webkit" ]; then
+        ln -s "${WEBKIT_SOURCE_DIR}" "/sdk/webkit"
+    else
+        error "ERROR: /sdk/webkit exists and is not a symlink. This is unexpected"
+    fi
+    exit 0
+fi
+
+CURUID="$(id -u)"
+CURGID="$(id -g)"
+ORGPWD="$(pwd)"
+SDKPWD="$(maybe_replace_path_prefix_to_rootsdk "${ORGPWD}")"
+# Try also with the realpath, just in case pwd is inside a symlinked dir.
+if [ "${ORGPWD}" = "${SDKPWD}" ]; then
+    ORGPWD="$(realpath -- "${ORGPWD}")"
+    SDKPWD="$(maybe_replace_path_prefix_to_rootsdk "${ORGPWD}")"
+fi
+# When $(pwd) is inside ${WEBKIT_SOURCE_DIR}, switch (cd) to the equivalent bind-mount path
+# under /sdk/webkit. Any relative path arguments that point outside ${WEBKIT_SOURCE_DIR} are
+# converted to absolute paths first, since they wouldn't resolve correctly after the switch.
+[ "${ORGPWD}" != "${SDKPWD}" ] && eval "set -- $(args_maybe_update_outside_relpaths "${@}")"
+
+# Since util-linux 2.27 is not needed to execute mount --make-rprivate /
+# because unshare does that automatically by default for new mount namespaces
+exec unshare -rm sh -c '
+    set -eu
+    WEBKIT_SOURCE_DIR="${1}"
+    SDKPWD="${2}"
+    CURUID="${3}"
+    CURGID="${4}"
+    shift 4
+    mount -t tmpfs -o size=16M tmpfs /sdk
+    mkdir /sdk/webkit
+    mount --bind "${WEBKIT_SOURCE_DIR}" /sdk/webkit
+    cd "${SDKPWD}"
+    export WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE=1
+    exec unshare --map-user="${CURUID}" --map-group="${CURGID}" -- "${@}"
+' -- "${WEBKIT_SOURCE_DIR}" "${SDKPWD}" "${CURUID}" "${CURGID}" "${@}"

--- a/Tools/Scripts/run-bindings-tests
+++ b/Tools/Scripts/run-bindings-tests
@@ -32,6 +32,8 @@ import optparse
 import os
 import sys
 from webkitpy.common.system import executive
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 def main(argv):
     """Runs WebCore bindings code generators on test IDL files and compares

--- a/Tools/Scripts/run-builtins-generator-tests
+++ b/Tools/Scripts/run-builtins-generator-tests
@@ -24,6 +24,8 @@
 
 import sys
 from webkitpy.common.system import executive
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 def main(argv):
     """Runs the JS builtins code generator on test input files and compares

--- a/Tools/Scripts/run-css-property-code-generation-tests
+++ b/Tools/Scripts/run-css-property-code-generation-tests
@@ -32,6 +32,8 @@ import optparse
 import os
 import sys
 from webkitpy.common.system import executive
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 def main(argv):
     """Runs WebCore css property code generator on test input and compares

--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -21,6 +21,9 @@ import logging
 import os
 import sys
 
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
+
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "jhbuild"))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -54,6 +54,7 @@ if (shouldUseFlatpak()) {
     my @command = (File::Spec->catfile(sourceDir(), "Tools", "Scripts", "run-javascriptcore-tests"));
     runInFlatpak(@command);
 }
+maybeUseContainerSDKRootDir();
 
 # These variables are intentionally left undefined.
 my $root;

--- a/Tools/Scripts/run-minibrowser
+++ b/Tools/Scripts/run-minibrowser
@@ -19,6 +19,8 @@
 """Wrapper around webkitpy/minibrowser/run_webkit_app.py"""
 import sys
 from webkitpy.minibrowser import run_webkit_app
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 if __name__ == '__main__':
     sys.exit(run_webkit_app.main(sys.argv[1:]))

--- a/Tools/Scripts/run-perf-tests
+++ b/Tools/Scripts/run-perf-tests
@@ -33,6 +33,8 @@ import logging
 import sys
 
 from webkitpy.performance_tests.perftestsrunner import PerfTestsRunner
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 if '__main__' == __name__:
     logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/Tools/Scripts/run-qt-wpe-minibrowser
+++ b/Tools/Scripts/run-qt-wpe-minibrowser
@@ -30,6 +30,7 @@ setConfiguration();
 if (!inFlatpakSandbox()) {
     push @ARGV, "--wpe";
 }
+maybeUseContainerSDKRootDir();
 
 my $launcherName;
 my $libPathQt5;

--- a/Tools/Scripts/run-webdriver
+++ b/Tools/Scripts/run-webdriver
@@ -24,6 +24,8 @@ import errno
 from webkitpy.common.host import Host
 from webkitpy.port import configuration_options, platform_options, factory
 from webkitcorepy.string_utils import decode
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 def system_has_ipv6():
     if not socket.has_ipv6:

--- a/Tools/Scripts/run-webdriver-tests
+++ b/Tools/Scripts/run-webdriver-tests
@@ -29,6 +29,8 @@ import sys
 from webkitpy.common.host import Host
 from webkitpy.webdriver_tests.webdriver_test_runner import WebDriverTestRunner
 from webkitpy.common.system.logutils import configure_logging
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 _log = logging.getLogger(__name__)
 

--- a/Tools/Scripts/run-webkit-httpd
+++ b/Tools/Scripts/run-webkit-httpd
@@ -31,6 +31,8 @@
 import sys
 
 from webkitpy.layout_tests.servers.run_webkit_httpd import parse_args, run_server
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 def main(argv, stdout, stderr):
     options, args = parse_args(argv)

--- a/Tools/Scripts/run-webkit-tests
+++ b/Tools/Scripts/run-webkit-tests
@@ -33,6 +33,8 @@
 import sys
 
 from webkitpy.layout_tests.run_webkit_tests import main
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:], sys.stdout, sys.stderr))

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -21,6 +21,9 @@ import logging
 import os
 import sys
 
+from webkitpy.port.linux_container_sdk_utils import maybe_use_container_sdk_root_dir
+maybe_use_container_sdk_root_dir()
+
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "jhbuild"))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))

--- a/Tools/Scripts/test262/Runner.pm
+++ b/Tools/Scripts/test262/Runner.pm
@@ -323,6 +323,7 @@ sub processCLI {
 sub setupEnvironment()
 {
     if ($^O eq "linux") {
+        maybeUseContainerSDKRootDir();
         setupUnixWebKitEnvironment(productDir());
     }
 }

--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2025 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import subprocess
+import sys
+
+
+def maybe_use_container_sdk_root_dir():
+    if not sys.platform.startswith('linux'):
+        return
+
+    if os.environ.get('WEBKIT_CONTAINER_SDK') != '1':
+        return
+
+    if os.environ.get('WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE') == '1':
+        return
+
+    source_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+    wrapper_script = os.path.join(source_dir, 'Tools', 'Scripts', 'container-sdk-rootdir-wrapper')
+    assert os.path.isfile(wrapper_script) and os.access(wrapper_script, os.X_OK), 'Error finding container-sdk-rootdir-wrapper'
+
+    if subprocess.call([wrapper_script, '--create-symlink']) != 0:
+        print('WARNING: Unable to create symlink at /sdk/webkit. Skipping setting up SDK common root dir feature', file=sys.stderr)
+        return
+
+    check_command = ['test', '-f', '/sdk/webkit/Tools/Scripts/build-webkit']
+    if subprocess.call([wrapper_script] + check_command) == 0:
+        command = sys.argv[0]
+        if command.startswith(source_dir):
+            command = '/sdk/webkit' + command[len(source_dir):]
+
+        print(f'Running in private mount namespace at /sdk/webkit')
+        args = [wrapper_script, command] + sys.argv[1:]
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.execv(wrapper_script, args)
+
+    print('WARNING: Unable to create /sdk/webkit private mount namespace. Continuing only with symlink support.', file=sys.stderr)


### PR DESCRIPTION
#### 6511e21704cb8062310091bf8a80729dd38e9981
<pre>
[Tools][WPE][GTK][SDK] Build webkit in a common directory at /sdk/webkit when using the SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=303645">https://bugs.webkit.org/show_bug.cgi?id=303645</a>

Reviewed by Nikolas Zimmermann.

Since we moved out of flatpak SDK to the new Container SDK we miss the feature
that it had Flatpak of building webkit in /app/webkit, as that allowed reusing
remote caches (ccache, sccache) when developers have the webkit checkout in
different directories very easy.

For ccache I tried a workaround at 301772@main but that ended causing issues
with GDB and the paths to the source files. Also for sccache that workaround
is not possible, sccache does not support at all sharing caches if the build
path on disk changes.

So this patch introduces a wrapper that can create a symlink from /sdk/webkit
to the webkit source directory and that also can create a private mount
namespace where /sdk/webkit is bind-mounted to the WebKit source directory.

That private mount namespace is only visible to the pid group executed by the
wrapper, so there can be multiple webkit builds or tests running each one
with its own private view of the /sdk/webkit bind-mount without interfering
between them. This allow to build or test from different webkit checkout paths
and each one of those processes would have a different /sdk/webkit mount point.

The symlink is created to support any test runner or program that doesn&apos;t run
with this wrapper, for example when using GDB to debug, that way the paths inside
/sdk/webkit can be resolved automatically.

For the symlink is not possible to have different views, so in case of working
from two different checkouts the last directory from where webkit was built, or
from where the tests were executed would be the one resolved.

This is not perfect, but I think is good enough. For example, if you run GDB it
is likely that before invoking GDB you would have executed any of the scripts
that use this wrapper (build-webkit, run-webkit-tests, run-minibrowser, etc) so
then the symlink would point to the right checkoutdir.

* Source/cmake/WebKitCompilerFlags.cmake:
* Tools/Scripts/browserperfdash-benchmark:
* Tools/Scripts/build-webkit:
* Tools/Scripts/container-sdk-rootdir-wrapper: Added.
* Tools/Scripts/run-bindings-tests:
* Tools/Scripts/run-builtins-generator-tests:
* Tools/Scripts/run-css-property-code-generation-tests:
* Tools/Scripts/run-gtk-tests:
* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-minibrowser:
* Tools/Scripts/run-perf-tests:
* Tools/Scripts/run-qt-wpe-minibrowser:
* Tools/Scripts/run-webdriver:
* Tools/Scripts/run-webdriver-tests:
* Tools/Scripts/run-webkit-httpd:
* Tools/Scripts/run-webkit-tests:
* Tools/Scripts/run-wpe-tests:
* Tools/Scripts/test262/Runner.pm:
(setupEnvironment):
* Tools/Scripts/webkitdirs.pm:
(maybeUseContainerSDKRootDir):
* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py: Added.
(maybe_use_container_sdk_root_dir):

Canonical link: <a href="https://commits.webkit.org/304672@main">https://commits.webkit.org/304672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d81989a3fc6a77f4bb2736bc91c6d6bdc862f81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143980 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85028 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135616 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6420 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4082 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4572 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128226 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146724 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134753 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112533 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112877 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6351 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118412 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20995 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36469 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167532 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8074 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43709 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->