### PR TITLE
String methods throw TypeError for non-callable

### DIFF
--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -34,8 +34,11 @@ function match(regexp)
 
     if (@isObject(regexp)) {
         var matcher = regexp.@@match;
-        if (!@isUndefinedOrNull(matcher))
+        if (!@isUndefinedOrNull(matcher)) {
+            if (!@isCallable(matcher))
+                @throwTypeError("Symbol.match property should be callable");
             return matcher.@call(regexp, this);
+        }
     }
 
     var thisString = @toString(this);
@@ -55,8 +58,11 @@ function matchAll(arg)
             @throwTypeError("String.prototype.matchAll argument must not be a non-global regular expression");
 
         var matcher = arg.@@matchAll;
-        if (!@isUndefinedOrNull(matcher))
+        if (!@isUndefinedOrNull(matcher)) {
+            if (!@isCallable(matcher))
+                @throwTypeError("Symbol.matchAll property should be callable");
             return matcher.@call(arg, this);
+        }
     }
 
     var string = @toString(this);
@@ -270,6 +276,8 @@ function replace(search, replace)
     if (@isObject(search)) {
         var replacer = search.@@replace;
         if (!@isUndefinedOrNull(replacer)) {
+            if (!@isCallable(replacer))
+                @throwTypeError("Symbol.replace property should be callable");
             if (!@hasObservableSideEffectsForStringReplace(search, replacer))
                 return @toString(this).@replaceUsingRegExp(search, replace);
             return replacer.@call(search, this, replace);
@@ -295,6 +303,8 @@ function replaceAll(search, replace)
 
         var replacer = search.@@replace;
         if (!@isUndefinedOrNull(replacer)) {
+            if (!@isCallable(replacer))
+                @throwTypeError("Symbol.replace property should be callable");
             if (!@hasObservableSideEffectsForStringReplace(search, replacer))
                 return @toString(this).@replaceUsingRegExp(search, replace);
             return replacer.@call(search, this, replace);
@@ -315,8 +325,11 @@ function search(regexp)
 
     if (@isObject(regexp)) {
         var searcher = regexp.@@search;
-        if (!@isUndefinedOrNull(searcher))
+        if (!@isUndefinedOrNull(searcher)) {
+            if (!@isCallable(searcher))
+                @throwTypeError("Symbol.search property should be callable");
             return searcher.@call(regexp, this);
+        }
     }
 
     var thisString = @toString(this);
@@ -327,16 +340,19 @@ function search(regexp)
 function split(separator, limit)
 {
     "use strict";
-    
+
     if (@isUndefinedOrNull(this))
         @throwTypeError("String.prototype.split requires that |this| not be null or undefined");
-    
+
     if (@isObject(separator)) {
         var splitter = separator.@@split;
-        if (!@isUndefinedOrNull(splitter))
+        if (!@isUndefinedOrNull(splitter)) {
+            if (!@isCallable(splitter))
+                @throwTypeError("Symbol.split property should be callable");
             return splitter.@call(separator, this, limit);
+        }
     }
-    
+
     return @stringSplitFast.@call(this, separator, limit);
 }
 


### PR DESCRIPTION
#### 4b7e683004d88708cc5e23f327c69d7d757a927e
<pre>
String methods throw TypeError for non-callable
<a href="https://bugs.webkit.org/show_bug.cgi?id=297423">https://bugs.webkit.org/show_bug.cgi?id=297423</a>

Reviewed by NOBODY (OOPS!).

String methods such as match, matchAll, replace, replaceAll, search, split
should check if the function argument (matcher etc.) is Callable, otherwise
they should throw a TypeError.

From <a href="https://tc39.es/ecma262/#sec-getmethod">https://tc39.es/ecma262/#sec-getmethod</a>,

1. Let func be ? GetV(V, P).
2. If func is either undefined or null, return undefined.
3. If IsCallable(func) is false, throw a TypeError exception.
4. Return func.

GetMethod is called from these methods, for example:
<a href="https://tc39.es/ecma262/#sec-string.prototype.search.">https://tc39.es/ecma262/#sec-string.prototype.search.</a>

No new tests (OOPS!).

* Source/JavaScriptCore/builtins/StringPrototype.js:
(match):
(matchAll):
(intrinsic.StringPrototypeReplaceIntrinsic.replace):
(intrinsic.StringPrototypeReplaceAllIntrinsic.replaceAll):
(search):
(split):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b7e683004d88708cc5e23f327c69d7d757a927e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70033 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5122 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2740 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2639 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126520 "Found 19 new JSC stress test failures: stress/string-symbol-customization.js.bytecode-cache, stress/string-symbol-customization.js.default, stress/string-symbol-customization.js.dfg-eager, stress/string-symbol-customization.js.dfg-eager-no-cjit-validate, stress/string-symbol-customization.js.eager-jettison-no-cjit, stress/string-symbol-customization.js.ftl-eager, stress/string-symbol-customization.js.ftl-eager-no-cjit, stress/string-symbol-customization.js.ftl-eager-no-cjit-b3o1, stress/string-symbol-customization.js.ftl-no-cjit-b3o0, stress/string-symbol-customization.js.ftl-no-cjit-no-inline-validate ... (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114334 "Found 5 new API test failures: TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenuSelect, TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenuHighlight, TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenu, TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenuDelegate, TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144690 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/132974 "Found 19 new JSC stress test failures: stress/string-symbol-customization.js.bytecode-cache, stress/string-symbol-customization.js.default, stress/string-symbol-customization.js.dfg-eager, stress/string-symbol-customization.js.dfg-eager-no-cjit-validate, stress/string-symbol-customization.js.eager-jettison-no-cjit, stress/string-symbol-customization.js.ftl-eager, stress/string-symbol-customization.js.ftl-eager-no-cjit, stress/string-symbol-customization.js.ftl-eager-no-cjit-b3o1, stress/string-symbol-customization.js.ftl-no-cjit-b3o0, stress/string-symbol-customization.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111184 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/133894 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111454 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4953 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116795 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60433 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6662 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34994 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165905 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70233 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43361 "Found 9 new JSC stress test failures: stress/string-symbol-customization.js.bytecode-cache, stress/string-symbol-customization.js.default, stress/string-symbol-customization.js.dfg-eager, stress/string-symbol-customization.js.dfg-eager-no-cjit-validate, stress/string-symbol-customization.js.eager-jettison-no-cjit, stress/string-symbol-customization.js.mini-mode, stress/string-symbol-customization.js.no-cjit-collect-continuously, stress/string-symbol-customization.js.no-cjit-validate-phases, stress/string-symbol-customization.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->