### PR TITLE
Adopt LIFETIME_BOUND in more places in WTF/

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6528,9 +6528,10 @@ void SpeculativeJIT::compile(Node* node)
         GPRReg tempGPR = temp.gpr();
 
         BytecodeIndex bytecodeIndex = node->origin.semantic.bytecodeIndex();
-        auto triggerIterator = jitCode()->tierUpEntryTriggers.find(bytecodeIndex);
-        DFG_ASSERT(m_graph, node, triggerIterator != jitCode()->tierUpEntryTriggers.end());
-        JITCode::TriggerReason* forceEntryTrigger = &(jitCode()->tierUpEntryTriggers.find(bytecodeIndex)->value);
+        RefPtr jitCode = this->jitCode();
+        auto triggerIterator = jitCode->tierUpEntryTriggers.find(bytecodeIndex);
+        DFG_ASSERT(m_graph, node, triggerIterator != jitCode->tierUpEntryTriggers.end());
+        JITCode::TriggerReason* forceEntryTrigger = &(jitCode->tierUpEntryTriggers.find(bytecodeIndex)->value);
         static_assert(!static_cast<uint8_t>(JITCode::TriggerReason::DontTrigger), "the JIT code assumes non-zero means 'enter'");
         static_assert(sizeof(JITCode::TriggerReason) == 1, "branchTest8 assumes this size");
 
@@ -6542,7 +6543,7 @@ void SpeculativeJIT::compile(Node* node)
         silentSpillAllRegistersImpl(false, savePlans, tempGPR);
 
         unsigned streamIndex = m_stream.size();
-        jitCode()->bytecodeIndexToStreamIndex.add(bytecodeIndex, streamIndex);
+        jitCode->bytecodeIndexToStreamIndex.add(bytecodeIndex, streamIndex);
 
         addSlowPathGeneratorLambda([=, this]() {
             forceOSREntry.link(this);

--- a/Source/WTF/wtf/Box.h
+++ b/Source/WTF/wtf/Box.h
@@ -58,15 +58,15 @@ public:
 
     bool isValid() const { return static_cast<bool>(m_data); }
 
-    T* get() const
+    T* get() const LIFETIME_BOUND
     {
         if (!isValid())
             return nullptr;
         return &**m_data;
     }
 
-    T& operator*() const { RELEASE_ASSERT(isValid()); return **m_data; }
-    T* operator->() const { RELEASE_ASSERT(isValid()); return &**m_data; }
+    T& operator*() const LIFETIME_BOUND { RELEASE_ASSERT(isValid()); return **m_data; }
+    T* operator->() const LIFETIME_BOUND { RELEASE_ASSERT(isValid()); return &**m_data; }
 
     explicit operator bool() const { return isValid(); }
 

--- a/Source/WTF/wtf/ButterflyArray.h
+++ b/Source/WTF/wtf/ButterflyArray.h
@@ -78,22 +78,22 @@ public:
         return WTF::roundUpToMultipleOf<alignof(Derived)>(sizeof(LeadingType) * leadingSize);
     }
 
-    std::span<LeadingType> leadingSpan()
+    std::span<LeadingType> leadingSpan() LIFETIME_BOUND
     {
         return std::span { leadingData(), m_leadingSize };
     }
 
-    std::span<const LeadingType> leadingSpan() const
+    std::span<const LeadingType> leadingSpan() const LIFETIME_BOUND
     {
         return std::span { leadingData(), m_leadingSize };
     }
 
-    std::span<TrailingType> trailingSpan()
+    std::span<TrailingType> trailingSpan() LIFETIME_BOUND
     {
         return std::span { trailingData(), m_trailingSize };
     }
 
-    std::span<const TrailingType> trailingSpan() const
+    std::span<const TrailingType> trailingSpan() const LIFETIME_BOUND
     {
         return std::span { trailingData(), m_trailingSize };
     }

--- a/Source/WTF/wtf/CagedPtr.h
+++ b/Source/WTF/wtf/CagedPtr.h
@@ -55,14 +55,14 @@ public:
         : m_ptr(ptr)
     { }
 
-    T* get() const
+    T* get() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         T* ptr = PtrTraits::unwrap(m_ptr);
         return Gigacage::caged(kind, ptr);
     }
 
-    T* getMayBeNull() const
+    T* getMayBeNull() const LIFETIME_BOUND
     {
         T* ptr = PtrTraits::unwrap(m_ptr);
         if (!ptr)
@@ -70,7 +70,7 @@ public:
         return Gigacage::caged(kind, ptr);
     }
 
-    T* getUnsafe() const
+    T* getUnsafe() const LIFETIME_BOUND
     {
         T* ptr = PtrTraits::unwrap(m_ptr);
         return Gigacage::cagedMayBeNull(kind, ptr);

--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -84,7 +84,7 @@ public:
         WTF::DefaultRefDerefTraits<T>::derefIfNotNull(m_data.pointer());
     }
 
-    T* pointer() const
+    T* pointer() const LIFETIME_BOUND
     {
         return m_data.pointer();
     }

--- a/Source/WTF/wtf/CompactUniquePtrTuple.h
+++ b/Source/WTF/wtf/CompactUniquePtrTuple.h
@@ -75,7 +75,7 @@ public:
         return *this;
     }
 
-    T* pointer() const { return m_data.pointer(); }
+    T* pointer() const LIFETIME_BOUND { return m_data.pointer(); }
 
     std::unique_ptr<T, Deleter> moveToUniquePtr()
     {

--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -85,7 +85,7 @@ public:
 
     explicit operator bool() const { return !!m_function; }
 
-    Impl* leak() { return m_function.leak(); }
+    Impl* leak() WARN_UNUSED_RETURN { return m_function.leak(); }
 
     Out operator()(In... in)
     {

--- a/Source/WTF/wtf/ConcurrentBuffer.h
+++ b/Source/WTF/wtf/ConcurrentBuffer.h
@@ -86,19 +86,19 @@ public:
         size_t size; // This is an immutable size.
         T data[1];
 
-        std::span<T> span() { return unsafeMakeSpan(data, size); }
-        std::span<const T> span() const { return unsafeMakeSpan(data, size); }
+        std::span<T> span() LIFETIME_BOUND { return unsafeMakeSpan(data, size); }
+        std::span<const T> span() const LIFETIME_BOUND { return unsafeMakeSpan(data, size); }
     };
 
     using ArrayPtr = std::unique_ptr<Array, NonDestructingDeleter<Array, ConcurrentBufferMalloc>>;
     
-    Array* array() const { return m_array; }
+    Array* array() const LIFETIME_BOUND { return m_array; }
     
-    T& operator[](size_t index) { return m_array->span()[index]; }
-    const T& operator[](size_t index) const { return m_array->span()[index]; }
+    T& operator[](size_t index) LIFETIME_BOUND { return m_array->span()[index]; }
+    const T& operator[](size_t index) const LIFETIME_BOUND { return m_array->span()[index]; }
     
 private:
-    ArrayPtr createArray(size_t size)
+    static ArrayPtr createArray(size_t size)
     {
         Checked<size_t> objectSize = sizeof(T);
         objectSize *= size;

--- a/Source/WTF/wtf/ConcurrentVector.h
+++ b/Source/WTF/wtf/ConcurrentVector.h
@@ -108,33 +108,33 @@ public:
 
     bool isEmpty() const { return !size(); }
 
-    T& at(size_t index)
+    T& at(size_t index) LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(index < m_size);
         return segmentFor(index)->entries[subscriptFor(index)];
     }
 
-    const T& at(size_t index) const
+    const T& at(size_t index) const LIFETIME_BOUND
     {
         return const_cast<ConcurrentVector<T, SegmentSize>*>(this)->at(index);
     }
 
-    T& operator[](size_t index)
+    T& operator[](size_t index) LIFETIME_BOUND
     {
         return at(index);
     }
 
-    const T& operator[](size_t index) const
+    const T& operator[](size_t index) const LIFETIME_BOUND
     {
         return at(index);
     }
 
-    T& first()
+    T& first() LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
         return at(0);
     }
-    const T& first() const
+    const T& first() const LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
         return at(0);
@@ -142,12 +142,12 @@ public:
     
     // This may crash if run concurrently to append(). If you want to accurately track the size of
     // this vector, use appendConcurrently().
-    T& last()
+    T& last() LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
         return at(size() - 1);
     }
-    const T& last() const
+    const T& last() const LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
         return at(size() - 1);
@@ -171,7 +171,7 @@ public:
     }
 
     template<typename... Args>
-    T& alloc(Args&&... args)
+    T& alloc(Args&&... args) LIFETIME_BOUND
     {
         append(std::forward<Args>(args)...);
         return last();

--- a/Source/WTF/wtf/DataRef.h
+++ b/Source/WTF/wtf/DataRef.h
@@ -52,32 +52,32 @@ public:
         return m_data.replace(WTFMove(other.m_data));
     }
 
-    operator const T&() const
+    operator const T&() const LIFETIME_BOUND
     {
         return m_data;
     }
 
-    const T* ptr() const
+    const T* ptr() const LIFETIME_BOUND
     {
         return m_data.ptr();
     }
 
-    const T& get() const
+    const T& get() const LIFETIME_BOUND
     {
         return m_data;
     }
 
-    const T& operator*() const
+    const T& operator*() const LIFETIME_BOUND
     {
         return m_data;
     }
 
-    const T* operator->() const
+    const T* operator->() const LIFETIME_BOUND
     {
         return m_data.ptr();
     }
 
-    T& access()
+    T& access() LIFETIME_BOUND
     {
         if (!m_data->hasOneRef())
             m_data = m_data->copy();

--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -114,9 +114,9 @@ public:
 
     void clear();
 
-    template<typename Predicate> iterator findIf(NOESCAPE const Predicate&);
-    template<typename Predicate> const_iterator findIf(NOESCAPE const Predicate&) const;
-    template<typename Predicate> bool containsIf(NOESCAPE const Predicate& predicate) const
+    template<typename Predicate> iterator findIf(NOESCAPE const Predicate&) LIFETIME_BOUND;
+    template<typename Predicate> const_iterator findIf(NOESCAPE const Predicate&) const LIFETIME_BOUND;
+    template<typename Predicate> bool containsIf(NOESCAPE const Predicate& predicate) const LIFETIME_BOUND
     {
         return findIf(predicate) != end();
     }

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -127,7 +127,7 @@ public:
         return *this;
     }
 
-    Impl* leak()
+    Impl* leak() WARN_UNUSED_RETURN
     {
         return m_callableWrapper.release();
     }

--- a/Source/WTF/wtf/GraphNodeWorklist.h
+++ b/Source/WTF/wtf/GraphNodeWorklist.h
@@ -64,7 +64,7 @@ public:
 
     bool saw(Node node) { return m_seen.contains(node); }
     
-    const Set& seen() const { return m_seen; }
+    const Set& seen() const LIFETIME_BOUND { return m_seen; }
 
 private:
     Set m_seen;

--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -68,26 +68,26 @@ public:
     const_iterator begin() const LIFETIME_BOUND;
     const_iterator end() const LIFETIME_BOUND;
 
-    iterator random() { return m_impl.random(); }
-    const_iterator random() const { return m_impl.random(); }
+    iterator random() LIFETIME_BOUND { return m_impl.random(); }
+    const_iterator random() const LIFETIME_BOUND { return m_impl.random(); }
 
-    ValuesIteratorRange values();
-    const ValuesConstIteratorRange values() const;
+    ValuesIteratorRange values() LIFETIME_BOUND;
+    const ValuesConstIteratorRange values() const LIFETIME_BOUND;
 
-    iterator find(const ValueType&);
-    const_iterator find(const ValueType&) const;
+    iterator find(const ValueType&) LIFETIME_BOUND;
+    const_iterator find(const ValueType&) const LIFETIME_BOUND;
     bool contains(const ValueType&) const;
     unsigned count(const ValueType&) const;
 
     // Increments the count if an equal value is already present.
     // The return value includes both an iterator to the value's location,
     // and an isNewEntry bool that indicates whether it is a new or existing entry.
-    AddResult add(const ValueType&);
-    AddResult add(ValueType&&);
+    AddResult add(const ValueType&) LIFETIME_BOUND;
+    AddResult add(ValueType&&) LIFETIME_BOUND;
 
     // Increments the count of a value by the passed amount.
-    AddResult add(const ValueType&, unsigned);
-    AddResult add(ValueType&&, unsigned);
+    AddResult add(const ValueType&, unsigned) LIFETIME_BOUND;
+    AddResult add(ValueType&&, unsigned) LIFETIME_BOUND;
 
     // Decrements the count of the value, and removes it if count goes down to zero.
     // Returns true if the value is removed.
@@ -107,9 +107,9 @@ public:
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
     template<SmartPtr V = ValueType>
-    iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) LIFETIME_BOUND;
     template<SmartPtr V = ValueType>
-    const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const LIFETIME_BOUND;
     template<SmartPtr V = ValueType>
     bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
     template<SmartPtr V = ValueType>
@@ -119,9 +119,9 @@ public:
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
     template<NonNullableSmartPtr V = ValueType>
-    iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) LIFETIME_BOUND;
     template<NonNullableSmartPtr V = ValueType>
-    const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const LIFETIME_BOUND;
     template<NonNullableSmartPtr V = ValueType>
     bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
     template<NonNullableSmartPtr V = ValueType>

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -125,17 +125,17 @@ public:
     const_iterator begin() const LIFETIME_BOUND;
     const_iterator end() const LIFETIME_BOUND;
     
-    iterator random() { return m_impl.random(); }
-    const_iterator random() const { return m_impl.random(); }
+    iterator random() LIFETIME_BOUND { return m_impl.random(); }
+    const_iterator random() const LIFETIME_BOUND { return m_impl.random(); }
 
-    KeysIteratorRange keys() { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
-    const KeysConstIteratorRange keys() const { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
+    KeysIteratorRange keys() LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
+    const KeysConstIteratorRange keys() const LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().keys(), end().keys()); }
 
-    ValuesIteratorRange values() { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
-    const ValuesConstIteratorRange values() const { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
+    ValuesIteratorRange values() LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
+    const ValuesConstIteratorRange values() const LIFETIME_BOUND { return makeSizedIteratorRange(*this, begin().values(), end().values()); }
 
-    iterator find(const KeyType&);
-    const_iterator find(const KeyType&) const;
+    iterator find(const KeyType&) LIFETIME_BOUND;
+    const_iterator find(const KeyType&) const LIFETIME_BOUND;
     bool contains(const KeyType&) const;
     MappedPeekType get(const KeyType&) const;
     std::optional<MappedType> getOptional(const KeyType&) const;
@@ -148,21 +148,21 @@ public:
     // Replaces the value but not the key if the key is already present.
     // Return value includes both an iterator to the key location,
     // and an isNewEntry boolean that's true if a new entry was added.
-    template<typename V> AddResult set(const KeyType&, V&&);
-    template<typename V> AddResult set(KeyType&&, V&&);
+    template<typename V> AddResult set(const KeyType&, V&&) LIFETIME_BOUND;
+    template<typename V> AddResult set(KeyType&&, V&&) LIFETIME_BOUND;
 
     // Does nothing if the key is already present.
     // Return value includes both an iterator to the key location,
     // and an isNewEntry boolean that's true if a new entry was added.
-    template<typename V> AddResult add(const KeyType&, V&&);
-    template<typename V> AddResult add(KeyType&&, V&&);
+    template<typename V> AddResult add(const KeyType&, V&&) LIFETIME_BOUND;
+    template<typename V> AddResult add(KeyType&&, V&&) LIFETIME_BOUND;
 
     // Same as add(), but aggressively inlined.
-    template<typename V> AddResult fastAdd(const KeyType&, V&&);
-    template<typename V> AddResult fastAdd(KeyType&&, V&&);
+    template<typename V> AddResult fastAdd(const KeyType&, V&&) LIFETIME_BOUND;
+    template<typename V> AddResult fastAdd(KeyType&&, V&&) LIFETIME_BOUND;
 
-    AddResult ensure(const KeyType&, NOESCAPE const Invocable<MappedType()> auto&);
-    AddResult ensure(KeyType&&, NOESCAPE const Invocable<MappedType()> auto&);
+    AddResult ensure(const KeyType&, NOESCAPE const Invocable<MappedType()> auto&) LIFETIME_BOUND;
+    AddResult ensure(KeyType&&, NOESCAPE const Invocable<MappedType()> auto&) LIFETIME_BOUND;
 
     bool remove(const KeyType&);
     bool remove(iterator);
@@ -180,8 +180,8 @@ public:
     // HashTranslator must have the following function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
-    template<typename HashTranslator, typename T> iterator find(const T&);
-    template<typename HashTranslator, typename T> const_iterator find(const T&) const;
+    template<typename HashTranslator, typename T> iterator find(const T&) LIFETIME_BOUND;
+    template<typename HashTranslator, typename T> const_iterator find(const T&) const LIFETIME_BOUND;
     template<typename HashTranslator, typename T> bool contains(const T&) const;
     template<typename HashTranslator, typename T> MappedPeekType get(const T&) const;
     template<typename HashTranslator, typename T> MappedPeekType inlineGet(const T&) const;
@@ -193,14 +193,14 @@ public:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
     //   static translate(ValueType&, const T&, unsigned hashCode);
-    template<typename HashTranslator, typename K, typename V> AddResult add(K&&, V&&);
-    template<typename HashTranslator> AddResult ensure(auto&& key, NOESCAPE const Invocable<MappedType()> auto&);
+    template<typename HashTranslator, typename K, typename V> AddResult add(K&&, V&&) LIFETIME_BOUND;
+    template<typename HashTranslator> AddResult ensure(auto&& key, NOESCAPE const Invocable<MappedType()> auto&) LIFETIME_BOUND;
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
     template<SmartPtr K = KeyType>
-    iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
+    iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) LIFETIME_BOUND;
     template<SmartPtr K = KeyType>
-    const_iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
+    const_iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const LIFETIME_BOUND;
     template<SmartPtr K = KeyType>
     bool contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
     template<SmartPtr K = KeyType>
@@ -214,9 +214,9 @@ public:
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
     template<NonNullableSmartPtr K = KeyType>
-    iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&);
+    iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) LIFETIME_BOUND;
     template<NonNullableSmartPtr K = KeyType>
-    const_iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
+    const_iterator find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const LIFETIME_BOUND;
     template<NonNullableSmartPtr K = KeyType>
     bool contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
     template<NonNullableSmartPtr K = KeyType>

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -92,9 +92,9 @@ public:
     iterator begin() const LIFETIME_BOUND;
     iterator end() const LIFETIME_BOUND;
 
-    iterator random() const { return m_impl.random(); }
+    iterator random() const LIFETIME_BOUND { return m_impl.random(); }
 
-    iterator find(const ValueType&) const;
+    iterator find(const ValueType&) const LIFETIME_BOUND;
     bool contains(const ValueType&) const;
 
     // An alternate version of find() that finds the object by hashing and comparing
@@ -102,15 +102,15 @@ public:
     // must have the following function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
-    template<typename HashTranslator, typename T> iterator find(const T&) const;
+    template<typename HashTranslator, typename T> iterator find(const T&) const LIFETIME_BOUND;
     template<typename HashTranslator, typename T> bool contains(const T&) const;
 
     ALWAYS_INLINE bool isNullStorage() const { return m_impl.isNullStorage(); }
 
     // The return value includes both an iterator to the added value's location,
     // and an isNewEntry bool that indicates if it is a new or existing entry in the set.
-    AddResult add(const ValueType&);
-    AddResult add(ValueType&&);
+    AddResult add(const ValueType&) LIFETIME_BOUND;
+    AddResult add(ValueType&&) LIFETIME_BOUND;
     void add(std::initializer_list<std::reference_wrapper<const ValueType>>);
 
     void addVoid(const ValueType&);
@@ -122,7 +122,7 @@ public:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
     //   static translate(ValueType&, const T&, unsigned hashCode);
-    template<typename HashTranslator, typename T> AddResult add(const T&);
+    template<typename HashTranslator, typename T> AddResult add(const T&) LIFETIME_BOUND;
     
     // An alternate version of translated add(), ensure() will still do translation
     // by hashing and comparing with some other type, to avoid the cost of type
@@ -132,7 +132,7 @@ public:
     // function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
-    template<typename HashTranslator> AddResult ensure(auto&&, NOESCAPE const Invocable<ValueType()> auto&);
+    template<typename HashTranslator> AddResult ensure(auto&&, NOESCAPE const Invocable<ValueType()> auto&) LIFETIME_BOUND;
 
     // Attempts to add a list of things to the set. Returns true if any of
     // them are new to the set. Returns false if the set is unchanged.
@@ -201,13 +201,13 @@ public:
     bool isSubset(const OtherCollection&);
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const LIFETIME_BOUND;
     template<SmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
     template<SmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
     template<SmartPtr V = ValueType> TakeType take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
-    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const LIFETIME_BOUND;
     template<NonNullableSmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
     template<NonNullableSmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
     template<NonNullableSmartPtr V = ValueType> TakeType take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -483,21 +483,21 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             setKeyCount(0);
         }
 
-        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> AddResult add(const ValueType& value) { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return value; }); }
-        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> AddResult add(ValueType&& value) { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
+        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> AddResult add(const ValueType& value) LIFETIME_BOUND { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return value; }); }
+        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> AddResult add(ValueType&& value) LIFETIME_BOUND { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
 
         // A special version of add() that finds the object by hashing and comparing
         // with some other type, to avoid the cost of type conversion if the object is already
         // in the table.
-        template<typename HashTranslator, ShouldValidateKey> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor);
-        template<typename HashTranslator, ShouldValidateKey> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor);
+        template<typename HashTranslator, ShouldValidateKey> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND;
+        template<typename HashTranslator, ShouldValidateKey> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND;
 
-        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> iterator find(const KeyType& key) { return find<IdentityTranslatorType, shouldValidateKey>(key); }
-        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType, shouldValidateKey>(key); }
+        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> iterator find(const KeyType& key) LIFETIME_BOUND { return find<IdentityTranslatorType, shouldValidateKey>(key); }
+        template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> const_iterator find(const KeyType& key) const LIFETIME_BOUND { return find<IdentityTranslatorType, shouldValidateKey>(key); }
         template<ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> bool contains(const KeyType& key) const { return contains<IdentityTranslatorType, shouldValidateKey>(key); }
 
-        template<typename HashTranslator, ShouldValidateKey, typename T> iterator find(const T&);
-        template<typename HashTranslator, ShouldValidateKey, typename T> const_iterator find(const T&) const;
+        template<typename HashTranslator, ShouldValidateKey, typename T> iterator find(const T&) LIFETIME_BOUND;
+        template<typename HashTranslator, ShouldValidateKey, typename T> const_iterator find(const T&) const LIFETIME_BOUND;
         template<typename HashTranslator, ShouldValidateKey, typename T> bool contains(const T&) const;
 
         template<ShouldValidateKey> void remove(const KeyType&);

--- a/Source/WTF/wtf/IndexMap.h
+++ b/Source/WTF/wtf/IndexMap.h
@@ -64,30 +64,30 @@ public:
 
     size_t size() const { return m_vector.size(); }
 
-    Value& at(const Key& key)
+    Value& at(const Key& key) LIFETIME_BOUND
     {
         return m_vector[IndexKeyType<Key>::index(key)];
     }
     
-    const Value& at(const Key& key) const
+    const Value& at(const Key& key) const LIFETIME_BOUND
     {
         return m_vector[IndexKeyType<Key>::index(key)];
     }
 
-    Value& at(size_t index)
+    Value& at(size_t index) LIFETIME_BOUND
     {
         return m_vector[index];
     }
 
-    const Value& at(size_t index) const
+    const Value& at(size_t index) const LIFETIME_BOUND
     {
         return m_vector[index];
     }
     
-    Value& operator[](size_t index) { return at(index); }
-    const Value& operator[](size_t index) const { return at(index); }
-    Value& operator[](const Key& key) { return at(key); }
-    const Value& operator[](const Key& key) const { return at(key); }
+    Value& operator[](size_t index) LIFETIME_BOUND { return at(index); }
+    const Value& operator[](size_t index) const LIFETIME_BOUND { return at(index); }
+    Value& operator[](const Key& key) LIFETIME_BOUND { return at(key); }
+    const Value& operator[](const Key& key) const LIFETIME_BOUND { return at(key); }
     
     template<typename PassedValue>
     void append(const Key& key, PassedValue&& value)

--- a/Source/WTF/wtf/IndexSet.h
+++ b/Source/WTF/wtf/IndexSet.h
@@ -125,8 +125,8 @@ public:
             BitVector::iterator m_iter;
         };
 
-        iterator begin() const { return iterator(m_collection, m_set.begin()); }
-        iterator end() const { return iterator(m_collection, m_set.end()); }
+        iterator begin() const LIFETIME_BOUND { return iterator(m_collection, m_set.begin()); }
+        iterator end() const LIFETIME_BOUND { return iterator(m_collection, m_set.end()); }
 
     private:
         const CollectionType& m_collection;

--- a/Source/WTF/wtf/IndexSparseSet.h
+++ b/Source/WTF/wtf/IndexSparseSet.h
@@ -103,7 +103,7 @@ public:
 
     void validate();
     
-    const ValueList& values() const { return m_values; }
+    const ValueList& values() const LIFETIME_BOUND { return m_values; }
 
 private:
     Vector<unsigned, 0, OverflowHandler, 1> m_map;

--- a/Source/WTF/wtf/Insertion.h
+++ b/Source/WTF/wtf/Insertion.h
@@ -41,8 +41,8 @@ public:
     }
     
     size_t index() const { return m_index; }
-    const T& element() const { return m_element; }
-    T& element() { return m_element; }
+    const T& element() const LIFETIME_BOUND { return m_element; }
+    T& element() LIFETIME_BOUND { return m_element; }
     
     bool operator<(const Insertion& other) const
     {

--- a/Source/WTF/wtf/InterferenceGraph.h
+++ b/Source/WTF/wtf/InterferenceGraph.h
@@ -139,8 +139,8 @@ public:
             unsigned m_index;
         };
 
-        iterator begin() const { return { *this, m_begin }; }
-        iterator end() const { return { *this, m_end }; }
+        iterator begin() const LIFETIME_BOUND { return { *this, m_begin }; }
+        iterator end() const LIFETIME_BOUND { return { *this, m_end }; }
 
         const BitVector& m_bitVector;
         unsigned m_startingIndex;

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -184,8 +184,8 @@ protected:
     void setObject(const String& name, Ref<ObjectBase>&&);
     void setArray(const String& name, Ref<ArrayBase>&&);
 
-    iterator find(const String& name);
-    const_iterator find(const String& name) const;
+    iterator find(const String& name) LIFETIME_BOUND;
+    const_iterator find(const String& name) const LIFETIME_BOUND;
 
     WTF_EXPORT_PRIVATE std::optional<bool> getBoolean(const String& name) const;
     WTF_EXPORT_PRIVATE std::optional<double> getDouble(const String& name) const;
@@ -281,10 +281,10 @@ protected:
     void pushObject(Ref<ObjectBase>&&);
     void pushArray(Ref<ArrayBase>&&);
 
-    iterator begin() { return m_map.begin(); }
-    iterator end() { return m_map.end(); }
-    const_iterator begin() const { return m_map.begin(); }
-    const_iterator end() const { return m_map.end(); }
+    iterator begin() LIFETIME_BOUND { return m_map.begin(); }
+    iterator end() LIFETIME_BOUND { return m_map.end(); }
+    const_iterator begin() const LIFETIME_BOUND { return m_map.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return m_map.end(); }
 
 protected:
     ArrayBase();

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -59,12 +59,12 @@ public:
 
     bool isInitialized() const { return !(m_pointer & lazyTag); }
 
-    const T& get(const OwnerType& owner) const
+    const T& get(const OwnerType& owner) const LIFETIME_BOUND
     {
         return const_cast<LazyRef&>(*this).get(const_cast<OwnerType&>(owner));
     }
 
-    T& get(OwnerType& owner)
+    T& get(OwnerType& owner) LIFETIME_BOUND
     {
         ASSERT(m_pointer);
         ASSERT(!(m_pointer & initializingTag));
@@ -75,12 +75,12 @@ public:
         return *std::bit_cast<T*>(m_pointer);
     }
 
-    const T* getIfExists() const
+    const T* getIfExists() const LIFETIME_BOUND
     {
         return const_cast<LazyRef&>(*this).getIfExists();
     }
 
-    T* getIfExists()
+    T* getIfExists() LIFETIME_BOUND
     {
         ASSERT(m_pointer);
         if (m_pointer & lazyTag)
@@ -88,8 +88,8 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) RETURNS_NONNULL { &get(owner); }
-    T* ptr(const OwnerType& owner) const RETURNS_NONNULL { return &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>
     void initLater(const Func&)

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -59,12 +59,12 @@ public:
 
     bool isInitialized() const { return !(m_pointer & lazyTag); }
 
-    T& get(OwnerType& owner) const
+    T& get(OwnerType& owner) const LIFETIME_BOUND
     {
         return const_cast<LazyUniqueRef&>(*this).get(owner);
     }
 
-    T& get(OwnerType& owner)
+    T& get(OwnerType& owner) LIFETIME_BOUND
     {
         ASSERT(m_pointer);
         ASSERT(!(m_pointer & initializingTag));
@@ -75,12 +75,12 @@ public:
         return *std::bit_cast<T*>(m_pointer);
     }
 
-    const T* getIfExists() const
+    const T* getIfExists() const LIFETIME_BOUND
     {
         return const_cast<LazyUniqueRef&>(*this).getIfExists();
     }
 
-    T* getIfExists()
+    T* getIfExists() LIFETIME_BOUND
     {
         ASSERT(m_pointer);
         if (m_pointer & lazyTag)
@@ -88,8 +88,8 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) RETURNS_NONNULL { &get(owner); }
-    T* ptr(const OwnerType& owner) const RETURNS_NONNULL { return &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>
     void initLater(const Func&)

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -127,37 +127,37 @@ public:
     void removeLast();
     ValueType takeLast();
 
-    iterator find(const ValueType&);
-    const_iterator find(const ValueType&) const;
+    iterator find(const ValueType&) LIFETIME_BOUND;
+    const_iterator find(const ValueType&) const LIFETIME_BOUND;
     bool contains(const ValueType&) const;
 
     // An alternate version of find() that finds the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion.
     // The HashTranslator interface is defined in HashSet.
-    template<typename HashTranslator, typename T> iterator find(const T&);
-    template<typename HashTranslator, typename T> const_iterator find(const T&) const;
+    template<typename HashTranslator, typename T> iterator find(const T&) LIFETIME_BOUND;
+    template<typename HashTranslator, typename T> const_iterator find(const T&) const LIFETIME_BOUND;
     template<typename HashTranslator, typename T> bool contains(const T&) const;
 
     // The return value of add is a pair of an iterator to the new value's location, 
     // and a bool that is true if an new entry was added.
-    AddResult add(const ValueType&);
-    AddResult add(ValueType&&);
+    AddResult add(const ValueType&) LIFETIME_BOUND;
+    AddResult add(ValueType&&) LIFETIME_BOUND;
 
     // Add the value to the end of the collection. If the value was already in
     // the list, it is moved to the end.
-    AddResult appendOrMoveToLast(const ValueType&);
-    AddResult appendOrMoveToLast(ValueType&&);
+    AddResult appendOrMoveToLast(const ValueType&) LIFETIME_BOUND;
+    AddResult appendOrMoveToLast(ValueType&&) LIFETIME_BOUND;
     bool moveToLastIfPresent(const ValueType&);
 
     // Add the value to the beginning of the collection. If the value was already in
     // the list, it is moved to the beginning.
-    AddResult prependOrMoveToFirst(const ValueType&);
-    AddResult prependOrMoveToFirst(ValueType&&);
+    AddResult prependOrMoveToFirst(const ValueType&) LIFETIME_BOUND;
+    AddResult prependOrMoveToFirst(ValueType&&) LIFETIME_BOUND;
 
-    AddResult insertBefore(const ValueType& beforeValue, const ValueType& newValue);
-    AddResult insertBefore(const ValueType& beforeValue, ValueType&& newValue);
-    AddResult insertBefore(iterator, const ValueType&);
-    AddResult insertBefore(iterator, ValueType&&);
+    AddResult insertBefore(const ValueType& beforeValue, const ValueType& newValue) LIFETIME_BOUND;
+    AddResult insertBefore(const ValueType& beforeValue, ValueType&& newValue) LIFETIME_BOUND;
+    AddResult insertBefore(iterator, const ValueType&) LIFETIME_BOUND;
+    AddResult insertBefore(iterator, ValueType&&) LIFETIME_BOUND;
 
     bool remove(const ValueType&);
     bool remove(iterator);
@@ -165,19 +165,19 @@ public:
     void clear();
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
-    template<SmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) LIFETIME_BOUND;
+    template<SmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const LIFETIME_BOUND;
     template<SmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
-    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, const ValueType&);
-    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, ValueType&&);
+    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, const ValueType&) LIFETIME_BOUND;
+    template<SmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, ValueType&&) LIFETIME_BOUND;
     template<SmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
 
     // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
-    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
-    template<NonNullableSmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<NonNullableSmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) LIFETIME_BOUND;
+    template<NonNullableSmartPtr V = ValueType> const_iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const LIFETIME_BOUND;
     template<NonNullableSmartPtr V = ValueType> bool contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
-    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&);
-    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&);
+    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&) LIFETIME_BOUND;
+    template<NonNullableSmartPtr V = ValueType> AddResult insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&) LIFETIME_BOUND;
     template<NonNullableSmartPtr V = ValueType> bool remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
 private:

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -104,8 +104,8 @@ public:
                 Workset::const_iterator m_sparceSetIterator;
             };
 
-            iterator begin() const { return iterator(m_liveness, m_liveness.m_workset.begin()); }
-            iterator end() const { return iterator(m_liveness, m_liveness.m_workset.end()); }
+            iterator begin() const LIFETIME_BOUND { return iterator(m_liveness, m_liveness.m_workset.begin()); }
+            iterator end() const LIFETIME_BOUND { return iterator(m_liveness, m_liveness.m_workset.end()); }
             
             bool contains(const typename Adapter::Thing& thing) const
             {
@@ -206,8 +206,8 @@ public:
             typename UnderlyingIterable::const_iterator m_iter;
         };
 
-        iterator begin() const { return iterator(m_liveness, m_iterable.begin()); }
-        iterator end() const { return iterator(m_liveness, m_iterable.end()); }
+        iterator begin() const LIFETIME_BOUND { return iterator(m_liveness, m_iterable.begin()); }
+        iterator end() const LIFETIME_BOUND { return iterator(m_liveness, m_iterable.end()); }
 
         bool contains(const typename Adapter::Thing& thing) const
         {

--- a/Source/WTF/wtf/LoggingHashMap.h
+++ b/Source/WTF/wtf/LoggingHashMap.h
@@ -102,20 +102,20 @@ public:
     unsigned capacity() const { return m_map.capacity(); }
     bool isEmpty() const { return m_map.isEmpty(); }
     
-    iterator begin() { return m_map.begin(); }
-    iterator end() { return m_map.end(); }
-    const_iterator begin() const { return m_map.begin(); }
-    const_iterator end() const { return m_map.end(); }
+    iterator begin() LIFETIME_BOUND { return m_map.begin(); }
+    iterator end() LIFETIME_BOUND { return m_map.end(); }
+    const_iterator begin() const LIFETIME_BOUND { return m_map.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return m_map.end(); }
 
-    iterator random() { return m_map.random(); }
-    const_iterator random() const { return m_map.random(); }
+    iterator random() LIFETIME_BOUND { return m_map.random(); }
+    const_iterator random() const LIFETIME_BOUND { return m_map.random(); }
     
-    auto keys() { return m_map.keys(); }
-    auto keys() const { return m_map.keys(); }
-    auto values() { return m_map.values(); }
-    auto values() const { return m_map.values(); }
+    auto keys() LIFETIME_BOUND { return m_map.keys(); }
+    auto keys() const LIFETIME_BOUND { return m_map.keys(); }
+    auto values() LIFETIME_BOUND { return m_map.values(); }
+    auto values() const LIFETIME_BOUND { return m_map.values(); }
     
-    iterator find(const KeyType& key)
+    iterator find(const KeyType& key) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print("{\n");
@@ -132,7 +132,7 @@ public:
         return result;
     }
     
-    const_iterator find(const KeyType& key) const
+    const_iterator find(const KeyType& key) const LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print("{\n");
@@ -167,7 +167,7 @@ public:
     }
     
     template<typename PassedType>
-    AddResult set(const KeyType& key, PassedType&& passedValue)
+    AddResult set(const KeyType& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->set(");
@@ -180,7 +180,7 @@ public:
     }
     
     template<typename PassedType>
-    AddResult set(KeyType&& key, PassedType&& passedValue)
+    AddResult set(KeyType&& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->set(");
@@ -193,7 +193,7 @@ public:
     }
     
     template<typename PassedType>
-    AddResult add(const KeyType& key, PassedType&& passedValue)
+    AddResult add(const KeyType& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->add(");
@@ -206,7 +206,7 @@ public:
     }
     
     template<typename PassedType>
-    AddResult add(KeyType&& key, PassedType&& passedValue)
+    AddResult add(KeyType&& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->add(");
@@ -219,19 +219,19 @@ public:
     }
     
     template<typename PassedType>
-    AddResult fastAdd(const KeyType& key, PassedType&& passedValue)
+    AddResult fastAdd(const KeyType& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         return add(key, std::forward<PassedType>(passedValue));
     }
     
     template<typename PassedType>
-    AddResult fastAdd(KeyType&& key, PassedType&& passedValue)
+    AddResult fastAdd(KeyType&& key, PassedType&& passedValue) LIFETIME_BOUND
     {
         return add(WTFMove(key), std::forward<PassedType>(passedValue));
     }
     
     template<typename Func>
-    AddResult ensure(const KeyType& key, Func&& func)
+    AddResult ensure(const KeyType& key, Func&& func) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->ensure(");
@@ -255,7 +255,7 @@ public:
     }
     
     template<typename Func>
-    AddResult ensure(KeyType&& key, Func&& func)
+    AddResult ensure(KeyType&& key, Func&& func) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->ensure(");

--- a/Source/WTF/wtf/LoggingHashSet.h
+++ b/Source/WTF/wtf/LoggingHashSet.h
@@ -97,13 +97,13 @@ public:
     unsigned capacity() const { return m_set.capacity(); }
     bool isEmpty() const { return m_set.isEmpty(); }
     
-    iterator begin() const { return m_set.begin(); }
-    iterator end() const { return m_set.end(); }
+    iterator begin() const LIFETIME_BOUND { return m_set.begin(); }
+    iterator end() const LIFETIME_BOUND { return m_set.end(); }
     
-    iterator random() { return m_set.random(); }
-    const_iterator random() const { return m_set.random(); }
+    iterator random() LIFETIME_BOUND { return m_set.random(); }
+    const_iterator random() const LIFETIME_BOUND { return m_set.random(); }
 
-    iterator find(const ValueType& value) const
+    iterator find(const ValueType& value) const LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print("{\n");
@@ -127,7 +127,7 @@ public:
     
     // FIXME: Implement the translator versions of find() and friends.
     
-    AddResult add(const ValueType& value)
+    AddResult add(const ValueType& value) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->add(");
@@ -137,7 +137,7 @@ public:
         return m_set.add(value);
     }
 
-    AddResult add(ValueType&& value)
+    AddResult add(ValueType&& value) LIFETIME_BOUND
     {
         StringPrintStream string;
         string.print(m_id, "->add(");

--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -49,7 +49,7 @@ public:
 
     explicit operator bool() const { return m_port != MACH_PORT_NULL; }
 
-    mach_port_t sendRight() const { return m_port; }
+    mach_port_t sendRight() const LIFETIME_BOUND { return m_port; }
 
     WTF_EXPORT_PRIVATE mach_port_t leakSendRight() WARN_UNUSED_RETURN;
 

--- a/Source/WTF/wtf/MainThreadData.h
+++ b/Source/WTF/wtf/MainThreadData.h
@@ -34,13 +34,13 @@ public:
         : m_data(WTFMove(data))
     { }
 
-    T* operator->()
+    T* operator->() LIFETIME_BOUND
     {
         ASSERT(isMainThread());
         return &m_data;
     }
 
-    T& operator*()
+    T& operator*() LIFETIME_BOUND
     {
         ASSERT(isMainThread());
         return m_data;

--- a/Source/WTF/wtf/MallocPtr.h
+++ b/Source/WTF/wtf/MallocPtr.h
@@ -57,7 +57,7 @@ public:
         Malloc::free(m_ptr);
     }
 
-    T* get() const
+    T* get() const LIFETIME_BOUND
     {
         return m_ptr;
     }
@@ -77,13 +77,13 @@ public:
         return !m_ptr;
     }
 
-    T& operator*() const
+    T& operator*() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         return *m_ptr;
     }
 
-    T* operator->() const
+    T* operator->() const LIFETIME_BOUND
     {
         return m_ptr;
     }

--- a/Source/WTF/wtf/RangeSet.h
+++ b/Source/WTF/wtf/RangeSet.h
@@ -129,12 +129,12 @@ public:
         out.print("{", listDump(m_ranges), ", isCompact = ", m_isCompact, "}");
     }
     
-    typename VectorType::const_iterator begin() const
+    typename VectorType::const_iterator begin() const LIFETIME_BOUND
     {
         return m_ranges.begin();
     }
     
-    typename VectorType::const_iterator end() const
+    typename VectorType::const_iterator end() const LIFETIME_BOUND
     {
         return m_ranges.end();
     }

--- a/Source/WTF/wtf/RefCountable.h
+++ b/Source/WTF/wtf/RefCountable.h
@@ -65,12 +65,12 @@ public:
     }
 #endif
 
-    T& operator*()
+    T& operator*() LIFETIME_BOUND
     {
         return m_value;
     }
 
-    const T& operator*() const
+    const T& operator*() const LIFETIME_BOUND
     {
         return m_value;
     }

--- a/Source/WTF/wtf/RefVector.h
+++ b/Source/WTF/wtf/RefVector.h
@@ -115,28 +115,28 @@ public:
 
     using Base::size;
 
-    iterator begin() { return iterator { Base::begin() }; }
-    iterator end() { return iterator { Base::end() }; }
-    const_iterator begin() const { return const_iterator { Base::begin() }; }
-    const_iterator end() const { return const_iterator { Base::end() }; }
-    reverse_iterator rbegin() { return reverse_iterator(end()); }
-    reverse_iterator rend() { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    iterator begin() LIFETIME_BOUND { return iterator { Base::begin() }; }
+    iterator end() LIFETIME_BOUND { return iterator { Base::end() }; }
+    const_iterator begin() const LIFETIME_BOUND { return const_iterator { Base::begin() }; }
+    const_iterator end() const LIFETIME_BOUND { return const_iterator { Base::end() }; }
+    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
     RefVector() = default;
     RefVector(std::initializer_list<WTF::Ref<T>>);
 
-    T& at(size_t i) { return Base::at(i).get(); }
-    const T& at(size_t i) const { return Base::at(i).get(); }
+    T& at(size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& at(size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& operator[](size_t i) { return Base::at(i).get(); }
-    const T& operator[](size_t i) const { return Base::at(i).get(); }
+    T& operator[](size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& first() { return Base::at(0).get(); }
-    const T& first() const { return Base::at(0).get(); }
-    T& last() { return Base::at(Base::size() - 1).get(); }
-    const T& last() const { return Base::at(Base::size() - 1).get(); }
+    T& first() LIFETIME_BOUND { return Base::at(0).get(); }
+    const T& first() const LIFETIME_BOUND { return Base::at(0).get(); }
+    T& last() LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
+    const T& last() const LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
 
     template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
     template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }

--- a/Source/WTF/wtf/ReferenceWrapperVector.h
+++ b/Source/WTF/wtf/ReferenceWrapperVector.h
@@ -124,28 +124,28 @@ public:
 
     using Base::size;
 
-    iterator begin() { return iterator { Base::begin() }; }
-    iterator end() { return iterator { Base::end() }; }
-    const_iterator begin() const { return const_iterator { Base::begin() }; }
-    const_iterator end() const { return const_iterator { Base::end() }; }
-    reverse_iterator rbegin() { return reverse_iterator(end()); }
-    reverse_iterator rend() { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    iterator begin() LIFETIME_BOUND { return iterator { Base::begin() }; }
+    iterator end() LIFETIME_BOUND { return iterator { Base::end() }; }
+    const_iterator begin() const LIFETIME_BOUND { return const_iterator { Base::begin() }; }
+    const_iterator end() const LIFETIME_BOUND { return const_iterator { Base::end() }; }
+    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
     ReferenceWrapperVector() = default;
     ReferenceWrapperVector(std::initializer_list<std::reference_wrapper<T>>);
 
-    T& at(size_t i) { return Base::at(i).get(); }
-    const T& at(size_t i) const { return Base::at(i).get(); }
+    T& at(size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& at(size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& operator[](size_t i) { return Base::at(i).get(); }
-    const T& operator[](size_t i) const { return Base::at(i).get(); }
+    T& operator[](size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& first() { return Base::at(0).get(); }
-    const T& first() const { return Base::at(0).get(); }
-    T& last() { return Base::at(Base::size() - 1).get(); }
-    const T& last() const { return Base::at(Base::size() - 1).get(); }
+    T& first() LIFETIME_BOUND { return Base::at(0).get(); }
+    const T& first() const LIFETIME_BOUND { return Base::at(0).get(); }
+    T& last() LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
+    const T& last() const LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
 
     template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
     template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -179,21 +179,21 @@ public:
         internalCheckTableConsistency();
     }
 
-    template<ShouldValidateKey shouldValidateKey> AddResult add(const ValueType& value) { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return value; }); }
-    template<ShouldValidateKey shouldValidateKey> AddResult add(ValueType&& value) { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
+    template<ShouldValidateKey shouldValidateKey> AddResult add(const ValueType& value) LIFETIME_BOUND { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return value; }); }
+    template<ShouldValidateKey shouldValidateKey> AddResult add(ValueType&& value) LIFETIME_BOUND { return add<IdentityTranslatorType, shouldValidateKey>(Extractor::extract(value), [&]() ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
 
     // A special version of add() that finds the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion if the object is already
     // in the table.
-    template<typename HashTranslator, ShouldValidateKey> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor);
-    template<typename HashTranslator, ShouldValidateKey> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor);
+    template<typename HashTranslator, ShouldValidateKey> AddResult add(auto&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND;
+    template<typename HashTranslator, ShouldValidateKey> AddResult addPassingHashCode(auto&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND;
 
-    template<ShouldValidateKey shouldValidateKey> iterator find(const KeyType& key) { return find<IdentityTranslatorType, shouldValidateKey>(key); }
-    template<ShouldValidateKey shouldValidateKey> const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType, shouldValidateKey>(key); }
+    template<ShouldValidateKey shouldValidateKey> iterator find(const KeyType& key) LIFETIME_BOUND { return find<IdentityTranslatorType, shouldValidateKey>(key); }
+    template<ShouldValidateKey shouldValidateKey> const_iterator find(const KeyType& key) const LIFETIME_BOUND { return find<IdentityTranslatorType, shouldValidateKey>(key); }
     template<ShouldValidateKey shouldValidateKey> bool contains(const KeyType& key) const { return contains<IdentityTranslatorType, shouldValidateKey>(key); }
 
-    template<typename HashTranslator, ShouldValidateKey, typename T> iterator find(const T&);
-    template<typename HashTranslator, ShouldValidateKey, typename T> const_iterator find(const T&) const;
+    template<typename HashTranslator, ShouldValidateKey, typename T> iterator find(const T&) LIFETIME_BOUND;
+    template<typename HashTranslator, ShouldValidateKey, typename T> const_iterator find(const T&) const LIFETIME_BOUND;
     template<typename HashTranslator, ShouldValidateKey, typename T> bool contains(const T&) const;
 
     void remove(const KeyType&);

--- a/Source/WTF/wtf/SingleRootGraph.h
+++ b/Source/WTF/wtf/SingleRootGraph.h
@@ -138,26 +138,26 @@ public:
 
     size_t size() const { return m_map.size() + 1; }
 
-    T& operator[](size_t index)
+    T& operator[](size_t index) LIFETIME_BOUND
     {
         if (!index)
             return m_root;
         return m_map[index - 1];
     }
 
-    const T& operator[](size_t index) const
+    const T& operator[](size_t index) const LIFETIME_BOUND
     {
         return (*const_cast<SingleRootMap*>(this))[index];
     }
 
-    T& operator[](const Node& node)
+    T& operator[](const Node& node) LIFETIME_BOUND
     {
         if (node.isRoot())
             return m_root;
         return m_map[node.node()];
     }
 
-    const T& operator[](const Node& node) const
+    const T& operator[](const Node& node) const LIFETIME_BOUND
     {
         return (*const_cast<SingleRootMap*>(this))[node];
     }

--- a/Source/WTF/wtf/SmallMap.h
+++ b/Source/WTF/wtf/SmallMap.h
@@ -45,7 +45,7 @@ public:
 
     static_assert(sizeof(Pair) <= 4 * sizeof(uint64_t), "Don't use SmallMap with large types. It probably wastes memory.");
 
-    Value& ensure(const Key& key, NOESCAPE const auto& functor)
+    Value& ensure(const Key& key, NOESCAPE const auto& functor) LIFETIME_BOUND
     {
         ASSERT(Map::isValidKey(key));
         if (std::holds_alternative<std::monostate>(m_storage)) {
@@ -73,7 +73,7 @@ public:
             map->remove(key);
     }
 
-    const Value* get(const Key& key) const
+    const Value* get(const Key& key) const LIFETIME_BOUND
     {
         ASSERT(Map::isValidKey(key));
         if (auto* pair = std::get_if<Pair>(&m_storage)) {
@@ -108,7 +108,7 @@ public:
         });
     }
 
-    const Storage& rawStorage() const { return m_storage; }
+    const Storage& rawStorage() const LIFETIME_BOUND { return m_storage; }
 
 private:
     Storage m_storage;

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -121,7 +121,7 @@ public:
         bool isNewEntry;
     };
 
-    inline AddResult add(T value)
+    inline AddResult add(T value) LIFETIME_BOUND
     {
         ASSERT(isValidEntry(value));
 

--- a/Source/WTF/wtf/StreamBuffer.h
+++ b/Source/WTF/wtf/StreamBuffer.h
@@ -89,7 +89,7 @@ public:
 
     size_t size() const { return m_size; }
 
-    const T* firstBlockData() const
+    const T* firstBlockData() const LIFETIME_BOUND
     {
         if (!m_size)
             return 0;

--- a/Source/WTF/wtf/UniqueRefVector.h
+++ b/Source/WTF/wtf/UniqueRefVector.h
@@ -115,25 +115,25 @@ public:
 
     using Base::size;
 
-    iterator begin() { return iterator { Base::begin() }; }
-    iterator end() { return iterator { Base::end() }; }
-    const_iterator begin() const { return const_iterator { Base::begin() }; }
-    const_iterator end() const { return const_iterator { Base::end() }; }
-    reverse_iterator rbegin() { return reverse_iterator(end()); }
-    reverse_iterator rend() { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    iterator begin() LIFETIME_BOUND { return iterator { Base::begin() }; }
+    iterator end() LIFETIME_BOUND { return iterator { Base::end() }; }
+    const_iterator begin() const LIFETIME_BOUND { return const_iterator { Base::begin() }; }
+    const_iterator end() const LIFETIME_BOUND { return const_iterator { Base::end() }; }
+    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
-    T& at(size_t i) { return Base::at(i).get(); }
-    const T& at(size_t i) const { return Base::at(i).get(); }
+    T& at(size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& at(size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& operator[](size_t i) { return Base::at(i).get(); }
-    const T& operator[](size_t i) const { return Base::at(i).get(); }
+    T& operator[](size_t i) LIFETIME_BOUND { return Base::at(i).get(); }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return Base::at(i).get(); }
 
-    T& first() { return Base::at(0).get(); }
-    const T& first() const { return Base::at(0).get(); }
-    T& last() { return Base::at(Base::size() - 1).get(); }
-    const T& last() const { return Base::at(Base::size() - 1).get(); }
+    T& first() LIFETIME_BOUND { return Base::at(0).get(); }
+    const T& first() const LIFETIME_BOUND { return Base::at(0).get(); }
+    T& last() LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
+    const T& last() const LIFETIME_BOUND { return Base::at(Base::size() - 1).get(); }
 
     template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
     template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }

--- a/Source/WTF/wtf/VariantList.h
+++ b/Source/WTF/wtf/VariantList.h
@@ -90,8 +90,8 @@ public:
     void append(const VariantList&);
     void append(VariantList&&);
 
-    auto begin() const { return const_iterator(spanToSize()); }
-    auto end() const   { return const_iterator(spanFromSizeToSize()); }
+    auto begin() const LIFETIME_BOUND { return const_iterator(spanToSize()); }
+    auto end() const LIFETIME_BOUND { return const_iterator(spanFromSizeToSize()); }
 
     template<typename...F> void forEach(F&&...) const;
 

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -32,7 +32,7 @@
 namespace WTF {
 
 #ifdef __OBJC__
-inline std::span<const uint8_t> span(NSData *data)
+inline std::span<const uint8_t> span(NSData *data LIFETIME_BOUND)
 {
     if (!data)
         return { };

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -55,8 +55,8 @@ public:
 
     unsigned existingHash() const { return isNull() ? 0 : impl()->existingHash(); }
 
-    operator const String&() const { return m_string; }
-    const String& string() const { return m_string; }
+    operator const String&() const LIFETIME_BOUND { return m_string; }
+    const String& string() const LIFETIME_BOUND { return m_string; }
     String releaseString() { return WTFMove(m_string); }
 
     // FIXME: What guarantees this isn't a SymbolImpl rather than an AtomStringImpl?

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -666,7 +666,8 @@ void NetworkTransportSession::terminate(WebCore::WebTransportSessionErrorCode co
     if (m_datagramConnection)
         nw_connection_cancel(m_datagramConnection.get());
 
-    for (auto& stream : std::exchange(m_streams, { }).values())
+    auto streams = std::exchange(m_streams, { });
+    for (auto& stream : streams.values())
         stream->cancel(code);
 
     nw_connection_group_cancel(m_connectionGroup.get());


### PR DESCRIPTION
#### fb03224060917c7d88ddfe678c5f3f9ccaee65de
<pre>
Adopt LIFETIME_BOUND in more places in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=303701">https://bugs.webkit.org/show_bug.cgi?id=303701</a>

Reviewed by Darin Adler and Geoffrey Garen.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/WTF/wtf/Box.h:
(WTF::Box::get const): Deleted.
(WTF::Box::operator* const): Deleted.
(WTF::Box::operator-&gt; const): Deleted.
* Source/WTF/wtf/ButterflyArray.h:
(WTF::ButterflyArray::leadingSpan): Deleted.
(WTF::ButterflyArray::leadingSpan const): Deleted.
(WTF::ButterflyArray::trailingSpan): Deleted.
(WTF::ButterflyArray::trailingSpan const): Deleted.
* Source/WTF/wtf/CagedPtr.h:
(WTF::CagedPtr::get const): Deleted.
(WTF::CagedPtr::getMayBeNull const): Deleted.
(WTF::CagedPtr::getUnsafe const): Deleted.
* Source/WTF/wtf/CompactRefPtrTuple.h:
* Source/WTF/wtf/CompactUniquePtrTuple.h:
* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
* Source/WTF/wtf/ConcurrentBuffer.h:
* Source/WTF/wtf/ConcurrentVector.h:
* Source/WTF/wtf/DataRef.h:
(WTF::DataRef::operator const T&amp; const): Deleted.
(WTF::DataRef::ptr const): Deleted.
(WTF::DataRef::get const): Deleted.
(WTF::DataRef::operator* const): Deleted.
(WTF::DataRef::operator-&gt; const): Deleted.
(WTF::DataRef::access): Deleted.
* Source/WTF/wtf/Deque.h:
* Source/WTF/wtf/Function.h:
(WTF::Function&lt;Out):
* Source/WTF/wtf/GraphNodeWorklist.h:
(WTF::GraphNodeWorklist::seen const): Deleted.
* Source/WTF/wtf/HashCountedSet.h:
* Source/WTF/wtf/HashMap.h:
* Source/WTF/wtf/HashSet.h:
* Source/WTF/wtf/HashTable.h:
(WTF::HashTable::add): Deleted.
(WTF::HashTable::find): Deleted.
(WTF::HashTable::find const): Deleted.
* Source/WTF/wtf/IndexMap.h:
(WTF::IndexMap::at): Deleted.
(WTF::IndexMap::at const): Deleted.
(WTF::IndexMap::operator[]): Deleted.
(WTF::IndexMap::operator[] const): Deleted.
* Source/WTF/wtf/IndexSet.h:
(WTF::IndexSet::Iterable::begin const): Deleted.
(WTF::IndexSet::Iterable::end const): Deleted.
* Source/WTF/wtf/IndexSparseSet.h:
(WTF::IndexSparseSet::values const): Deleted.
* Source/WTF/wtf/Insertion.h:
(WTF::Insertion::element const): Deleted.
(WTF::Insertion::element): Deleted.
* Source/WTF/wtf/InterferenceGraph.h:
(WTF::InterferenceBitVector::Iterable::begin const): Deleted.
(WTF::InterferenceBitVector::Iterable::end const): Deleted.
* Source/WTF/wtf/JSONValues.h:
* Source/WTF/wtf/LazyRef.h:
(WTF::LazyRef::get const): Deleted.
(WTF::LazyRef::get): Deleted.
(WTF::LazyRef::getIfExists const): Deleted.
(WTF::LazyRef::getIfExists): Deleted.
* Source/WTF/wtf/LazyUniqueRef.h:
(WTF::LazyUniqueRef::get const): Deleted.
(WTF::LazyUniqueRef::get): Deleted.
(WTF::LazyUniqueRef::getIfExists const): Deleted.
(WTF::LazyUniqueRef::getIfExists): Deleted.
* Source/WTF/wtf/ListHashSet.h:
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::LocalCalc::Iterable::begin const): Deleted.
(WTF::Liveness::LocalCalc::Iterable::end const): Deleted.
(WTF::Liveness::Iterable::begin const): Deleted.
(WTF::Liveness::Iterable::end const): Deleted.
* Source/WTF/wtf/LoggingHashMap.h:
* Source/WTF/wtf/LoggingHashSet.h:
* Source/WTF/wtf/MachSendRight.h:
(WTF::MachSendRight::sendRight const): Deleted.
* Source/WTF/wtf/MainThreadData.h:
(WTF::MainThreadData::operator-&gt;): Deleted.
(WTF::MainThreadData::operator*): Deleted.
* Source/WTF/wtf/MallocPtr.h:
(WTF::MallocPtr::get const): Deleted.
(WTF::MallocPtr::operator* const): Deleted.
(WTF::MallocPtr::operator-&gt; const): Deleted.
* Source/WTF/wtf/RangeSet.h:
* Source/WTF/wtf/RefCountable.h:
(WTF::RefCountable::operator*): Deleted.
(WTF::RefCountable::operator* const): Deleted.
* Source/WTF/wtf/RefVector.h:
(WTF::RefVector::begin): Deleted.
(WTF::RefVector::end): Deleted.
(WTF::RefVector::begin const): Deleted.
(WTF::RefVector::end const): Deleted.
(WTF::RefVector::rbegin): Deleted.
(WTF::RefVector::rend): Deleted.
(WTF::RefVector::rbegin const): Deleted.
(WTF::RefVector::rend const): Deleted.
(WTF::RefVector::at): Deleted.
(WTF::RefVector::at const): Deleted.
(WTF::RefVector::operator[]): Deleted.
(WTF::RefVector::operator[] const): Deleted.
(WTF::RefVector::first): Deleted.
(WTF::RefVector::first const): Deleted.
(WTF::RefVector::last): Deleted.
(WTF::RefVector::last const): Deleted.
* Source/WTF/wtf/ReferenceWrapperVector.h:
(WTF::ReferenceWrapperVector::begin): Deleted.
(WTF::ReferenceWrapperVector::end): Deleted.
(WTF::ReferenceWrapperVector::begin const): Deleted.
(WTF::ReferenceWrapperVector::end const): Deleted.
(WTF::ReferenceWrapperVector::rbegin): Deleted.
(WTF::ReferenceWrapperVector::rend): Deleted.
(WTF::ReferenceWrapperVector::rbegin const): Deleted.
(WTF::ReferenceWrapperVector::rend const): Deleted.
(WTF::ReferenceWrapperVector::at): Deleted.
(WTF::ReferenceWrapperVector::at const): Deleted.
(WTF::ReferenceWrapperVector::operator[]): Deleted.
(WTF::ReferenceWrapperVector::operator[] const): Deleted.
(WTF::ReferenceWrapperVector::first): Deleted.
(WTF::ReferenceWrapperVector::first const): Deleted.
(WTF::ReferenceWrapperVector::last): Deleted.
(WTF::ReferenceWrapperVector::last const): Deleted.
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::RobinHoodHashTable::add): Deleted.
(WTF::RobinHoodHashTable::find): Deleted.
(WTF::RobinHoodHashTable::find const): Deleted.
* Source/WTF/wtf/SingleRootGraph.h:
(WTF::SingleRootMap::operator[]): Deleted.
(WTF::SingleRootMap::operator[] const): Deleted.
* Source/WTF/wtf/SmallMap.h:
(WTF::SmallMap::ensure): Deleted.
(WTF::SmallMap::get const): Deleted.
(WTF::SmallMap::rawStorage const): Deleted.
* Source/WTF/wtf/SmallSet.h:
* Source/WTF/wtf/StreamBuffer.h:
(WTF::StreamBuffer::firstBlockData const): Deleted.
* Source/WTF/wtf/UniqueRefVector.h:
(WTF::UniqueRefVector::begin): Deleted.
(WTF::UniqueRefVector::end): Deleted.
(WTF::UniqueRefVector::begin const): Deleted.
(WTF::UniqueRefVector::end const): Deleted.
(WTF::UniqueRefVector::rbegin): Deleted.
(WTF::UniqueRefVector::rend): Deleted.
(WTF::UniqueRefVector::rbegin const): Deleted.
(WTF::UniqueRefVector::rend const): Deleted.
(WTF::UniqueRefVector::at): Deleted.
(WTF::UniqueRefVector::at const): Deleted.
(WTF::UniqueRefVector::operator[]): Deleted.
(WTF::UniqueRefVector::operator[] const): Deleted.
(WTF::UniqueRefVector::first): Deleted.
(WTF::UniqueRefVector::first const): Deleted.
(WTF::UniqueRefVector::last): Deleted.
(WTF::UniqueRefVector::last const): Deleted.
* Source/WTF/wtf/VariantList.h:
(WTF::VariantList::begin const): Deleted.
(WTF::VariantList::end const): Deleted.
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(WTF::span):
* Source/WTF/wtf/text/AtomString.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::terminate):

Canonical link: <a href="https://commits.webkit.org/304077@main">https://commits.webkit.org/304077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a27476044df7aa14c2a41c680bd1217f552ea6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134492 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f5a840a-6851-46a9-9455-54048b7911a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70067 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a77c56ea-b8ab-4384-a651-16322ff5a85b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5278 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/83588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c09be359-66ce-4b21-a86f-f4d502cd7646) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2756 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126546 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133000 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6631 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28272 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4971 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60485 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6684 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35014 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70259 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43369 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->