### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AudioSessionRoutingArbitrationClient

### DIFF
--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -40,15 +40,6 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
-namespace WebCore {
-class AudioSessionRoutingArbitrationClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioSessionRoutingArbitrationClient> : std::true_type { };
-}
-
 namespace WTF {
 class Logger;
 }
@@ -163,7 +154,7 @@ public:
 
     virtual bool isActive() const { return m_active; }
 
-    virtual void setRoutingArbitrationClient(WeakPtr<AudioSessionRoutingArbitrationClient>&& client) { m_routingArbitrationClient = client; }
+    void setRoutingArbitrationClient(AudioSessionRoutingArbitrationClient& client) { m_routingArbitrationClient = client; }
 
     static bool shouldManageAudioSessionCategory();
     static void setShouldManageAudioSessionCategory(bool);
@@ -211,7 +202,7 @@ public:
 
 enum class AudioSessionRoutingArbitrationError : uint8_t { None, Failed, Cancelled };
 
-class WEBCORE_EXPORT AudioSessionRoutingArbitrationClient : public CanMakeWeakPtr<AudioSessionRoutingArbitrationClient> {
+class WEBCORE_EXPORT AudioSessionRoutingArbitrationClient : public AbstractRefCountedAndCanMakeWeakPtr<AudioSessionRoutingArbitrationClient> {
 public:
     USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<AudioSessionRoutingArbitrationClient>);
 
@@ -223,7 +214,7 @@ public:
     using ArbitrationCallback = CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>;
 
     virtual void beginRoutingArbitrationWithCategory(AudioSession::CategoryType, ArbitrationCallback&&) = 0;
-    virtual void leaveRoutingAbritration() = 0;
+    virtual void leaveRoutingArbitration() = 0;
 
     virtual uint64_t logIdentifier() const = 0;
     virtual bool canLog() const = 0;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1343,9 +1343,8 @@ void GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary()
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    ASSERT(!m_routingArbitrator);
-    m_routingArbitrator = LocalAudioSessionRoutingArbitrator::create(*this);
-    m_gpuProcess->protectedAudioSessionManager()->protectedSession()->setRoutingArbitrationClient(m_routingArbitrator.get());
+    lazyInitialize(m_routingArbitrator, makeUniqueWithoutRefCountedCheck<LocalAudioSessionRoutingArbitrator>(*this));
+    m_gpuProcess->protectedAudioSessionManager()->protectedSession()->setRoutingArbitrationClient(*m_routingArbitrator);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -134,7 +134,7 @@ class RemoteGraphicsContextGL;
 class GPUConnectionToWebProcess
     : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GPUConnectionToWebProcess, WTF::DestructionThread::Main>
     , public WebCore::NowPlayingManagerClient
-    , IPC::Connection::Client {
+    , public IPC::Connection::Client {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(GPUConnectionToWebProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUConnectionToWebProcess);
 public:
@@ -472,7 +472,7 @@ private:
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    std::unique_ptr<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;
+    const std::unique_ptr<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;
 #endif
 #if ENABLE(IPC_TESTING_API)
     const Ref<IPCTester> m_ipcTester;

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -48,17 +48,19 @@ class LocalAudioSessionRoutingArbitrator final
 public:
     USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionRoutingArbitrationClient);
 
-    static std::unique_ptr<LocalAudioSessionRoutingArbitrator> create(GPUConnectionToWebProcess&);
     LocalAudioSessionRoutingArbitrator(GPUConnectionToWebProcess&);
     virtual ~LocalAudioSessionRoutingArbitrator();
 
     void processDidTerminate();
 
-private:
+    // WebCore::AudioSessionRoutingArbitrationClient.
+    void ref() const final;
+    void deref() const final;
 
+private:
     // AudioSessionRoutingArbitrationClient
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, ArbitrationCallback&&) final;
-    void leaveRoutingAbritration() final;
+    void leaveRoutingArbitration() final;
 
     Logger& logger();
     ASCIILiteral logClassName() const { return "LocalAudioSessionRoutingArbitrator"_s; }
@@ -66,7 +68,7 @@ private:
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
-    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
+    const CheckedRef<GPUConnectionToWebProcess> m_connectionToWebProcess;
     const uint64_t m_logIdentifier;
 };
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -179,7 +179,7 @@ void GPUProcessConnection::didClose(IPC::Connection&)
 
 #if ENABLE(ROUTING_ARBITRATION)
     if (auto* arbitrator = webProcess->audioSessionRoutingArbitrator())
-        arbitrator->leaveRoutingAbritration();
+        arbitrator->leaveRoutingArbitration();
 #endif
 
     m_clients.forEach([protectedThis = Ref { *this }] (auto& client) {
@@ -387,7 +387,7 @@ void GPUProcessConnection::beginRoutingArbitrationWithCategory(AudioSession::Cat
 void GPUProcessConnection::endRoutingArbitration()
 {
     if (auto* arbitrator = WebProcess::singleton().audioSessionRoutingArbitrator()) {
-        arbitrator->leaveRoutingAbritration();
+        arbitrator->leaveRoutingArbitration();
         return;
     }
 

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioSessionRoutingArbitrator);
 AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process)
     : m_observer(WebCore::AudioSession::ChangedObserver::create([weakThis = WeakPtr { *this }] (AudioSession& session) {
         if (RefPtr protectedThis = weakThis.get())
-            session.setRoutingArbitrationClient(protectedThis.get());
+            session.setRoutingArbitrationClient(*protectedThis);
     }))
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 {
@@ -69,7 +69,7 @@ void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSes
     WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), AudioSessionRoutingArbitratorProxy::destinationId());
 }
 
-void AudioSessionRoutingArbitrator::leaveRoutingAbritration()
+void AudioSessionRoutingArbitrator::leaveRoutingArbitration()
 {
     WebProcess::singleton().protectedParentProcessConnection()->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
 }

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -43,14 +43,15 @@ public:
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();
 
-    void ref() const;
-    void deref() const;
+    // WebCore::AudioSessionRoutingArbitrationClient.
+    void ref() const final;
+    void deref() const final;
 
     static ASCIILiteral supplementName();
 
     // AudioSessionRoutingAbritrator
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&&) final;
-    void leaveRoutingAbritration() final;
+    void leaveRoutingArbitration() final;
 
 private:
     uint64_t logIdentifier() const final { return m_logIdentifier; }


### PR DESCRIPTION
#### 91dd0b165b15b7b08534c29a18d6685f62c0343c
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AudioSessionRoutingArbitrationClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303719">https://bugs.webkit.org/show_bug.cgi?id=303719</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::setCategory):
(WebCore::AudioSessionMac::logIdentifier const):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp:
(WebKit::LocalAudioSessionRoutingArbitrator::ref const):
(WebKit::LocalAudioSessionRoutingArbitrator::deref const):
(WebKit::LocalAudioSessionRoutingArbitrator::processDidTerminate):
(WebKit::LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory):
(WebKit::LocalAudioSessionRoutingArbitrator::leaveRoutingArbitration):
(WebKit::LocalAudioSessionRoutingArbitrator::logger):
(WebKit::LocalAudioSessionRoutingArbitrator::canLog const):
(WebKit::LocalAudioSessionRoutingArbitrator::create): Deleted.
(WebKit::LocalAudioSessionRoutingArbitrator::leaveRoutingAbritration): Deleted.
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didClose):
(WebKit::GPUProcessConnection::endRoutingArbitration):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::leaveRoutingArbitration):
(WebKit::AudioSessionRoutingArbitrator::leaveRoutingAbritration): Deleted.
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:

Canonical link: <a href="https://commits.webkit.org/304117@main">https://commits.webkit.org/304117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a3f8bc4fa1d07a50381354530a1c647cdd00629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134507 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f309e8a7-978c-4bc1-889c-338e72faeabf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102805 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70086 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/93abbdd9-51cc-4e7b-9295-3a6ed73aaa22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61766a9d-5c21-4e49-9451-63f3e373b6f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2765 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2656 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144729 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6645 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111207 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111480 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4981 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60506 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35027 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6629 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->