### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for LegacyCDMSessionClient

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -46,6 +46,7 @@ class WebKitMediaKeySession final : public RefCounted<WebKitMediaKeySession>, pu
 public:
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
+    // ActiveDOMObject, LegacyCDMSessionClient.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -28,23 +28,14 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include <JavaScriptCore/Forward.h>
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class LegacyCDMSessionClient;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::LegacyCDMSessionClient> : std::true_type { };
-}
-
-namespace WebCore {
-
-class LegacyCDMSessionClient : public CanMakeWeakPtr<LegacyCDMSessionClient> {
+class LegacyCDMSessionClient : public AbstractRefCountedAndCanMakeWeakPtr<LegacyCDMSessionClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(LegacyCDMSessionClient);
 public:
     virtual ~LegacyCDMSessionClient() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -224,7 +224,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
             if (m_sessionId == String(playbackSessionIdValue.get())) {
                 ALWAYS_LOG(LOGIDENTIFIER, "found session, sending expiration message");
                 m_expiredSession = expiredSessionData;
-                m_client->sendMessage(Uint8Array::create(span(m_expiredSession.get())).ptr(), emptyString());
+                Ref { *m_client }->sendMessage(Uint8Array::create(span(m_expiredSession.get())).ptr(), emptyString());
                 break;
             }
         }
@@ -311,7 +311,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         ASSERT(contentKeyRequest);
         RetainPtr certificateData = toNSData(m_certificate->span());
 
-        RetainPtr options = CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt(m_client->mediaKeysHashSalt());
+        RetainPtr options = CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt(Ref { *m_client }->mediaKeysHashSalt());
 
         if (!m_protocolVersions.isEmpty() && PAL::canLoad_AVFoundation_AVContentKeyRequestProtocolVersionsKey()) {
             RetainPtr mutableOptions = adoptNS([[NSMutableDictionary alloc] init]);
@@ -491,10 +491,11 @@ void CDMSessionAVContentKeySession::setInitData(SharedBuffer& initData)
 
 String CDMSessionAVContentKeySession::storagePath() const
 {
-    if (!m_client)
+    RefPtr client = m_client.get();
+    if (!client)
         return emptyString();
 
-    String storageDirectory = m_client->mediaKeysStorageDirectory();
+    String storageDirectory = client->mediaKeysStorageDirectory();
     if (storageDirectory.isEmpty())
         return emptyString();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -142,13 +142,14 @@ RefPtr<ArrayBuffer> CDMSessionAVFoundationObjC::cachedKeyForKeyID(const String&)
 
 void CDMSessionAVFoundationObjC::playerDidReceiveError(NSError *error)
 {
-    if (!m_client)
+    RefPtr client = m_client.get();
+    if (!client)
         return;
 
     ERROR_LOG(LOGIDENTIFIER, error);
 
     unsigned long code = mediaKeyErrorSystemCode(error);
-    m_client->sendError(LegacyCDMSessionClient::MediaKeyErrorDomain, code);
+    client->sendError(LegacyCDMSessionClient::MediaKeyErrorDomain, code);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -52,6 +52,7 @@ public:
     static Ref<RemoteLegacyCDMSessionProxy> create(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
     ~RemoteLegacyCDMSessionProxy();
 
+    // IPC::MessageReceiver, WebCore::LegacyCDMSessionClient.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 


### PR DESCRIPTION
#### 540b8a243d495aad79fbd0eb00279092d8638a65
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for LegacyCDMSessionClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303722">https://bugs.webkit.org/show_bug.cgi?id=303722</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/platform/graphics/LegacyCDMSession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
(WebCore::CDMSessionAVContentKeySession::update):
(WebCore::CDMSessionAVContentKeySession::storagePath const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::playerDidReceiveError):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::generateKeyRequest):
(WebKit::RemoteLegacyCDMSession::sendMessage):
(WebKit::RemoteLegacyCDMSession::sendError):

Canonical link: <a href="https://commits.webkit.org/304120@main">https://commits.webkit.org/304120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f312f615ab046c0afd76dd34027b683fcc2d0ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2bfe6cf8-81e5-4a43-bb91-37eac4b1d1d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102810 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70084 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76d79c3d-590e-4cd0-a487-45d110cad1d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3eec4a48-35b4-47a9-9515-08c0c2554d78) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2768 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2658 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144735 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28293 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4985 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6703 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35054 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->