### PR TITLE
Adopt LIFETIME_BOUND in JavaScriptCore/dfg

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCFG.h
+++ b/Source/JavaScriptCore/dfg/DFGCFG.h
@@ -100,7 +100,7 @@ template<typename> struct CFGSelection;
 
 template<>
 struct CFGSelection<CPSCFG> {
-    static CPSCFG& select(Graph& graph)
+    static CPSCFG& select(Graph& graph LIFETIME_BOUND)
     {
         return graph.ensureCPSCFG();
     }
@@ -108,7 +108,7 @@ struct CFGSelection<CPSCFG> {
 
 template<>
 struct CFGSelection<SSACFG> {
-    static SSACFG& select(Graph& graph)
+    static SSACFG& select(Graph& graph LIFETIME_BOUND)
     {
         RELEASE_ASSERT(graph.m_ssaCFG);
         return *graph.m_ssaCFG;
@@ -116,7 +116,7 @@ struct CFGSelection<SSACFG> {
 };
 
 template<typename T>
-auto& selectCFG(Graph& graph)
+auto& selectCFG(Graph& graph LIFETIME_BOUND)
 {
     return CFGSelection<T>::select(graph);
 }

--- a/Source/JavaScriptCore/dfg/DFGDominators.h
+++ b/Source/JavaScriptCore/dfg/DFGDominators.h
@@ -55,7 +55,7 @@ template<typename> struct DominatorsSelection;
 
 template<>
 struct DominatorsSelection<CPSCFG> {
-    static CPSDominators& select(Graph& graph)
+    static CPSDominators& select(Graph& graph LIFETIME_BOUND)
     {
         return graph.ensureCPSDominators();
     }
@@ -63,14 +63,14 @@ struct DominatorsSelection<CPSCFG> {
 
 template<>
 struct DominatorsSelection<SSACFG> {
-    static SSADominators& select(Graph& graph)
+    static SSADominators& select(Graph& graph LIFETIME_BOUND)
     {
         return graph.ensureSSADominators();
     }
 };
 
 template<typename T>
-auto& ensureDominatorsForCFG(Graph& graph)
+auto& ensureDominatorsForCFG(Graph& graph LIFETIME_BOUND)
 {
     return DominatorsSelection<T>::select(graph);
 }


### PR DESCRIPTION
#### 706190d9c6b697bdbbe33657d3b922cac37e6ca8
<pre>
Adopt LIFETIME_BOUND in JavaScriptCore/dfg
<a href="https://bugs.webkit.org/show_bug.cgi?id=303721">https://bugs.webkit.org/show_bug.cgi?id=303721</a>
<a href="https://rdar.apple.com/166026951">rdar://166026951</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/dfg/DFGCFG.h:
(JSC::DFG::CFGSelection&lt;CPSCFG&gt;::select):
(JSC::DFG::CFGSelection&lt;SSACFG&gt;::select):
(JSC::DFG::selectCFG):
* Source/JavaScriptCore/dfg/DFGDominators.h:
(JSC::DFG::DominatorsSelection&lt;CPSCFG&gt;::select):
(JSC::DFG::DominatorsSelection&lt;SSACFG&gt;::select):
(JSC::DFG::ensureDominatorsForCFG):

Canonical link: <a href="https://commits.webkit.org/304093@main">https://commits.webkit.org/304093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66a339e9393bed2408924e514bae9c6ea9de0763

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102808 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2770 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126564 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144733 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133019 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6648 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111208 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28280 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4983 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6701 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35024 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165940 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70278 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43373 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->