### PR TITLE
[Site Isolation] WebContent processes in iframes can start up without correct activity state

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17437,6 +17437,15 @@ void WebPageProxy::takeActivitiesOnRemotePage(RemotePageProxy& remotePage)
     if (hasValidVisibleActivity())
         remotePage.processActivityState().takeVisibleActivity();
 
+    if (hasValidAudibleActivity())
+        remotePage.processActivityState().takeAudibleActivity();
+
+    if (hasValidCapturingActivity())
+        remotePage.processActivityState().takeCapturingActivity();
+
+    if (hasValidMutedCaptureAssertion())
+        remotePage.processActivityState().takeMutedCaptureAssertion();
+
     if (hasValidNetworkActivity())
         remotePage.processActivityState().takeNetworkActivity();
 }


### PR DESCRIPTION
#### a8a3ab1f03e156bc1e8fbddbfd161dc64cf9795b
<pre>
[Site Isolation] WebContent processes in iframes can start up without correct activity state
<a href="https://bugs.webkit.org/show_bug.cgi?id=303692">https://bugs.webkit.org/show_bug.cgi?id=303692</a>
<a href="https://rdar.apple.com/165979299">rdar://165979299</a>

Reviewed by Sihui Liu.

We aim to keep the activity states in sync between the main frame WebContent process and the iframe WebContent
processes. See e.g. WebPageProxy::takeVisibleActivity(), where the visible activity is being taken on the main
frame process and iframe processes. Currently, an iframe WebContent process can be started without the right
set of activities. In WebPageProxy::takeActivitiesOnRemotePage, we are only taking the visible and network
activity, but we should be taking the other activity types too if the main frame process has them. Otherwise,
we depend on the activities to be set when activity state is changing, which is not happening deterministically.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeActivitiesOnRemotePage):

Canonical link: <a href="https://commits.webkit.org/304106@main">https://commits.webkit.org/304106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bcbab953c3fe1b9f6ccae75139861eb6347ddee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86411 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b957f4ee-ba71-40bd-8f44-23f772a3cb87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70006 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3ec60e6-1a67-4a25-ba22-1834e15dfa0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2730b685-6756-4337-aa82-6736564c8395) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2705 "Passed tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114295 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111421 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4920 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60369 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6623 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34950 "Found 1 new test failure: fast/images/mac/play-all-pause-all-animations-context-menu-items.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->