### PR TITLE
[threaded-animations] Remove explicit enablement of `ThreadedScrollDrivenAnimationsEnabled` in layout tests

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/pending-animation-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/pending-animation-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html>
 <style>
 
 @keyframes fade {

--- a/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
+++ b/LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html>
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <body>
     
 <style>

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <script src="threaded-animations-utils.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedScrollDrivenAnimationsEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <style>
 

--- a/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedScrollDrivenAnimationsEnabled=true ] -->
+<!DOCTYPE html>
 <style>
 
 body {


### PR DESCRIPTION
#### ff8b0a1a56eb2393b51df47b82989619736d5bd8
<pre>
[threaded-animations] Remove explicit enablement of `ThreadedScrollDrivenAnimationsEnabled` in layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=303685">https://bugs.webkit.org/show_bug.cgi?id=303685</a>

Reviewed by Anne van Kesteren.

Several layout tests opt into `ThreadedScrollDrivenAnimationsEnabled` explicitly, but
since that feature is now enabled by default, it&apos;s really not necessary.

* LayoutTests/webanimations/threaded-animations/pending-animation-crash.html:
* LayoutTests/webanimations/threaded-animations/resources/scroll-timeline-in-iframe-content.html:
* LayoutTests/webanimations/threaded-animations/scroll-animation-no-timeline-invalidation-after-acceleration.html:
* LayoutTests/webanimations/threaded-animations/scroll-driven-animations.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-in-iframe.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-nested-scroller.html:
* LayoutTests/webanimations/threaded-animations/scroll-timeline-root-scroller.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-different-accelerated-property.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property-dynamic.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-on-same-element-for-same-accelerated-property.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations-scroll-source-composition-change.html:
* LayoutTests/webanimations/threaded-animations/threaded-and-non-threaded-animations.html:
* LayoutTests/webanimations/threaded-animations/transform-animation-extent-crash.html:

Canonical link: <a href="https://commits.webkit.org/304062@main">https://commits.webkit.org/304062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6026e2c854cd3bc3b1e2ed6ed2007035fda36558

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86399 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f26dcd21-1da8-4c19-ba3b-c654e10b81c1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102737 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc740834-3198-4040-85b0-9fc1a138e254) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120463 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83528 "Found 1 new API test failure: TestWTF:WTF_Condition.TenProducersOneConsumerHundredSlotsNotifyAll (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2695 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144636 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6556 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4909 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60338 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6608 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34939 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->