### PR TITLE
[LibWebRTC] Build fix for Linux after 303981@main

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -195,17 +195,21 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/api/audio_options.cc
     Source/webrtc/api/call/transport.cc
     Source/webrtc/api/candidate.cc
+    Source/webrtc/api/create_modular_peer_connection_factory.cc
     Source/webrtc/api/create_peerconnection_factory.cc
     Source/webrtc/api/crypto/crypto_options.cc
     Source/webrtc/api/data_channel_interface.cc
+    Source/webrtc/api/datagram_connection_factory.cc
     Source/webrtc/api/dtls_transport_interface.cc
     Source/webrtc/api/enable_media.cc
     Source/webrtc/api/enable_media_with_defaults.cc
+    Source/webrtc/api/environment/deprecated_global_field_trials.cc
     Source/webrtc/api/environment/environment_factory.cc
     Source/webrtc/api/field_trials.cc
     Source/webrtc/api/field_trials_registry.cc
     Source/webrtc/api/frame_transformer_factory.cc
     Source/webrtc/api/frame_transformer_interface.cc
+    Source/webrtc/api/ice_server_parsing.cc
     Source/webrtc/api/ice_transport_factory.cc
     Source/webrtc/api/jsep.cc
     Source/webrtc/api/jsep_ice_candidate.cc
@@ -232,15 +236,14 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/api/rtp_sender_interface.cc
     Source/webrtc/api/rtp_transceiver_interface.cc
     Source/webrtc/api/sctp_transport_interface.cc
-    # Source/webrtc/api/task_queue/default_task_queue_factory_gcd.cc
     Source/webrtc/api/task_queue/default_task_queue_factory_stdlib.cc
     Source/webrtc/api/task_queue/default_task_queue_factory_win.cc
     Source/webrtc/api/task_queue/pending_task_safety_flag.cc
     Source/webrtc/api/task_queue/task_queue_base.cc
     Source/webrtc/api/transport/bitrate_settings.cc
-    Source/webrtc/api/transport/field_trial_based_config.cc
     Source/webrtc/api/transport/goog_cc_factory.cc
     Source/webrtc/api/transport/network_types.cc
+    Source/webrtc/api/transport/rtp/corruption_detection_message.cc
     Source/webrtc/api/transport/rtp/dependency_descriptor.cc
     Source/webrtc/api/transport/stun.cc
     Source/webrtc/api/units/data_rate.cc
@@ -250,6 +253,10 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/api/units/timestamp.cc
     Source/webrtc/api/video/builtin_video_bitrate_allocator_factory.cc
     Source/webrtc/api/video/color_space.cc
+    Source/webrtc/api/video/corruption_detection/frame_instrumentation_data.cc
+    Source/webrtc/api/video/corruption_detection/frame_instrumentation_data_reader.cc
+    Source/webrtc/api/video/corruption_detection/frame_instrumentation_evaluation.cc
+    Source/webrtc/api/video/corruption_detection/frame_instrumentation_generator.cc
     Source/webrtc/api/video/encoded_frame.cc
     Source/webrtc/api/video/encoded_image.cc
     Source/webrtc/api/video/frame_buffer.cc
@@ -276,7 +283,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/api/video_codecs/builtin_video_encoder_factory.cc
     Source/webrtc/api/video_codecs/h264_profile_level_id.cc
     Source/webrtc/api/video_codecs/h265_profile_tier_level.cc
-    # Source/webrtc/api/video_codecs/libaom_av1_encoder_factory.cc
     Source/webrtc/api/video_codecs/scalability_mode.cc
     Source/webrtc/api/video_codecs/scalability_mode_helper.cc
     Source/webrtc/api/video_codecs/sdp_video_format.cc
@@ -293,6 +299,7 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/api/video_codecs/vp8_temporal_layers_factory.cc
     Source/webrtc/api/video_codecs/vp9_profile.cc
     Source/webrtc/api/voip/voip_engine_factory.cc
+    Source/webrtc/api/webrtc_sdp.cc
     Source/webrtc/audio/audio_level.cc
     Source/webrtc/audio/audio_receive_stream.cc
     Source/webrtc/audio/audio_send_stream.cc
@@ -404,7 +411,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/common_audio/wav_header.cc
     Source/webrtc/common_audio/window_generator.cc
     Source/webrtc/common_video/bitrate_adjuster.cc
-    Source/webrtc/common_video/corruption_detection_converters.cc
     Source/webrtc/common_video/frame_rate_estimator.cc
     Source/webrtc/common_video/framerate_controller.cc
     Source/webrtc/common_video/generic_frame_descriptor/generic_frame_info.cc
@@ -438,6 +444,7 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/logging/rtc_event_log/events/rtc_event_begin_log.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_bwe_update_delay_based.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_bwe_update_loss_based.cc
+    Source/webrtc/logging/rtc_event_log/events/rtc_event_bwe_update_scream.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_dtls_transport_state.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_dtls_writable_state.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_end_log.cc
@@ -445,9 +452,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/logging/rtc_event_log/events/rtc_event_field_encoding_parser.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_field_extraction.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_frame_decoded.cc
-    Source/webrtc/logging/rtc_event_log/events/rtc_event_generic_ack_received.cc
-    Source/webrtc/logging/rtc_event_log/events/rtc_event_generic_packet_received.cc
-    Source/webrtc/logging/rtc_event_log/events/rtc_event_generic_packet_sent.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_ice_candidate_pair.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_ice_candidate_pair_config.cc
     Source/webrtc/logging/rtc_event_log/events/rtc_event_neteq_set_minimum_delay.cc
@@ -778,6 +782,10 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/congestion_controller/rtp/control_handler.cc
     Source/webrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc
     Source/webrtc/modules/congestion_controller/rtp/transport_feedback_demuxer.cc
+    Source/webrtc/modules/congestion_controller/scream/delay_based_congestion_control.cc
+    Source/webrtc/modules/congestion_controller/scream/scream_network_controller.cc
+    Source/webrtc/modules/congestion_controller/scream/scream_v2.cc
+    Source/webrtc/modules/congestion_controller/scream/scream_v2_parameters.cc
     Source/webrtc/modules/pacing/bitrate_prober.cc
     Source/webrtc/modules/pacing/interval_budget.cc
     Source/webrtc/modules/pacing/pacing_controller.cc
@@ -805,7 +813,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/rtp_rtcp/source/capture_clock_offset_updater.cc
     Source/webrtc/modules/rtp_rtcp/source/corruption_detection_extension.cc
     Source/webrtc/modules/rtp_rtcp/source/create_video_rtp_depacketizer.cc
-    Source/webrtc/modules/rtp_rtcp/source/deprecated/deprecated_rtp_sender_egress.cc
     Source/webrtc/modules/rtp_rtcp/source/dtmf_queue.cc
     Source/webrtc/modules/rtp_rtcp/source/fec_private_tables_bursty.cc
     Source/webrtc/modules/rtp_rtcp/source/fec_private_tables_random.cc
@@ -876,7 +883,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/rtp_rtcp/source/rtp_packet_to_send.cc
     Source/webrtc/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
     Source/webrtc/modules/rtp_rtcp/source/rtp_packetizer_h265.cc
-    Source/webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl.cc
     Source/webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl2.cc
     Source/webrtc/modules/rtp_rtcp/source/rtp_sender.cc
     Source/webrtc/modules/rtp_rtcp/source/rtp_sender_audio.cc
@@ -975,6 +981,7 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/video_coding/utility/corruption_detection_settings_generator.cc
     Source/webrtc/modules/video_coding/utility/decoded_frames_history.cc
     Source/webrtc/modules/video_coding/utility/frame_dropper.cc
+    Source/webrtc/modules/video_coding/utility/frame_sampler.cc
     Source/webrtc/modules/video_coding/utility/framerate_controller_deprecated.cc
     Source/webrtc/modules/video_coding/utility/ivf_file_reader.cc
     Source/webrtc/modules/video_coding/utility/ivf_file_writer.cc
@@ -1099,6 +1106,7 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/pc/connection_context.cc
     Source/webrtc/pc/data_channel_controller.cc
     Source/webrtc/pc/data_channel_utils.cc
+    Source/webrtc/pc/datagram_connection_internal.cc
     Source/webrtc/pc/dtls_srtp_transport.cc
     Source/webrtc/pc/dtls_transport.cc
     Source/webrtc/pc/dtmf_sender.cc
@@ -1106,8 +1114,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/pc/ice_server_parsing.cc
     Source/webrtc/pc/ice_transport.cc
     Source/webrtc/pc/jitter_buffer_delay.cc
-    Source/webrtc/pc/jsep_ice_candidate.cc
-    Source/webrtc/pc/jsep_session_description.cc
     Source/webrtc/pc/jsep_transport.cc
     Source/webrtc/pc/jsep_transport_collection.cc
     Source/webrtc/pc/jsep_transport_controller.cc
@@ -1122,9 +1128,9 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/pc/peer_connection_factory.cc
     Source/webrtc/pc/peer_connection_message_handler.cc
     Source/webrtc/pc/remote_audio_source.cc
-    Source/webrtc/pc/rtcp_mux_filter.cc
     Source/webrtc/pc/rtc_stats_collector.cc
     Source/webrtc/pc/rtc_stats_traversal.cc
+    Source/webrtc/pc/rtcp_mux_filter.cc
     Source/webrtc/pc/rtp_media_utils.cc
     Source/webrtc/pc/rtp_parameters_conversion.cc
     Source/webrtc/pc/rtp_receiver.cc
@@ -1153,7 +1159,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/pc/video_track.cc
     Source/webrtc/pc/video_track_source.cc
     Source/webrtc/pc/video_track_source_proxy.cc
-    Source/webrtc/pc/webrtc_sdp.cc
     Source/webrtc/pc/webrtc_session_description_factory.cc
     Source/webrtc/rtc_base/async_dns_resolver.cc
     Source/webrtc/rtc_base/async_packet_socket.cc
@@ -1184,12 +1189,14 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/rtc_base/experiments/alr_experiment.cc
     Source/webrtc/rtc_base/experiments/balanced_degradation_settings.cc
     Source/webrtc/rtc_base/experiments/encoder_info_settings.cc
+    Source/webrtc/rtc_base/experiments/encoder_speed_experiment.cc
     Source/webrtc/rtc_base/experiments/field_trial_list.cc
     Source/webrtc/rtc_base/experiments/field_trial_parser.cc
     Source/webrtc/rtc_base/experiments/field_trial_units.cc
     Source/webrtc/rtc_base/experiments/keyframe_interval_settings.cc
     Source/webrtc/rtc_base/experiments/min_video_bitrate_experiment.cc
     Source/webrtc/rtc_base/experiments/normalize_simulcast_size_experiment.cc
+    Source/webrtc/rtc_base/experiments/psnr_experiment.cc
     Source/webrtc/rtc_base/experiments/quality_scaler_settings.cc
     Source/webrtc/rtc_base/experiments/quality_scaling_experiment.cc
     Source/webrtc/rtc_base/experiments/rate_control_settings.cc
@@ -1304,8 +1311,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/video/config/video_encoder_config.cc
     Source/webrtc/video/corruption_detection/corruption_classifier.cc
     Source/webrtc/video/corruption_detection/evaluation/utils.cc
-    Source/webrtc/video/corruption_detection/frame_instrumentation_evaluation.cc
-    Source/webrtc/video/corruption_detection/frame_instrumentation_generator.cc
     Source/webrtc/video/corruption_detection/frame_pair_corruption_score.cc
     Source/webrtc/video/corruption_detection/generic_mapping_functions.cc
     Source/webrtc/video/corruption_detection/halton_frame_sampler.cc
@@ -1336,6 +1341,9 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/video/stats_counter.cc
     Source/webrtc/video/stream_synchronization.cc
     Source/webrtc/video/task_queue_frame_decode_scheduler.cc
+    Source/webrtc/video/timing/simulator/assembler.cc
+    Source/webrtc/video/timing/simulator/decodability_tracker.cc
+    Source/webrtc/video/timing/simulator/rendering_tracker.cc
     Source/webrtc/video/transport_adapter.cc
     Source/webrtc/video/unique_timestamp_counter.cc
     Source/webrtc/video/video_loopback_main.cc

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -60,9 +60,8 @@ public:
         return webrtc::make_ref_counted<GStreamerEncodedImageBuffer>(data);
     }
 
-    const uint8_t* data() const final { return m_data.data(); }
-    uint8_t* data() final { return const_cast<uint8_t*>(m_data.data()); }
-    size_t size() const final { return m_data.size_bytes(); }
+    const uint8_t* data() const override { return m_data.data(); }
+    size_t size() const override { return m_data.size_bytes(); }
 
 protected:
     GStreamerEncodedImageBuffer(std::span<const uint8_t> data)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -50,9 +50,10 @@
 #else // PLATFORM(COCOA)
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <webrtc/api/environment/environment_factory.h>
 #include <webrtc/rtc_base/async_packet_socket.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif // PLATFORM(COCOA)
+#endif // !PLATFORM(COCOA)
 
 namespace WebKit {
 using namespace WebCore;
@@ -325,7 +326,7 @@ void NetworkRTCProvider::createUDPSocket(LibWebRTCSocketIdentifier identifier, c
 {
     assertIsRTCNetworkThread();
 
-    std::unique_ptr<webrtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(address.rtcAddress(), minPort, maxPort));
+    std::unique_ptr<webrtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(webrtc::CreateEnvironment(), address.rtcAddress(), minPort, maxPort));
     createSocket(identifier, WTFMove(socket), Socket::Type::UDP, m_ipcConnection.copyRef());
 }
 
@@ -355,7 +356,7 @@ void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identif
 
             webrtc::PacketSocketTcpOptions tcpOptions;
             tcpOptions.opts = options;
-            std::unique_ptr<webrtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateClientTcpSocket(localAddress, remoteAddress, tcpOptions));
+            std::unique_ptr<webrtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateClientTcpSocket(webrtc::CreateEnvironment(), localAddress, remoteAddress, tcpOptions));
             createSocket(identifier, WTFMove(socket), Socket::Type::ClientTCP, m_ipcConnection.copyRef());
         });
     });


### PR DESCRIPTION
#### 652380e22fffc1e26c4c0f78194aa26080a11fb0
<pre>
[LibWebRTC] Build fix for Linux after 303981@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=303477">https://bugs.webkit.org/show_bug.cgi?id=303477</a>

Reviewed by Philippe Normand.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:

Canonical link: <a href="https://commits.webkit.org/304090@main">https://commits.webkit.org/304090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/551c538f1310879208be01fc8e1984b9953cd1dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120609 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83650 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2815 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39332 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111533 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5031 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60573 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20773 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6752 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70334 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->