### PR TITLE
[JSC] Update JSBigInt division algorithm

### DIFF
--- a/JSTests/stress/big-int-out-of-memory-tests.js
+++ b/JSTests/stress/big-int-out-of-memory-tests.js
@@ -30,7 +30,7 @@ try {
 }
 
 try {
-    let b = a / a;
+    let b = a * 2n / a;
     assert(false, "Should throw OutOfMemoryError, but executed without exception");
 } catch(e) {
     assert(e.message == "Out of memory: BigInt generated from this operation is too big", "Expected OutOfMemoryError, but got: " + e);


### PR DESCRIPTION
#### 69c4fc83032081fdcc44ea81a17a0999e83c4215
<pre>
[JSC] Update JSBigInt division algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=303683">https://bugs.webkit.org/show_bug.cgi?id=303683</a>
<a href="https://rdar.apple.com/165964882">rdar://165964882</a>

Reviewed by Justin Michaud.

This patch imports V8&apos;s BigInt division algorithm. We imports necessary
helper functions and replace our existing implementation with newer one.
We also use std::span&lt;Digit&gt; std::span&lt;const Digit&gt; to represent mutable /
immutable data behind the BigInt. And we use Vector to allocate
temporary data before the final JSBigInt creation, which avoids
unnecessary GC object allocations. Also we can avoid heap allocations
for small BigInt cases due to pre-capacity of Vector.

* JSTests/stress/big-int-out-of-memory-tests.js:
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::HeapBigIntImpl::digits):
(JSC::Int32BigIntImpl::Int32BigIntImpl):
(JSC::Int32BigIntImpl::digits):
(JSC::Int64BigIntImpl::Int64BigIntImpl):
(JSC::Int64BigIntImpl::digits):
(JSC::JSBigInt::multiplySingle):
(JSC::JSBigInt::multiplyTextbook):
(JSC::JSBigInt::multiplyImpl):
(JSC::JSBigInt::divideSingle):
(JSC::JSBigInt::addAndReturnCarry):
(JSC::JSBigInt::subtractAndReturnBorrow):
(JSC::JSBigInt::inplaceAdd):
(JSC::JSBigInt::inplaceSub):
(JSC::spanCopy):
(JSC::normalize):
(JSC::JSBigInt::leftShift):
(JSC::JSBigInt::rightShift):
(JSC::JSBigInt::divideTextbook):
(JSC::JSBigInt::divideImpl):
(JSC::JSBigInt::remainderImpl):
(JSC::JSBigInt::toStringGeneric):
(JSC::JSBigInt::createFrom):
(JSC::JSBigInt::absoluteDivWithDigitDivisor): Deleted.
(JSC::JSBigInt::absoluteDivWithBigIntDivisor): Deleted.
(JSC::JSBigInt::absoluteInplaceAdd): Deleted.
(JSC::JSBigInt::absoluteInplaceSub): Deleted.
(JSC::JSBigInt::inplaceRightShift): Deleted.
(JSC::JSBigInt::absoluteLeftShiftAlwaysCopy): Deleted.
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/304114@main">https://commits.webkit.org/304114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25e7124f0d83539cbbf748ce45124ce279c6697e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134422 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86406 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4095d2f7-73f6-417b-81ab-e2b26c177716) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70001 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dbf81d97-bf98-41a5-9bce-03ceef59ba57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83535 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed6a1d7a-9cc0-48e2-82c0-c0c7d34fb3fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2701 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126476 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144645 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132930 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111417 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4916 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60359 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20786 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6618 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34944 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165861 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70189 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43351 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->