### PR TITLE
[threaded-animations] creating a new animation removes the timeline for a previous animation

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Remote timelines are preserved as new timelines are created for animations targeting another element.
+

--- a/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack.html
+++ b/LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+.target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const make_animation = t => {
+    const target = createDiv(t);
+    target.className = "target";
+    const timeline = new ScrollTimeline({ source: document.documentElement });
+    const animation = target.animate({ translate: '100px' }, { timeline });
+    return animation;
+};
+
+promise_test(async t => {
+    const initialAnimation = make_animation(t);
+    await animationAcceleration(initialAnimation);
+    const initialTimeline = await UIHelper.remoteTimeline(initialAnimation.timeline);
+    assert_not_equals(initialTimeline, undefined, "Remote timeline for the initial animation was created.");
+
+    const additionalAnimation = make_animation(t);
+    await animationAcceleration(additionalAnimation);
+    const additionalTimeline = await UIHelper.remoteTimeline(additionalAnimation.timeline);
+    const preservedInitialTimeline = await UIHelper.remoteTimeline(initialAnimation.timeline);
+    assert_not_equals(additionalTimeline, undefined, "Remote timeline for the additional animation was created.");
+    assert_not_equals(preservedInitialTimeline, undefined, "Remote timeline for the initial animation was preserved.");
+
+    initialAnimation.cancel();
+    await threadedAnimationsCommit();
+    const removedInitialTimeline = await UIHelper.remoteTimeline(initialAnimation.timeline);
+    const preservedAdditionalTimeline = await UIHelper.remoteTimeline(additionalAnimation.timeline);
+    assert_equals(removedInitialTimeline, undefined, "Canceling the additional animation removed its remote timeline.");
+    assert_not_equals(preservedAdditionalTimeline, undefined, "Remote timeline for the additional animation was preserved.");
+
+    additionalAnimation.cancel();
+    await threadedAnimationsCommit();
+    const removedAdditionalTimeline = await UIHelper.remoteTimeline(additionalAnimation.timeline);
+    assert_equals(removedAdditionalTimeline, undefined, "Canceling the additional animation removed its remote timeline.");
+}, "Remote timelines are preserved as new timelines are created for animations targeting another element.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -28,12 +28,14 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
+#include "AcceleratedTimeline.h"
 #include "KeyframeEffectStack.h"
 #include "RenderElement.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
 #include "RenderLayerModelObject.h"
 #include "RenderStyleConstants.h"
+#include "ScrollTimeline.h"
 #include "Styleable.h"
 
 namespace WebCore {
@@ -43,7 +45,7 @@ void AcceleratedEffectStackUpdater::update()
     if (!hasTargetsPendingUpdate())
         return;
 
-    m_timelines.clear();
+    HashSet<Ref<AcceleratedTimeline>> timelinesInUpdate;
 
     auto targetsPendingUpdate = std::exchange(m_targetsPendingUpdate, { });
     for (auto [element, pseudoElementIdentifier] : targetsPendingUpdate) {
@@ -58,13 +60,55 @@ void AcceleratedEffectStackUpdater::update()
 
         auto* renderLayer = renderer->layer();
         ASSERT(renderLayer && renderLayer->backing());
-        renderLayer->backing()->updateAcceleratedEffectsAndBaseValues(m_timelines);
+        renderLayer->backing()->updateAcceleratedEffectsAndBaseValues(timelinesInUpdate);
+    }
+
+    for (auto& timeline : timelinesInUpdate) {
+        auto& timelineIdentifier = timeline->identifier();
+        auto addResult = m_timelines.add(timelineIdentifier, timeline.ptr());
+        if (addResult.isNewEntry)
+            m_timelinesUpdate.created.add(timeline);
     }
 }
 
 void AcceleratedEffectStackUpdater::scheduleUpdateForTarget(const Styleable& target)
 {
     m_targetsPendingUpdate.add({ &target.element, target.pseudoElementIdentifier });
+}
+
+void AcceleratedEffectStackUpdater::scrollTimelineDidChange(ScrollTimeline& timeline)
+{
+    m_scrollTimelinesPendingUpdate.add(timeline);
+}
+
+AcceleratedTimelinesUpdate AcceleratedEffectStackUpdater::takeTimelinesUpdate()
+{
+    // All known accelerated timelines that got destroyed since the last update
+    // will now be null references. Add them to the list of destroyed timelines.
+    for (auto& [timelineIdentifier, timeline] : m_timelines) {
+        if (!timeline)
+            m_timelinesUpdate.destroyed.add(timelineIdentifier);
+    }
+
+    // Prune all those destroyed timelines from our list of know accelerated timelines.
+    for (auto& identifierToRemove : m_timelinesUpdate.destroyed)
+        m_timelines.remove(identifierToRemove);
+
+    // Finally, process all timelines that were marked as requiring an update, either
+    // marking them as modified or destroyed if they no longer are accelerated.
+    auto scrollTimelinesPendingUpdate = std::exchange(m_scrollTimelinesPendingUpdate, { });
+    for (auto& scrollTimeline : scrollTimelinesPendingUpdate) {
+        auto timelineIdentifier = scrollTimeline->acceleratedTimelineIdentifier();
+        auto acceleratedTimeline = m_timelines.getOptional(timelineIdentifier);
+        if (acceleratedTimeline && scrollTimeline->canBeAccelerated()) {
+            ASSERT(*acceleratedTimeline);
+            scrollTimeline->updateAcceleratedRepresentation();
+            m_timelinesUpdate.modified.add(**acceleratedTimeline);
+        } else
+            m_timelinesUpdate.destroyed.add(timelineIdentifier);
+    }
+
+    return std::exchange(m_timelinesUpdate, { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -28,13 +28,17 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #include <WebCore/AcceleratedEffect.h>
+#include <WebCore/AcceleratedTimeline.h>
 #include <WebCore/AnimationMalloc.h>
+#include <WebCore/TimelineIdentifier.h>
 #include <wtf/HashSet.h>
 
 namespace WebCore {
 
+class AcceleratedTimeline;
 class Document;
 class Element;
+class ScrollTimeline;
 struct Styleable;
 
 class AcceleratedEffectStackUpdater {
@@ -45,13 +49,16 @@ public:
     void update();
     void scheduleUpdateForTarget(const Styleable&);
     bool hasTargetsPendingUpdate() const { return !m_targetsPendingUpdate.isEmpty(); }
+    void scrollTimelineDidChange(ScrollTimeline&);
 
-    const HashSet<Ref<AcceleratedTimeline>>& timelines() const { return m_timelines; }
+    WEBCORE_EXPORT AcceleratedTimelinesUpdate takeTimelinesUpdate();
 
 private:
     using HashedStyleable = std::pair<Element*, std::optional<Style::PseudoElementIdentifier>>;
     HashSet<HashedStyleable> m_targetsPendingUpdate;
-    HashSet<Ref<AcceleratedTimeline>> m_timelines;
+    HashSet<Ref<ScrollTimeline>> m_scrollTimelinesPendingUpdate;
+    HashMap<TimelineIdentifier, WeakPtr<AcceleratedTimeline>> m_timelines;
+    AcceleratedTimelinesUpdate m_timelinesUpdate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -126,11 +126,15 @@ Style::SingleAnimationRange AnimationTimeline::defaultRange() const
 
 
 #if ENABLE(THREADED_ANIMATIONS)
-AcceleratedTimeline& AnimationTimeline::acceleratedRepresentation()
+Ref<AcceleratedTimeline> AnimationTimeline::acceleratedRepresentation()
 {
-    if (!m_acceleratedRepresentation)
-        m_acceleratedRepresentation = createAcceleratedRepresentation();
-    return *m_acceleratedRepresentation;
+    ASSERT(canBeAccelerated());
+    if (m_acceleratedRepresentation)
+        return *m_acceleratedRepresentation;
+
+    auto acceleratedRepresentation = createAcceleratedRepresentation();
+    m_acceleratedRepresentation = acceleratedRepresentation.ptr();
+    return acceleratedRepresentation;
 }
 
 Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation() const
@@ -141,8 +145,6 @@ Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation() co
 
 void AnimationTimeline::runPostRenderingUpdateTasks()
 {
-    m_acceleratedRepresentation = nullptr;
-
     bool previousCanBeAccelerated = std::exchange(m_canBeAccelerated, computeCanBeAccelerated());
     if (m_canBeAccelerated == previousCanBeAccelerated)
         return;

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -82,15 +82,16 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     bool canBeAccelerated() const { return m_canBeAccelerated; }
     virtual bool computeCanBeAccelerated() const { return false; }
-    AcceleratedTimeline& acceleratedRepresentation();
+    Ref<AcceleratedTimeline> acceleratedRepresentation();
     void runPostRenderingUpdateTasks();
-    const TimelineIdentifier& acceleratedTimelineIdentifierForTesting() const { return m_acceleratedTimelineIdentifier; }
+    const TimelineIdentifier& acceleratedTimelineIdentifier() const { return m_acceleratedTimelineIdentifier; }
 #endif
 
 protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
 #if ENABLE(THREADED_ANIMATIONS)
+    WeakPtr<AcceleratedTimeline> m_acceleratedRepresentation;
     virtual Ref<AcceleratedTimeline> createAcceleratedRepresentation() const;
 #endif
 
@@ -102,7 +103,6 @@ protected:
 
 private:
 #if ENABLE(THREADED_ANIMATIONS)
-    RefPtr<AcceleratedTimeline> m_acceleratedRepresentation;
     bool m_canBeAccelerated { false };
 #endif
     std::optional<WebAnimationTime> m_currentTime;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3112,14 +3112,13 @@ void KeyframeEffect::timelineAccelerationAbilityDidChange()
     scheduleAssociatedAcceleratedEffectStackUpdate();
 }
 
-RefPtr<AcceleratedEffect> KeyframeEffect::updatedAcceleratedRepresentation(const TimelineIdentifier& timelineIdentifier, const IntRect& borderBoxRect, const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>& disallowedProperties)
+Ref<AcceleratedEffect> KeyframeEffect::acceleratedRepresentation(const IntRect& borderBoxRect, const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>& disallowedProperties)
 {
     updateComputedKeyframeOffsetsIfNeeded();
-    RefPtr acceleratedEffect = AcceleratedEffect::create(*this, timelineIdentifier, borderBoxRect, baseValues, disallowedProperties);
-    m_acceleratedRepresentation = acceleratedEffect.get();
+    Ref acceleratedEffect = AcceleratedEffect::create(*this, borderBoxRect, baseValues, disallowedProperties);
+    m_acceleratedRepresentation = acceleratedEffect.ptr();
     return acceleratedEffect;
 }
-
 #endif
 
 const KeyframeInterpolation::Keyframe& KeyframeEffect::keyframeAtIndex(size_t index) const
@@ -3164,10 +3163,6 @@ void KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const 
 {
     AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(animationAttachmentRange);
     m_needsComputedKeyframeOffsetsUpdate = true;
-#if ENABLE(THREADED_ANIMATIONS)
-    if (canHaveAcceleratedRepresentation())
-        updateAcceleratedAnimationIfNecessary();
-#endif
 }
 
 void KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded()

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -195,8 +195,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATIONS)
     bool canHaveAcceleratedRepresentation() const;
-    const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
-    RefPtr<AcceleratedEffect> updatedAcceleratedRepresentation(const TimelineIdentifier&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
+    Ref<AcceleratedEffect> acceleratedRepresentation(const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
     void timelineAccelerationAbilityDidChange();
 #endif
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -86,6 +86,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATIONS)
     WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeIDForTesting() const;
+    void updateAcceleratedRepresentation();
 #endif
 
 protected:
@@ -99,8 +100,12 @@ protected:
     virtual Data computeTimelineData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const;
 
     static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);
-
     ResolvedScrollDirection resolvedScrollDirection() const;
+    void sourceMetricsDidChange();
+
+#if ENABLE(THREADED_ANIMATIONS)
+    void scheduleAcceleratedRepresentationUpdate();
+#endif
 
 private:
     explicit ScrollTimeline();
@@ -119,6 +124,9 @@ private:
         float maxScrollOffset { 0 };
     };
 
+#if ENABLE(THREADED_ANIMATIONS)
+    ProgressResolutionData computeProgressResolutionData() const;
+#endif
     CurrentTimeData computeCurrentTimeData() const;
     void cacheCurrentTime();
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -414,10 +414,8 @@ void ViewTimeline::cacheCurrentTime()
         || previousCurrentTimeData.insetEnd != m_cachedCurrentTimeData.insetEnd
         || previousCurrentTimeData.stickinessData != m_cachedCurrentTimeData.stickinessData;
 
-    if (metricsChanged) {
-        for (auto& animation : m_animations)
-            animation->progressBasedTimelineSourceDidChangeMetrics();
-    }
+    if (metricsChanged)
+        sourceMetricsDidChange();
 }
 
 AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ViewTimeline::documentWillUpdateAnimationsAndSendEvents()

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -74,7 +74,7 @@ public:
         OptionSet<AcceleratedEffectProperty> m_animatedProperties;
     };
 
-    static RefPtr<AcceleratedEffect> create(const KeyframeEffect&, const TimelineIdentifier&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
+    static Ref<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
     WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, TimelineIdentifier&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
 
     virtual ~AcceleratedEffect() = default;
@@ -104,7 +104,7 @@ public:
     bool animatesTransformRelatedProperty() const;
 
 private:
-    AcceleratedEffect(const KeyframeEffect&, const TimelineIdentifier&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);
+    AcceleratedEffect(const KeyframeEffect&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);
     explicit AcceleratedEffect(AnimationEffectTiming, TimelineIdentifier&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
@@ -81,6 +81,12 @@ std::optional<ProgressResolutionData> AcceleratedTimeline::progressResolutionDat
     return std::nullopt;
 }
 
+void AcceleratedTimeline::setProgressResolutionData(ProgressResolutionData&& progressResolutionData)
+{
+    ASSERT(!originTime());
+    m_data = WTFMove(progressResolutionData);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.h
@@ -29,13 +29,15 @@
 
 #include <WebCore/ProgressResolutionData.h>
 #include <WebCore/TimelineIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Variant.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class AcceleratedTimeline : public RefCounted<AcceleratedTimeline> {
+class AcceleratedTimeline : public RefCountedAndCanMakeWeakPtr<AcceleratedTimeline> {
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedTimeline);
 public:
 
@@ -47,6 +49,8 @@ public:
 
     WEBCORE_EXPORT std::optional<Seconds> originTime() const;
     WEBCORE_EXPORT std::optional<ProgressResolutionData> progressResolutionData() const;
+
+    void setProgressResolutionData(ProgressResolutionData&&);
 
     // Encoding support.
     using Data = Variant<Seconds, ProgressResolutionData>;
@@ -63,6 +67,14 @@ private:
 
     TimelineIdentifier m_identifier;
     Data m_data;
+};
+
+struct AcceleratedTimelinesUpdate {
+    HashSet<Ref<AcceleratedTimeline>> created;
+    HashSet<Ref<AcceleratedTimeline>> modified;
+    HashSet<TimelineIdentifier> destroyed;
+
+    bool isEmpty() const { return created.isEmpty() && modified.isEmpty() && destroyed.isEmpty(); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1442,7 +1442,7 @@ ExceptionOr<void> Internals::resumeAnimations() const
 uint64_t Internals::identifierForTimeline(AnimationTimeline& timeline) const
 {
 #if ENABLE(THREADED_ANIMATIONS)
-    return timeline.acceleratedTimelineIdentifierForTesting().toRawValue();
+    return timeline.acceleratedTimelineIdentifier().toRawValue();
 #else
     UNUSED_PARAM(timeline);
     return 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -119,7 +119,7 @@ header: "RemoteLayerBackingStore.h"
     WebCore::IntPoint m_scrollPosition;
 
 #if ENABLE(THREADED_ANIMATIONS)
-    HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
+    WebCore::AcceleratedTimelinesUpdate m_timelinesUpdate;
 #endif
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -43,7 +43,7 @@
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(THREADED_ANIMATIONS)
-#include <WebCore/AcceleratedTimeline.h>
+#include <WebCore/AcceleratedEffectStackUpdater.h>
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
@@ -172,8 +172,8 @@ public:
     void setScrollPosition(WebCore::IntPoint p) { m_scrollPosition = p; }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines() const { return m_timelines; }
-    void setTimelines(const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelines) { m_timelines = timelines; }
+    const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate() const { return m_timelinesUpdate; }
+    void setTimelinesUpdate(WebCore::AcceleratedTimelinesUpdate&& timelinesUpdate) { m_timelinesUpdate = WTFMove(timelinesUpdate); }
 #endif
 
 private:
@@ -194,7 +194,7 @@ private:
     WebCore::IntPoint m_scrollPosition;
 
 #if ENABLE(THREADED_ANIMATIONS)
-    HashSet<Ref<WebCore::AcceleratedTimeline>> m_timelines;
+    WebCore::AcceleratedTimelinesUpdate m_timelinesUpdate;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6528,6 +6528,13 @@ struct WebCore::ProgressResolutionData {
     Variant<Seconds, WebCore::ProgressResolutionData> data();
 };
 
+header: <WebCore/AcceleratedTimeline.h>
+[CustomHeader] struct WebCore::AcceleratedTimelinesUpdate {
+    HashSet<Ref<WebCore::AcceleratedTimeline>> created;
+    HashSet<Ref<WebCore::AcceleratedTimeline>> modified;
+    HashSet<WebCore::TimelineIdentifier> destroyed;
+};
+
 header: <WebCore/AcceleratedEffect.h>
 [CustomHeader, Nested] class WebCore::AcceleratedEffect::Keyframe {
     double offset();
@@ -6551,7 +6558,6 @@ header: <WebCore/AcceleratedEffect.h>
     std::optional<WebCore::WebAnimationTime> startTime();
     std::optional<WebCore::WebAnimationTime> holdTime();
 };
-
 #endif // ENABLE(THREADED_ANIMATIONS)
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -86,7 +86,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
+    void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -922,10 +922,10 @@ void RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode(RemoteLayerT
         page->checkedScrollingCoordinatorProxy()->animationsWereRemovedFromNode(node);
 }
 
-void RemoteLayerTreeDrawingAreaProxy::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
+void RemoteLayerTreeDrawingAreaProxy::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)
 {
     if (RefPtr page = this->page())
-        page->checkedScrollingCoordinatorProxy()->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
+        page->checkedScrollingCoordinatorProxy()->updateTimelinesRegistration(processIdentifier, timelinesUpdate, now);
 }
 
 RefPtr<const RemoteAnimationTimeline> RemoteLayerTreeDrawingAreaProxy::timeline(const TimelineID& timelineID) const
@@ -939,7 +939,6 @@ RefPtr<const RemoteAnimationStack> RemoteLayerTreeDrawingAreaProxy::animationSta
 {
     return m_remoteLayerTreeHost->animationStackForNodeWithIDForTesting(layerID);
 }
-
 #endif // ENABLE(THREADED_ANIMATIONS)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -207,8 +207,8 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
 #if ENABLE(THREADED_ANIMATIONS)
     // FIXME: with site isolation, a single process can send multiple transactions.
     // https://bugs.webkit.org/show_bug.cgi?id=301261
-    if (threadedAnimationsEnabled())
-        Ref { *m_drawingArea }->updateTimelineRegistration(processIdentifier, transaction.timelines(), MonotonicTime::now());
+    if (threadedAnimationsEnabled() && !transaction.timelinesUpdate().isEmpty())
+        Ref { *m_drawingArea }->updateTimelinesRegistration(processIdentifier, transaction.timelinesUpdate(), MonotonicTime::now());
 #endif
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h
@@ -39,7 +39,7 @@ public:
     RemoteMonotonicTimelineRegistry() = default;
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
-    void update(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
+    void update(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
     RemoteMonotonicTimeline* get(const TimelineID&) const;
     void advanceCurrentTime(MonotonicTime);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -41,7 +41,7 @@ public:
     RemoteProgressBasedTimelineRegistry() = default;
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
-    void update(const RemoteScrollingTree&, WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
+    void update(const RemoteScrollingTree&, WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
     RemoteProgressBasedTimeline* get(const TimelineID&) const;
     void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
     bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -151,7 +151,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
-    virtual void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) { }
+    virtual void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime) { }
     virtual RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const { return nullptr; }
     virtual void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) { }
     virtual RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const { return nullptr; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -300,11 +300,11 @@ void RemoteScrollingTree::tryToApplyLayerPositions()
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
-void RemoteScrollingTree::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations)
+void RemoteScrollingTree::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate)
 {
     if (!m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry = makeUnique<RemoteProgressBasedTimelineRegistry>();
-    m_progressBasedTimelineRegistry->update(*this, processIdentifier, timelineRepresentations);
+    m_progressBasedTimelineRegistry->update(*this, processIdentifier, timelinesUpdate);
     if (m_progressBasedTimelineRegistry->isEmpty())
         m_progressBasedTimelineRegistry = nullptr;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -93,7 +93,7 @@ public:
     void tryToApplyLayerPositions();
 
 #if ENABLE(THREADED_ANIMATIONS)
-    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&);
+    void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
     bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -73,7 +73,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
-    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
+    void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime) override;
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const override;
     void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -684,12 +684,12 @@ void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLay
         drawingAreaIOS().pauseDisplayRefreshCallbacksForAnimation();
 }
 
-void RemoteScrollingCoordinatorProxyIOS::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
+void RemoteScrollingCoordinatorProxyIOS::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)
 {
-    scrollingTree().updateTimelineRegistration(processIdentifier, timelineRepresentations);
+    scrollingTree().updateTimelinesRegistration(processIdentifier, timelinesUpdate);
     if (!m_monotonicTimelineRegistry)
         m_monotonicTimelineRegistry = makeUnique<RemoteMonotonicTimelineRegistry>();
-    m_monotonicTimelineRegistry->update(processIdentifier, timelineRepresentations, now);
+    m_monotonicTimelineRegistry->update(processIdentifier, timelinesUpdate, now);
     if (m_monotonicTimelineRegistry->isEmpty())
         m_monotonicTimelineRegistry = nullptr;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -112,7 +112,7 @@ public:
     void unlockForAnimationChanges() WTF_RELEASES_LOCK(m_animationLock);
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime);
+    void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&);
     void updateAnimations();
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -660,14 +660,14 @@ void RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode(RemoteLayerTr
         animationStack->clear(node.protectedLayer().get());
 }
 
-void RemoteLayerTreeEventDispatcher::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
+void RemoteLayerTreeEventDispatcher::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)
 {
     assertIsHeld(m_animationLock);
     if (auto scrollingTree = this->scrollingTree())
-        scrollingTree->updateTimelineRegistration(processIdentifier, timelineRepresentations);
+        scrollingTree->updateTimelinesRegistration(processIdentifier, timelinesUpdate);
     if (!m_monotonicTimelineRegistry)
         m_monotonicTimelineRegistry = makeUnique<RemoteMonotonicTimelineRegistry>();
-    m_monotonicTimelineRegistry->update(processIdentifier, timelineRepresentations, now);
+    m_monotonicTimelineRegistry->update(processIdentifier, timelinesUpdate, now);
     if (m_monotonicTimelineRegistry->isEmpty())
         m_monotonicTimelineRegistry = nullptr;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -75,7 +75,7 @@ private:
 
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
-    void updateTimelineRegistration(WebCore::ProcessIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>&, MonotonicTime) override;
+    void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime) override;
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const override;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -285,9 +285,9 @@ void RemoteScrollingCoordinatorProxyMac::animationsWereRemovedFromNode(RemoteLay
     m_eventDispatcher->animationsWereRemovedFromNode(node);
 }
 
-void RemoteScrollingCoordinatorProxyMac::updateTimelineRegistration(WebCore::ProcessIdentifier processIdentifier, const HashSet<Ref<WebCore::AcceleratedTimeline>>& timelineRepresentations, MonotonicTime now)
+void RemoteScrollingCoordinatorProxyMac::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)
 {
-    m_eventDispatcher->updateTimelineRegistration(processIdentifier, timelineRepresentations, now);
+    m_eventDispatcher->updateTimelinesRegistration(processIdentifier, timelinesUpdate, now);
 }
 
 RefPtr<const RemoteAnimationTimeline> RemoteScrollingCoordinatorProxyMac::timeline(const TimelineID& timelineID) const


### PR DESCRIPTION
#### f27e060bbaf0b9b69e085ab05fbe447cc17536d0
<pre>
[threaded-animations] creating a new animation removes the timeline for a previous animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303655">https://bugs.webkit.org/show_bug.cgi?id=303655</a>
<a href="https://rdar.apple.com/165937022">rdar://165937022</a>

Reviewed by Simon Fraser.

If a scroll-driven animation is created for a given target, and later on a different
scroll-driven animation is created for another target, then the timeline for the first
animation is removed from the remote layer tree.

This is due to our ill-conceived method to gather relevant timelines for a given remote
layer tree transaction and updating them upon reception in the remote layer tree. Indeed,
until now, when we would create an update, we would gather all elements marked as required
an update in `AcceleratedEffectStackUpdater::update()` and keep a list of all timelines
seen for animations targeting said elements. For each such update, that list of timelines
would replace the one from the previous update, and would be made available in the remote
layer tree transaction.

As such, if we weren&apos;t updating animations for the same elements that were previously updated,
their timelines would be forgotten and the logic on the remote layer tree side would assume
they needed to be removed.

Additionally, we also naively always considered that timelines were part of the remote layer
tree transaction, assuming an empty list of timelines meant all timelines needed to be removed.
This meant that, even on pages where we never had timelines, we would attempt to update our
timelines registration on each remote layer tree transaction.

We overhaul this entire system by doing two main things.

First, we rethink the accelerated timeline ownership in the Web process such that the only
object that has a strong pointer (`RefPtr`) are the accelerated effects that are stored on
the GraphicsLayer matching the animation&apos;s target element. The `AcceleratedEffectStackUpdater`
maintains a list of known timelines but keeps weak pointers (`WeakPtr`), so does `AnimationTimeline`
for its accelerated representation. This now means that if, during an update, all of the effects
linked to a given timeline are removed, the timeline will no longer have strong references
and `AcceleratedEffectStackUpdater` will be able to check for null pointers and determine these
timelines indeed need to be destroyed.

Second, we now have a dedicated `TimelinesUpdate` struct used in remote layer tree transactions
sorting timelines in three categories: `created`, `modified` and `destroyed`. In the new system
outlined above, `AcceleratedEffectStackUpdater` is able to determine, during an update, how to
categorize timelines, making it clear on the receiving end, the remote layer tree, which timelines
to register, update and remove. Additionally, we can now determine if the remote layer tree
transaction contains any timelines to update and will do no processing whatsoever if we figure
out there are no timelines in any of those three buckets.

A new test validates that this new approach works as expected and we can update animations associated
with different targets across different updates.

Additional details as necessary in the function-per-function ChangeLog below.

Test: webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack.html

* LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/remote-progress-based-timeline-preservation-with-new-remote-animation-stack.html: Added.
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
(WebCore::AcceleratedEffectStackUpdater::scrollTimelineDidChange):
(WebCore::AcceleratedEffectStackUpdater::takeTimelinesUpdate):
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
(WebCore::AcceleratedEffectStackUpdater::timelines const): Deleted.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::acceleratedRepresentation): Return a Ref that will be stored by the `AcceleratedEffect` caller, keeping only a
weak pointer to that timeline as a member.
(WebCore::AnimationTimeline::runPostRenderingUpdateTasks): Make sure _not_ to clear the accelerated representation pointer as we now want
to keep the `AcceleratedTimeline` instance as long as it is used by an `AcceleratedEffect`.
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::acceleratedTimelineIdentifier const):
(WebCore::AnimationTimeline::acceleratedTimelineIdentifierForTesting const): Deleted.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::acceleratedRepresentation): Return a `Ref` instead of a `RefPtr` now that we know `AcceleratedEffect` will also
return a `Ref` always.
(WebCore::KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics): No need to trigger an animation update here, scroll timelines
themselves will inform `AcceleratedEffectStackUpdater` that they require an update, not needing the animation stack to be updated.
(WebCore::KeyframeEffect::updatedAcceleratedRepresentation): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::cacheCurrentTime):
(WebCore::ScrollTimeline::sourceMetricsDidChange): Introduce this new protected method to be called also by `ViewTimeline` when metrics change,
informing `AcceleratedEffectStackUpdater` that the accelerated representation needs to be updated.
(WebCore::ScrollTimeline::scheduleAcceleratedRepresentationUpdate):
(WebCore::ScrollTimeline::computeProgressResolutionData const): New function to compute the `ProgressResolutionData` such that it can be used
both when an update is needed, or when the accelerated representation is created.
(WebCore::ScrollTimeline::updateAcceleratedRepresentation):
(WebCore::ScrollTimeline::createAcceleratedRepresentation const):
(WebCore::ScrollTimeline::scrollingNodeIDForTesting const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create): Switch this method to a `Ref` which is a more common idiom that returning a `RefPtr`. The logic previously
used to determine whether this effect should be accelerated is now contained in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`.
(WebCore::AcceleratedEffect::AcceleratedEffect): Create and store the accelerated timeline as a strong pointer.
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedTimeline.cpp:
(WebCore::AcceleratedTimeline::setProgressResolutionData):
* Source/WebCore/platform/animation/AcceleratedTimeline.h:
(WebCore::AcceleratedTimelinesUpdate::isEmpty const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::identifierForTimeline const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateTimelinesRegistration):
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationStackForNodeWithIDForTesting const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateTimelineRegistration): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree): Only initiate a timelines registration update if we have any data.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.cpp:
(WebKit::RemoteMonotonicTimelineRegistry::update): change the registration code to work the new `TimelinesUpdate` struct and its
three `created`, `modified` and `destroyed` buckets.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::update): change the registration code to work the new `TimelinesUpdate` struct and
its three `created`, `modified` and `destroyed` buckets.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::updateTimelinesRegistration):
(WebKit::RemoteScrollingCoordinatorProxy::updateTimelineRegistration): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::updateTimelinesRegistration):
(WebKit::RemoteScrollingTree::updateTimelineRegistration): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimelinesRegistration):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimelineRegistration): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::updateTimelinesRegistration):
(WebKit::RemoteLayerTreeEventDispatcher::updateTimelineRegistration): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::updateTimelinesRegistration):
(WebKit::RemoteScrollingCoordinatorProxyMac::updateTimelineRegistration): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitLayerTree): Assemble all the `TimelinesUpdate` for all documents into a single update.

Canonical link: <a href="https://commits.webkit.org/304042@main">https://commits.webkit.org/304042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d5bb5dc7efc7f116888bd20ad2371f5005914c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134347 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86351 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cbe818f-ca5d-4482-b533-a2da459e2c34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83490 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e83a2609-6a30-4ba3-9681-80647e576127) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5033 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2652 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111098 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111365 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4869 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60285 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6554 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34878 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->