### PR TITLE
Adopt isReleasedWeakValue in WeakPtr

### DIFF
--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -1258,6 +1258,11 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         unsigned tableSize = this->tableSize();
         for (unsigned i = 0; i < tableSize; ++i) {
             auto& entry = m_table[i];
+            if constexpr (!HashFunctions::safeToCompareToEmptyOrDeleted) {
+                if (isEmptyOrDeletedBucket(entry))
+                    continue;
+            }
+
             if (isReleasedWeakBucket(entry)) {
                 deleteBucket(entry);
                 setDeletedCount(deletedCount() + 1);

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -92,6 +92,7 @@ public:
 
     bool isHashTableDeletedValue() const { return m_impl.isHashTableDeletedValue(); }
     bool isHashTableEmptyValue() const { return !m_impl; }
+    bool isWeakNullValue() const { return !*m_impl; }
 
     T* ptrAllowingHashTableEmptyValue() const
     {
@@ -308,6 +309,9 @@ template<typename P, typename WeakPtrImpl> struct WeakPtrHashTraits : SimpleClas
 
     static constexpr bool hasIsEmptyValueFunction = true;
     static bool isEmptyValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isHashTableEmptyValue(); }
+
+    static constexpr bool hasIsReleasedWeakValueFunction = true;
+    static bool isReleasedWeakValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isWeakNullValue(); }
 
     using PeekType = P*;
     static PeekType peek(const WeakPtr<P, WeakPtrImpl>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -1996,6 +1996,19 @@ TEST(WTF_WeakPtr, WeakHashMap_iterator_destruction)
     }
 }
 
+TEST(WTF_WeakPtr, ListHashSetBoundedGrowth)
+{
+    ListHashSet<WeakPtr<BaseObjectWithRefAndWeakPtr>> set;
+    for (size_t i = 0; i < 128; ++i)
+        set.add(BaseObjectWithRefAndWeakPtr::create().get());
+
+    size_t entryCount = 0;
+    for (auto entry : set)
+        ++entryCount;
+
+    EXPECT_LT(entryCount, 16u);
+}
+
 template <typename T>
 unsigned computeSizeOfWeakListHashSet(const WeakListHashSet<T>& set)
 {


### PR DESCRIPTION
#### 87fd6dd1eafd8a66987994fe7996c3b69feffb65
<pre>
Adopt isReleasedWeakValue in WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=303711">https://bugs.webkit.org/show_bug.cgi?id=303711</a>
&lt;<a href="https://rdar.apple.com/problem/166015837">rdar://problem/166015837</a>&gt;

Reviewed by Ryosuke Niwa.

This is a step toward a more efficient weak pointer.

The isReleasedWeakValue function makes HashTable responsible for shrinking the
table when it accumulates too many weak nulls.

ListHashSet was not compatible with this strategy. It depended on being notified
when an item was removed so that it could unlink and delete the item&apos;s linked
list node.

Changed ListHashSet to use a Linux-style sentinel / circular list. This has the
nice property that individual nodes can remove themselves from the list without
maintaining a back-pointer to the list owner.

Now the hash table owns the list nodes and destruction is automatic: Removing a
node deletes it, which removes it from the list.

Canonical link: <a href="https://commits.webkit.org/304265@main">https://commits.webkit.org/304265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c57a5e956fd1c2a7affa409699f4b4d2a1d02f08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134823 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86722 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4b54d94-5fc4-40b2-b0d7-c5de906d6138) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103030 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70322 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c4e66a5-0e08-4017-803b-f94e79943205) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83863 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c68b993-234e-47c8-896f-992c61fb9b98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3007 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2930 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126861 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145035 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133330 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111412 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111745 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5237 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60869 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20835 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35310 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70564 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43444 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7008 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->