### PR TITLE
Test (JSPI WORK IN PROGRESS)

### DIFF
--- a/JSTests/wasm/stress/jspi-basic.js
+++ b/JSTests/wasm/stress/jspi-basic.js
@@ -1,0 +1,120 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Basic JSPI invocation: a suspension that then returns directly out of Wasm,
+// for different depths of overall Wasm stack.
+
+let depth1 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (func $a (export "entry") (result i32)
+    i32.const 20
+    call $get_number
+    i32.const 30
+    i32.add
+    i32.add
+  )
+)`;
+
+let depth2 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (func $z (result i32)
+    i32.const 20
+    call $get_number
+    i32.const 30
+    i32.add
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    i32.const 60
+    call $z
+    i32.const 40
+    i32.add
+    i32.add
+  )
+)`;
+
+let depth3 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (func $z (result i32)
+    i32.const 20
+    call $get_number
+    i32.const 30
+    i32.add
+    i32.add
+  )
+  (func $b (result i32)
+    i32.const 60
+    call $z
+    i32.const 40
+    i32.add
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    i32.const 120
+    call $b
+    i32.const 80
+    i32.add
+    i32.add
+  )
+)`;
+
+let depth4 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (func $z (result i32)
+    i32.const 20
+    call $get_number
+    i32.const 30
+    i32.add
+    i32.add
+  )
+  (func $c (result i32)
+    i32.const 60
+    call $z
+    i32.const 40
+    i32.add
+    i32.add
+  )
+  (func $b (result i32)
+    i32.const 30
+    call $c
+    i32.const 70
+    i32.add
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    i32.const 120
+    call $b
+    i32.const 80
+    i32.add
+    i32.add
+  )
+)`;
+
+async function asyncReturn42() {
+    return 42;
+}
+
+async function test(watSource, expected) {
+  const instance = await instantiate(watSource, {
+    env: {
+      get_number: new WebAssembly.Suspending(asyncReturn42)
+    }
+  });
+  const runTest = WebAssembly.promising(instance.exports.entry);
+
+  for (let i = 0; i < wasmTestLoopCount; i++) {
+    // print(i);
+    assert.eq(await runTest(), expected)
+  }
+}
+
+await test(depth1, 92);
+await test(depth2, 192);
+await test(depth3, 392);
+await test(depth4, 492);

--- a/JSTests/wasm/stress/jspi-exceptions-from-js.js
+++ b/JSTests/wasm/stress/jspi-exceptions-from-js.js
@@ -1,0 +1,116 @@
+//@ skip
+// WORK IN PROGRESS - requires us to rebuild a usable VM entry frame above the implanted
+// slice for unwinding to find the VM boundary as expected. Currently crashes.
+
+// Here we test the throwing of Wasm exceptions in JS code called from Wasm code via a
+// Suspending wrapper. An exception like that turns into a rejection of the promise
+// returned to Suspending. The rejection (being a Wasm exceptions) should then turn back
+// into an exception propagated through the suspended Wasm stack. If uncaught in Wasm, an
+// exception should turn back into a rejection of the promise returned by promising().
+
+import Builder from '../Builder.js'
+import * as assert from '../assert.js'
+
+let exceptionTag = null;
+let shouldNotBeCalledFlag = false;
+
+async function throwingFunc() {
+    // Throw a Wasm exception with payload value 42
+    throw new WebAssembly.Exception(exceptionTag, [42]);
+}
+
+function shouldNotBeCalled() {
+    shouldNotBeCalledFlag = true;
+}
+
+async function testCatchWasmExceptionThrownFromJS() {
+
+  const b = new Builder();
+  b.Type().End()
+      .Import()
+          .Function("env", "throwingFunc", { params: [], ret: "i32" })
+          .Function("env", "shouldNotBeCalled", { params: [], ret: "void" })
+      .End()
+      .Function().End()
+      .Exception().Signature({ params: ["i32"] }).End()
+      .Export()
+          .Function("testCatch")
+          .Exception("tag", 0)
+      .End()
+      .Code()
+          .Function("testCatch", { params: [], ret: "i32" })
+              .Try("i32")
+                  .Call(0) // call throwingFunc
+              .Catch(0)
+                  // Exception caught, payload is on stack
+              .End()
+          .End()
+      .End();
+
+  const bin = b.WebAssembly().get();
+  const module = new WebAssembly.Module(bin);
+  const instance = new WebAssembly.Instance(module, {
+    env: {
+      throwingFunc: new WebAssembly.Suspending(throwingFunc),
+      shouldNotBeCalled: shouldNotBeCalled,
+    }
+  });
+
+  exceptionTag = instance.exports.tag;
+  const promisingFunc = WebAssembly.promising(instance.exports.testCatch);
+  try {
+    const result = await promisingFunc();
+    assert.eq(result, 42, "Should catch exception and return payload value");
+  } catch(error) {
+    throw new Error("Exception has not been caught in Wasm code");
+  }
+}
+
+async function testPropagateUncaughtWasmException() {
+  shouldNotBeCalledFlag = false;
+
+  exceptionTag = new WebAssembly.Tag({ parameters: ["i32"] });
+
+  const b = new Builder();
+  b.Type().End()
+      .Import()
+          .Function("env", "throwingFunc", { params: [], ret: "i32" })
+          .Function("env", "shouldNotBeCalled", { params: [], ret: "void" })
+      .End()
+      .Function().End()
+      .Export()
+          .Function("testNoCatch")
+      .End()
+      .Code()
+          .Function("testNoCatch", { params: [], ret: "i32" })
+              .Call(0) // call throwingFunc
+              .Drop()
+              .Call(1) // call shouldNotBeCalled
+              .I32Const(999)
+          .End()
+      .End();
+
+  const bin = b.WebAssembly().get();
+  const module = new WebAssembly.Module(bin);
+  const instance = new WebAssembly.Instance(module, {
+    env: {
+      throwingFunc: new WebAssembly.Suspending(throwingFunc),
+      shouldNotBeCalled: shouldNotBeCalled
+    }
+  });
+
+  const promisingFunc = WebAssembly.promising(instance.exports.testNoCatch);
+
+  try {
+    await promisingFunc();
+    throw new Error("Exception should have propagated out");
+  } catch (error) {
+    assert.truthy(error instanceof WebAssembly.Exception, "Should be a WebAssembly.Exception");
+    assert.eq(error.getArg(exceptionTag, 0), 42, "Exception payload should match");
+  }
+
+  assert.falsy(shouldNotBeCalledFlag, "Wasm function should not have continued after exception");
+}
+
+await testCatchWasmExceptionThrownFromJS();
+await testPropagateUncaughtWasmException();

--- a/JSTests/wasm/stress/jspi-exceptions-from-wasm.js
+++ b/JSTests/wasm/stress/jspi-exceptions-from-wasm.js
@@ -1,0 +1,43 @@
+//@ requireOptions("--useJSPI=1")
+
+// Here we test the throwing of a Wasm exception in Wasm code called from JS via a
+// promising() wrapper. The exception should turn into a rejection of the promise
+// returned by promising().
+
+import Builder from '../Builder.js'
+import * as assert from '../assert.js'
+
+async function testWasmExceptionBecomesPromisingRejection() {
+  const b = new Builder();
+  b.Type().End()
+      .Import().End()
+      .Function().End()
+      .Exception().Signature({ params: ["i32"] }).End()
+      .Export()
+          .Function("throwingWasmFunc")
+          .Exception("tag", 0)
+      .End()
+      .Code()
+          .Function("throwingWasmFunc", { params: [], ret: "i32" })
+              .I32Const(42)  // Exception payload
+              .Throw(0)      // Throw exception with tag 0
+          .End()
+      .End();
+
+  const bin = b.WebAssembly().get();
+  const module = new WebAssembly.Module(bin);
+  const instance = new WebAssembly.Instance(module, { });
+
+  const exceptionTag = instance.exports.tag;
+  const promisingFunc = WebAssembly.promising(instance.exports.throwingWasmFunc);
+
+  try {
+    await promisingFunc();
+    throw new Error("Promise should have been rejected");
+  } catch (error) {
+    assert.truthy(error instanceof WebAssembly.Exception, "Should be a WebAssembly.Exception");
+    assert.eq(error.getArg(exceptionTag, 0), 42, "Exception payload should be 42");
+  }
+}
+
+await testWasmExceptionBecomesPromisingRejection();

--- a/JSTests/wasm/stress/jspi-rejection.js
+++ b/JSTests/wasm/stress/jspi-rejection.js
@@ -1,0 +1,83 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+  (import "env" "createPromise" (func $createPromise (result i32)))
+  (import "env" "shouldNotBeCalled" (func $shouldNotBeCalled))
+  (func $testFunc (export "testFunc") (result i32)
+    call $createPromise
+    call $shouldNotBeCalled
+  )
+)`;
+
+let doRejectPromise = null;
+let hasBeenCalledFlag = false;
+const rejectionReason = new Error("Test rejection reason");
+
+function createPromise() {
+    const promise = new Promise((resolve, reject) => {
+        doRejectPromise = reject;
+    });
+    return promise;
+}
+
+async function rejectByThrowing() {
+  throw rejectionReason;
+}
+
+function shouldNotBeCalled() {
+    hasBeenCalledFlag = true;
+}
+
+async function test1() {
+  hasBeenCalledFlag = false;
+
+  const instance = await instantiate(wat, {
+    env: {
+      createPromise: new WebAssembly.Suspending(createPromise),
+      shouldNotBeCalled: shouldNotBeCalled
+    }
+  });
+
+  const promisingFunc = WebAssembly.promising(instance.exports.testFunc);
+  const resultPromise = promisingFunc();
+  doRejectPromise(rejectionReason);
+
+  try {
+    await resultPromise;
+    throw new Error("test1: Promise should have been rejected");
+  } catch (error) {
+    assert.eq(error, rejectionReason, "test1: Rejection reason should match");
+  }
+
+  assert.falsy(hasBeenCalledFlag, "test1: WASM function has been resumed after rejection");
+}
+
+async function test2() {
+  hasBeenCalledFlag = false;
+
+  const instance = await instantiate(wat, {
+    env: {
+      createPromise: new WebAssembly.Suspending(rejectByThrowing),
+      shouldNotBeCalled: shouldNotBeCalled
+    }
+  });
+
+  const promisingFunc = WebAssembly.promising(instance.exports.testFunc);
+  const resultPromise = promisingFunc();
+
+  try {
+    await resultPromise;
+    throw new Error("test2: Promise should have been rejected by throwing");
+  } catch (error) {
+    assert.eq(error, rejectionReason, "test2: Rejection reason should match");
+  }
+
+  assert.falsy(hasBeenCalledFlag, "test2: WASM function has been resumed after rejection");
+}
+
+await test1();
+await test2();

--- a/JSTests/wasm/stress/jspi-resuspension.js
+++ b/JSTests/wasm/stress/jspi-resuspension.js
@@ -1,0 +1,124 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// The different test modules test resuspension at different depths in the Wasm stack.
+
+let depth1 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (import "env" "get_number2" (func $get_number2 (result i32)))
+  (func $c (result i32)
+    i32.const 500
+    call $get_number
+    i32.const 500
+    call $get_number2
+    i32.add
+    i32.add
+    i32.add
+  )
+  (func $b (result i32)
+    call $c
+    i32.const 100
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    call $b
+    i32.const 50
+    i32.add
+    i32.const 1000
+    i32.sub
+  )
+)`;
+
+let depth2 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (import "env" "get_number2" (func $get_number2 (result i32)))
+  (func $c (result i32)
+    call $get_number
+  )
+  (func $b (result i32)
+    call $c
+    i32.const 100
+    call $get_number2
+    i32.add
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    call $b
+    i32.const 50
+    i32.add
+  )
+)`;
+
+let depth3 = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (import "env" "get_number2" (func $get_number2 (result i32)))
+  (func $c (result i32)
+    call $get_number
+  )
+  (func $b (result i32)
+    call $c
+    i32.const 100
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    call $b
+    i32.const 50
+    i32.add
+    call $get_number2
+    i32.add
+  )
+)`;
+
+let depth3inverted = `
+(module
+  (import "env" "get_number" (func $get_number (result i32)))
+  (import "env" "get_number2" (func $get_number2 (result i32)))
+  (func $c (result i32)
+    call $get_number
+  )
+  (func $b (result i32)
+    call $c
+    i32.const 100
+    i32.add
+  )
+  (func $a (export "entry") (result i32)
+    call $get_number2
+    i32.const 50
+    call $b
+    i32.add
+    i32.add
+  )
+)`;
+
+async function asyncReturn42() {
+    return 42;
+}
+
+async function asyncReturn67() {
+    return 67;
+}
+
+async function test(watSource) {
+  const instance = await instantiate(watSource, {
+    env: {
+      get_number: new WebAssembly.Suspending(asyncReturn42),
+      get_number2: new WebAssembly.Suspending(asyncReturn67)
+    }
+  });
+
+  const probe = WebAssembly.promising(instance.exports.entry);
+
+  for (let i = 0; i < wasmTestLoopCount; i++) {
+    assert.eq(await probe(), 259)
+  }
+}
+
+await test(depth1);
+await test(depth2);
+await test(depth3);
+await test(depth3inverted);

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -153,6 +153,8 @@ set(JavaScriptCore_OBJECT_LUT_SOURCES
     wasm/js/WebAssemblyModulePrototype.cpp
     wasm/js/WebAssemblyRuntimeErrorConstructor.cpp
     wasm/js/WebAssemblyRuntimeErrorPrototype.cpp
+    wasm/js/WebAssemblySuspendErrorConstructor.cpp
+    wasm/js/WebAssemblySuspendErrorPrototype.cpp
     wasm/js/WebAssemblyStructConstructor.cpp
     wasm/js/WebAssemblyStructPrototype.cpp
     wasm/js/WebAssemblyTableConstructor.cpp
@@ -1087,6 +1089,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/ErrorInstance.h
     runtime/ErrorPrototype.h
     runtime/ErrorType.h
+    runtime/EvacuatedStack.h
     runtime/EvalExecutable.h
     runtime/Exception.h
     runtime/ExceptionEventLocation.h
@@ -1290,6 +1293,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/OrderedHashTableHelper.h
     runtime/PageCount.h
     runtime/ParseInt.h
+    runtime/PinballCompletion.h
     runtime/PrivateFieldPutKind.h
     runtime/PrivateName.h
     runtime/ProfilerSupport.h
@@ -1475,6 +1479,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/js/JSWebAssemblyLinkError.h
     wasm/js/JSWebAssemblyMemory.h
     wasm/js/JSWebAssemblyModule.h
+    wasm/js/JSWebAssemblyPromisingFunction.h
+    wasm/js/JSWebAssemblySuspendingFunction.h
     wasm/js/JSWebAssemblyTable.h
     wasm/js/WebAssemblyBuiltin.h
     wasm/js/WebAssemblyFunction.h
@@ -1483,6 +1489,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/js/WebAssemblyLinkErrorConstructor.h
     wasm/js/WebAssemblyLinkErrorPrototype.h
     wasm/js/WebAssemblyModuleRecord.h
+    wasm/js/WebAssemblySuspendingConstructor.h
+    wasm/js/WebAssemblySuspendingPrototype.h
     wasm/js/WebAssemblyWrapperFunction.h
 
     yarr/RegularExpression.h

--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -249,6 +249,8 @@ $(PROJECT_DIR)/wasm/js/WebAssemblyRuntimeErrorConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyRuntimeErrorPrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyStructConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyStructPrototype.cpp
+$(PROJECT_DIR)/wasm/js/WebAssemblySuspendErrorConstructor.cpp
+$(PROJECT_DIR)/wasm/js/WebAssemblySuspendErrorPrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTableConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTablePrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTagConstructor.cpp

--- a/Source/JavaScriptCore/DerivedSources-output.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-output.xcfilelist
@@ -111,6 +111,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyRuntimeErrorConst
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyRuntimeErrorPrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyStructConstructor.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyStructPrototype.lut.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblySuspendErrorConstructor.lut.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblySuspendErrorPrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyTableConstructor.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyTablePrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/WebAssemblyTagConstructor.lut.h

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -245,6 +245,8 @@ OBJECT_LUT_HEADERS = \
     WebAssemblyModulePrototype.lut.h \
     WebAssemblyRuntimeErrorConstructor.lut.h \
     WebAssemblyRuntimeErrorPrototype.lut.h \
+    WebAssemblySuspendErrorConstructor.lut.h \
+    WebAssemblySuspendErrorPrototype.lut.h \
     WebAssemblyStructConstructor.lut.h \
     WebAssemblyStructPrototype.lut.h \
     WebAssemblyTableConstructor.lut.h \

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -802,9 +802,18 @@
 		233D768F2E288BCA00EB9FFB /* missingImport.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767B2E288A8600EB9FFB /* missingImport.js */; };
 		233D76902E288BCA00EB9FFB /* referenceError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767C2E288A8600EB9FFB /* referenceError.js */; };
 		233D76912E288BCA00EB9FFB /* syntaxError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767D2E288A8600EB9FFB /* syntaxError.js */; };
+		234E91BF2EE2571E000BAE2C /* JSWebAssemblySuspendError.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91BD2EE2571E000BAE2C /* JSWebAssemblySuspendError.h */; };
+		234E91C52EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */; };
+		234E91C62EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C12EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h */; };
+		236F6FC22E86FACA008450C8 /* JSWebAssemblyPromisingFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 236F6FC12E86FACA008450C8 /* JSWebAssemblyPromisingFunction.h */; };
+		237C93D72E95A83400F62455 /* JSWebAssemblySuspendingFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93D52E95A83400F62455 /* JSWebAssemblySuspendingFunction.h */; };
+		237C93DD2E95A87900F62455 /* WebAssemblySuspendingConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */; };
+		237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */; };
 		23863EEB2E5EC93E00E57879 /* WebAssemblyBuiltinTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */; };
 		2392A1302DD51DB100DD1CB9 /* WebAssemblyBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; };
+		23A356912E9790F40039C82A /* PinballCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A3568E2E9790F40039C82A /* PinballCompletion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		23A9696C2E95A903005A36F5 /* EvacuatedStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A969692E95A903005A36F5 /* EvacuatedStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2600B5A7152BAAA70091EE5F /* JSStringJoiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */; };
 		262D85B71C0D650F006ACB61 /* AirFixPartialRegisterStalls.h in Headers */ = {isa = PBXBuildFile; fileRef = 262D85B51C0D650F006ACB61 /* AirFixPartialRegisterStalls.h */; };
 		2684D4381C00161C0081D663 /* AirLiveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4371C00161C0081D663 /* AirLiveness.h */; };
@@ -3948,12 +3957,30 @@
 		233D767D2E288A8600EB9FFB /* syntaxError.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = syntaxError.js; sourceTree = "<group>"; };
 		233D767F2E288A8600EB9FFB /* testapi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = testapi.js; sourceTree = "<group>"; };
 		233D76802E288A8600EB9FFB /* testapi-function-overrides.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "testapi-function-overrides.js"; sourceTree = "<group>"; };
+		234E91BD2EE2571E000BAE2C /* JSWebAssemblySuspendError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblySuspendError.h; path = js/JSWebAssemblySuspendError.h; sourceTree = "<group>"; };
+		234E91BE2EE2571E000BAE2C /* JSWebAssemblySuspendError.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSWebAssemblySuspendError.cpp; path = js/JSWebAssemblySuspendError.cpp; sourceTree = "<group>"; };
+		234E91C12EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendErrorConstructor.h; path = js/WebAssemblySuspendErrorConstructor.h; sourceTree = "<group>"; };
+		234E91C22EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorConstructor.cpp; path = js/WebAssemblySuspendErrorConstructor.cpp; sourceTree = "<group>"; };
+		234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendErrorPrototype.h; path = js/WebAssemblySuspendErrorPrototype.h; sourceTree = "<group>"; };
+		234E91C42EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorPrototype.cpp; path = js/WebAssemblySuspendErrorPrototype.cpp; sourceTree = "<group>"; };
+		236F6FC12E86FACA008450C8 /* JSWebAssemblyPromisingFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblyPromisingFunction.h; path = js/JSWebAssemblyPromisingFunction.h; sourceTree = "<group>"; };
+		236F6FC32E86FADF008450C8 /* JSWebAssemblyPromisingFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSWebAssemblyPromisingFunction.cpp; path = js/JSWebAssemblyPromisingFunction.cpp; sourceTree = "<group>"; };
+		237C93D52E95A83400F62455 /* JSWebAssemblySuspendingFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblySuspendingFunction.h; path = js/JSWebAssemblySuspendingFunction.h; sourceTree = "<group>"; };
+		237C93D62E95A83400F62455 /* JSWebAssemblySuspendingFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSWebAssemblySuspendingFunction.cpp; path = js/JSWebAssemblySuspendingFunction.cpp; sourceTree = "<group>"; };
+		237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingConstructor.h; path = js/WebAssemblySuspendingConstructor.h; sourceTree = "<group>"; };
+		237C93DA2E95A85F00F62455 /* WebAssemblySuspendingConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingConstructor.cpp; path = js/WebAssemblySuspendingConstructor.cpp; sourceTree = "<group>"; };
+		237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingPrototype.h; path = js/WebAssemblySuspendingPrototype.h; sourceTree = "<group>"; };
+		237C93DC2E95A85F00F62455 /* WebAssemblySuspendingPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingPrototype.cpp; path = js/WebAssemblySuspendingPrototype.cpp; sourceTree = "<group>"; };
 		23863EE92E5EC91500E57879 /* WebAssemblyBuiltinTrampoline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyBuiltinTrampoline.cpp; path = js/WebAssemblyBuiltinTrampoline.cpp; sourceTree = "<group>"; };
 		23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyBuiltinTrampoline.h; path = js/WebAssemblyBuiltinTrampoline.h; sourceTree = "<group>"; };
 		2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyBuiltin.h; path = js/WebAssemblyBuiltin.h; sourceTree = "<group>"; };
 		2392A12B2DD51DB100DD1CB9 /* WebAssemblyBuiltin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyBuiltin.cpp; path = js/WebAssemblyBuiltin.cpp; sourceTree = "<group>"; };
 		2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyCompileOptions.h; path = js/WebAssemblyCompileOptions.h; sourceTree = "<group>"; };
 		2392A12D2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyCompileOptions.cpp; path = js/WebAssemblyCompileOptions.cpp; sourceTree = "<group>"; };
+		23A3568E2E9790F40039C82A /* PinballCompletion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballCompletion.h; sourceTree = "<group>"; };
+		23A3568F2E9790F40039C82A /* PinballCompletion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PinballCompletion.cpp; sourceTree = "<group>"; };
+		23A969692E95A903005A36F5 /* EvacuatedStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EvacuatedStack.h; sourceTree = "<group>"; };
+		23A9696A2E95A903005A36F5 /* EvacuatedStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EvacuatedStack.cpp; sourceTree = "<group>"; };
 		2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringJoiner.cpp; sourceTree = "<group>"; };
 		2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringJoiner.h; sourceTree = "<group>"; };
 		262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirFixPartialRegisterStalls.cpp; path = b3/air/AirFixPartialRegisterStalls.cpp; sourceTree = "<group>"; };
@@ -8458,6 +8485,8 @@
 				276B385E2A71D0B600252F4E /* ErrorPrototypeInlines.h */,
 				E3EE137521FBD43400D83C4B /* ErrorType.cpp */,
 				E3EE137421FBD43400D83C4B /* ErrorType.h */,
+				23A9696A2E95A903005A36F5 /* EvacuatedStack.cpp */,
+				23A969692E95A903005A36F5 /* EvacuatedStack.h */,
 				147341DB1DC2CE9600AA29BA /* EvalExecutable.cpp */,
 				147341D11DC02E2E00AA29BA /* EvalExecutable.h */,
 				276B38532A71D0B400252F4E /* EvalExecutableInlines.h */,
@@ -9004,6 +9033,8 @@
 				E389D851291226BC0085C3DC /* PageCount.cpp */,
 				E389D852291226BC0085C3DC /* PageCount.h */,
 				37C738D11EDB5672003F2B0B /* ParseInt.h */,
+				23A3568F2E9790F40039C82A /* PinballCompletion.cpp */,
+				23A3568E2E9790F40039C82A /* PinballCompletion.h */,
 				CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */,
 				CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */,
 				86B8690224B8A20800487C95 /* PrivateFieldPutKind.cpp */,
@@ -10339,10 +10370,16 @@
 				AD2FCBAB1DB58DA400B3E736 /* JSWebAssemblyMemory.h */,
 				AD2FCB8C1DB5844000B3E736 /* JSWebAssemblyModule.cpp */,
 				AD2FCB8D1DB5844000B3E736 /* JSWebAssemblyModule.h */,
+				236F6FC32E86FADF008450C8 /* JSWebAssemblyPromisingFunction.cpp */,
+				236F6FC12E86FACA008450C8 /* JSWebAssemblyPromisingFunction.h */,
 				AD2FCBAC1DB58DA400B3E736 /* JSWebAssemblyRuntimeError.cpp */,
 				AD2FCBAD1DB58DA400B3E736 /* JSWebAssemblyRuntimeError.h */,
 				14CC3BA22138F3700CAE0D0D /* JSWebAssemblyStruct.cpp */,
 				14D01BE026DEEF3800CAE0D0 /* JSWebAssemblyStruct.h */,
+				234E91BE2EE2571E000BAE2C /* JSWebAssemblySuspendError.cpp */,
+				234E91BD2EE2571E000BAE2C /* JSWebAssemblySuspendError.h */,
+				237C93D62E95A83400F62455 /* JSWebAssemblySuspendingFunction.cpp */,
+				237C93D52E95A83400F62455 /* JSWebAssemblySuspendingFunction.h */,
 				AD2FCBAE1DB58DA400B3E736 /* JSWebAssemblyTable.cpp */,
 				AD2FCBAF1DB58DA400B3E736 /* JSWebAssemblyTable.h */,
 				14D01BE426DEEF3800CAE0D0 /* JSWebAssemblyTag.cpp */,
@@ -10405,6 +10442,14 @@
 				14D01BE326DFEF3800CAE0D0 /* WebAssemblyStructConstructor.h */,
 				14D01BE226DEEF3CFECAE0D0 /* WebAssemblyStructPrototype.cpp */,
 				14D01BDD26DEEF378CCAE0D0 /* WebAssemblyStructPrototype.h */,
+				234E91C22EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.cpp */,
+				234E91C12EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h */,
+				234E91C42EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.cpp */,
+				234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */,
+				237C93DA2E95A85F00F62455 /* WebAssemblySuspendingConstructor.cpp */,
+				237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */,
+				237C93DC2E95A85F00F62455 /* WebAssemblySuspendingPrototype.cpp */,
+				237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */,
 				AD2FCBC01DB58DA400B3E736 /* WebAssemblyTableConstructor.cpp */,
 				AD2FCBC11DB58DA400B3E736 /* WebAssemblyTableConstructor.h */,
 				AD2FCBC21DB58DA400B3E736 /* WebAssemblyTablePrototype.cpp */,
@@ -11240,6 +11285,7 @@
 				BC02E90F0E1839DB000F9297 /* ErrorPrototype.h in Headers */,
 				276B386D2A71D0B600252F4E /* ErrorPrototypeInlines.h in Headers */,
 				E3EE137621FBD43500D83C4B /* ErrorType.h in Headers */,
+				23A9696C2E95A903005A36F5 /* EvacuatedStack.h in Headers */,
 				14AD910C1DCA92940014F9FE /* EvalCodeBlock.h in Headers */,
 				278D25F52A70CE27007F5BC3 /* EvalCodeBlockInlines.h in Headers */,
 				147341D21DC02E2E00AA29BA /* EvalExecutable.h in Headers */,
@@ -11828,8 +11874,11 @@
 				ADE802991E08F1DE0058DE78 /* JSWebAssemblyLinkError.h in Headers */,
 				AD2FCBE71DB58DAD00B3E736 /* JSWebAssemblyMemory.h in Headers */,
 				AD2FCC051DB58DAD00B3E736 /* JSWebAssemblyModule.h in Headers */,
+				236F6FC22E86FACA008450C8 /* JSWebAssemblyPromisingFunction.h in Headers */,
 				AD2FCBE91DB58DAD00B3E736 /* JSWebAssemblyRuntimeError.h in Headers */,
 				14D01A7721FBEF3800CAE0D0 /* JSWebAssemblyStruct.h in Headers */,
+				234E91BF2EE2571E000BAE2C /* JSWebAssemblySuspendError.h in Headers */,
+				237C93D72E95A83400F62455 /* JSWebAssemblySuspendingFunction.h in Headers */,
 				AD2FCBEB1DB58DAD00B3E736 /* JSWebAssemblyTable.h in Headers */,
 				14D01BEC26DEEF3800CAE0D0 /* JSWebAssemblyTag.h in Headers */,
 				1442566215EDE98D0066A49B /* JSWithScope.h in Headers */,
@@ -11987,6 +12036,7 @@
 				792CB34A1C4EED5C00D13AF3 /* PCToCodeOriginMap.h in Headers */,
 				E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */,
 				A5AB49DD1BEC8086007020FB /* PerGlobalObjectWrapperWorld.h in Headers */,
+				23A356912E9790F40039C82A /* PinballCompletion.h in Headers */,
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
 				521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */,
 				0F070A4B1D543A98006E7232 /* PreciseAllocation.h in Headers */,
@@ -12451,6 +12501,10 @@
 				AD2FCBFB1DB58DAD00B3E736 /* WebAssemblyRuntimeErrorPrototype.h in Headers */,
 				14D01DEF26DEEF3800CAE0D0 /* WebAssemblyStructConstructor.h in Headers */,
 				14D01BE926DECC3800CAE0D0 /* WebAssemblyStructPrototype.h in Headers */,
+				234E91C62EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h in Headers */,
+				234E91C52EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h in Headers */,
+				237C93DD2E95A87900F62455 /* WebAssemblySuspendingConstructor.h in Headers */,
+				237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */,
 				AD2FCBFD1DB58DAD00B3E736 /* WebAssemblyTableConstructor.h in Headers */,
 				AD2FCBFF1DB58DAD00B3E736 /* WebAssemblyTablePrototype.h in Headers */,
 				14D01BE626DEEF3800CAE0D0 /* WebAssemblyTagConstructor.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -806,6 +806,7 @@ runtime/ErrorHandlingScope.cpp
 runtime/ErrorInstance.cpp
 runtime/ErrorPrototype.cpp
 runtime/ErrorType.cpp
+runtime/EvacuatedStack.cpp
 runtime/EvalExecutable.cpp
 runtime/Exception.cpp
 runtime/ExceptionEventLocation.cpp
@@ -1009,6 +1010,7 @@ runtime/Operations.cpp
 runtime/Options.cpp
 runtime/OrderedHashTable.cpp
 runtime/PageCount.cpp
+runtime/PinballCompletion.cpp
 runtime/PredictionFileCreatingFuzzerAgent.cpp
 runtime/PrivateFieldPutKind.cpp
 runtime/ProfilerSupport.cpp
@@ -1207,8 +1209,11 @@ wasm/js/JSWebAssemblyInstance.cpp
 wasm/js/JSWebAssemblyLinkError.cpp
 wasm/js/JSWebAssemblyMemory.cpp
 wasm/js/JSWebAssemblyModule.cpp
+wasm/js/JSWebAssemblyPromisingFunction.cpp
 wasm/js/JSWebAssemblyRuntimeError.cpp
+wasm/js/JSWebAssemblySuspendError.cpp
 wasm/js/JSWebAssemblyStruct.cpp
+wasm/js/JSWebAssemblySuspendingFunction.cpp
 wasm/js/JSWebAssemblyTable.cpp
 wasm/js/JSWebAssemblyTag.cpp
 wasm/js/WasmToJS.cpp
@@ -1239,8 +1244,12 @@ wasm/js/WebAssemblyModulePrototype.cpp
 wasm/js/WebAssemblyModuleRecord.cpp
 wasm/js/WebAssemblyRuntimeErrorConstructor.cpp
 wasm/js/WebAssemblyRuntimeErrorPrototype.cpp
+wasm/js/WebAssemblySuspendErrorConstructor.cpp
+wasm/js/WebAssemblySuspendErrorPrototype.cpp
 wasm/js/WebAssemblyStructConstructor.cpp
 wasm/js/WebAssemblyStructPrototype.cpp
+wasm/js/WebAssemblySuspendingConstructor.cpp
+wasm/js/WebAssemblySuspendingPrototype.cpp
 wasm/js/WebAssemblyTableConstructor.cpp
 wasm/js/WebAssemblyTablePrototype.cpp
 wasm/js/WebAssemblyTagConstructor.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -62,6 +62,8 @@
 #include "JSWeakMap.h"
 #include "JSWeakObjectRef.h"
 #include "JSWeakSet.h"
+#include "JSWebAssemblyPromisingFunction.h"
+#include "JSWebAssemblySuspendingFunction.h"
 #include "MachineStackMarker.h"
 #include "MarkStackMergingConstraint.h"
 #include "MarkedJSValueRefArray.h"
@@ -69,6 +71,7 @@
 #include "MarkingConstraintSet.h"
 #include "MegamorphicCache.h"
 #include "NumberObject.h"
+#include "PinballCompletion.h"
 #include "PreventCollectionScope.h"
 #include "SamplingProfiler.h"
 #include "ShadowChicken.h"
@@ -891,16 +894,17 @@ void Heap::gatherStackRoots(ConservativeRoots& roots)
 #endif
 }
 
-void Heap::gatherScratchBufferRoots(ConservativeRoots& roots)
+void Heap::gatherVMRoots(ConservativeRoots& roots)
 {
-#if ENABLE(DFG_JIT)
-    if (!Options::useJIT())
-        return;
     VM& vm = this->vm();
-    vm.gatherScratchBufferRoots(roots);
-    vm.scanSideState(roots);
-#else
-    UNUSED_PARAM(roots);
+#if ENABLE(DFG_JIT)
+    if (Options::useJIT()) {
+        vm.gatherScratchBufferRoots(roots);
+        vm.scanSideState(roots);
+    }
+#endif
+#if ENABLE(WEBASSEMBLY)
+    vm.gatherEvacuatedStackRoots(roots);
 #endif
 }
 
@@ -3006,7 +3010,7 @@ void Heap::addCoreConstraints()
                 ConservativeRoots conservativeRoots(*this);
 
                 gatherStackRoots(conservativeRoots);
-                gatherScratchBufferRoots(conservativeRoots);
+                gatherVMRoots(conservativeRoots);
 
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::ConservativeScan);
                 visitor.append(conservativeRoots);

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -188,6 +188,10 @@ class Heap;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v) \
+    v(pinballCompletionSpace, destructibleCellHeapCellType, PinballCompletion) \
+    v(pinballHandlerSpace, cellHeapCellType, PinballHandler) \
+    v(promisingFunctionSpace, cellHeapCellType, JSWebAssemblyPromisingFunction) \
+    v(suspendingFunctionSpace, cellHeapCellType, JSWebAssemblySuspendingFunction) \
     v(webAssemblyExceptionSpace, webAssemblyExceptionHeapCellType, JSWebAssemblyException) \
     v(webAssemblyFunctionSpace, webAssemblyFunctionHeapCellType, WebAssemblyFunction) \
     v(webAssemblyGlobalSpace, webAssemblyGlobalHeapCellType, JSWebAssemblyGlobal) \
@@ -738,7 +742,7 @@ private:
     void prepareForMarking();
     
     void gatherStackRoots(ConservativeRoots&);
-    void gatherScratchBufferRoots(ConservativeRoots&);
+    void gatherVMRoots(ConservativeRoots&);
     void beginMarking();
     void visitCompilerWorklistWeakReferences();
     void removeDeadCompilerWorklistEntries();

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1525,6 +1525,277 @@ defineWasmBuiltinTrampoline(jsstring, equals, a2)
 # (externref, externref, wasmInstance) -> i32
 defineWasmBuiltinTrampoline(jsstring, compare, a2)
 
+# Low-level logic for the handling of JSPI futures
+
+# void captureABICalleeSaves(CPURegister* buffer)
+global _captureABICalleeSaves
+_captureABICalleeSaves:
+    functionPrologue()
+    copyCalleeSavesToBuffer(a0)
+    functionEpilogue()
+    ret
+
+# void teleportForJSPI(CPURegister* calleeSaves, CallFrame* returnOutOfFrame, EncodedJSValue result)
+global _teleportForJSPI
+_teleportForJSPI:
+    restoreCalleeSavesFromBuffer(a0)
+    move a1, sp
+    move a2, r0
+    functionEpilogue()
+    ret
+
+# Move $sp down enough to contain an instance of the given struct, ensuring proper alignment.
+macro allocaStruct(structName, temp)
+    move constexpr(sizeof(PinballFulfillContext)), temp
+    addp StackAlignmentMask, temp
+    andp ~StackAlignmentMask, temp
+    subp temp, sp
+end
+
+# a0 = globalObject, a1 = callFrame
+global _enterWebAssemblySuspendingFunction
+_enterWebAssemblySuspendingFunction:
+    functionPrologue()
+    # allocate the callee saves buffer and save them
+    subp 40 * 8, sp # FIXME: use the actual platform number of callee saves
+    copyCalleeSavesToBuffer(sp)
+    move sp, a2
+
+    call _runWebAssemblySuspendingFunction
+
+    restoreCalleeSavesFromBuffer(sp)
+    addp 40 * 8, sp
+    functionEpilogue()
+    ret
+
+# a0 = globalObject, a1 = callFrame
+global  _pinballHandlerFulfillFunction
+_pinballHandlerFulfillFunction:
+    # This is the host function implementing the fulfilling PinballHandler.
+    # Because it needs to engage in invasive stack surgery and register juggling, the core logic is implemented
+    # here in assembly, with calls to C++ functions implementing higher-level "normal" logic.
+    # Execution state is kept on the stack as a struct PinballFulfillContext, and SP always points at it.
+    # Key invariant: SP is stable and not perturbed by any calls we make.
+    functionPrologue()
+    allocaStruct(PinballFulfillContext, t2)
+    # Save all callee saves - wasm will trample over them all
+    leap PinballFulfillContext::cppCalleeSaves[sp], t2
+    copyCalleeSavesToBuffer(t2)
+    move sp, a2 # additional arg to the init call: the context pointer
+    call _pinballHandlerFulfillFunctionInit
+    # Restore callee saves expected by Wasm
+    loadp PinballFulfillContext::evacuatedCalleeSaves[sp], t0
+    restoreCalleeSavesFromBuffer(t0)
+
+.execute:
+    move sp, a0
+    # Push two nulls above the future sentinel frame record in place of callee/codeBlock,
+    # so StackVisitor can enter the sentinel without choking. This avoids extra complexity in StackSlicer.
+    subp 16, sp
+    storep 0, [sp]
+    storep 0, 8[sp]
+    call .execute_evacuated_slice
+    addp 16, sp
+    # Capture all return registers to later pass them on to the next slice. For now we just save all argument registers.
+    forEachWasmArgumentGPR(macro(index, reg1, reg2)
+        if ARM64 or ARM64E
+            storepairq reg1, reg2, index * MachineRegisterSize + PinballFulfillContext::arguments[sp]
+        elsif JSVALUE64
+            storeq reg1, (index + 0) * MachineRegisterSize + PinballFulfillContext::arguments[sp]
+            storeq reg2, (index + 1) * MachineRegisterSize + PinballFulfillContext::arguments[sp]
+        else
+            store2ia reg1, reg2, index * MachineRegisterSize + PinballFulfillContext::arguments[sp]
+        end
+    end)
+    forEachWasmArgumentFPR(macro(index, reg1, reg2)
+        if ARM64 or ARM64E
+            storepaird reg1, reg2, NumberOfWasmArgumentGPRs * MachineRegisterSize + index * FPRRegisterSize + PinballFulfillContext::arguments[sp]
+        else
+            stored reg1, NumberOfWasmArgumentGPRs * MachineRegisterSize + (index + 0) * FPRRegisterSize + PinballFulfillContext::arguments[sp]
+            stored reg2, NumberOfWasmArgumentGPRs * MachineRegisterSize + (index + 1) * FPRRegisterSize + PinballFulfillContext::arguments[sp]
+        end
+    end)
+    # Examine the outcome of last slice execution and proceed accordingly
+    move sp, a0
+    call _pinballHandlerFulfillFunctionContinue
+    btinz r0, .execute
+
+    # Done. At this point the context destructor already executed, but it's still on the stack
+    # and plain old data in its callee saves array is okay to use.
+    leap PinballFulfillContext::cppCalleeSaves[sp], t5
+    restoreCalleeSavesFromBuffer(t5)
+    loadp PinballFulfillContext::arguments[sp], r0
+    move cfr, sp
+    functionEpilogue()
+    ret
+
+.execute_evacuated_slice:
+    # FIXME: sentinel frame should be enhanced to become a proper VM entry frame, registered with the VM as the top entry frame.
+    #
+    # Perform stack surgery to implant the frames from the slice currently in the context onto the execution stack
+    # and kick off their execution. The function sets up multiple frames on the stack (shown in square brackets):
+    #
+    #      ( caller )
+    #   [ sentinel     ]
+    #   [ Wasm Frame N ]
+    #         ...
+    #   [ Wasm Frame 0 ]
+    #   [ return frame ]
+    #
+    # The sentinel frame ensures that SP is reset to its original value when returning from the implanted Wasm frames.
+    # That is essential because the caller expects SP to be stable. Wasm slices include additional "headroom" slots
+    # above the topmost frame record and returning from them does not by itself reset SP to the bottom of the caller.
+    #
+    # After all the surgery, the 'ret' at the end of this function does not return to the caller, it returns to Wasm Frame 0.
+    # Prior to that return we must load argument registers with values expected by the slice.
+    # After all Wasm frame have executed, Wasm Frame N returns to the sentinel which then returns to
+    # the caller (pinballHandlerFulfillFunction).
+
+    # construct the sentinel frame
+    functionPrologue()
+    # Complete the initialization of the active JSPIContext by making the sentinel its limit.
+    leap PinballFulfillContext::jspiContext[a0], t5
+    storep cfr, JSPIContext::limitFrame[t5]
+    # Allocate stack space for the frames to implant and prepare the 4 arguments of the implant call.
+    # a0 = context, already in the register
+    loadp PinballFulfillContext::sliceByteSize[a0], t5
+    subp t5, sp # sliceByteSize is always stack-aligned by construction
+    move sp, a1 # a1 = implantation base
+    move cfr, a2 # a2 = returnFP (the sentinel frame)
+    if ARM64 or ARM64E
+        pcrtoaddr _exit_implanted_slice, a3 # a3 = returnPC
+    else
+        leap _exit_implanted_slice, a3
+    end
+    # Preserve on the stack the arguments buffer ptr (plus another value to pad it to 16 bytes)
+    leap PinballFulfillContext::arguments[a0], t5
+    push t5, a0
+    # Create the return frame
+    functionPrologue()
+    # Create the implanted Wasm frames in the allocated space.
+    call _pinballHandlerFulfillFunctionImplant
+    # The implant function returns the FP and the return PC of Wasm Frame 0 as r0 and r1.
+    # Use these values to link the return frame to return into Wasm Frame 0.
+    # r1 should be signed with the address of the slot just above the current frame record,
+    # which incidentally also holds the pointer to load argument registers from.
+    move cfr, t5
+    addp 2 * MachineRegisterSize, t5
+    tagCodePtr r1, t5
+    if ARM64 or ARM64E
+        storepairq r0, r1, [cfr]
+    else
+        storep r0, [cfr]
+        storep r1, MachineRegisterSize[cfr]
+    end
+    # Restore the arguments buffer ptr, load the return/argument registers and return into Wasm Frame 0.
+    loadp [t5], sc0 # sc0 = arguments buffer
+    forEachWasmArgumentGPR(macro(index, gpr1, gpr2)
+        if ARM64 or ARM64E
+            loadpairq index * MachineRegisterSize[sc0], gpr1, gpr2
+        elsif JSVALUE64
+            loadq (index + 0) * MachineRegisterSize[sc0], gpr1
+            loadq (index + 1) * MachineRegisterSize[sc0], gpr2
+        else
+            load2ia index * MachineRegisterSize[sc0], gpr1, gpr2
+        end
+    end)
+    forEachWasmArgumentFPR(macro(index, fpr1, fpr2)
+        if ARM64 or ARM64E
+            loadpaird NumberOfWasmArgumentGPRs * MachineRegisterSize + index * FPRRegisterSize[sc0], fpr1, fpr2
+        else
+            loadd NumberOfWasmArgumentGPRs * MachineRegisterSize + (index + 0) * FPRRegisterSize[sc0], fpr1
+            loadd NumberOfWasmArgumentGPRs * MachineRegisterSize + (index + 1) * FPRRegisterSize[sc0], fpr2
+        end
+    end)
+    functionEpilogue()
+    ret
+
+op(exit_implanted_slice, macro()
+    move cfr, sp
+    functionEpilogue()
+    ret
+end)
+
+# EncodedJSValue pinballHandlerPropagateException(JSGlobalObject*, PinballHandler*, JSWebAssemblyException*);
+global _pinballHandlerPropagateException
+_pinballHandlerPropagateException:
+    functionPrologue()
+    allocaStruct(PinballUnwindContext, t5)
+    # Save all callee saves - wasm will trample over them all
+    leap PinballUnwindContext::cppCalleeSaves[sp], t5
+    copyCalleeSavesToBuffer(t5)
+    move sp, a3 # additional arg to the init call: the context pointer
+    call _pinballHandlerUnwindInit
+    # Restore callee saves expected by Wasm
+    loadp PinballUnwindContext::evacuatedCalleeSaves[sp], t0
+    restoreCalleeSavesFromBuffer(t0)
+    # from this point on, wasmInstance is valid
+    move sp, a0
+    move wasmInstance, a1
+    call _pinballHandlerUnwindInitWasm
+
+    move sp, a0
+    loadp PinballUnwindContext::zombieFrameCallee[sp], sc0
+    subp 32, sp
+    storep 0, [sp]
+    storep sc0, 8[sp]
+    # preserve sc0 past this point until another store in .unwind_evacuated_slice
+    call .unwind_evacuated_slice
+    addp 32, sp
+
+    move cfr, sp
+    functionEpilogue()
+    ret
+
+.unwind_evacuated_slice:
+    functionPrologue()
+    # Allocate stack space for the frames to implant and prepare the 4 arguments of the implant call.
+    # a0 = context, already in the register
+    loadp PinballUnwindContext::sliceByteSize[a0], t5
+    subp t5, sp # sliceByteSize is always stack-aligned by construction
+    move sp, a1 # a1 = implantation base
+    move cfr, a2 # a2 = returnFP (the sentinel frame)
+    if ARM64 or ARM64E
+        pcrtoaddr _exit_implanted_slice, a3 # a3 = returnPC
+    else
+        leap _exit_implanted_slice, a3
+    end
+    # Create a fake throwing frame, with a zombie callee and a null codeblock
+    subp 32, sp
+    storep 0, [sp]
+    storep sc0, 8[sp]
+    functionPrologue()
+    push a0, a0 # we'll need the context again later
+    # Create the implanted Wasm frames in the allocated space.
+    call _pinballHandlerUnwindImplant
+
+    move cfr, t5
+    addp 2 * MachineRegisterSize, t5
+    tagCodePtr r1, t5
+    if ARM64 or ARM64E
+        storepairq r0, r1, [cfr]
+    else
+        storep r0, [cfr]
+        storep r1, MachineRegisterSize[cfr]
+    end
+
+    # CLARIFY: this makes it not collect the stack trace, but should we?
+    loadp JSWebAssemblyInstance::m_vm[wasmInstance], t5
+    storep 0, VM::topCallFrame[t5]
+
+    pop a0, a1 # a0 = context
+    # loadi PinballUnwindContext::exceptionIndex[a0], a3
+    # move wasmInstance, a0
+    # move cfr, a1
+    # move sp, a2
+
+    loadp PinballUnwindContext::exception[a0], t4
+    storep t4, VM::m_exception[t5]
+
+    jmp _wasm_unwind_from_slow_path_trampoline
+    # operationCall(macro() cCall4(_ipint_extern_throw_exception) end)
+    # jumpToException()
+
 
 #################################
 # 5. Instruction implementation #

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -61,6 +61,7 @@
 #include "MarkedSpace.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "NativeExecutable.h"
+#include "PinballCompletion.h"
 #include "PrivateFieldPutKind.h"
 #include "ProtoCallFrame.h"
 #include "PutByIdFlags.h"

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1047,60 +1047,64 @@ macro forEachFPCalleeSave(func)
     end
 end
 
+macro copyCalleeSavesToBuffer(buffer)
+    if ARM64 or ARM64E
+        storepairq csr0, csr1, [buffer]
+        storepairq csr2, csr3, 16[buffer]
+        storepairq csr4, csr5, 32[buffer]
+        storepairq csr6, csr7, 48[buffer]
+        storepairq csr8, csr9, 64[buffer]
+        storepaird csfr0, csfr1, 80[buffer]
+        storepaird csfr2, csfr3, 96[buffer]
+        storepaird csfr4, csfr5, 112[buffer]
+        storepaird csfr6, csfr7, 128[buffer]
+    elsif X86_64
+        storeq csr0, [buffer]
+        storeq csr1, 8[buffer]
+        storeq csr2, 16[buffer]
+        storeq csr3, 24[buffer]
+        storeq csr4, 32[buffer]
+    elsif ARMv7
+        storep csr0, [buffer]
+        storep csr1, 4[buffer]
+        stored csfr0, 8[buffer]
+        stored csfr1, 16[buffer]
+        stored csfr2, 24[buffer]
+        stored csfr3, 32[buffer]
+        stored csfr4, 40[buffer]
+        stored csfr5, 48[buffer]
+    elsif RISCV64
+        storep csr0, [buffer]
+        storep csr1, 8[buffer]
+        storep csr2, 16[buffer]
+        storep csr3, 24[buffer]
+        storep csr4, 32[buffer]
+        storep csr5, 40[buffer]
+        storep csr6, 48[buffer]
+        storep csr7, 56[buffer]
+        storep csr8, 64[buffer]
+        storep csr9, 72[buffer]
+        storep csr10, 80[buffer]
+        stored csfr0, 88[buffer]
+        stored csfr1, 96[buffer]
+        stored csfr2, 104[buffer]
+        stored csfr3, 112[buffer]
+        stored csfr4, 120[buffer]
+        stored csfr5, 128[buffer]
+        stored csfr6, 136[buffer]
+        stored csfr7, 144[buffer]
+        stored csfr8, 152[buffer]
+        stored csfr9, 160[buffer]
+        stored csfr10, 168[buffer]
+        stored csfr11, 176[buffer]
+    end
+end
+
 macro copyCalleeSavesToEntryFrameCalleeSavesBuffer(entryFrame)
     if ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64
         vmEntryRecord(entryFrame, entryFrame)
         leap VMEntryRecord::calleeSaveRegistersBuffer[entryFrame], entryFrame
-        if ARM64 or ARM64E
-            storepairq csr0, csr1, [entryFrame]
-            storepairq csr2, csr3, 16[entryFrame]
-            storepairq csr4, csr5, 32[entryFrame]
-            storepairq csr6, csr7, 48[entryFrame]
-            storepairq csr8, csr9, 64[entryFrame]
-            storepaird csfr0, csfr1, 80[entryFrame]
-            storepaird csfr2, csfr3, 96[entryFrame]
-            storepaird csfr4, csfr5, 112[entryFrame]
-            storepaird csfr6, csfr7, 128[entryFrame]
-        elsif X86_64
-            storeq csr0, [entryFrame]
-            storeq csr1, 8[entryFrame]
-            storeq csr2, 16[entryFrame]
-            storeq csr3, 24[entryFrame]
-            storeq csr4, 32[entryFrame]
-        elsif ARMv7
-            storep csr0, [entryFrame]
-            storep csr1, 4[entryFrame]
-            stored csfr0, 8[entryFrame]
-            stored csfr1, 16[entryFrame]
-            stored csfr2, 24[entryFrame]
-            stored csfr3, 32[entryFrame]
-            stored csfr4, 40[entryFrame]
-            stored csfr5, 48[entryFrame]
-        elsif RISCV64
-            storep csr0, [entryFrame]
-            storep csr1, 8[entryFrame]
-            storep csr2, 16[entryFrame]
-            storep csr3, 24[entryFrame]
-            storep csr4, 32[entryFrame]
-            storep csr5, 40[entryFrame]
-            storep csr6, 48[entryFrame]
-            storep csr7, 56[entryFrame]
-            storep csr8, 64[entryFrame]
-            storep csr9, 72[entryFrame]
-            storep csr10, 80[entryFrame]
-            stored csfr0, 88[entryFrame]
-            stored csfr1, 96[entryFrame]
-            stored csfr2, 104[entryFrame]
-            stored csfr3, 112[entryFrame]
-            stored csfr4, 120[entryFrame]
-            stored csfr5, 128[entryFrame]
-            stored csfr6, 136[entryFrame]
-            stored csfr7, 144[entryFrame]
-            stored csfr8, 152[entryFrame]
-            stored csfr9, 160[entryFrame]
-            stored csfr10, 168[entryFrame]
-            stored csfr11, 176[entryFrame]
-        end
+        copyCalleeSavesToBuffer(entryFrame)
     end
 end
 
@@ -1111,61 +1115,65 @@ macro copyCalleeSavesToVMEntryFrameCalleeSavesBuffer(vm, temp)
     end
 end
 
+macro restoreCalleeSavesFromBuffer(buffer)
+    if ARM64 or ARM64E
+        loadpairq [buffer], csr0, csr1
+        loadpairq 16[buffer], csr2, csr3
+        loadpairq 32[buffer], csr4, csr5
+        loadpairq 48[buffer], csr6, csr7
+        loadpairq 64[buffer], csr8, csr9
+        loadpaird 80[buffer], csfr0, csfr1
+        loadpaird 96[buffer], csfr2, csfr3
+        loadpaird 112[buffer], csfr4, csfr5
+        loadpaird 128[buffer], csfr6, csfr7
+    elsif X86_64
+        loadq [buffer], csr0
+        loadq 8[buffer], csr1
+        loadq 16[buffer], csr2
+        loadq 24[buffer], csr3
+        loadq 32[buffer], csr4
+    elsif ARMv7
+        loadp [buffer], csr0
+        loadp 4[buffer], csr1
+        loadd 8[buffer], csfr0
+        loadd 16[buffer], csfr1
+        loadd 24[buffer], csfr2
+        loadd 32[buffer], csfr3
+        loadd 40[buffer], csfr4
+        loadd 48[buffer], csfr5
+    elsif RISCV64
+        loadq [buffer], csr0
+        loadq 8[buffer], csr1
+        loadq 16[buffer], csr2
+        loadq 24[buffer], csr3
+        loadq 32[buffer], csr4
+        loadq 40[buffer], csr5
+        loadq 48[buffer], csr6
+        loadq 56[buffer], csr7
+        loadq 64[buffer], csr8
+        loadq 72[buffer], csr9
+        loadq 80[buffer], csr10
+        loadd 88[buffer], csfr0
+        loadd 96[buffer], csfr1
+        loadd 104[buffer], csfr2
+        loadd 112[buffer], csfr3
+        loadd 120[buffer], csfr4
+        loadd 128[buffer], csfr5
+        loadd 136[buffer], csfr6
+        loadd 144[buffer], csfr7
+        loadd 152[buffer], csfr8
+        loadd 160[buffer], csfr9
+        loadd 168[buffer], csfr10
+        loadd 176[buffer], csfr11
+    end
+end
+
 macro restoreCalleeSavesFromVMEntryFrameCalleeSavesBuffer(vm, temp)
     if ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64
         loadp VM::topEntryFrame[vm], temp
         vmEntryRecord(temp, temp)
         leap VMEntryRecord::calleeSaveRegistersBuffer[temp], temp
-        if ARM64 or ARM64E
-            loadpairq [temp], csr0, csr1
-            loadpairq 16[temp], csr2, csr3
-            loadpairq 32[temp], csr4, csr5
-            loadpairq 48[temp], csr6, csr7
-            loadpairq 64[temp], csr8, csr9
-            loadpaird 80[temp], csfr0, csfr1
-            loadpaird 96[temp], csfr2, csfr3
-            loadpaird 112[temp], csfr4, csfr5
-            loadpaird 128[temp], csfr6, csfr7
-        elsif X86_64
-            loadq [temp], csr0
-            loadq 8[temp], csr1
-            loadq 16[temp], csr2
-            loadq 24[temp], csr3
-            loadq 32[temp], csr4
-        elsif ARMv7
-            loadp [temp], csr0
-            loadp 4[temp], csr1
-            loadd 8[temp], csfr0
-            loadd 16[temp], csfr1
-            loadd 24[temp], csfr2
-            loadd 32[temp], csfr3
-            loadd 40[temp], csfr4
-            loadd 48[temp], csfr5
-        elsif RISCV64
-            loadq [temp], csr0
-            loadq 8[temp], csr1
-            loadq 16[temp], csr2
-            loadq 24[temp], csr3
-            loadq 32[temp], csr4
-            loadq 40[temp], csr5
-            loadq 48[temp], csr6
-            loadq 56[temp], csr7
-            loadq 64[temp], csr8
-            loadq 72[temp], csr9
-            loadq 80[temp], csr10
-            loadd 88[temp], csfr0
-            loadd 96[temp], csfr1
-            loadd 104[temp], csfr2
-            loadd 112[temp], csfr3
-            loadd 120[temp], csfr4
-            loadd 128[temp], csfr5
-            loadd 136[temp], csfr6
-            loadd 144[temp], csfr7
-            loadd 152[temp], csfr8
-            loadd 160[temp], csfr9
-            loadd 168[temp], csfr10
-            loadd 176[temp], csfr11
-        end
+        restoreCalleeSavesFromBuffer(temp)
     end
 end
 

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
@@ -1,0 +1,469 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EvacuatedStack.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSWebAssemblyPromisingFunction.h"
+#include "NativeCallee.h"
+#include "WasmCallee.h"
+
+namespace JSC {
+
+std::unique_ptr<EvacuatedStackSlice> EvacuatedStackSlice::create(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const void* entryPC)
+{
+    ASSERT(stackSpan.size());
+    return std::unique_ptr<EvacuatedStackSlice> {
+        new (NotNull, fastMalloc(Base::allocationSize(stackSpan.size()))) EvacuatedStackSlice(stackSpan, WTFMove(frameOffsets), entryPC)
+    };
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+CallFrame* EvacuatedStackSlice::implant(Register* base, CallFrame* lastFrame, void* returnPC)
+{
+    memcpySpan(std::span<Register>(base, size()), slots());
+    for (unsigned i = m_frameOffsets.size(); i > 0; --i) {
+        bool isTopFrame = i == m_frameOffsets.size();
+        unsigned offset = m_frameOffsets[i - 1];
+        CallerFrameAndPC* frameRecord = reinterpret_cast<CallerFrameAndPC*>(base + offset);
+        // Fix the caller frame pointer
+        frameRecord->callerFrame = lastFrame;
+        // Resign the return address for the new position
+        void* resignedAddr = nullptr;
+#if CPU(ARM64E)
+        if (isTopFrame) {
+            // The returnPC passed in as an argument is a label address signed by Clang using asia and a magic value of 0x590c as the discriminator.
+            auto unsignedAddr = ptrauth_strip(returnPC, 0);
+            auto discriminator = frameRecord + 1;
+            resignedAddr = ptrauth_sign_unauthenticated(unsignedAddr, ptrauth_key_asib, discriminator);
+        } else {
+            auto discriminatorFrom = &first() + offset;
+            auto discriminatorTo = frameRecord + 1;
+            resignedAddr = ptrauth_auth_and_resign(frameRecord->returnPC, ptrauth_key_asib, discriminatorFrom, ptrauth_key_asib, discriminatorTo);
+        }
+#else
+        resignedAddr = returnPC;
+        UNUSED_VARIABLE(isTopFrame);
+#endif
+        frameRecord->returnPC = resignedAddr;
+        lastFrame = static_cast<CallFrame*>(static_cast<void*>(frameRecord));
+    }
+    return lastFrame;
+}
+
+// Called during slice creation to resign all return PCs in the saved data. The signing
+// discriminator is the address of the frame record itself. This is not how it works in
+// a live frame, but the saved data is not used as a live frame.
+void EvacuatedStackSlice::reauthenticateReturnPCs(const Register* originalBottom)
+{
+#if CPU(ARM64E)
+    Register* copiedBottom = &first();
+    for (unsigned offset : m_frameOffsets) {
+        CallerFrameAndPC* frameRecord = reinterpret_cast<CallerFrameAndPC*>(copiedBottom + offset);
+        const Register* signatureSP = originalBottom + offset + 2;
+        frameRecord->returnPC = ptrauth_auth_and_resign(frameRecord->returnPC, ptrauth_key_asib, signatureSP, ptrauth_key_asib, frameRecord);
+    }
+#else
+    UNUSED_PARAM(originalBottom);
+#endif
+}
+
+void EvacuatedStackSlice::dump(PrintStream& out) const
+{
+    out.print("EvacuatedStackSlice{ size: ", size());
+    out.print(" frame offsets: [");
+    CommaPrinter comma;
+    for (auto offset : m_frameOffsets)
+        out.print(comma, offset);
+    out.print("]");
+    out.print(", entryPC=", RawPointer(m_entryPC), " }");
+}
+
+static const Register* topOfFrame(const CallFrame* callFrame)
+{
+    // We include a few extra slots above the frame record via the
+    // headroomSlotCount parameter of StackSlicer::evacuatePendingSlice, but we still count
+    // the frame record as the real top of Wasm frames and the bottom of the next frame.
+    CalleeBits calleeBits = callFrame->callee();
+    if (calleeBits.isNativeCallee()) {
+        auto* nativeCallee = calleeBits.asNativeCallee();
+        ASSERT(nativeCallee->category() == NativeCallee::Category::Wasm);
+        auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+
+        switch (wasmCallee->compilationMode()) {
+        case Wasm::CompilationMode::WasmToJSMode:
+        case Wasm::CompilationMode::IPIntMode:
+        case Wasm::CompilationMode::BBQMode:
+        case Wasm::CompilationMode::OMGMode:
+            return callFrame->registers() + 2;
+        case Wasm::CompilationMode::JSToWasmMode:
+            return callFrame->registers() + static_cast<size_t>(CallFrameSlot::firstArgument) + callFrame->argumentCount();
+        default:
+            RELEASE_ASSERT_NOT_REACHED(); // case not accounted for
+        }
+    } else {
+        // Assuming a JSFunction callee with a well-formed frame.
+        return callFrame->registers() + static_cast<size_t>(CallFrameSlot::firstArgument) + callFrame->argumentCount();
+    }
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+static std::optional<Wasm::CompilationMode> compilationModeOfCallee(CalleeBits calleeBits)
+{
+    if (!calleeBits.isNativeCallee())
+        return std::nullopt;
+    auto* nativeCallee = calleeBits.asNativeCallee();
+    if (nativeCallee->category() != NativeCallee::Category::Wasm)
+        return std::nullopt;
+    auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+    return wasmCallee->compilationMode();
+}
+
+// We save this many extra slots above the actual frame record (the fp/lr pair) of a Wasm
+// frame because IPInt stores register values there before a call. This value used to be
+// conditional based on the frame type but it appears tiering up breaks without a
+// consistent headroom.
+constexpr unsigned StandardHeadroom = 8;
+
+void StackSlicerBase::commitPendingSliceWithAdditionalFrame(CallFrame* callFrame)
+{
+    m_futureSliceTop = topOfFrame(callFrame);
+    m_pendingFrameRecords.append(callFrame);
+    m_lastVisitedFrame = callFrame;
+    commitPendingSlice();
+}
+
+void StackSlicerBase::commitPendingSlice()
+{
+    auto slice = evacuatePendingSlice(StandardHeadroom);
+    m_slices.append(WTFMove(slice));
+    m_futureSliceBottom = nullptr;
+    m_futureSliceTop = nullptr;
+    m_futureReturnPC = nullptr;
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+std::unique_ptr<EvacuatedStackSlice> StackSlicerBase::evacuatePendingSlice(unsigned headroomSlotCount)
+{
+    ASSERT(m_futureSliceBottom);
+    ASSERT(m_futureSliceTop);
+    ASSERT(m_futureReturnPC);
+    ASSERT(!m_pendingFrameRecords.isEmpty());
+
+    Vector<unsigned> frameOffsets;
+    for (auto* callFrame : m_pendingFrameRecords) {
+        unsigned frameOffset = callFrame->registers() - m_futureSliceBottom;
+        frameOffsets.append(frameOffset);
+    }
+
+    std::span<Register> span(const_cast<Register*>(m_futureSliceBottom), m_futureSliceTop - m_futureSliceBottom + headroomSlotCount);
+    auto result = EvacuatedStackSlice::create(span, WTFMove(frameOffsets), m_futureReturnPC);
+    result->reauthenticateReturnPCs(m_futureSliceBottom);
+    m_pendingFrameRecords.clear();
+    m_futureReturnPC = nullptr;
+    return result;
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+Vector<std::unique_ptr<EvacuatedStackSlice>> StackSlicerBase::reverseAndTakeSlices()
+{
+    m_slices.reverse();
+    return WTFMove(m_slices);
+}
+
+/*
+    Slicing Strategies Overview
+
+    Before slicing (always initiated by a Suspending function), the stack is in one of the
+    following configurations, as indicated by the value of JSPIContext::purpose of
+    vmTopJSPIContext (Promising vs Completing). There is always one or more Wasm frames
+    (IPInt, BBQ, or OMG) between JSToWasm and WasmToJS frames. The position of
+    JSPIContext::limitFrame is indicated by an arrow. Higher addresses/older calls are on
+    top.
+
+    Promising stack configuration:
+
+    ->  Promising
+        JSToWasm
+        Wasm +
+        WasmToJS
+        Suspending
+
+    Completing stack configuration. The JSToWasm frame is shown in brackets to indicate
+    that it may or may not be present, depending on whether the slice is from the
+    (logical) bottom of the original stack or not. WasmToJS frame is always present
+    because slicing is always initiated by a Suspending function, reached by Wasm via
+    a WasmToJSFrame.
+
+        PinballHandlerFulfillFunction
+    ->  Sentinel
+        [JSToWasm]
+        Wasm +
+        WasmToJS
+        Suspending
+
+    SlabSlicer simply walks the stack until it reaches the limit frame, noting frame
+    positions. It then saves as a single slice all frames from WasmToJS and up to but not
+    including the limit frame.
+
+    FragSlicer combines a JSToWasm and WasmToJS frame with an adjacent Wasm frame into
+    one slice. If there is only one Wasm frame, it and the adjacent WasmToJS and JSToWasm
+    frames are combined into a single slice.
+
+    Stack walk begins at a Suspending frame, and FragSlicer goes through the following
+    sequence of states:
+
+        Initial - expecting a Suspending frame
+        ScannedSuspending - expecting a WasmToJS frame
+        ScannedWasmToJS - expecting a Wasm frame
+        ScanningWasm - scanned a Wasm frame, expecting one of: Wasm, JSToWasm, limitFrame (Promising or Sentinel)
+
+    The first three states are traversed sequentially. Once the ScanningWasm state is
+    reached, the slicer may remain in it for a while as more Wasm frames are visited. If a
+    JSToWasmFrame is encountered in this state, the slicer switches to the ScannedJSToWasm
+    state. Once in ScannedJSToWasm state, the next visited frame must be the limit frame.
+    Limit frame may also be encountered while in ScanningWasm state without an intervening
+    JSToWasm state, but that is only valid when JSPIContext::purpose is Completing.
+    With Promising purpose, a limit frame must always be preceded by a JSToWasm frame.
+
+    Once limitFrame is reached, the walk is complete.
+*/
+
+IterationStatus SlabSlicer::step(VM& vm, StackVisitor& visitor)
+{
+    CallFrame* callFrame = visitor->callFrame();
+    auto compilationMode = compilationModeOfCallee(visitor->callee());
+
+    if (callFrame == m_lastVisitedFrame) {
+        // Inlining causes apparently the same frame to be visited multiple times.
+        // These additional visits do not affect the slicing decisions.
+        return IterationStatus::Continue;
+    }
+
+    JSPIContext* context = vm.topJSPIContext;
+    bool inPromisingContext = context->purpose == JSPIContext::Purpose::Promising;
+
+    if (callFrame == context->limitFrame) {
+        if (m_state == State::ScannedJSToWasm || (m_state == State::Scanning && !inPromisingContext)) {
+            m_futureSliceTop = topOfFrame(m_lastVisitedFrame);
+            commitPendingSlice();
+            m_state = State::Success;
+        } else {
+            m_errorMessage = "JSPI stack scan reached the limit frame unexpectedly"_s;
+            m_state = State::Failure;
+        }
+        m_teleportFrame = const_cast<CallFrame*>(m_lastVisitedFrame);
+        return IterationStatus::Done;
+    }
+
+    switch (m_state) {
+    case State::Initial: {
+        if (!compilationMode) {
+            m_futureSliceBottom = topOfFrame(callFrame);
+#if CPU(ARM64E)
+            m_futureReturnPC = ptrauth_strip(callFrame->rawReturnPC(), 0);
+#else
+            m_futureReturnPC = callFrame->rawReturnPC();
+#endif
+            m_state = State::Scanning;
+        } else {
+            m_errorMessage = "expected suspending frame not found"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::Scanning: {
+        if (compilationMode.has_value()) {
+            switch (*compilationMode) {
+            case Wasm::CompilationMode::WasmToJSMode:
+            case Wasm::CompilationMode::IPIntMode:
+            case Wasm::CompilationMode::BBQMode:
+            case Wasm::CompilationMode::OMGMode: {
+                m_pendingFrameRecords.append(callFrame);
+                break;
+            }
+            case Wasm::CompilationMode::JSToWasmMode: {
+                m_pendingFrameRecords.append(callFrame);
+                m_state = State::ScannedJSToWasm;
+                break;
+            }
+            default: {
+                m_errorMessage = "encountered an unrecognized type of Wasm frame"_s;
+                m_state = State::Failure;
+            }
+            }
+        } else { // no compilationMode - a JS frame
+            m_errorMessage = "encountered an unexpected non-Wasm frame"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ScannedJSToWasm: {
+        m_errorMessage = "unexpected frames after seeing a JSToWasmFrame"_s;
+        m_state = State::Failure;
+        break;
+    }
+    default: {
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    }
+
+    m_lastVisitedFrame = callFrame;
+    if (m_state == State::Failure)
+        return IterationStatus::Done;
+    return IterationStatus::Continue;
+}
+
+IterationStatus FragSlicer::step(VM& vm, StackVisitor& visitor)
+{
+    CallFrame* callFrame = visitor->callFrame();
+    auto compilationMode = compilationModeOfCallee(visitor->callee());
+
+    if (callFrame == m_lastVisitedFrame) {
+        // Inlining causes apparently the same frame to be visited multiple times.
+        // These additional visits do not affect the slicing decisions.
+        return IterationStatus::Continue;
+    }
+
+    JSPIContext* context = vm.topJSPIContext;
+    bool inPromisingContext = context->purpose == JSPIContext::Purpose::Promising;
+
+    if (callFrame == context->limitFrame) {
+        if (m_state == State::ScannedJSToWasm) {
+            m_state = State::Success;
+        } else if (m_state == State::ScanningWasm && !inPromisingContext) {
+            commitPendingSlice();
+            m_state = State::Success;
+        } else {
+            m_errorMessage = "JSPI stack scan reached the limit frame unexpectedly"_s;
+            m_state = State::Failure;
+        }
+        m_teleportFrame = const_cast<CallFrame*>(m_lastVisitedFrame);
+        return IterationStatus::Done;
+    }
+
+    switch (m_state) {
+    case State::Initial: {
+        if (!compilationMode) {
+            m_futureSliceBottom = topOfFrame(callFrame);
+#if CPU(ARM64E)
+            m_futureReturnPC = ptrauth_strip(callFrame->rawReturnPC(), 0);
+#else
+            m_futureReturnPC = callFrame->rawReturnPC();
+#endif
+            m_state = State::ScannedSuspending;
+        } else {
+            m_errorMessage = "expected suspending frame not found"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ScannedSuspending: {
+        if (compilationMode == Wasm::CompilationMode::WasmToJSMode) {
+            ASSERT(m_futureReturnPC);
+            m_pendingFrameRecords.append(callFrame);
+            m_state = State::ScannedWasmToJS;
+        } else {
+            m_errorMessage = "suspending frame not followed by a WasmToJS frame as expected"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ScannedWasmToJS: {
+        if (compilationMode == Wasm::CompilationMode::IPIntMode
+            || compilationMode == Wasm::CompilationMode::BBQMode
+            || compilationMode == Wasm::CompilationMode::OMGMode
+        ) {
+            ASSERT(m_futureSliceBottom && m_futureReturnPC);
+            m_futureSliceTop = topOfFrame(callFrame);
+            m_pendingFrameRecords.append(callFrame);
+            m_state = State::ScanningWasm;
+        } else {
+            m_errorMessage = "a WasmToJSFrame not followed by a recognized Wasm frame"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ScanningWasm: {
+        if (compilationMode.has_value()) {
+            switch (*compilationMode) {
+            case Wasm::CompilationMode::IPIntMode:
+            case Wasm::CompilationMode::BBQMode:
+            case Wasm::CompilationMode::OMGMode: {
+                // commit the pending slice and start a new pending from the bottom of this frame
+                void* nextReturnPC = m_pendingFrameRecords.last()->rawReturnPC();
+                auto* nextBottom = m_futureSliceTop;
+                commitPendingSlice();
+                m_futureSliceBottom = nextBottom;
+                m_futureSliceTop = topOfFrame(callFrame);
+#if CPU(ARM64E)
+                m_futureReturnPC = ptrauth_strip(nextReturnPC, 0);
+#else
+                m_futureReturnPC = nextReturnPC;
+#endif
+                m_pendingFrameRecords.append(callFrame);
+                break;
+            }
+            case Wasm::CompilationMode::JSToWasmMode: {
+                commitPendingSliceWithAdditionalFrame(callFrame);
+                m_state = State::ScannedJSToWasm;
+                break;
+            }
+            default: {
+                m_errorMessage = "encountered an unrecognized type of Wasm frame"_s;
+                m_state = State::Failure;
+            }
+            }
+        } else { // no compilationMode - a JS frame
+            m_errorMessage = "encountered an unexpected non-Wasm frame"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ScannedJSToWasm: {
+        m_errorMessage = "unexpected frames after seeing a JSToWasmFrame"_s;
+        m_state = State::Failure;
+        break;
+    }
+    default: {
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    }
+
+    m_lastVisitedFrame = callFrame;
+    if (m_state == State::Failure)
+        return IterationStatus::Done;
+    return IterationStatus::Continue;
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.h
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/Register.h>
+#include <JavaScriptCore/VMEntryRecord.h>
+
+#include <wtf/TrailingArray.h>
+#include <wtf/Vector.h>
+
+namespace JSC {
+
+// A fragment of of the main execution stack copied to the heap as a unit. A slice may
+// include one or more frames. In addition to the actual data copied from the stack, it
+// carries a "map" of the copied data that will allow us to install the slice back onto
+// the execution stack and kick off the execution of the top (logical top, i.e. most
+// recently executed) frame. Instances are created by StackSlicer.
+class EvacuatedStackSlice final : public TrailingArray<EvacuatedStackSlice, Register> {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EvacuatedStackSlice);
+    friend class LLIntOffsetsExtractor;
+public:
+    using Base = TrailingArray<EvacuatedStackSlice, Register>;
+
+    static std::unique_ptr<EvacuatedStackSlice> create(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const void* entryPC);
+
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    std::span<Register> slots() { return { &first(), size() }; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    // Offsets of frame records in the trailing array data, in units of Register size.
+    // Ordered from most to least recently executed frames (increasing offset values).
+    const Vector<unsigned>& frameOffsets() const { return m_frameOffsets; }
+
+    // Copy the stack data captured by this instance to the memory location identified by
+    // 'base' and prepare it for execution by relocating all internal pointers. Link the
+    // topmost (physically, deepest logically) frame to return to the specified
+    // 'previousFrame' and 'returnPC'. Return the FP of the bottommost implanted frame.
+    CallFrame* implant(Register* base, CallFrame* previousFrame, void* returnPC);
+
+    // The address to go to to start executing this slice after it's been implanted.
+    // SP must be set to the base and FP to the value returned by implant().
+    const void* entryPC() const;
+
+    void dump(PrintStream& out) const;
+
+private:
+    friend class StackSlicerBase;
+
+    EvacuatedStackSlice(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const void* entryPC);
+
+    void reauthenticateReturnPCs(const Register* originalBottom);
+
+    Vector<unsigned> m_frameOffsets;
+    const void* m_entryPC;
+};
+
+inline EvacuatedStackSlice::EvacuatedStackSlice(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const void* entryPC)
+    : Base(stackSpan.size())
+    , m_frameOffsets(WTFMove(frameOffsets))
+#if CPU(ARM64E)
+    , m_entryPC(ptrauth_sign_unauthenticated(entryPC, ptrauth_key_asib, this))
+#else
+    , m_entryPC(entryPC)
+#endif
+{
+    memcpySpan(slots(), stackSpan);
+}
+
+inline const void* EvacuatedStackSlice::entryPC() const
+{
+#if CPU(ARM64E)
+    return ptrauth_auth_data(m_entryPC, ptrauth_key_asib, this);
+#else
+    return m_entryPC;
+#endif
+}
+
+// An abstract class with a set of utilities for implementing a concrete stack slicer.
+// A stack slicer is a class driven by a StackVisitor via a StackSlicerFunctor. It
+// walks the stack from a Suspending frame to a Promising or PinballHandler frame and
+// moves the frames to the heap as a series of EvacuatedStackSlices. A concrete slicer
+// class determines the policy of how exactly the frames on the stack are grouped into
+// slices.
+class StackSlicerBase {
+public:
+    const String& errorMessage() const { return m_errorMessage; }
+    const Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() const { return m_slices; }
+
+    // Return the accumulated slices in the order from top to bottom (least recently to
+    // most recently executed). This places the first slice to execute at the end of the
+    // vector, and the vector acts as a stack with pop=takeLast() and push=append().
+    Vector<std::unique_ptr<EvacuatedStackSlice>> reverseAndTakeSlices();
+
+    // The frame to return into to skip over the evacuated stack slices.
+    CallFrame* teleportFrame() const { return m_teleportFrame; }
+
+protected:
+    // Create a slice for the stack area identified by the future bottom and top pointers.
+    // Include extra 'headroomSlotCount' registers above the actual frame top pointer.
+    // The amount of the headroom is dictated by the frame callee.
+    std::unique_ptr<EvacuatedStackSlice> evacuatePendingSlice(unsigned headroomSlotCount);
+    void commitPendingSliceWithAdditionalFrame(CallFrame*);
+    void commitPendingSlice();
+
+    String m_errorMessage { "?"_s };
+    Vector<std::unique_ptr<EvacuatedStackSlice>> m_slices;
+    const CallFrame* m_lastVisitedFrame { nullptr };
+    const Register* m_futureSliceBottom { nullptr };
+    const Register* m_futureSliceTop { nullptr };
+    const void* m_futureReturnPC { nullptr }; // with auth stripped
+    Vector<CallFrame*> m_pendingFrameRecords;
+    CallFrame* m_teleportFrame;
+};
+
+template<typename T>
+concept ConcreteStackSlicer =
+    std::derived_from<T, StackSlicerBase>
+    && requires(T& t, VM& vm, StackVisitor& sv) {
+        // IterationStatus step(VM&, StackVisitor&);
+        { t.step(vm, sv) } -> std::same_as<IterationStatus>;
+    };
+
+// A concrete stack slicer that evacuates the stack as a single slice
+// containing all interesting frames.
+class SlabSlicer : public StackSlicerBase {
+public:
+    IterationStatus step(VM&, StackVisitor&);
+
+    bool succeeded() const { return m_state == State::Success; }
+
+private:
+    enum class State {
+        Initial,
+        Scanning,
+        ScannedJSToWasm,
+        Success,
+        Failure
+    };
+
+    State m_state { State::Initial };
+};
+
+// A concrete stack slicer that evacuates the stack such that each Wasm frame
+// gets a slice of its own, except for the topmost and bottommost Wasm frames
+// which are combined with the adjacent WasmToJS and JSToWasm frames.
+class FragSlicer : public StackSlicerBase {
+public:
+    IterationStatus step(VM&, StackVisitor&);
+
+    bool succeeded() const { return m_state == State::Success; }
+
+private:
+    enum class State {
+        Initial,
+        ScannedSuspending,
+        ScannedWasmToJS,
+        ScanningWasm,
+        ScannedJSToWasm,
+        Success,
+        Failure
+    };
+
+    State m_state { State::Initial };
+};
+
+// A functor given to the standard StackVisitor to drive a concrete stack slicer.
+template<ConcreteStackSlicer Slicer>
+class StackSlicerFunctor : UnwindFunctorBase {
+public:
+    StackSlicerFunctor(VM& vm, Slicer& scanner)
+        : UnwindFunctorBase(vm)
+        , m_scanner(scanner)
+    { }
+
+    IterationStatus operator() (StackVisitor&) const;
+
+private:
+    Slicer& m_scanner;
+};
+
+
+template <ConcreteStackSlicer Slicer>
+IterationStatus StackSlicerFunctor<Slicer>::operator() (StackVisitor& visitor) const
+{
+    visitor.unwindToMachineCodeBlockFrame();
+
+    IterationStatus result = m_scanner.step(m_vm, visitor);
+
+    if (result == IterationStatus::Continue) {
+        auto* currentFrame = visitor->callFrame();
+        JSGlobalObject* lexicalGlobalObject = currentFrame->lexicalGlobalObject(m_vm);
+        notifyDebuggerOfUnwinding(lexicalGlobalObject, currentFrame);
+        copyCalleeSavesToEntryFrameCalleeSavesBuffer(visitor);
+    }
+    return result;
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -199,6 +199,7 @@
 #include "JSWebAssemblyModule.h"
 #include "JSWebAssemblyRuntimeError.h"
 #include "JSWebAssemblyStruct.h"
+#include "JSWebAssemblySuspendingFunction.h"
 #include "JSWebAssemblyTable.h"
 #include "JSWebAssemblyTag.h"
 #include "JSWithScope.h"
@@ -226,6 +227,7 @@
 #include "ObjectPropertyChangeAdaptiveWatchpoint.h"
 #include "ObjectPropertyConditionSet.h"
 #include "ObjectPrototypeInlines.h"
+#include "PinballCompletion.h"
 #include "ProfilerSupport.h"
 #include "ProxyConstructorInlines.h"
 #include "ProxyObjectInlines.h"
@@ -308,6 +310,10 @@
 #include "WebAssemblyRuntimeErrorPrototype.h"
 #include "WebAssemblyStructConstructor.h"
 #include "WebAssemblyStructPrototype.h"
+#include "WebAssemblySuspendErrorConstructor.h"
+#include "WebAssemblySuspendErrorPrototype.h"
+#include "WebAssemblySuspendingConstructor.h"
+#include "WebAssemblySuspendingPrototype.h"
 #include "WebAssemblyTableConstructor.h"
 #include "WebAssemblyTablePrototype.h"
 #include "WebAssemblyTagConstructor.h"
@@ -2119,6 +2125,10 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             [] (const Initializer<Structure>& init) {
                 init.set(WebAssemblyWrapperFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
             });
+        m_pinballHandlerStructure.initLater(
+            [] (const Initializer<Structure>& init) {
+                init.set(PinballHandler::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
+            });
         m_webAssemblyJSTag.initLater(
             [] (const Initializer<JSWebAssemblyTag>& init) {
                 init.set(JSWebAssemblyTag::create(init.vm, init.owner, init.owner->webAssemblyTagStructure(), Wasm::Tag::jsExceptionTag()));
@@ -2977,6 +2987,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_webAssemblyModuleRecordStructure.visit(visitor);
     thisObject->m_webAssemblyFunctionStructure.visit(visitor);
     thisObject->m_webAssemblyWrapperFunctionStructure.visit(visitor);
+    thisObject->m_pinballHandlerStructure.visit(visitor);
     thisObject->m_webAssemblyJSTag.visit(visitor);
     FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(VISIT_LAZY_TYPE)
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -198,6 +198,8 @@ constexpr bool typeExposedByDefault = true;
     macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,       Memory,       object, typeExposedByDefault) \
     macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,       Module,       object, typeExposedByDefault) \
     macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,             RuntimeError, error,  typeExposedByDefault) \
+    macro(WebAssemblySuspendError, webAssemblySuspendError, webAssemblySuspendError, ErrorInstance,             SuspendError, error,  typeExposedByDefault) \
+    macro(WebAssemblySuspending,   webAssemblySuspending,   webAssemblySuspending,   JSWebAssemblySuspendingFunction,   Suspending, object, typeExposedByDefault) \
     macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,        Table,        object, typeExposedByDefault) \
     macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,          Tag,          object, typeExposedByDefault) 
 #else
@@ -428,6 +430,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_webAssemblyModuleRecordStructure;
     LazyProperty<JSGlobalObject, Structure> m_webAssemblyFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_webAssemblyWrapperFunctionStructure;
+    LazyProperty<JSGlobalObject, Structure> m_pinballHandlerStructure;
     LazyProperty<JSGlobalObject, JSWebAssemblyTag> m_webAssemblyJSTag;
     FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(DEFINE_STORAGE_FOR_LAZY_TYPE)
 #endif // ENABLE(WEBASSEMBLY)
@@ -945,6 +948,7 @@ public:
     Structure* webAssemblyModuleRecordStructure() const { return m_webAssemblyModuleRecordStructure.get(this); }
     Structure* webAssemblyFunctionStructure() const { return m_webAssemblyFunctionStructure.get(this); }
     Structure* webAssemblyWrapperFunctionStructure() const { return m_webAssemblyWrapperFunctionStructure.get(this); }
+    Structure* pinballHandlerStructure() const { return m_pinballHandlerStructure.get(this); }
     JSWebAssemblyTag* webAssemblyJSTag() { return m_webAssemblyJSTag.get(this); }
 #endif // ENABLE(WEBASSEMBLY)
     Structure* collatorStructure() { return m_collatorStructure.get(this); }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -646,6 +646,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
+    v(Bool, useJSPI, true, Normal, "Enable the implementation of the JSPI proposal."_s) \
+    v(OptionString, useJSPISlicing, nullptr, Normal, nullptr /* For testing only; one of: slab, frag, mixed. Default: slab. */) \
     v(Bool, useMapGetOrInsert, true, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
     v(Bool, useMathSumPreciseMethod, true, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PinballCompletion.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "ConservativeRoots.h"
+#include "FunctionPrototype.h"
+#include "JSPromise.h"
+#include "JSWebAssemblyException.h"
+#include "JSWebAssemblyInstance.h"
+#include "StackAlignment.h"
+
+namespace JSC {
+
+const ClassInfo PinballCompletion::s_info = { "PinballCompletion"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(PinballCompletion) };
+
+Structure* PinballCompletion::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue proto)
+{
+    return Structure::create(vm, globalObject, proto, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+PinballCompletion* PinballCompletion::create(VM& vm, Vector<std::unique_ptr<EvacuatedStackSlice>>&& slices, CPURegister* calleeSaves)
+{
+    Structure* structure = vm.pinballCompletionStructure.get();
+    auto* instance = new (NotNull, allocateCell<PinballCompletion>(vm)) PinballCompletion(vm, structure, WTFMove(slices), calleeSaves);
+    for (auto& slice : instance->m_slices)
+        vm.addEvacuatedStackSlice(slice.get());
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    vm.addEvacuatedCalleeSaves(std::span(reinterpret_cast<Register*>(instance->m_calleeSaves), NUMBER_OF_CALLEE_SAVES_REGISTERS));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    instance->finishCreation(vm);
+    return instance;
+}
+
+
+PinballCompletion::PinballCompletion(VM& vm, Structure* structure, Vector<std::unique_ptr<EvacuatedStackSlice>>&& slices, CPURegister* calleeSaves)
+    : Base(vm, structure)
+    , m_slices(WTFMove(slices))
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    memcpySpan(std::span(m_calleeSaves), std::span(calleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+
+void PinballCompletion::destroy(JSCell* cell)
+{
+    PinballCompletion* thisObject = static_cast<PinballCompletion*>(cell);
+    thisObject->PinballCompletion::~PinballCompletion();
+}
+
+void PinballCompletion::setResultPromise(VM& vm, JSPromise* promise)
+{
+    m_resultPromise.set(vm, this, promise);
+}
+
+void PinballCompletion::assimilate(VM& vm, PinballCompletion* other)
+{
+    other->m_slices.appendVector(WTFMove(m_slices));
+    m_slices = WTFMove(other->m_slices);
+    setResultPromise(vm, other->resultPromise());
+}
+
+template<typename Visitor>
+void PinballCompletion::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<PinballCompletion*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    if (thisObject->m_resultPromise)
+        visitor.append(thisObject->m_resultPromise);
+    // Evacuated stack slices are registered with the VM and are added to conservative roots.
+}
+
+DEFINE_VISIT_CHILDREN(PinballCompletion);
+
+extern "C" JSC_DECLARE_HOST_FUNCTION(pinballHandlerFulfillFunction); // defined in InPlaceInterpreter.asm
+static JSC_DECLARE_HOST_FUNCTION(pinballHandlerRejectFunction);
+
+const ClassInfo PinballHandler::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(PinballHandler) };
+
+PinballHandler* PinballHandler::createFulfiller(VM& vm, JSGlobalObject* globalObject, PinballCompletion* pinballCompletion)
+{
+    return create(vm, globalObject, pinballHandlerFulfillFunction, pinballCompletion);
+}
+
+PinballHandler* PinballHandler::createRejecter(VM& vm, JSGlobalObject* globalObject, PinballCompletion* pinballCompletion)
+{
+    return create(vm, globalObject, pinballHandlerRejectFunction, pinballCompletion);
+}
+
+PinballHandler* PinballHandler::create(VM& vm, JSGlobalObject* globalObject, NativeFunction handlerImpl, PinballCompletion* pinballCompletion)
+{
+    const String name = "<pinball handler>"_s;
+    NativeExecutable* executable = vm.getHostFunction(handlerImpl, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    Structure* structure = globalObject->pinballHandlerStructure();
+    PinballHandler* function = new (NotNull, allocateCell<PinballHandler>(vm)) PinballHandler(vm, executable, globalObject, structure, pinballCompletion);
+    function->finishCreation(vm, executable, name);
+    return function;
+}
+
+Structure* PinballHandler::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
+}
+
+void PinballHandler::finishCreation(VM& vm, NativeExecutable* executable, const String& name)
+{
+    Base::finishCreation(vm, executable, 1, name);
+    ASSERT(inherits(info()));
+}
+
+template<typename Visitor>
+void PinballHandler::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    PinballHandler* self = jsCast<PinballHandler*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(self, info());
+    Base::visitChildren(self, visitor);
+    visitor.append(self->m_pinballCompletion);
+}
+
+DEFINE_VISIT_CHILDREN(PinballHandler);
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+/*
+    The following three C++ functions implement the "normal" part of the logic of reviving and executing suspended Wasm stack
+    when the suspension promise has been fulfilled. The magical stack and register manipulation is done by the
+    core handler code implemented in offlineasm.
+*/
+
+extern "C" void SYSV_ABI pinballHandlerFulfillFunctionInit(JSGlobalObject*, CallFrame*, PinballFulfillContext*);
+extern "C" UGPRPair SYSV_ABI pinballHandlerFulfillFunctionImplant(PinballFulfillContext*, Register*, CallFrame*, void*);
+extern "C" bool SYSV_ABI pinballHandlerFulfillFunctionContinue(PinballFulfillContext*);
+
+extern "C" EncodedJSValue SYSV_ABI pinballHandlerPropagateException(JSGlobalObject*, PinballCompletion*, JSWebAssemblyException*);
+extern "C" void SYSV_ABI pinballHandlerUnwindInit(JSGlobalObject*, PinballCompletion*, JSWebAssemblyException*, PinballUnwindContext*);
+extern "C" void SYSV_ABI pinballHandlerUnwindInitWasm(PinballUnwindContext*, JSWebAssemblyInstance*);
+extern "C" UGPRPair SYSV_ABI pinballHandlerUnwindImplant(PinballUnwindContext*, Register *base, CallFrame* returnFP, void* returnPC);
+
+void pinballHandlerFulfillFunctionInit(JSGlobalObject* globalObject, CallFrame* callFrame, PinballFulfillContext* context)
+{
+    PinballHandler* self = jsCast<PinballHandler*>(callFrame->jsCallee());
+    ASSERT(self);
+
+    ASSERT(callFrame->argumentCount() == 1);
+    PinballCompletion* pinball = self->pinballCompletion();
+    ASSERT(pinball->hasSlices());
+    auto* slice = pinball->slices().last().get(); // keep the slice owned by pinball until implanted
+
+#if ASSERT_ENABLED
+    context->magic = 0xBA11FEED;
+#endif
+    context->globalObject = globalObject;
+    context->handler = self;
+    constexpr CallFrame* noHandlerFrame = nullptr; // set later by the assembly logic when the handler frame is created
+    new (&context->jspiContext) JSPIContext(JSPIContext::Purpose::Completing, globalObject->vm(), noHandlerFrame);
+    context->slice = slice;
+    context->sliceByteSize = slice->size() * sizeof(Register);
+    ASSERT(!(context->sliceByteSize % stackAlignmentBytes()), "invalid stack slice detected with an odd number of slots");
+    context->evacuatedCalleeSaves = pinball->calleeSaves();
+    context->arguments[0] = JSValue::encode(callFrame->argument(0));
+}
+
+SUPPRESS_ASAN
+UGPRPair pinballHandlerFulfillFunctionImplant(PinballFulfillContext* context, Register *base, CallFrame* returnFP, void* returnPC)
+{
+    ASSERT(context->magic == 0xBA11FEED);
+    VM& vm = context->globalObject->vm();
+    PinballCompletion* pinball = context->handler->pinballCompletion();
+
+    auto* slice = context->slice;
+    CallFrame* entryFP = slice->implant(base, returnFP, returnPC);
+    vm.removeEvacuatedStackSlice(slice); // the slice is now scanned as part of the stack
+    const void* entryPC = slice->entryPC();
+    pinball->takeTopSlice(); // and drop
+    context->slice = nullptr;
+    // At this point callee saves have been loaded into the registers and it is safe for the VM to forget them.
+    vm.removeEvacuatedCalleeSaves(std::span(reinterpret_cast<Register*>(pinball->calleeSaves()), NUMBER_OF_CALLEE_SAVES_REGISTERS));
+
+    return makeUGPRPair(reinterpret_cast<UCPURegister>(entryFP), reinterpret_cast<UCPURegister>(entryPC));
+}
+
+// After the execution of a slice returns, determine how to proceed.
+// True return means a new slice is now ready for another execution cycle, false means exit.
+bool pinballHandlerFulfillFunctionContinue(PinballFulfillContext* context)
+{
+    ASSERT(context->magic == 0xBA11FEED);
+    ASSERT(!context->slice);
+
+    VM& vm = context->globalObject->vm();
+    JSPIContext& jspiContext = context->jspiContext;
+    PinballCompletion* pinball = context->handler->pinballCompletion();
+
+    if (jspiContext.completion) {
+        // Computation was suspended again; the remainder of this completion should be added to the new one.
+        jspiContext.completion->assimilate(vm, pinball);
+        jspiContext.deactivate(vm);
+        context->arguments[0] = JSValue::encode(jsUndefined());
+        context->~PinballFulfillContext(); // context is owned by the asm caller frame, destruct it from here just in case
+        return false;
+    }
+
+    if (pinball->hasSlices()) {
+        auto* slice = pinball->takeTopSlice().release();
+        context->slice = slice;
+        context->sliceByteSize = slice->size() * sizeof(Register);
+        return true;
+    }
+
+    jspiContext.deactivate(vm);
+    JSValue arg = JSValue::decode(context->arguments[0]);
+
+    JSPromise* resultPromise = pinball->resultPromise();
+    ASSERT(resultPromise);
+    resultPromise->resolve(context->globalObject, arg);
+
+    context->arguments[0] = JSValue::encode(jsUndefined());
+    context->~PinballFulfillContext();
+    return false;
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+static void discardEvacuatedStackAndPropagateRejection(JSGlobalObject* globalObject, PinballCompletion* pinball, JSValue rejectionReason)
+{
+    VM& vm = globalObject->vm();
+
+    JSPromise* resultPromise = pinball->resultPromise();
+    ASSERT(resultPromise);
+    while (pinball->hasSlices()) {
+        auto slice = pinball->takeTopSlice();
+        vm.removeEvacuatedStackSlice(slice.get());
+    }
+    resultPromise->reject(vm, globalObject, rejectionReason);
+}
+
+JSC_DEFINE_HOST_FUNCTION(pinballHandlerRejectFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue reason = callFrame->argument(0);
+
+    PinballHandler* self = jsCast<PinballHandler*>(callFrame->jsCallee());
+    PinballCompletion* pinball = self->pinballCompletion();
+
+    auto* wasmException = jsDynamicCast<JSWebAssemblyException*>(reason);
+    if (!wasmException) {
+        discardEvacuatedStackAndPropagateRejection(globalObject, pinball, reason);
+        return JSValue::encode(jsUndefined());
+    }
+
+    // If the reason is a Wasm exception, we should revive the Wasm stack and give it a chance to handle it.
+    EncodedJSValue result = pinballHandlerPropagateException(globalObject, pinball, wasmException);
+    JSPromise* resultPromise = pinball->resultPromise();
+    Exception* exception = scope.exception();
+    if (exception) {
+        JSValue exceptionValue = exception->value();
+        scope.clearException();
+        resultPromise->reject(vm, globalObject, exceptionValue);
+    } else
+        resultPromise->resolve(globalObject, JSValue::decode(result));
+
+    return JSValue::encode(jsUndefined());
+}
+
+void pinballHandlerUnwindInit(JSGlobalObject* globalObject, PinballCompletion* pinball, JSWebAssemblyException* exception, PinballUnwindContext* context)
+{
+    ASSERT(pinball->slices().size() == 1); // Right now we only support the slab slicing strategy
+    auto* slice = pinball->takeTopSlice().release();
+
+#if ASSERT_ENABLED
+    context->magic = 0xBA11FEED;
+#endif
+    context->vm = &globalObject->vm();
+    context->zombieFrameCallee = globalObject->zombieFrameCallee();
+    context->slice = slice;
+    context->sliceByteSize = slice->size() * sizeof(Register);
+    context->exception = exception;
+    ASSERT(!(context->sliceByteSize % stackAlignmentBytes()), "invalid stack slice detected with an odd number of slots");
+    context->evacuatedCalleeSaves = pinball->calleeSaves();
+}
+
+// FIXME: is there a nice official way of doing this?
+static bool lookupExceptionIndex(JSWebAssemblyInstance* instance, JSWebAssemblyException* exception, unsigned* result)
+{
+    const auto& moduleInfo = instance->moduleInformation();
+    unsigned tagCount = moduleInfo.exceptionIndexSpaceSize();
+    for (unsigned i = 0; i < tagCount; ++i) {
+        if (&instance->tag(i) == &exception->tag()) {
+            *result = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+void pinballHandlerUnwindInitWasm(PinballUnwindContext* context, JSWebAssemblyInstance* instance)
+{
+    ASSERT(context->magic == 0xBA11FEED);
+    bool found = lookupExceptionIndex(instance, context->exception, &context->exceptionIndex);
+    RELEASE_ASSERT(found);
+}
+
+// TODO: this is virtually identical to the fulfill case and we should be able to have just one
+UGPRPair pinballHandlerUnwindImplant(PinballUnwindContext* context, Register *base, CallFrame* returnFP, void* returnPC)
+{
+    ASSERT(context->magic == 0xBA11FEED);
+
+    // dataLogLn("unwind implant base: ", RawPointer(base), " return FP: ", RawPointer(returnFP));
+
+    auto* slice = context->slice;
+    CallFrame* entryFP = slice->implant(base, returnFP, returnPC);
+    context->vm->removeEvacuatedStackSlice(slice);
+    const void* entryPC = slice->entryPC();
+    slice->~EvacuatedStackSlice();
+    EvacuatedStackSlice::freeAfterDestruction(slice);
+    context->slice = nullptr;
+    return makeUGPRPair(reinterpret_cast<UCPURegister>(entryFP), reinterpret_cast<UCPURegister>(entryPC));
+}
+
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/PinballCompletion.h
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/EvacuatedStack.h>
+#include <JavaScriptCore/JSFunction.h>
+
+namespace JSC {
+
+// Orchestrates incremental slice-by-slice return for JSPI to pass the result of a
+// resolved promise through a series of synchronous code frames, with the value produced
+// by that code ultimately used to resolve another promise. "Pinball" because instead of
+// returning straight down the system stack, we may do so in a series of bumps.
+class PinballCompletion : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.pinballCompletionSpace<mode>();
+    }
+
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
+    static void destroy(JSCell*);
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue proto);
+    static PinballCompletion* create(VM&, Vector<std::unique_ptr<EvacuatedStackSlice>>&&, CPURegister* calleeSaves);
+
+    JSPromise* resultPromise() { return m_resultPromise.get(); }
+    void setResultPromise(VM&, JSPromise*);
+
+    Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() { return m_slices; }
+    std::unique_ptr<EvacuatedStackSlice> takeTopSlice() { return m_slices.takeLast(); }
+    bool hasSlices() const { return !m_slices.isEmpty(); }
+
+    CPURegister* calleeSaves() { return m_calleeSaves; }
+
+    void assimilate(VM&, PinballCompletion*);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+private:
+    PinballCompletion(VM&, Structure*, Vector<std::unique_ptr<EvacuatedStackSlice>>&& slices, CPURegister* calleeSaves);
+    Vector<std::unique_ptr<EvacuatedStackSlice>> m_slices;
+    CPURegister m_calleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS];
+    WriteBarrier<JSPromise> m_resultPromise;
+};
+
+// A JS function used as promise fulfill or reject handler to hook it up to the pinball
+// return machinery. Which handler it is depends on the factory method used to create the
+// function.
+class PinballHandler final : public JSFunction {
+public:
+    using Base = JSFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.pinballHandlerSpace<mode>();
+    }
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    static PinballHandler* createFulfiller(VM&, JSGlobalObject*, PinballCompletion*);
+    static PinballHandler* createRejecter(VM&, JSGlobalObject*, PinballCompletion*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
+
+    PinballCompletion* pinballCompletion() { return m_pinballCompletion.get(); }
+
+private:
+    static PinballHandler* create(VM&, JSGlobalObject*, NativeFunction, PinballCompletion*);
+
+    PinballHandler(VM& vm, NativeExecutable* native, JSGlobalObject* globalObject, Structure* structure, PinballCompletion* pinball)
+        : Base(vm, native, globalObject, structure)
+        , m_pinballCompletion(pinball, WriteBarrierEarlyInit)
+    { }
+
+    void finishCreation(VM&, NativeExecutable*, const String&);
+
+    WriteBarrier<PinballCompletion> m_pinballCompletion;
+};
+
+// Effectively the local variables of the function pinballCompletionFulfillmentHandler implemented in offlineasm.
+struct PinballFulfillContext {
+#if ASSERT_ENABLED
+    size_t magic;
+#endif
+    JSGlobalObject* globalObject;
+    PinballHandler* handler;
+    JSPIContext jspiContext;
+    EvacuatedStackSlice* slice;
+    size_t sliceByteSize;
+    CPURegister* evacuatedCalleeSaves; // callee saves from the handler's pinballCompletion, to pass into Wasm
+    CPURegister cppCalleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS]; // callee saves state on entering the handler
+    CPURegister arguments[GPRInfo::numberOfArgumentRegisters + FPRInfo::numberOfArgumentRegisters];
+};
+
+// TODO: once we have full unwind handling this might be close enough to the fulfill context to be merged
+struct PinballUnwindContext {
+#if ASSERT_ENABLED
+    size_t magic;
+#endif
+    VM* vm;
+    JSCallee* zombieFrameCallee;
+    EvacuatedStackSlice* slice;
+    size_t sliceByteSize;
+    JSWebAssemblyException* exception;
+    unsigned exceptionIndex;
+    CPURegister* evacuatedCalleeSaves; // callee saves from the handler's pinballCompletion, to pass into Wasm
+    CPURegister cppCalleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS]; // callee saves state on entering the handler
+};
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -49,6 +49,7 @@
 #include "ErrorInstance.h"
 #include "EvalCodeBlockInlines.h"
 #include "EvalExecutableInlines.h"
+#include "EvacuatedStack.h"
 #include "Exception.h"
 #include "FTLThunks.h"
 #include "FileBasedFuzzerAgent.h"
@@ -98,6 +99,7 @@
 #include "NarrowingNumberPredictionFuzzerAgent.h"
 #include "NativeExecutable.h"
 #include "NumberObject.h"
+#include "PinballCompletion.h"
 #include "PredictionFileCreatingFuzzerAgent.h"
 #include "ProfilerDatabase.h"
 #include "ProgramCodeBlockInlines.h"
@@ -323,6 +325,9 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     evalExecutableStructure.setWithoutWriteBarrier(EvalExecutable::createStructure(*this, nullptr, jsNull()));
     programExecutableStructure.setWithoutWriteBarrier(ProgramExecutable::createStructure(*this, nullptr, jsNull()));
     functionExecutableStructure.setWithoutWriteBarrier(FunctionExecutable::createStructure(*this, nullptr, jsNull()));
+#if ENABLE(WEBASSEMBLY)
+    pinballCompletionStructure.setWithoutWriteBarrier(PinballCompletion::createStructure(*this, nullptr, jsNull()));
+#endif
     moduleProgramExecutableStructure.setWithoutWriteBarrier(ModuleProgramExecutable::createStructure(*this, nullptr, jsNull()));
     promiseReactionStructure.setWithoutWriteBarrier(JSPromiseReaction::createStructure(*this, nullptr, jsNull()));
     promiseAllContextStructure.setWithoutWriteBarrier(JSPromiseAllContext::createStructure(*this, nullptr, jsNull()));
@@ -1124,6 +1129,21 @@ void VM::scanSideState(ConservativeRoots& roots) const
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif // ENABLE(DFG_JIT)
 
+#if ENABLE(WEBASSEMBLY)
+
+void VM::gatherEvacuatedStackRoots(ConservativeRoots& roots)
+{
+    Locker locker { m_evacuatedStacksLock };
+    for (auto* slice : m_evacuatedStackSlices) {
+        std::span<Register> slots = slice->slots();
+        roots.add(slots.data(), slots.data() + slots.size());
+    }
+    for (const auto& span : m_evacuatedCalleeSaves)
+        roots.add(span.data(), span.data() + span.size());
+}
+
+#endif // ENABLE(WEBASSEMBLY)
+
 void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&& payload)
 {
     ASSERT(currentThreadIsHoldingAPILock());
@@ -1485,6 +1505,32 @@ bool VM::isScratchBuffer(void* ptr)
     return false;
 }
 
+void VM::addEvacuatedStackSlice(EvacuatedStackSlice* slice)
+{
+    Locker lock { m_evacuatedStacksLock };
+    m_evacuatedStackSlices.append(slice);
+}
+
+void VM::removeEvacuatedStackSlice(EvacuatedStackSlice* slice)
+{
+    Locker lock { m_evacuatedStacksLock };
+    m_evacuatedStackSlices.removeAll(slice);
+}
+
+void VM::addEvacuatedCalleeSaves(std::span<Register> span)
+{
+    Locker lock { m_evacuatedStacksLock };
+    m_evacuatedCalleeSaves.constructAndAppend(span);
+}
+
+void VM::removeEvacuatedCalleeSaves(std::span<Register> span)
+{
+    Locker lock { m_evacuatedStacksLock };
+    m_evacuatedCalleeSaves.removeAllMatching([&](const std::span<Register>& existing) {
+        return existing.data() == span.data() && existing.size() == span.size();
+    });
+}
+
 Ref<Waiter> VM::syncWaiter()
 {
     return m_syncWaiter;
@@ -1711,6 +1757,7 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(programExecutableStructure);
     visitor.append(functionExecutableStructure);
 #if ENABLE(WEBASSEMBLY)
+    visitor.append(pinballCompletionStructure);
     visitor.append(webAssemblyCalleeGroupStructure);
 #endif
     visitor.append(moduleProgramExecutableStructure);
@@ -1888,6 +1935,11 @@ void VM::DrainMicrotaskDelayScope::decrement()
         JSLockHolder locker(*m_vm);
         m_vm->drainMicrotasks();
     }
+}
+
+JSPIContext::~JSPIContext()
+{
+    ASSERT_WITH_MESSAGE(!limitFrame, "JSPIContext is still active when leaving its scope");
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -88,6 +88,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/text/SymbolRegistry.h>
 #include <wtf/text/UniquedStringImpl.h>
 
+#include <span>
+
 #if ENABLE(REGEXP_TRACING)
 #include <wtf/ListHashSet.h>
 #endif
@@ -125,6 +127,7 @@ class CommonIdentifiers;
 class CompactTDZEnvironmentMap;
 class ConservativeRoots;
 class ControlFlowProfiler;
+class EvacuatedStackSlice;
 class Exception;
 class ExceptionScope;
 class FuzzerAgent;
@@ -143,6 +146,7 @@ class MegamorphicCache;
 class NativeExecutable;
 class Debugger;
 class DeferredWorkTimer;
+class PinballCompletion;
 class RegExp;
 class RegExpCache;
 class Register;
@@ -219,6 +223,25 @@ public:
 
 private:
     ScratchBuffer* m_scratchBuffer;
+};
+
+// A record marking the top (in memory address terms) of the "interesting" stack span when
+// handling a JSPI suspension. A pointer to it is saved in the VM as the 'topJSPIContext' field.
+struct JSPIContext {
+    enum class Purpose {
+        Promising, // Started in a 'WebAssembly.promising()' wrapper function.
+        Completing // Started in a PinballCompletion fulfillment handler.
+    };
+
+    JSPIContext(Purpose, VM&, CallFrame*);
+    ~JSPIContext();
+
+    void deactivate(VM&);
+
+    Purpose purpose;
+    JSPIContext* previousContext;
+    CallFrame* limitFrame; // scan up to this frame, and return from it after evacuating the stack
+    PinballCompletion* completion { nullptr };
 };
 
 enum VMIdentifierType { };
@@ -389,6 +412,7 @@ public:
     CallFrame* topCallFrame { nullptr };
     EntryFrame* topEntryFrame { nullptr };
     void* maybeReturnPC { nullptr };
+    JSPIContext* topJSPIContext { nullptr };
 private:
 
     struct EntryScopeServicesBits {
@@ -516,6 +540,7 @@ public:
     WriteBarrier<Structure> programExecutableStructure;
     WriteBarrier<Structure> functionExecutableStructure;
 #if ENABLE(WEBASSEMBLY)
+    WriteBarrier<Structure> pinballCompletionStructure;
     WriteBarrier<Structure> webAssemblyCalleeGroupStructure;
 #endif
     WriteBarrier<Structure> moduleProgramExecutableStructure;
@@ -885,6 +910,11 @@ public:
     void clearScratchBuffers();
     bool isScratchBuffer(void*);
 
+    void addEvacuatedStackSlice(EvacuatedStackSlice*);
+    void removeEvacuatedStackSlice(EvacuatedStackSlice*);
+    void addEvacuatedCalleeSaves(std::span<Register>);
+    void removeEvacuatedCalleeSaves(std::span<Register>);
+
     EncodedJSValue* exceptionFuzzingBuffer(size_t size)
     {
         ASSERT(Options::useExceptionFuzz());
@@ -894,6 +924,7 @@ public:
     }
 
     void gatherScratchBufferRoots(ConservativeRoots&);
+    void gatherEvacuatedStackRoots(ConservativeRoots&);
 
     static constexpr unsigned expectedMaxActiveSideStateCount = 4;
     void pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&&);
@@ -1222,6 +1253,9 @@ private:
     Lock m_scratchBufferLock;
     Vector<ScratchBuffer*> m_scratchBuffers;
     size_t m_sizeOfLastScratchBuffer { 0 };
+    Lock m_evacuatedStacksLock;
+    Vector<EvacuatedStackSlice*> m_evacuatedStackSlices;
+    Vector<std::span<Register>> m_evacuatedCalleeSaves;
     Vector<std::unique_ptr<CheckpointOSRExitSideState>, expectedMaxActiveSideStateCount> m_checkpointSideState;
     InlineWatchpointSet m_primitiveGigacageEnabled { IsWatched };
     FunctionHasExecutedCache m_functionHasExecutedCache;
@@ -1308,6 +1342,21 @@ extern "C" void SYSV_ABI sanitizeStackForVMImpl(VM*);
 #endif
 
 JS_EXPORT_PRIVATE void sanitizeStackForVM(VM&);
+
+inline JSPIContext::JSPIContext(Purpose purpose, VM& vm, CallFrame* callFrame)
+    : purpose(purpose)
+    , previousContext(vm.topJSPIContext)
+    , limitFrame(callFrame)
+{
+    vm.topJSPIContext = this;
+}
+
+inline void JSPIContext::deactivate(VM& vm)
+{
+    vm.topJSPIContext = previousContext;
+    limitFrame = nullptr; // indicates that this has been deactivated
+}
+
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -43,6 +43,8 @@
 #include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyInstance.h"
 #include "JSWebAssemblyModule.h"
+#include "JSWebAssemblyPromisingFunction.h"
+#include "JSWebAssemblySuspendingFunction.h"
 #include "JSWebAssemblyTag.h"
 #include "ObjectConstructor.h"
 #include "Options.h"
@@ -71,8 +73,11 @@ FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(DEFINE_CALLBACK_FOR_CONSTRUCTOR)
 
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyCompileFunc);
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyInstantiateFunc);
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyPromisingFunc);
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyValidateFunc);
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyGetterJSTag);
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyGetterSuspending);
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyGetterSuspendError);
 
 }
 
@@ -122,6 +127,11 @@ void JSWebAssembly::finishCreation(VM& vm, JSGlobalObject* globalObject)
     if (globalObject->globalObjectMethodTable()->instantiateStreaming)
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("instantiateStreaming"_s, webAssemblyInstantiateStreamingCodeGenerator, static_cast<unsigned>(0));
     JSC_NATIVE_GETTER_WITHOUT_TRANSITION("JSTag"_s, webAssemblyGetterJSTag, PropertyAttribute::ReadOnly);
+    if (Options::useJSPI()) {
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION("Suspending"_s, webAssemblyGetterSuspending, PropertyAttribute::DontEnum);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION("SuspendError"_s, webAssemblyGetterSuspendError, PropertyAttribute::DontEnum);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("promising"_s, webAssemblyPromisingFunc, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
+    }
 }
 
 JSWebAssembly::JSWebAssembly(VM& vm, Structure* structure)
@@ -377,6 +387,20 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateFunc, (JSGlobalObject* globalObje
     RELEASE_AND_RETURN(scope, JSValue::encode(promise));
 }
 
+JSC_DEFINE_HOST_FUNCTION(webAssemblyPromisingFunc, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* arg = callFrame->argument(0).getObject();
+    JSFunction* wrapped = jsCast<JSFunction*>(arg);
+    // FIXME: throw if the arguments are invalid
+    RELEASE_ASSERT(wrapped);
+    JSWebAssemblyPromisingFunction* wrapper = JSWebAssemblyPromisingFunction::create(vm, globalObject, wrapped);
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(wrapper));
+}
+
 /**
  * namespace WebAssembly {
  *     boolean validate(BufferSource bytes, optional WebAssemblyCompileOptions options);
@@ -440,6 +464,16 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyGetterJSTag, (JSGlobalObject* globalObject, 
 {
     // https://webassembly.github.io/exception-handling/js-api/#dom-webassembly-jstag
     return JSValue::encode(globalObject->webAssemblyJSTag());
+}
+
+JSC_DEFINE_HOST_FUNCTION(webAssemblyGetterSuspending, (JSGlobalObject* globalObject, CallFrame*))
+{
+    return JSValue::encode(globalObject->webAssemblySuspendingConstructor());
+}
+
+JSC_DEFINE_HOST_FUNCTION(webAssemblyGetterSuspendError, (JSGlobalObject* globalObject, CallFrame*))
+{
+    return JSValue::encode(globalObject->webAssemblySuspendErrorConstructor());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyPromisingFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyPromisingFunction.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSWebAssemblyPromisingFunction.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "ArgList.h"
+#include "ExceptionHelpers.h"
+#include "FunctionPrototype.h"
+#include "JSObjectInlines.h"
+#include "JSPromise.h"
+#include "PinballCompletion.h"
+
+namespace JSC {
+
+static JSC_DECLARE_HOST_FUNCTION(runWebAssemblyPromisingFunction);
+
+JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* callee = callFrame->jsCallee();
+    JSWebAssemblyPromisingFunction* thisFunction = jsCast<JSWebAssemblyPromisingFunction*>(callee);
+    ASSERT(thisFunction);
+    JSFunction* wrappedFunction = thisFunction->wrappedFunction();
+
+    MarkedArgumentBuffer args;
+    for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
+        args.append(callFrame->uncheckedArgument(i));
+    if (args.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    auto callData = JSC::getCallData(wrappedFunction);
+    if (callData.type == CallData::Type::None) {
+        throwTypeError(globalObject, scope, "Object is not callable"_s);
+        return { };
+    }
+
+    JSPIContext context(JSPIContext::Purpose::Promising, vm, callFrame);
+    JSValue result = call(globalObject, wrappedFunction, callData, jsUndefined(), args);
+    context.deactivate(vm);
+
+    JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    if (scope.exception()) [[unlikely]] {
+        // exception was thrown in wasm code
+        JSValue exceptionValue = scope.exception()->value();
+        scope.clearException();
+        resultPromise->reject(vm, globalObject, exceptionValue);
+    } else if (context.completion) {
+        // wasm called out to js and was suspended
+        context.completion->setResultPromise(vm, resultPromise);
+    } else {
+        // the call returned normally, result is meaningful
+        resultPromise->resolve(globalObject, result);
+    }
+    scope.release();
+    return JSValue::encode(resultPromise);
+}
+
+const ClassInfo JSWebAssemblyPromisingFunction::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyPromisingFunction) };
+
+JSWebAssemblyPromisingFunction* JSWebAssemblyPromisingFunction::create(VM& vm, JSGlobalObject*globalObject, JSFunction* wrappedWasmFunction)
+{
+    const String name = "<promising wrapper>"_s;
+    NativeExecutable* executable = vm.getHostFunction(runWebAssemblyPromisingFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    Structure* structure = createStructure(vm, globalObject);
+    JSWebAssemblyPromisingFunction* function = new (NotNull, allocateCell<JSWebAssemblyPromisingFunction>(vm)) JSWebAssemblyPromisingFunction(vm, executable, globalObject, structure, wrappedWasmFunction);
+    function->finishCreation(vm, executable, name);
+    return function;
+}
+
+Structure* JSWebAssemblyPromisingFunction::createStructure(VM& vm, JSGlobalObject* globalObject)
+{
+    JSValue prototype = globalObject->functionPrototype();
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
+}
+
+void JSWebAssemblyPromisingFunction::finishCreation(VM& vm, NativeExecutable* executable, const String& name)
+{
+    Base::finishCreation(vm, executable, 1, name);
+    ASSERT(inherits(info()));
+}
+
+template<typename Visitor>
+void JSWebAssemblyPromisingFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    JSWebAssemblyPromisingFunction* thisObject = jsCast<JSWebAssemblyPromisingFunction*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_wrappedFunction);
+}
+
+DEFINE_VISIT_CHILDREN(JSWebAssemblyPromisingFunction);
+
+} // namespace JSC
+
+#endif

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyPromisingFunction.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyPromisingFunction.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSFunction.h"
+
+namespace JSC {
+
+// The function object returned by a call to 'WebAssembly.promising()'.
+class JSWebAssemblyPromisingFunction final : public JSFunction {
+public:
+    using Base = JSFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.promisingFunctionSpace<mode>();
+    }
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    static JSWebAssemblyPromisingFunction* create(VM&, JSGlobalObject*, JSFunction*);
+    static Structure* createStructure(VM&, JSGlobalObject*);
+
+    // The function passed to the 'WebAssembly.promising()' call that created this.
+    JSFunction* wrappedFunction() const { return m_wrappedFunction.get(); }
+
+private:
+    JSWebAssemblyPromisingFunction(VM& vm, NativeExecutable* native, JSGlobalObject* globalObject, Structure* structure, JSFunction* wrapped)
+        : Base(vm, native, globalObject, structure)
+        , m_wrappedFunction(wrapped, WriteBarrierEarlyInit)
+    { }
+
+    void finishCreation(VM&, NativeExecutable*, const String&);
+
+    WriteBarrier<JSFunction> m_wrappedFunction;
+};
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendError.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendError.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSWebAssemblySuspendError.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSCJSValueInlines.h"
+
+namespace JSC {
+
+JSObject* createJSWebAssemblySuspendError(JSGlobalObject* globalObject, VM& vm, const String& message)
+{
+    ASSERT(!message.isEmpty());
+    return ErrorInstance::create(vm, globalObject->webAssemblySuspendErrorStructure(), message, JSValue(), defaultSourceAppender, TypeNothing, ErrorType::Error, true);
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendError.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendError.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "ErrorInstance.h"
+
+namespace JSC {
+
+JSObject* createJSWebAssemblySuspendError(JSGlobalObject*, VM&, const String&);
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendingFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendingFunction.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSWebAssemblySuspendingFunction.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "ArgList.h"
+#include "Debugger.h"
+#include "EvacuatedStack.h"
+#include "ExceptionHelpers.h"
+#include "FrameTracers.h"
+#include "FunctionPrototype.h"
+#include "InterpreterInlines.h"
+#include "JSObjectInlines.h"
+#include "JSPromise.h"
+#include "JSWebAssemblySuspendError.h"
+#include "PinballCompletion.h"
+
+namespace JSC {
+
+extern "C" {
+    void captureABICalleeSaves(void* buffer);
+    void teleportForJSPI(CPURegister* calleeSaves, CallFrame* returnOutOfFrame, EncodedJSValue result);
+}
+
+extern "C" JSC_DECLARE_HOST_FUNCTION(enterWebAssemblySuspendingFunction);
+JSC_DECLARE_HOST_FUNCTION(runWebAssemblySuspendingFunction);
+
+template<typename T>
+struct SlicerDriver {
+    static bool slice(VM& vm, CallFrame* callFrame, String& errorMessage, Vector<std::unique_ptr<EvacuatedStackSlice>>& slices, CallFrame*& teleportFrame)
+    {
+        T slicer;
+        StackSlicerFunctor<T> functor(vm, slicer);
+        StackVisitor::visit(callFrame, vm, functor);
+
+        if (!slicer.succeeded()) {
+            errorMessage = slicer.errorMessage();
+            return false;
+        }
+        slices = slicer.reverseAndTakeSlices();
+        teleportFrame = slicer.teleportFrame();
+        return true;
+    }
+};
+
+extern "C" EncodedJSValue SYSV_ABI runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* callFrame, CPURegister* hereCalleeSaves);
+
+EncodedJSValue runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* callFrame, CPURegister* hereCalleeSaves)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    CPURegister* vmEntryFrameCalleeSaves = vmEntryRecord(vm.topEntryFrame)->calleeSaveRegistersBuffer;
+    memcpySpan(std::span<CPURegister>(vmEntryFrameCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS), std::span(hereCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
+
+    JSObject* callee = callFrame->jsCallee();
+    JSWebAssemblySuspendingFunction* self = jsCast<JSWebAssemblySuspendingFunction*>(callee);
+    JSFunction* wrappedFunction = self->wrappedFunction();
+
+    MarkedArgumentBuffer args;
+    for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
+        args.append(callFrame->uncheckedArgument(i));
+    if (args.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    auto callData = JSC::getCallData(wrappedFunction);
+    if (callData.type == CallData::Type::None) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Object is not callable"_s);
+        return { };
+    }
+
+    JSValue result = call(globalObject, wrappedFunction, callData, jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSPromise* promise = jsDynamicCast<JSPromise*>(result);
+    if (!promise)
+        return JSValue::encode(result);
+
+    if (!vm.topJSPIContext) {
+        auto errorMessage = makeString("JSPI stack scan failed: "_s);
+        throwException(globalObject, scope, createJSWebAssemblySuspendError(globalObject, vm, "Suspending() wrapper called outside of a promising() context"_s));
+        return { };
+    }
+
+    String errorMessage;
+    Vector<std::unique_ptr<EvacuatedStackSlice>> slices;
+    CallFrame* returnOutOfFrame = nullptr;
+    bool success = false;
+
+    // There are multiple ways of slicing the wasm stack here. What is the optimal way is
+    // something we will have to research on real workloads. It will likely be some
+    // adaptive scheme, perhaps with profile data associated with the promising wrapper.
+    // For now we offer 3 strategies, for testing more than for performance tuning. The
+    // default is 'slab', which saves the whole stack as a single slice if no option is
+    // supplied. 'mixed' is an attempt at a quick and easy adaptive scheme, so that on
+    // the first suspension we use 'slab', betting on a straight return, but on a resuspension
+    // use 'frag', betting that more resuspensions will follow.
+    const char* strategy = Options::useJSPISlicing();
+    if (!strategy || equal(unsafeSpan(strategy), "slab"_s)) {
+        success = SlicerDriver<SlabSlicer>::slice(vm, callFrame, errorMessage, slices, returnOutOfFrame);
+    } else if (equal(unsafeSpan(strategy), "frag"_s)) {
+        success = SlicerDriver<FragSlicer>::slice(vm, callFrame, errorMessage, slices, returnOutOfFrame);
+    } else if (equal(unsafeSpan(strategy), "mixed"_s)) {
+        if (vm.topJSPIContext->purpose == JSPIContext::Purpose::Promising)
+            success = SlicerDriver<SlabSlicer>::slice(vm, callFrame, errorMessage, slices, returnOutOfFrame);
+        else
+            success = SlicerDriver<FragSlicer>::slice(vm, callFrame, errorMessage, slices, returnOutOfFrame);
+    } else
+        FATAL("unrecognized JSPI strategy");
+
+    if (!success) {
+        auto errorString = makeString("JSPI stack scan failed: "_s, errorMessage);
+        throwVMError(globalObject, scope, errorString);
+        return { };
+    }
+
+    auto* pinball = PinballCompletion::create(vm, WTFMove(slices), hereCalleeSaves);
+    vm.topJSPIContext->completion = pinball;
+
+    auto* fulfiller = PinballHandler::createFulfiller(vm, globalObject, pinball);
+    auto* rejecter = PinballHandler::createRejecter(vm, globalObject, pinball);
+    promise->performPromiseThen(vm, globalObject, fulfiller, rejecter, jsUndefined());
+
+    teleportForJSPI(vmEntryFrameCalleeSaves, returnOutOfFrame, JSValue::encode(jsUndefined())); // returns in to promising or pinball handler frame
+    RELEASE_ASSERT_NOT_REACHED();
+    return JSValue::encode(jsNull());
+}
+
+const ClassInfo JSWebAssemblySuspendingFunction::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblySuspendingFunction) };
+
+JSWebAssemblySuspendingFunction* JSWebAssemblySuspendingFunction::create(VM& vm, JSGlobalObject* globalObject, JSFunction* wrappedFunction)
+{
+    const String name = "WebAssembly.Suspending"_s;
+    NativeExecutable* executable = vm.getHostFunction(enterWebAssemblySuspendingFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    Structure* structure = globalObject->webAssemblySuspendingStructure();
+    auto* function = new (NotNull, allocateCell<JSWebAssemblySuspendingFunction>(vm)) JSWebAssemblySuspendingFunction(vm, executable, globalObject, structure, wrappedFunction);
+    function->finishCreation(vm, executable, name);
+    return function;
+}
+
+Structure* JSWebAssemblySuspendingFunction::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
+}
+
+void JSWebAssemblySuspendingFunction::finishCreation(VM& vm, NativeExecutable* executable, const String& name)
+{
+    constexpr unsigned length = 0;
+    Base::finishCreation(vm, executable, length, name);
+    ASSERT(inherits(info()));
+}
+
+template<typename Visitor>
+void JSWebAssemblySuspendingFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSWebAssemblySuspendingFunction*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_wrappedFunction);
+}
+
+DEFINE_VISIT_CHILDREN(JSWebAssemblySuspendingFunction);
+
+}
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendingFunction.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblySuspendingFunction.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSFunction.h"
+
+namespace JSC {
+
+// A function object created by 'new WebAssembly.Suspending(f)'.
+class JSWebAssemblySuspendingFunction final : public JSFunction {
+public:
+    using Base = JSFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.suspendingFunctionSpace<mode>();
+    }
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    static JSWebAssemblySuspendingFunction* create(VM&, JSGlobalObject*, JSFunction*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
+
+    // The function passed to the 'new WebAssembly.Suspending()' call that created this.
+    JSFunction* wrappedFunction() const { return m_wrappedFunction.get(); }
+
+private:
+    JSWebAssemblySuspendingFunction(VM& vm, NativeExecutable* native, JSGlobalObject* globalObject, Structure* structure, JSFunction* wrapped)
+        : Base(vm, native, globalObject, structure)
+        , m_wrappedFunction(wrapped, WriteBarrierEarlyInit)
+    { }
+
+    void finishCreation(VM&, NativeExecutable*, const String&);
+
+    WriteBarrier<JSFunction> m_wrappedFunction;
+};
+
+}
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorConstructor.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblySuspendErrorConstructor.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSCInlines.h"
+#include "JSWebAssemblySuspendError.h"
+#include "WebAssemblySuspendErrorPrototype.h"
+
+namespace JSC {
+
+const ClassInfo WebAssemblySuspendErrorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblySuspendErrorConstructor) };
+
+static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblySuspendError);
+static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblySuspendError);
+
+JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblySuspendError, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue message = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, webAssemblySuspendErrorStructure, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(ErrorInstance::create(globalObject, structure, message, options, nullptr, TypeNothing, ErrorType::Error, false)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblySuspendError, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    JSValue message = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    Structure* errorStructure = globalObject->webAssemblySuspendErrorStructure();
+    return JSValue::encode(ErrorInstance::create(globalObject, errorStructure, message, options, nullptr, TypeNothing, ErrorType::Error, false));
+}
+
+WebAssemblySuspendErrorConstructor* WebAssemblySuspendErrorConstructor::create(VM& vm, Structure* structure, WebAssemblySuspendErrorPrototype* thisPrototype)
+{
+    auto* constructor = new (NotNull, allocateCell<WebAssemblySuspendErrorConstructor>(vm)) WebAssemblySuspendErrorConstructor(vm, structure);
+    constructor->finishCreation(vm, thisPrototype);
+    return constructor;
+}
+
+Structure* WebAssemblySuspendErrorConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+void WebAssemblySuspendErrorConstructor::finishCreation(VM& vm, WebAssemblySuspendErrorPrototype* prototype)
+{
+    Base::finishCreation(vm, 1, "SuspendError"_s, PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
+}
+
+WebAssemblySuspendErrorConstructor::WebAssemblySuspendErrorConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callJSWebAssemblySuspendError, constructJSWebAssemblySuspendError)
+{
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorConstructor.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "InternalFunction.h"
+#include "JSObject.h"
+
+namespace JSC {
+
+class WebAssemblySuspendErrorPrototype;
+
+class WebAssemblySuspendErrorConstructor final : public InternalFunction {
+public:
+    typedef InternalFunction Base;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static WebAssemblySuspendErrorConstructor* create(VM&, Structure*, WebAssemblySuspendErrorPrototype*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    WebAssemblySuspendErrorConstructor(VM&, Structure*);
+    void finishCreation(VM&, WebAssemblySuspendErrorPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblySuspendErrorConstructor, InternalFunction);
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorPrototype.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblySuspendErrorPrototype.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "AuxiliaryBarrierInlines.h"
+#include "JSCInlines.h"
+
+namespace JSC {
+
+const ClassInfo WebAssemblySuspendErrorPrototype::s_info = { "WebAssembly.SuspendError"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblySuspendErrorPrototype) };
+
+WebAssemblySuspendErrorPrototype* WebAssemblySuspendErrorPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
+{
+    auto* object = new (NotNull, allocateCell<WebAssemblySuspendErrorPrototype>(vm)) WebAssemblySuspendErrorPrototype(vm, structure);
+    object->finishCreation(vm);
+    return object;
+}
+
+Structure* WebAssemblySuspendErrorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+void WebAssemblySuspendErrorPrototype::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+    putDirectWithoutTransition(vm, vm.propertyNames->name, jsNontrivialString(vm, "SuspendError"_s), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    putDirectWithoutTransition(vm, vm.propertyNames->message, jsEmptyString(vm), static_cast<unsigned>(PropertyAttribute::DontEnum));
+}
+
+WebAssemblySuspendErrorPrototype::WebAssemblySuspendErrorPrototype(VM& vm, Structure* structure)
+    : Base(vm, structure)
+{
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendErrorPrototype.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSDestructibleObject.h"
+#include "JSObject.h"
+
+namespace JSC {
+
+class WebAssemblySuspendErrorPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblySuspendErrorPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static WebAssemblySuspendErrorPrototype* create(VM&, JSGlobalObject*, Structure*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    WebAssemblySuspendErrorPrototype(VM&, Structure*);
+    void finishCreation(VM&);
+};
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingConstructor.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblySuspendingConstructor.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "Error.h"
+#include "JSCInlines.h"
+#include "JSWebAssemblySuspendingFunction.h"
+
+namespace JSC {
+
+const ClassInfo WebAssemblySuspendingConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblySuspendingConstructor) };
+
+static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblySuspending);
+static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblySuspending);
+
+JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblySuspending, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSFunction* wrappedFunction = nullptr;
+    if (!(callFrame->argumentCount() == 1 && (wrappedFunction = jsDynamicCast<JSFunction*>(callFrame->argument(0).getObject())))) {
+        throwVMError(globalObject, scope, "new WebAssembly.Suspending() expects a function"_s);
+        return { };
+    }
+
+    auto* suspending = JSWebAssemblySuspendingFunction::create(vm, globalObject, wrappedFunction);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return JSValue::encode(suspending);
+}
+
+JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblySuspending, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Suspending"_s));
+}
+
+WebAssemblySuspendingConstructor* WebAssemblySuspendingConstructor::create(VM& vm, Structure* structure, WebAssemblySuspendingPrototype* thisPrototype)
+{
+    auto* constructor = new (NotNull, allocateCell<WebAssemblySuspendingConstructor>(vm)) WebAssemblySuspendingConstructor(vm, structure);
+    constructor->finishCreation(vm, thisPrototype);
+    return constructor;
+}
+
+Structure* WebAssemblySuspendingConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+void WebAssemblySuspendingConstructor::finishCreation(VM& vm, WebAssemblySuspendingPrototype* prototype)
+{
+    constexpr unsigned length = 1;
+    Base::finishCreation(vm, length, "WebAssembly.Suspending"_s, PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
+}
+
+WebAssemblySuspendingConstructor::WebAssemblySuspendingConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callJSWebAssemblySuspending, constructJSWebAssemblySuspending)
+{
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingConstructor.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "WebAssemblySuspendingPrototype.h"
+
+namespace JSC {
+
+// The function behind the 'new WebAssembly.Suspending()' calls.
+class WebAssemblySuspendingConstructor final : public InternalFunction {
+public:
+    using Base = InternalFunction;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static WebAssemblySuspendingConstructor* create(VM&, Structure*, WebAssemblySuspendingPrototype*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    WebAssemblySuspendingConstructor(VM&, Structure*);
+    void finishCreation(VM&, WebAssemblySuspendingPrototype*);
+};
+
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblySuspendingConstructor, InternalFunction);
+
+}
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingPrototype.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblySuspendingPrototype.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "AuxiliaryBarrierInlines.h"
+#include "JSCInlines.h"
+
+namespace JSC {
+
+const ClassInfo WebAssemblySuspendingPrototype::s_info = { "WebAssembly.Suspending"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblySuspendingPrototype) };
+
+WebAssemblySuspendingPrototype* WebAssemblySuspendingPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
+{
+    auto* object = new (NotNull, allocateCell<WebAssemblySuspendingPrototype>(vm)) WebAssemblySuspendingPrototype(vm, structure);
+    object->finishCreation(vm);
+    return object;
+}
+
+Structure* WebAssemblySuspendingPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+void WebAssemblySuspendingPrototype::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspendingPrototype.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSDestructibleObject.h"
+#include "JSObject.h"
+
+namespace JSC {
+
+// The prototype associated with WebAssemblySuspendingConstructors.
+class WebAssemblySuspendingPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblySuspendingPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static WebAssemblySuspendingPrototype* create(VM&, JSGlobalObject*, Structure*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    WebAssemblySuspendingPrototype(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    { }
+
+    void finishCreation(VM&);
+};
+
+}
+
+#endif // ENABLE(WEBASSEMBLY)


### PR DESCRIPTION
#### 7d8587868cea93d566740dd89a98ea9ffae2b390
<pre>
Test (JSPI WORK IN PROGRESS)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8587868cea93d566740dd89a98ea9ffae2b390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134464 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141997 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2dcfec7a-ba79-4854-8148-0773fca0a61e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6794 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102777 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.worker.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9986409e-16d7-4806-99e1-02fc3dd6a754) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120511 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83568 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9aecea2-0003-4015-9aae-7afad89bf0d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5119 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2738 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126518 "Found 28 new JSC stress test failures: wasm.yaml/wasm/stress/jspi-basic.js.default-wasm, wasm.yaml/wasm/stress/jspi-basic.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/jspi-basic.js.wasm-bbq, wasm.yaml/wasm/stress/jspi-basic.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/jspi-basic.js.wasm-collect-continuously, wasm.yaml/wasm/stress/jspi-basic.js.wasm-eager, wasm.yaml/wasm/stress/jspi-basic.js.wasm-eager-jettison, wasm.yaml/wasm/stress/jspi-basic.js.wasm-graph-reg-alloc, wasm.yaml/wasm/stress/jspi-basic.js.wasm-no-cjit, wasm.yaml/wasm/stress/jspi-basic.js.wasm-no-jit ... (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38652 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/overlay/overlay-computed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144688 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132972 "Found 28 new JSC stress test failures: wasm.yaml/wasm/stress/jspi-basic.js.default-wasm, wasm.yaml/wasm/stress/jspi-basic.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/jspi-basic.js.wasm-bbq, wasm.yaml/wasm/stress/jspi-basic.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/jspi-basic.js.wasm-collect-continuously, wasm.yaml/wasm/stress/jspi-basic.js.wasm-eager, wasm.yaml/wasm/stress/jspi-basic.js.wasm-eager-jettison, wasm.yaml/wasm/stress/jspi-basic.js.wasm-graph-reg-alloc, wasm.yaml/wasm/stress/jspi-basic.js.wasm-no-cjit, wasm.yaml/wasm/stress/jspi-basic.js.wasm-no-jit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6607 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39236 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.worker.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5547 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.worker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111452 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4954 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116788 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60431 "Hash 7d858786 for PR 54988 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6660 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34986 "Found 5 new test failures: imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/notraps.any.worker.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.html imported/w3c/web-platform-tests/wasm/jsapi/jspi/rejects.any.worker.html (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165903 "Hash 7d858786 for PR 54988 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6482 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70231 "Found 5 new failures in runtime/PinballCompletion.cpp, runtime/EvacuatedStack.cpp, runtime/PinballCompletion.h") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/165903 "Hash 7d858786 for PR 54988 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6719 "Hash 7d858786 for PR 54988 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->