### PR TITLE
[JSC] Implement `String.prototype.concat` in C++

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-concat-2-args.js
+++ b/JSTests/microbenchmarks/string-prototype-concat-2-args.js
@@ -2,6 +2,6 @@ const str = "a".repeat(10);
 const arg1 = "b".repeat(10);
 const arg2 = "c".repeat(10);
 
-for (let i = 0; i < 1e6; i++) {
+for (let i = 0; i < 1e5; i++) {
   str.concat(arg1, arg2);
 }

--- a/JSTests/microbenchmarks/string-prototype-concat-5-args.js
+++ b/JSTests/microbenchmarks/string-prototype-concat-5-args.js
@@ -1,0 +1,10 @@
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+const arg3 = "d".repeat(10);
+const arg4 = "e".repeat(10);
+const arg5 = "f".repeat(10);
+
+for (let i = 0; i < 1e5; i++) {
+  str.concat(arg1, arg2, arg3, arg4, arg5);
+}

--- a/JSTests/stress/string-prototype-concat-no-args.js
+++ b/JSTests/stress/string-prototype-concat-no-args.js
@@ -1,0 +1,16 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a) {
+  return String.prototype.concat.call(a);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+
+for (let i = 0; i < testLoopCount; i++) {
+  const result = concat(str);
+  shouldBe(result, str);
+}

--- a/JSTests/stress/string-prototype-concat-this-null.js
+++ b/JSTests/stress/string-prototype-concat-this-null.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+let errorCount = 0;
+let thisShouldBeNull = false;
+for (let i = 0; i < testLoopCount; i++) {
+  if (i === testLoopCount / 2) {
+    thisShouldBeNull = true;
+  }
+  try {
+    concat(thisShouldBeNull ? null : str, arg1, arg2);
+  } catch {
+    errorCount++;
+  }
+}
+
+shouldBe(errorCount, testLoopCount / 2);

--- a/JSTests/stress/string-prototype-concat-this-undefined.js
+++ b/JSTests/stress/string-prototype-concat-this-undefined.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+let errorCount = 0;
+let thisShouldBeNull = false;
+for (let i = 0; i < testLoopCount; i++) {
+  if (i === testLoopCount / 2) {
+    thisShouldBeNull = true;
+  }
+  try {
+    concat(thisShouldBeNull ? undefined : str, arg1, arg2);
+  } catch {
+    errorCount++;
+  }
+}
+
+shouldBe(errorCount, testLoopCount / 2);

--- a/JSTests/stress/string-prototype-concat.js
+++ b/JSTests/stress/string-prototype-concat.js
@@ -1,0 +1,18 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+for (let i = 0; i < testLoopCount; i++) {
+  const result = concat(str, arg1, arg2);
+  shouldBe(result, `${str}${arg1}${arg2}`);
+}

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -341,32 +341,6 @@ function split(separator, limit)
 }
 
 @linkTimeConstant
-function stringConcatSlowPath()
-{
-    "use strict";
-
-    var result = @toString(this);
-    for (var i = 0, length = @argumentCount(); i < length; ++i)
-        result += @toString(arguments[i]);
-    return result;
-}
-
-function concat(arg /* ... */)
-{
-    "use strict";
-
-    if (@isUndefinedOrNull(this))
-        @throwTypeError("String.prototype.concat requires that |this| not be null or undefined");
-
-    if (@argumentCount() === 1)
-        return @toString(this) + @toString(arg);
-    if (@argumentCount() === 2)
-        return @toString(this) + @toString(arg) + @toString(arguments[1]);
-
-    return @tailCallForwardArguments(@stringConcatSlowPath, this);
-}
-
-@linkTimeConstant
 function createHTML(func, string, tag, attribute, value)
 {
     "use strict";

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -96,6 +96,7 @@ public:
         case AnyIntUse:
         case DoubleRepAnyIntUse:
         case NotDoubleUse:
+        case NotOtherUse:
         case NeitherDoubleNorHeapBigIntNorStringUse:
         case NeitherDoubleNorHeapBigIntUse:
             return;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12308,9 +12308,24 @@ void SpeculativeJIT::speculateOther(Edge edge)
 {
     if (!needsTypeCheck(edge, SpecOther))
         return;
-    
+
     JSValueOperand operand(this, edge, ManualOperandSpeculation);
     speculateOther(edge, operand.jsValueRegs());
+}
+
+void SpeculativeJIT::speculateNotOther(Edge edge, JSValueRegs regs, GPRReg tempGPR)
+{
+    DFG_TYPE_CHECK(regs, edge, ~SpecOther, branchIfOther(regs, tempGPR));
+}
+
+void SpeculativeJIT::speculateNotOther(Edge edge)
+{
+    if (!needsTypeCheck(edge, ~SpecOther))
+        return;
+
+    JSValueOperand operand(this, edge, ManualOperandSpeculation);
+    GPRTemporary temp(this);
+    speculateNotOther(edge, operand.jsValueRegs(), temp.gpr());
 }
 
 void SpeculativeJIT::speculateMisc(Edge edge, JSValueRegs regs)
@@ -12480,6 +12495,9 @@ void SpeculativeJIT::speculate(Node*, Edge edge)
         break;
     case NotDoubleUse:
         speculateNotDouble(edge);
+        break;
+    case NotOtherUse:
+        speculateNotOther(edge);
         break;
     case NeitherDoubleNorHeapBigIntUse:
         speculateNeitherDoubleNorHeapBigInt(edge);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1985,6 +1985,8 @@ public:
     void speculateOther(Edge, JSValueRegs, GPRReg temp);
     void speculateOther(Edge, JSValueRegs);
     void speculateOther(Edge);
+    void speculateNotOther(Edge, JSValueRegs, GPRReg temp);
+    void speculateNotOther(Edge);
     void speculateMisc(Edge, JSValueRegs);
     void speculateMisc(Edge);
     void speculate(Node*, Edge);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1881,4 +1881,3 @@ bool performStrengthReduction(Graph& graph)
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)
-

--- a/Source/JavaScriptCore/dfg/DFGUseKind.cpp
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.cpp
@@ -182,6 +182,9 @@ void printInternal(PrintStream& out, UseKind useKind)
     case NotDoubleUse:
         out.print("NotDouble");
         return;
+    case NotOtherUse:
+        out.print("NotOther");
+        return;
     case NeitherDoubleNorHeapBigIntUse:
         out.print("NeitherDoubleNorHeapBigInt");
         return;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -85,6 +85,7 @@ enum UseKind : uint8_t {
     NotCellUse,
     NotCellNorBigIntUse,
     NotDoubleUse,
+    NotOtherUse,
     NeitherDoubleNorHeapBigIntUse,
     NeitherDoubleNorHeapBigIntNorStringUse,
     KnownOtherUse,
@@ -201,6 +202,8 @@ inline SpeculatedType typeFilterFor(UseKind useKind)
         return ~SpecCellCheck & ~SpecBigInt;
     case NotDoubleUse:
         return ~SpecFullDouble;
+    case NotOtherUse:
+        return ~SpecOther;
     case NeitherDoubleNorHeapBigIntUse:
         return ~SpecFullDouble & ~SpecHeapBigInt;
     case NeitherDoubleNorHeapBigIntNorStringUse:
@@ -338,6 +341,7 @@ inline bool checkMayCrashIfInputIsEmpty(UseKind kind)
     case NotCellUse:
     case NotCellNorBigIntUse:
     case NotDoubleUse:
+    case NotOtherUse:
     case NeitherDoubleNorHeapBigIntUse:
     case NeitherDoubleNorHeapBigIntNorStringUse:
         return false;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -607,6 +607,7 @@ CapabilityLevel canCompile(Graph& graph)
                 case AnyIntUse:
                 case DoubleRepAnyIntUse:
                 case NotDoubleUse:
+                case NotOtherUse:
                 case NeitherDoubleNorHeapBigIntUse:
                 case NeitherDoubleNorHeapBigIntNorStringUse:
                     // These are OK.

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -23545,6 +23545,9 @@ IGNORE_CLANG_WARNINGS_END
         case NotDoubleUse:
             speculateNotDouble(edge);
             break;
+        case NotOtherUse:
+            speculateNotOther(edge);
+            break;
         case NeitherDoubleNorHeapBigIntUse:
             speculateNeitherDoubleNorHeapBigInt(edge);
             break;
@@ -24501,6 +24504,15 @@ IGNORE_CLANG_WARNINGS_END
 
         LValue value = lowJSValue(edge, ManualOperandSpeculation);
         typeCheck(jsValueValue(value), edge, SpecOther, isNotOther(value));
+    }
+
+    void speculateNotOther(Edge edge)
+    {
+        if (!m_interpreter.needsTypeCheck(edge))
+            return;
+
+        LValue value = lowJSValue(edge, ManualOperandSpeculation);
+        typeCheck(jsValueValue(value), edge, ~SpecOther, isOther(value));
     }
 
     void speculateMisc(Edge edge)

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -115,6 +115,7 @@ namespace JSC {
     macro(ReflectGetPrototypeOfIntrinsic) \
     macro(ReflectOwnKeysIntrinsic) \
     macro(StringConstructorIntrinsic) \
+    macro(StringPrototypeConcatIntrinsic) \
     macro(StringPrototypeAtIntrinsic) \
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \


### PR DESCRIPTION
#### 91036c3fd11247b926d7d43e2b228c2468935c5a
<pre>
[JSC] Implement `String.prototype.concat` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=303680">https://bugs.webkit.org/show_bug.cgi?id=303680</a>

Reviewed by Yusuke Suzuki.

This patch implements `String.prototype.concat` in C++ with the following changes:

- Adds a new use kind `NotOtherUse` to implement the `RequireObjectCoercible`
  abstract operation[1] using a `Check` node.
- Handles `String#concat` in DFG/FTL using the existing `StrCat` DFG node.
  `StrCat` is already used for template literals and well optimized.

[1]: <a href="https://tc39.es/ecma262/#sec-requireobjectcoercible">https://tc39.es/ecma262/#sec-requireobjectcoercible</a>

                                        TipOfTree                  Patched

string-prototype-concat-2-args        1.8105+-0.1984     ^      0.3626+-0.0556        ^ definitely 4.9929x faster
string-prototype-concat-5-args        2.7280+-0.0825     ^      0.4609+-0.0415        ^ definitely 5.9184x faster

* JSTests/microbenchmarks/string-prototype-concat-2-args.js:
* JSTests/microbenchmarks/string-prototype-concat-5-args.js: Added.
* JSTests/stress/string-prototype-concat-no-args.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat-this-null.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat-this-undefined.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat.js: Added.
(shouldBe):
(concat):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.stringConcatSlowPath): Deleted.
(concat): Deleted.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::SafeToExecuteEdge::operator()):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGUseKind.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGUseKind.h:
(JSC::DFG::typeFilterFor):
(JSC::DFG::checkMayCrashIfInputIsEmpty):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/304079@main">https://commits.webkit.org/304079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69742574521cf7d93610b076d6806829bef2cb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6839 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5157 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126568 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144738 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133024 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39279 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111491 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4987 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60513 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6706 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165945 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70283 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43375 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->