### PR TITLE
Add a way to convert std ranges to wtf containers

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		CDD4AC792D9C309A00D11414 /* CStringView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD4AC772D9C309A00D11414 /* CStringView.cpp */; };
 		CDD4AC7A2D9C309A00D11414 /* CStringView.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD4AC782D9C309A00D11414 /* CStringView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CEA072AA236FFBF70018839C /* CrashReporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEA072A9236FFBF70018839C /* CrashReporter.cpp */; };
+		D6135B2E2EE4BCE0002B5F19 /* RangeAdaptors.h in Headers */ = {isa = PBXBuildFile; fileRef = D6135B2D2EE4BCE0002B5F19 /* RangeAdaptors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DCEE22011CEA7551000C2396 /* BlockObjCExceptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = DCEE21FD1CEA7551000C2396 /* BlockObjCExceptions.mm */; };
 		DD03059327B5DA0D00344002 /* SignedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 862A8D32278DE74A0014120C /* SignedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD28468829248DDA0009A61D /* UnifiedWebPreferences.yaml in Headers */ = {isa = PBXBuildFile; fileRef = DD284687292442F30009A61D /* UnifiedWebPreferences.yaml */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1705,6 +1706,7 @@
 		CE1132832370634900A8C83B /* AnsiColors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnsiColors.h; sourceTree = "<group>"; };
 		CEA072A8236FFBF70018839C /* CrashReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReporter.h; sourceTree = "<group>"; };
 		CEA072A9236FFBF70018839C /* CrashReporter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CrashReporter.cpp; sourceTree = "<group>"; };
+		D6135B2D2EE4BCE0002B5F19 /* RangeAdaptors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RangeAdaptors.h; sourceTree = "<group>"; };
 		DCEE21FC1CEA7551000C2396 /* BlockObjCExceptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockObjCExceptions.h; sourceTree = "<group>"; };
 		DCEE21FD1CEA7551000C2396 /* BlockObjCExceptions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BlockObjCExceptions.mm; sourceTree = "<group>"; };
 		DCEE22041CEB9869000C2396 /* BackwardsGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackwardsGraph.h; sourceTree = "<group>"; };
@@ -2632,6 +2634,7 @@
 				C8F597CA2A57417FBAB92FD6 /* RandomDevice.cpp */,
 				24F1B248619F412296D1C19C /* RandomDevice.h */,
 				0F2AC5601E89F70C0001EE3F /* Range.h */,
+				D6135B2D2EE4BCE0002B5F19 /* RangeAdaptors.h */,
 				0F725CAB1C50461600AD943A /* RangeSet.h */,
 				FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */,
 				0F87105916643F190090B0AD /* RawPointer.h */,
@@ -3786,6 +3789,7 @@
 				DD3DC8E827A4BF8E007E5B61 /* RAMSize.h in Headers */,
 				DD3DC8B327A4BF8E007E5B61 /* RandomDevice.h in Headers */,
 				DD3DC92027A4BF8E007E5B61 /* Range.h in Headers */,
+				D6135B2E2EE4BCE0002B5F19 /* RangeAdaptors.h in Headers */,
 				DD3DC8EB27A4BF8E007E5B61 /* RangeSet.h in Headers */,
 				FE7ACFEF285DC2F9007FC8E9 /* RawHex.h in Headers */,
 				DD3DC8DC27A4BF8E007E5B61 /* RawPointer.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -251,6 +251,7 @@ set(WTF_PUBLIC_HEADERS
     RAMSize.h
     RandomDevice.h
     Range.h
+    RangeAdaptors.h
     RangeSet.h
     RawHex.h
     RawPointer.h

--- a/Source/WTF/wtf/RangeAdaptors.h
+++ b/Source/WTF/wtf/RangeAdaptors.h
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <ranges>
+
+namespace WTF {
+
+// This our WTF version of c++23's std::from_range and std::from_range_t
+// The std version is not exposed on every compiler yet, so we roll our own for now
+// Replace with std::from_range and std::from_range_t if/when it is implemented
+// in the major compilers
+// see: https://en.cppreference.com/w/cpp/ranges/from_range.html
+struct FromRange {
+    explicit FromRange() = default;
+};
+
+// Global instance for use as tag
+inline constexpr FromRange fromRange { };
+
+// This is our WTF version of c++23's std::ranges::range_adaptor closure
+// We should remove this and switch to the std version once it is implemented
+// in the major compilers
+// see: https://en.cppreference.com/w/cpp/ranges/range_adaptor_closure.html
+template<typename Derived>
+struct RangeAdaptorClosure {
+    template<std::ranges::input_range Range>
+    friend auto operator|(Range&& range, const Derived& adaptor)
+    {
+        return adaptor(std::forward<Range>(range));
+    }
+
+    template<typename OtherClosure>
+    friend auto operator|(const Derived& left, const OtherClosure& right)
+    {
+        return [=](auto&& range) {
+            return right(left(std::forward<decltype(range)>(range)));
+        };
+    }
+};
+
+template<typename Container>
+struct FromRangeConverter : RangeAdaptorClosure<FromRangeConverter<Container>> {
+    template<std::ranges::input_range Range>
+        requires requires(Range&& range) { Container(fromRange, std::forward<Range>(range)); }
+    auto operator()(Range&& range) const
+    {
+        return Container(fromRange, std::forward<Range>(range));
+    }
+};
+
+template<typename Container>
+constexpr inline FromRangeConverter<Container> rangeTo()
+{
+    return FromRangeConverter<Container> { };
+};
+
+}
+
+using WTF::fromRange;
+using WTF::FromRange;
+using WTF::rangeTo;


### PR DESCRIPTION
#### aa649b89f25e6ca725769ed3300e2264fbee3efb
<pre>
Add a way to convert std ranges to wtf containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=303699">https://bugs.webkit.org/show_bug.cgi?id=303699</a>
<a href="https://rdar.apple.com/165990982">rdar://165990982</a>

Reviewed by Sam Weinig.

This patch exposes a functor WTF::rangesTo&lt;ContainerT&gt; that will convert
any range to any WTF container that implements a constructor that takes
a std::from_range_t and an std::ranges::input_range.

I added the proper constructors to the wtf Vector and HashMap. The constructors
did not need use the disambiguation tag (std::from_range_t), but I did this
so it would not interfere with any existing constructors.

After this patch the following is possible:

Vector&lt;int&gt; v = std::views::iota(0, 10) | WTF::rangeTo&lt;Vector&lt;int&gt;&gt;;

Tests: Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
       Tools/TestWebKitAPI/Tests/WTF/Vector.cpp

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/HashMap.h:
* Source/WTF/wtf/RangeAdaptors.h: Added.
(WTF::RangeAdaptorClosure::operator|):
(WTF::FromRangeConverter::requires):
(WTF::FromRangeConverter::operator() const):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorBasicTypes)):
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorInitializerList)):
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorEmptyRange)):
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorMoveOnlyValues)):
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorStringKeys)):
(TestWebKitAPI::TEST(WTF_HashMap, fromRangeConstructorCustomHashTraits)):
(TestWebKitAPI::TEST(WTF_HashMap, RangeToBasicUsage)):
(TestWebKitAPI::TEST(WTF_HashMap, RangeToChainedOperations)):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, fromRangeConstructorBasicTypes)):
(TestWebKitAPI::TEST(WTF_Vector, fromRangeConstructorArray)):
(TestWebKitAPI::TEST(WTF_Vector, fromRangeConstructorInitializerList)):
(TestWebKitAPI::TEST(WTF_Vector, fromRangeConstructorEmptyRange)):
(TestWebKitAPI::TEST(WTF_Vector, fromRangeConstructorStrings)):
(TestWebKitAPI::TEST(WTF_Vector, RangeToBasicUsage)):
(TestWebKitAPI::TEST(WTF_Vector, RangeToChainedOperations)):
(TestWebKitAPI::TEST(WTF_Vector, RangeToMoveOnly)):

Canonical link: <a href="https://commits.webkit.org/304212@main">https://commits.webkit.org/304212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e08a69f59ec125781c025e8c974cd49881053f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86742 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22569445-9297-4fcd-b342-0ab3b58e44ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70336 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/695329f7-055d-4dd9-a0ee-b9d1cbea784f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83890 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6faf4d20-d760-4271-8410-6107d6c883af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3026 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2963 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126886 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145067 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133359 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111433 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5249 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60891 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35334 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166256 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70586 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43454 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->