### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for MediaSessionHelperClient

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -29,17 +29,9 @@
 #if PLATFORM(IOS_FAMILY)
 
 #include <WebCore/MediaPlaybackTarget.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ProcessID.h>
 #include <wtf/WeakHashSet.h>
-
-namespace WebCore {
-class MediaSessionHelperClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaSessionHelperClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -50,7 +42,7 @@ enum class ShouldPause : bool { No, Yes };
 enum class SupportsAirPlayVideo : bool { No, Yes };
 enum class SupportsSpatialAudioPlayback : bool { No, Yes };
 
-class MediaSessionHelperClient : public CanMakeWeakPtr<MediaSessionHelperClient> {
+class MediaSessionHelperClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaSessionHelperClient> {
 public:
     virtual ~MediaSessionHelperClient() = default;
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -174,39 +174,45 @@ void MediaSessionHelper::removeClient(MediaSessionHelperClient& client)
 
 void MediaSessionHelper::activeAudioRouteDidChange(ShouldPause shouldPause)
 {
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.activeAudioRouteDidChange(shouldPause);
+    });
 }
 
 void MediaSessionHelper::applicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.uiApplicationWillEnterForeground(suspendedUnderLock);
+    });
 }
 
 void MediaSessionHelper::applicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
 {
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.uiApplicationDidEnterBackground(suspendedUnderLock);
+    });
 }
 
 void MediaSessionHelper::applicationWillBecomeInactive()
 {
-    for (auto& client : m_clients)
+    m_clients.forEach([](auto& client) {
         client.uiApplicationWillBecomeInactive();
+    });
 }
 
 void MediaSessionHelper::applicationDidBecomeActive()
 {
-    for (auto& client : m_clients)
+    m_clients.forEach([](auto& client) {
         client.uiApplicationDidBecomeActive();
+    });
 }
 
 void MediaSessionHelper::externalOutputDeviceAvailableDidChange(HasAvailableTargets hasAvailableTargets)
 {
     m_isExternalOutputDeviceAvailable = hasAvailableTargets == HasAvailableTargets::Yes;
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.externalOutputDeviceAvailableDidChange(hasAvailableTargets);
+    });
 }
 
 void MediaSessionHelper::isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit playingToAutomotiveHeadUnit)
@@ -216,16 +222,18 @@ void MediaSessionHelper::isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomot
         return;
 
     m_isPlayingToAutomotiveHeadUnit = newValue;
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.isPlayingToAutomotiveHeadUnitDidChange(playingToAutomotiveHeadUnit);
+    });
 }
 
 void MediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, Ref<MediaPlaybackTarget>&& playbackTarget)
 {
     m_playbackTarget = WTFMove(playbackTarget);
     m_activeVideoRouteSupportsAirPlayVideo = supportsAirPlayVideo == SupportsAirPlayVideo::Yes;
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.activeVideoRouteDidChange(supportsAirPlayVideo, *m_playbackTarget);
+    });
 }
 
 void MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
@@ -234,8 +242,9 @@ void MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(Suppor
         return;
 
     m_activeAudioRouteSupportsSpatialPlayback = supportsSpatialPlayback;
-    for (auto& client : m_clients)
+    m_clients.forEach([&](auto& client) {
         client.activeAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback);
+    });
 }
 
 void MediaSessionHelper::startMonitoringWirelessRoutes()

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -57,6 +57,7 @@ public:
     bool hasWirelessTargetsAvailable() final;
     bool isMonitoringWirelessTargets() const final;
 
+    // MediaSessionHelperClient, AudioSessionInterruptionObserver.
     void ref() const override { MediaSessionManagerCocoa::ref(); }
     void deref() const override { MediaSessionManagerCocoa::deref(); }
 

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -50,6 +50,7 @@ public:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    // WebCore::MediaSessionHelperClient, IPC::MessageReceiver.
     void ref() const final;
     void deref() const final;
 


### PR DESCRIPTION
#### 86102c03e4a6ca9f0f7f0d3e87e24fb8c0c1c5fb
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for MediaSessionHelperClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303717">https://bugs.webkit.org/show_bug.cgi?id=303717</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::activeAudioRouteDidChange):
(MediaSessionHelper::applicationWillEnterForeground):
(MediaSessionHelper::applicationDidEnterBackground):
(MediaSessionHelper::applicationWillBecomeInactive):
(MediaSessionHelper::applicationDidBecomeActive):
(MediaSessionHelper::externalOutputDeviceAvailableDidChange):
(MediaSessionHelper::isPlayingToAutomotiveHeadUnitDidChange):
(MediaSessionHelper::activeVideoRouteDidChange):
(MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:

Canonical link: <a href="https://commits.webkit.org/304118@main">https://commits.webkit.org/304118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12686fcf28892696983a72343cca2df573a3876

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86479 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102800 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70080 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a81806e9-17f8-4961-b513-34664b4369ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83593 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/48342451-29b7-479f-a240-36393e769eb2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2764 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2655 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144725 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6642 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111205 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111478 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4980 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6695 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35022 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->