### PR TITLE
Adopt smart pointers in RTCRtpScriptTransformer.cpp, RadioNodeList.cpp, DocumentWriter.cpp, HasSelectorFilter.cpp

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -34,6 +34,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "MessageWithMessagePorts.h"
 #include "RTCEncodedStreamProducer.h"
+#include "ScriptExecutionContextInlines.h"
 #include "WorkerThread.h"
 
 namespace WebCore {
@@ -138,7 +139,7 @@ void RTCRtpScriptTransformer::sendKeyFrameRequest(Ref<DeferredPromise>&& promise
     m_streamProducer->sendKeyFrameRequest();
 
     // FIXME: We should be able to know when the FIR request is sent to resolve the promise at this exact time.
-    context->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise)]() mutable {
+    context->checkedEventLoop()->queueTask(TaskSource::Networking, [promise = WTFMove(promise)]() mutable {
         promise->resolve();
     });
 }

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp
-Modules/mediastream/RTCRtpScriptTransformer.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
 Modules/push-api/PushDatabase.cpp
@@ -214,7 +213,6 @@ html/MediaDocument.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
 html/PluginDocument.cpp
-html/RadioNodeList.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp
@@ -331,7 +329,6 @@ loader/ApplicationManifestLoader.cpp
 loader/CrossOriginPreflightChecker.cpp
 loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
-loader/DocumentWriter.cpp
 loader/FrameLoadRequest.cpp
 loader/FrameLoader.cpp
 loader/ImageLoader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -471,7 +471,6 @@ style/ChildChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp
 style/ContainerQueryEvaluator.cpp
 style/ElementRuleCollector.cpp
-style/HasSelectorFilter.cpp
 style/IdChangeInvalidation.cpp
 style/InlineTextBoxStyle.cpp
 style/MatchResultCache.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -431,7 +431,6 @@ html/MediaElementSession.cpp
 html/ModelDocument.cpp
 html/OffscreenCanvas.cpp
 html/PluginDocument.cpp
-html/RadioNodeList.cpp
 [ iOS ] html/TextFieldInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
@@ -506,7 +505,6 @@ layout/integration/inline/LayoutIntegrationLineLayout.cpp
 loader/ApplicationManifestLoader.cpp
 loader/CrossOriginPreflightChecker.cpp
 loader/DocumentThreadableLoader.cpp
-loader/DocumentWriter.cpp
 loader/FrameLoadRequest.cpp
 [ iOS ] loader/FrameLoader.cpp
 loader/MediaResourceLoader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -418,7 +418,6 @@ rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
 style/AttributeChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp
-style/HasSelectorFilter.cpp
 style/IdChangeInvalidation.cpp
 style/InspectorCSSOMWrappers.cpp
 style/MatchResultCache.cpp

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -72,7 +72,8 @@ String RadioNodeList::value() const
 {
     auto length = this->length();
     for (unsigned i = 0; i < length; ++i) {
-        if (auto button = nonEmptyRadioButton(*item(i))) {
+        Ref node = *item(i);
+        if (RefPtr button = nonEmptyRadioButton(node)) {
             if (button->checked())
                 return button->value();
         }
@@ -84,7 +85,8 @@ void RadioNodeList::setValue(const String& value)
 {
     auto length = this->length();
     for (unsigned i = 0; i < length; ++i) {
-        if (auto button = nonEmptyRadioButton(*item(i))) {
+        Ref node = *item(i);
+        if (RefPtr button = nonEmptyRadioButton(node)) {
             if (button->value() == value) {
                 button->setChecked(true);
                 return;

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -63,9 +63,10 @@ namespace WebCore {
 
 static inline bool canReferToParentFrameEncoding(const LocalFrame* frame, const LocalFrame* parentFrame) 
 {
-    if (is<XMLDocument>(frame->document()))
+    RefPtr document = frame->document();
+    if (is<XMLDocument>(document))
         return false;
-    return parentFrame && parentFrame->document()->protectedSecurityOrigin()->isSameOriginDomain(frame->document()->securityOrigin());
+    return parentFrame && parentFrame->protectedDocument()->protectedSecurityOrigin()->isSameOriginDomain(document->protectedSecurityOrigin());
 }
     
 // This is only called by ScriptController::executeIfJavaScriptURL
@@ -234,7 +235,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
-                document->checkedContentSecurityPolicy()->updateSourceSelf(parentFrame->document()->securityOrigin());
+                document->checkedContentSecurityPolicy()->updateSourceSelf(parentFrame->protectedDocument()->protectedSecurityOrigin());
             }
         } else if (triggeringAction && triggeringAction->requester() && !isLoadingBrowserControlledHTML()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -44,11 +44,11 @@ HasSelectorFilter::HasSelectorFilter(const Element& element, Type type)
 {
     switch (type) {
     case Type::Descendants:
-        for (auto& descendant : descendantsOfType<Element>(element))
+        for (Ref descendant : descendantsOfType<Element>(element))
             add(descendant);
         break;
     case Type::Children:
-        for (auto& child : childrenOfType<Element>(element))
+        for (Ref child : childrenOfType<Element>(element))
             add(child);
         break;
     }


### PR DESCRIPTION
#### 91e6611254f2e06633aa25828c619b08113750a9
<pre>
Adopt smart pointers in RTCRtpScriptTransformer.cpp, RadioNodeList.cpp, DocumentWriter.cpp, HasSelectorFilter.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=303714">https://bugs.webkit.org/show_bug.cgi?id=303714</a>
<a href="https://rdar.apple.com/166025055">rdar://166025055</a>

Reviewed by NOBODY (OOPS!).

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

No new test needed.

* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::sendKeyFrameRequest):
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/html/RadioNodeList.cpp:
(WebCore::RadioNodeList::value const):
(WebCore::RadioNodeList::setValue):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::canReferToParentFrameEncoding):
(WebCore::DocumentWriter::begin):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::HasSelectorFilter):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91e6611254f2e06633aa25828c619b08113750a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86600 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f390cb50-d8c1-421d-9ddd-2255c71e76a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102919 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70201 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6efa7cc7-b26c-4a21-8ed1-d234ba0084e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83724 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cec0ab4d-fa7f-4d2d-ae9e-631eb1d877de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5267 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2884 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2773 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144874 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39418 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111311 "Failure limit exceed. At least found 2 new test failures: http/wpt/service-workers/service-worker-crashing-while-fetching.https.html http/wpt/service-workers/service-worker-preload-when-not-activated.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111606 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5103 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60674 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20802 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6840 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->