### PR TITLE
Workaround Swift name mangling

### DIFF
--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -32,6 +32,12 @@ import WebGPU_Internal
 import USDStageKit
 import _USDStageKit_SwiftUI
 import ShaderGraph
+
+// FIXME: rdar://166014064 - this shouldn't be necessary yet it seems to be
+extension _USDStageKit_SwiftUI._Proto_MeshDataUpdate_v1 {
+    @_silgen_name("$s20_USDStageKit_SwiftUI24_Proto_MeshDataUpdate_v1V18instanceTransformsSaySo13simd_float4x4aGvg")
+    fileprivate func instanceTransformsCompat() -> [simd_float4x4]
+}
 #endif
 
 @objc
@@ -1151,13 +1157,13 @@ final class Converter {
     ) -> DDBridgeUpdateMesh {
         var webRequestInstanceTransforms: DDBridgeChainedFloat4x4?
 
-        if request.instanceTransforms.count > 0 {
-            let countMinusOne = request.instanceTransforms.count - 1
-            webRequestInstanceTransforms = DDBridgeChainedFloat4x4(transform: request.instanceTransforms[0])
+        if request.instanceTransformsCompat().count > 0 {
+            let countMinusOne = request.instanceTransformsCompat().count - 1
+            webRequestInstanceTransforms = DDBridgeChainedFloat4x4(transform: request.instanceTransformsCompat()[0])
             var instanceTransforms = webRequestInstanceTransforms
             if countMinusOne > 0 {
                 for i in 1...countMinusOne {
-                    instanceTransforms?.next = DDBridgeChainedFloat4x4(transform: request.instanceTransforms[i])
+                    instanceTransforms?.next = DDBridgeChainedFloat4x4(transform: request.instanceTransformsCompat()[i])
                     instanceTransforms = instanceTransforms?.next
                 }
             }
@@ -1176,7 +1182,7 @@ final class Converter {
             indexData: request.indexData,
             vertexData: request.vertexData,
             instanceTransforms: webRequestInstanceTransforms,
-            instanceTransformsCount: request.instanceTransforms.count,
+            instanceTransformsCount: request.instanceTransformsCompat().count,
             materialPrims: request.materialPrims
         )
     }


### PR DESCRIPTION
#### 3026ab13830c27f6670f77d345a9029cb3cbd3f9
<pre>
Workaround Swift name mangling
<a href="https://bugs.webkit.org/show_bug.cgi?id=303708">https://bugs.webkit.org/show_bug.cgi?id=303708</a>
<a href="https://rdar.apple.com/166014149">rdar://166014149</a>

Reviewed by NOBODY (OOPS!).

Ld can&apos;t find the symbol even though it exists, so tell
Swift the symbol name which can be found in the framework.

@_silgen didn&apos;t work for instance properties either so its
staged as a method instead

* Source/WebGPU/WebGPU/USDModel.swift:
(_USDStageKit_SwiftUI.instanceTransformsCompat):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3026ab13830c27f6670f77d345a9029cb3cbd3f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7322b8c-0a30-4ea8-abed-82f83f9bf66e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70099 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/878080e6-e188-4452-a21c-e8f46975d74f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83620 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f562ca9f-d702-495f-895f-9569ba85875d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2783 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2670 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114391 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111225 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111500 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5000 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35044 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->