### PR TITLE
Test

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2744,17 +2744,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2248,6 +2248,8 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
         DefersLoadingPolicy::AllowDefersLoading,
         CachingPolicy::AllowCaching);
 
+    mainResourceLoadOptions.shouldEnableContentExtensionsCheck = isContinuingLoadAfterProvisionalLoadStarted() ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
+
     auto isSandboxingAllowingServiceWorkerFetchHandling = [](SandboxFlags flags) {
         return !(flags.contains(SandboxFlag::Origin)) && !(flags.contains(SandboxFlag::Scripts));
     };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5542,8 +5542,11 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         ASSERT(!existingNetworkResourceLoadIdentifierToResume || !navigation->substituteData());
         if (auto& substituteData = navigation->substituteData())
             provisionalPage->loadData(navigation, SharedBuffer::create(Vector(substituteData->content)), substituteData->MIMEType, substituteData->encoding, substituteData->baseURL, substituteData->userData.get(), shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain(), WTFMove(websitePolicies), substituteData->sessionHistoryVisibility);
-        else
+        else {
+            if (provisionalPage->process().enhancedSecurity() == EnhancedSecurity::EnabledInsecure)
+                shouldTreatAsContinuingLoad = ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted;
             provisionalPage->loadRequest(navigation, ResourceRequest { navigation->currentRequest() }, nullptr, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain(), WTFMove(websitePolicies), existingNetworkResourceLoadIdentifierToResume, isPerformingHTTPFallback);
+        }
     };
 
     Ref process = provisionalPage->process();


### PR DESCRIPTION
#### 71946805bf83884c7bc1d604540f69e5663690ff
<pre>
Test

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
</pre>
----------------------------------------------------------------------
#### 3eb340f02ab0d81aacd26449ed31bcedd097f0f4
<pre>
Enable Enhanced Security HTTP heuristics by default.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303635">https://bugs.webkit.org/show_bug.cgi?id=303635</a>
<a href="https://rdar.apple.com/165921010">rdar://165921010</a>

Reviewed by NOBODY (OOPS!).

Toggle this on by default on Apple platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71946805bf83884c7bc1d604540f69e5663690ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86409 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2567026e-79d0-474e-af27-15f37c3dc5c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70003 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f1a8f443-e24b-4265-96f0-03f7c5c66691) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6208 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120473 "Found 78 new API test failures: TestWebKitAPI.WebKit.ConfigurationHTTPSUpgrade, TestWebKitAPI.WKWebExtensionAPITabs.ExecuteScriptWithDocumentId, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeRedirect, TestWebKitAPI.WKNavigation.HTTPSOnlyInitialLoad, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyUserMediatedHTTPFallbackInitialLoad, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.EnhancedSecurityPolicies.CrossSiteHttpToHttpsRedirect, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyUserMediatedHTTPFallbackHTTPFallbackContinue, TestWebKitAPI.WKWebExtensionAPIWebNavigation.BeforeNavigateEvent, TestWebKitAPI.WKWebExtensionAPIScripting.CSSAuthorOrigin ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83537 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e164b37-0833-4b98-b641-a268fde24450) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5983 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2703 "Found 330 new API test failures: TestWebKitAPI.WKNavigation.HTTPSFirstLocalHostIPAddress, TestWebKitAPI.WKWebExtensionAPIMenus.ActionMenus, TestWebKitAPI.WKWebExtensionAPITabs.SendMessageFromBackgroundToSubframe, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.MainFrameAllowAllRequests, TestWebKitAPI.EnhancedSecurityPolicies.MultiHopThenBackJavascript, TestWebKitAPI.WebKit.ConfigurationHTTPSUpgrade, TestWebKitAPI.EnhancedSecurityPolicies.HttpThenNavigateToHttpsSetCookiesThenNavigateToHttpsAgain, TestWebKitAPI.WKWebExtensionAPIDevTools.Basics, TestWebKitAPI.WKWebExtensionAPIScripting.PersistentRegisteredScriptIsInjectedAfterContextReloads, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself ... (failure)") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126479 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115207 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144648 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132933 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6569 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111149 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111419 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4918 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60363 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6621 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34948 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165864 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70192 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43352 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6680 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->