### PR TITLE
Caption Preview is not shown in default media controls

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -57,6 +57,7 @@ WK_EXTERN
 #endif
 
 - (BOOL)isAncestorOf:(PlatformMenu*)menu;
+- (BOOL)hasAncestor:(PlatformMenu*)menu;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
@@ -31,7 +31,7 @@
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
-#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+#if PLATFORM(IOS_FAMILY)
 @class UIContextMenuInteraction;
 @class UIAction;
 #endif
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKCaptionStyleMenuController ()
 {
     WTF::RetainPtr<PlatformMenu> _menu;
-#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)
     WTF::RetainPtr<UIContextMenuInteraction> _interaction;
 #endif
 }
@@ -50,8 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSString *savedActiveProfileID;
 @property (nonatomic, strong) PlatformMenu *menu;
-#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)
 @property (nonatomic, strong) UIContextMenuInteraction *interaction;
+#endif
+#if PLATFORM(IOS_FAMILY)
+- (void)notifyMenuWillOpen;
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -78,19 +78,17 @@ using namespace WTF;
     self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
 }
 
-- (BOOL)isAncestorOf:(PlatformMenu*)menu
-{
-    if (!self.menu)
-        return NO;
-    return [menu isEqual:self.menu];
-}
-
 #pragma mark - AVLegibleMediaOptionsMenuControllerDelegate
 
 - (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID
 {
     [self setPreviewProfileID:profileID];
     [self rebuildMenu];
+
+    // UIMenu does not have the ability to notify clients when a submenu opens or closes.
+    // Provide a similar functionality for previewing subtitle changes by triggering the
+    // preview of subtitle styles when the first profile menu item is selected.
+    [self notifyMenuWillOpen];
 
     if (auto delegate = self.delegate; delegate && [delegate respondsToSelector:@selector(captionStyleMenu:didSelectProfile:)])
         [delegate captionStyleMenu:self.menu didSelectProfile:profileID];

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -76,6 +76,8 @@ public:
     RetainPtr<CGImageRef> imageForCopySubject() const final { return m_copySubjectResult; }
 #endif
 
+    void didShowContextMenu(NSMenu *);
+    void didDismissContextMenu(NSMenu *);
     void captionStyleMenuWillOpen();
     void captionStyleMenuDidClose();
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -212,12 +212,12 @@
 
 - (void)menuWillOpen:(NSMenu *)menu
 {
-    Ref { *_menuProxy }->protectedPage()->didShowContextMenu();
+    Ref { *_menuProxy }->didShowContextMenu(menu);
 }
 
 - (void)menuDidClose:(NSMenu *)menu
 {
-    Ref { *_menuProxy }->protectedPage()->didDismissContextMenu();
+    Ref { *_menuProxy }->didDismissContextMenu(menu);
 }
 
 #pragma mark - WKCaptionStyleMenuControllerDelegate
@@ -1101,6 +1101,19 @@ WKMenuDelegate *WebContextMenuProxyMac::menuDelegate()
     if (!m_menuDelegate)
         m_menuDelegate = adoptNS([[WKMenuDelegate alloc] initWithMenuProxy:*this]);
     return m_menuDelegate.get();
+}
+
+void WebContextMenuProxyMac::didShowContextMenu(NSMenu *)
+{
+    protectedPage()->didShowContextMenu();
+}
+
+void WebContextMenuProxyMac::didDismissContextMenu(NSMenu *menu)
+{
+    protectedPage()->didDismissContextMenu();
+
+    if (m_captionStyleMenuController && [m_captionStyleMenuController hasAncestor:menu])
+        captionStyleMenuDidClose();
 }
 
 void WebContextMenuProxyMac::captionStyleMenuWillOpen()

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
@@ -84,20 +84,6 @@ using namespace WTF;
     self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
 }
 
-- (BOOL)isAncestorOf:(NSMenu *)menu
-{
-    if (!self.menu)
-        return NO;
-
-    do {
-        if (self.menu == menu)
-            return YES;
-        menu = menu.supermenu;
-    } while (menu);
-
-    return NO;
-}
-
 - (NSMenu *)captionStyleMenu
 {
     return self.menu;
@@ -113,20 +99,6 @@ using namespace WTF;
 - (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController
 {
     [self setPreviewProfileID:nil];
-}
-
-#pragma mark - NSMenuDelegate
-
-- (void)menuWillOpen:(NSMenu *)menu
-{
-    if (auto delegate = self.delegate)
-        [delegate captionStyleMenuWillOpen:menu];
-}
-
-- (void)menuDidClose:(NSMenu *)menu
-{
-    if (auto delegate = self.delegate)
-        [delegate captionStyleMenuDidClose:menu];
 }
 
 @end


### PR DESCRIPTION
#### 82c5da0f43373e343c6e0c313fdf67e7cd64276f
<pre>
Caption Preview is not shown in default media controls
<a href="https://rdar.apple.com/165931046">rdar://165931046</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303647">https://bugs.webkit.org/show_bug.cgi?id=303647</a>

Reviewed by Eric Carlson.

On both iOS and macOS, a notification is not sent when a submenu is
presented. Since the styles menu is a submenu of the captions menu
from within the default media controls, clients are not notified when
that submenu is presented, and therefore the preview placeholder is
not shown.

Solve this differently on iOS and macOS. On macOS, where there is a
highlight state, tell clients the style menu was opened whenever the
highlight value changes. On iOS, do the same when a profile menu item
is selected.

Drive-by fix: add tests to validate that the menu items&apos; state property
updates when the menu items are selected.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm

* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit legibleMenuController:didRequestCaptionPreviewForProfileID:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
(menuHasMenuAncestor):
(-[WKCaptionStyleMenuController isAncestorOf:]):
(-[WKCaptionStyleMenuController hasAncestor:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuDelegate menuWillOpen:]):
(-[WKMenuDelegate menuDidClose:]):
(WebKit::WebContextMenuProxyMac::didShowContextMenu):
(WebKit::WebContextMenuProxyMac::didDismissContextMenu):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm:
(-[_WKCaptionStyleMenuControllerAVKitMac menuWillOpen:]): Deleted.
(-[_WKCaptionStyleMenuControllerAVKitMac menuDidClose:]): Deleted.
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm:
(menuHasMenuAncestor):
(-[WKCaptionStyleMenuController isAncestorOf:]):
(-[WKCaptionStyleMenuController hasAncestor:]):
(-[WKCaptionStyleMenuController profileMenuItemSelected:]):
(-[WKCaptionStyleMenuController setPreviewProfileID:]):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(-[CaptionPreferenceTestMenuControllerDelegate captionStyleMenu:didSelectProfile:]):
(TestWebKitAPI::CaptionPreferenceTests::ensureController):
(TestWebKitAPI::CaptionPreferenceTests::runAndWaitForLastSelectedProfileToChange):
(TestWebKitAPI::CaptionPreferenceTests::selectProfileAtIndex):
(TestWebKitAPI::CaptionPreferenceTests::highlightProfileAtIndex):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, MenuAncestryCheck)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, MenuItemChangesAfterSelection)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenSelected)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenHighlighted)):

Canonical link: <a href="https://commits.webkit.org/304070@main">https://commits.webkit.org/304070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b9fc06eb8520e9c9475adb1a5b61472c928bfc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb2febdc-d012-4e18-b21f-d580549c9e31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102772 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2f24978-919f-4a43-a35a-1d7903ec313b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83563 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/787a0cf4-e3aa-4ee4-9ec0-3fe13611e1da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5112 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2729 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144680 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111175 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111445 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4945 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34978 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->