### PR TITLE
Optimize hash table key validation & close the HashTranslator loophole

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -309,13 +309,6 @@ template<typename P, typename WeakPtrImpl> struct WeakPtrHashTraits : SimpleClas
     static constexpr bool hasIsEmptyValueFunction = true;
     static bool isEmptyValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isHashTableEmptyValue(); }
 
-    // FIXME: HashTable::checkHashTableKey() defeats the "lookup using P* without converting to smart pointer" optimization.
-    // These helper functions preserve the optimization at the expense of some encapsulation. We should either change how
-    // checkHashTableKey() works, or change all smart pointer HashTraits to add this workaround.
-    static bool isEmptyValue(const P* value) { return !value; }
-    static bool isDeletedValue(const P* value) { return value == reinterpret_cast<const P*>(-1); }
-    using SimpleClassHashTraits<WeakPtr<P, WeakPtrImpl>>::isDeletedValue;
-
     using PeekType = P*;
     static PeekType peek(const WeakPtr<P, WeakPtrImpl>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }
     static PeekType peek(P* value) { return value; }

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -957,4 +957,92 @@ TEST(WTF_HashSet, RangesAllAnyNoneOf)
     }));
 }
 
+// FIXME: Tests using ASSERT_DEATH currently panic on playstation
+#if !PLATFORM(PLAYSTATION)
+TEST(WTF_HashSetDeathTest, StringViewHashTranslatorEmptyValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<StringViewHashTranslator>(StringView(String())); // Results in HashTraits empty value
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_HashSetDeathTest, StringViewHashTranslatorDeletedValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<StringViewHashTranslator>(StringView(String(WTF::HashTableDeletedValue))); // Results in HashTraits deleted value
+    };
+
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_HashSetDeathTest, ASCIICaseInsensitiveStringViewHashTranslatorEmptyValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<ASCIICaseInsensitiveStringViewHashTranslator>(StringView(String())); // Results in HashTraits empty value
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_HashSetDeathTest, ASCIICaseInsensitiveStringViewHashTranslatorDeletedValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<ASCIICaseInsensitiveStringViewHashTranslator>(StringView(String(WTF::HashTableDeletedValue))); // Results in HashTraits deleted value
+    };
+
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralEmptyValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<HashTranslatorASCIILiteral>(ASCIILiteral()); // Results in HashTraits empty value
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralDeletedValue)
+{
+    HashSet<String> hashSet;
+    auto shouldCrash = [&] {
+        hashSet.add<HashTranslatorASCIILiteral>(ASCIILiteral::deletedValue()); // Results in HashTraits deleted value
+    };
+
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+#ifdef NDEBUG
+TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralCaseInsensitiveEmptyValue)
+{
+    HashSet<String> hashSet;
+    hashSet.reserveInitialCapacity(8); // All empty buckets
+    auto invalidLookup = [&] {
+        return hashSet.contains<HashTranslatorASCIILiteralCaseInsensitive>(ASCIILiteral()); // Results in HashTraits empty value
+    };
+    EXPECT_FALSE(invalidLookup());
+}
+
+TEST(WTF_HashSet, HashTranslatorASCIILiteralCaseInsensitiveDeletedValue)
+{
+    HashSet<String> hashSet;
+    hashSet.reserveInitialCapacity(8);
+    for (size_t i = 0; i < 8; ++i)
+        hashSet.add(String::number(i));
+    for (size_t i = 0; i < 8; ++i)
+        hashSet.remove(String::number(i)); // Lots of deleted buckets (100% deleted buckets is impossible, so we do our best)
+    auto invalidLookup = [&] {
+        return hashSet.contains<HashTranslatorASCIILiteralCaseInsensitive>(ASCIILiteral::deletedValue()); // Results in HashTraits deleted value
+    };
+
+    EXPECT_FALSE(invalidLookup());
+}
+#endif
+
+#endif
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 815f292434d34a9f4f93866e851d9697c323aff6
<pre>
Optimize hash table key validation &amp; close the HashTranslator loophole
<a href="https://bugs.webkit.org/show_bug.cgi?id=303648">https://bugs.webkit.org/show_bug.cgi?id=303648</a>
<a href="https://rdar.apple.com/165932284">rdar://165932284</a>

Reviewed by Darin Adler.

Changed hash table key validation to happen after insertion.

This has a few benefits:

1. Key validation happens less frequently. Lookup is far more common than
insertion, on average.

2. Key validation no longer does type conversion. Some conversions have a cost,
like P* =&gt; RefPtr&lt;P&gt; or, worse, std::span&lt;const char&gt; =&gt; String.

Hopefully these optimizations will enable key validation in more cases -- though
I haven&apos;t tested end-to-end performance yet.

3. HashTranslator no longer skips key validation. It does take some doing to
sneak a bad key through a HashTranslator. But it&apos;s possible. For example:

    HashSet&lt;String&gt; hashSet;
    hashSet.add&lt;StringViewHashTranslator&gt;(
        StringView(String())); // Oops!
    hashSet.add&lt;StringViewHashTranslator&gt;(
        StringView(String(WTF::HashTableDeletedValue))); // Oops!

This patch introduces a small behavior change: In release builds only, if you
try to look up the empty or deleted key, you&apos;ll get &quot;not present&quot; now instead
of a crash.

Added API tests to cover these behavior changes.

* Source/WTF/wtf/HashTable.h:
(WTF::HashTable::isValidKey):
(WTF::HashTable::validateKey):
(WTF::Malloc&gt;::inlineLookup):
(WTF::Malloc&gt;::lookupForReinsert):
(WTF::Malloc&gt;::fullLookupForWriting):
(WTF::Malloc&gt;::addUniqueForInitialization):
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::checkHashTableKey): Deleted.
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtrHashTraits::isDeletedValue): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp:
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, StringViewHashTranslatorEmptyValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, StringViewHashTranslatorDeletedValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, ASCIICaseInsensitiveStringViewHashTranslatorEmptyValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, ASCIICaseInsensitiveStringViewHashTranslatorDeletedValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralEmptyValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralDeletedValue)):
(TestWebKitAPI::TEST(WTF_HashSetDeathTest, HashTranslatorASCIILiteralCaseInsensitiveEmptyValue)):
(TestWebKitAPI::TEST(WTF_HashSet, HashTranslatorASCIILiteralCaseInsensitiveDeletedValue)):

Canonical link: <a href="https://commits.webkit.org/304074@main">https://commits.webkit.org/304074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5e21cebf0533299c61187e96ee924f3a0e4fef2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b6dcf0d6-be66-4fc7-be62-1a3e9695353a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70037 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/768e2aaa-ff2a-4064-8e84-ac4ff1f35234) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83573 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41c89d68-6702-4706-9c6e-b157cdd0514e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5121 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2741 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126521 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114332 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144691 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132975 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39240 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111455 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4956 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60434 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6663 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34991 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165906 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70234 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43362 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->