### PR TITLE
Push weak null removal logic down into HashTable

### DIFF
--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -36,8 +36,8 @@ namespace JSC {
 
 template<typename T>
 struct WeakGCSetHashTraits : HashTraits<Weak<T>> {
-    static constexpr bool hasIsReleasedWeakValueFunction = true;
-    static bool isReleasedWeakValue(const Weak<T>& value)
+    static constexpr bool hasIsWeakNullValueFunction = true;
+    static bool isWeakNullValue(const Weak<T>& value)
     {
         return !value.isHashTableDeletedValue() && !value.isHashTableEmptyValue() && !value;
     }

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -183,6 +183,7 @@ public:
     bool remove(iterator);
     // FIXME: This feels like it should be Invocable<bool(const KeyValuePairType&)>
     bool removeIf(NOESCAPE const Invocable<bool(KeyValuePairType&)> auto&);
+    void removeWeakNullEntries();
     void clear();
 
     MappedTakeType take(const KeyType&); // efficient combination of get with remove
@@ -577,6 +578,12 @@ template<typename T, typename U, typename V, typename W, typename X, typename Y,
 inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(const KeyType& key)
 {
     return remove(find(key));
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::removeWeakNullEntries()
+{
+    m_impl.removeWeakNullEntries();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -144,6 +144,7 @@ public:
     bool remove(const ValueType&);
     bool remove(iterator);
     bool removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto&);
+    void removeWeakNullEntries();
     void clear();
 
     TakeType take(const ValueType&);
@@ -403,6 +404,12 @@ template<typename T, typename U, typename V, typename W, ShouldValidateKey shoul
 inline bool HashSet<T, U, V, W, shouldValidateKey>::removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
+}
+
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::removeWeakNullEntries()
+{
+    m_impl.removeWeakNullEntries();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -46,7 +46,7 @@ template<typename T> struct GenericHashTraitsBase<false, T> {
     static constexpr bool hasIsEmptyValueFunction = false;
 
     // Used by WeakPtr to indicate that the value may become deleted without being explicitly removed.
-    static constexpr bool hasIsReleasedWeakValueFunction = false;
+    static constexpr bool hasIsWeakNullValueFunction = false;
 
     // The starting table size. Can be overridden when we know beforehand that
     // a hash table will have at least N entries.
@@ -307,16 +307,16 @@ template<typename Traits, typename T> inline bool isHashTraitsEmptyValue(const T
     return HashTraitsEmptyValueChecker<Traits, Traits::hasIsEmptyValueFunction>::isEmptyValue(value);
 }
 
-template<typename Traits, bool hasIsReleasedWeakValueFunction> struct HashTraitsReleasedWeakValueChecker;
-template<typename Traits> struct HashTraitsReleasedWeakValueChecker<Traits, true> {
-    template<typename T> static bool isReleasedWeakValue(const T& value) { return Traits::isReleasedWeakValue(value); }
+template<typename Traits, bool hasIsWeakNullValueFunction> struct HashTraitsWeakNullValueChecker;
+template<typename Traits> struct HashTraitsWeakNullValueChecker<Traits, true> {
+    template<typename T> static bool isWeakNullValue(const T& value) { return Traits::isWeakNullValue(value); }
 };
-template<typename Traits> struct HashTraitsReleasedWeakValueChecker<Traits, false> {
-    template<typename T> static bool isReleasedWeakValue(const T&) { return false; }
+template<typename Traits> struct HashTraitsWeakNullValueChecker<Traits, false> {
+    template<typename T> static bool isWeakNullValue(const T&) { return false; }
 };
-template<typename Traits, typename T> inline bool isHashTraitsReleasedWeakValue(const T& value)
+template<typename Traits, typename T> inline bool isHashTraitsWeakNullValue(const T& value)
 {
-    return HashTraitsReleasedWeakValueChecker<Traits, Traits::hasIsReleasedWeakValueFunction>::isReleasedWeakValue(value);
+    return HashTraitsWeakNullValueChecker<Traits, Traits::hasIsWeakNullValueFunction>::isWeakNullValue(value);
 }
 
 template<typename Traits, typename T>

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -91,8 +91,8 @@ private:
     struct NodeTraits : public HashTraits<std::unique_ptr<Node>> {
         using ValueTraits = HashTraits<ValueArg>;
 
-        static constexpr bool hasIsReleasedWeakValueFunction = ValueTraits::hasIsReleasedWeakValueFunction;
-        static bool isReleasedWeakValue(const std::unique_ptr<Node>& node) { return isHashTraitsReleasedWeakValue<ValueTraits>(node->m_value); }
+        static constexpr bool hasIsWeakNullValueFunction = ValueTraits::hasIsWeakNullValueFunction;
+        static bool isWeakNullValue(const std::unique_ptr<Node>& node) { return isHashTraitsWeakNullValue<ValueTraits>(node->m_value); }
     };
 
     typedef ListHashSetNodeHashFunctions<HashArg> NodeHash;
@@ -184,6 +184,7 @@ public:
     bool remove(const ValueType&);
     bool remove(iterator);
     bool removeIf(NOESCAPE const Invocable<bool(ValueType&)> auto&);
+    void removeWeakNullEntries();
     void clear();
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
@@ -799,6 +800,12 @@ inline bool ListHashSet<T, U>::remove(const ValueType& value)
         return false;
     m_impl.remove(it);
     return true;
+}
+
+template<typename T, typename U>
+inline void ListHashSet<T, U>::removeWeakNullEntries()
+{
+    m_impl.removeWeakNullEntries();
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -118,7 +118,7 @@ public:
 
     static constexpr unsigned probeDistanceThreshold = 128;
 
-    static_assert(!KeyTraits::hasIsReleasedWeakValueFunction);
+    static_assert(!KeyTraits::hasIsWeakNullValueFunction);
     static_assert(HashFunctions::hasHashInValue);
 
     RobinHoodHashTable() = default;

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -371,11 +371,10 @@ public:
         return m_map.size();
     }
 
-    NEVER_INLINE bool removeNullReferences()
+    NEVER_INLINE void removeNullReferences()
     {
-        bool result = m_map.removeIf([](auto& iterator) { return !iterator.key.get(); });
+        m_map.removeWeakNullEntries();
         cleanupHappened();
-        return result;
     }
 
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -224,11 +224,10 @@ private:
         m_maxOperationCountWithoutCleanup = std::min(std::numeric_limits<unsigned>::max() / 2, m_set.size()) * 2;
     }
 
-    ALWAYS_INLINE bool removeNullReferences()
+    ALWAYS_INLINE void removeNullReferences()
     {
-        bool didRemove = m_set.removeIf([] (auto& value) { return !value.get(); });
+        m_set.removeWeakNullEntries();
         cleanupHappened();
-        return didRemove;
     }
 
     ALWAYS_INLINE unsigned increaseOperationCountSinceLastCleanup(unsigned count = 1) const

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -339,11 +339,10 @@ public:
 
     void checkConsistency() { } // To be implemented.
 
-    bool removeNullReferences()
+    void removeNullReferences()
     {
-        bool didRemove = m_set.removeIf([] (auto& value) { return !value.get(); });
+        m_set.removeWeakNullEntries();
         cleanupHappened();
-        return didRemove;
     }
 
     T& first()

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -310,8 +310,8 @@ template<typename P, typename WeakPtrImpl> struct WeakPtrHashTraits : SimpleClas
     static constexpr bool hasIsEmptyValueFunction = true;
     static bool isEmptyValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isHashTableEmptyValue(); }
 
-    static constexpr bool hasIsReleasedWeakValueFunction = true;
-    static bool isReleasedWeakValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isWeakNullValue(); }
+    static constexpr bool hasIsWeakNullValueFunction = true;
+    static bool isWeakNullValue(const WeakPtr<P, WeakPtrImpl>& value) { return value.isWeakNullValue(); }
 
     using PeekType = P*;
     static PeekType peek(const WeakPtr<P, WeakPtrImpl>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }


### PR DESCRIPTION
#### b47e7f0debf438d2eecef6ca63e94e525601a65a
<pre>
Push weak null removal logic down into HashTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=303710">https://bugs.webkit.org/show_bug.cgi?id=303710</a>
&lt;<a href="https://rdar.apple.com/problem/166015673">rdar://problem/166015673</a>&gt;

Reviewed by Ryosuke Niwa.

This is a step toward a more efficient weak pointer.

We need HashTable to remove weak nulls for us because soon it won&apos;t allow us to
see them by explicit iteration.

Canonical link: <a href="https://commits.webkit.org/304266@main">https://commits.webkit.org/304266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75a027e88ac76a927302850459b10dc56ed9a446

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135071 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46324 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8101 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/142585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138017 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/5756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/3174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/127091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133567 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/7153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/145276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20837 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7203 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/166446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/166446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->