### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PlatformSpeechSynthesisUtteranceClient

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -255,15 +255,14 @@ void SpeechSynthesis::boundaryEventOccurred(PlatformSpeechSynthesisUtterance& pl
     static NeverDestroyed<const String> wordBoundaryString(MAKE_STATIC_STRING_IMPL("word"));
     static NeverDestroyed<const String> sentenceBoundaryString(MAKE_STATIC_STRING_IMPL("sentence"));
 
-    ASSERT(platformUtterance.client());
-
-    RefPtr utterance = static_cast<SpeechSynthesisUtterance*>(platformUtterance.client());
+    RefPtr client = platformUtterance.client();
+    ASSERT(client);
     switch (boundary) {
     case SpeechBoundary::SpeechWordBoundary:
-        utterance->eventOccurred(eventNames().boundaryEvent, charIndex, charLength, wordBoundaryString);
+        client->eventOccurred(eventNames().boundaryEvent, charIndex, charLength, wordBoundaryString);
         break;
     case SpeechBoundary::SpeechSentenceBoundary:
-        utterance->eventOccurred(eventNames().boundaryEvent, charIndex, charLength, sentenceBoundaryString);
+        client->eventOccurred(eventNames().boundaryEvent, charIndex, charLength, sentenceBoundaryString);
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -67,16 +67,13 @@ Ref<SpeechSynthesisUtterance> SpeechSynthesisUtterance::create(ScriptExecutionCo
 
 SpeechSynthesisUtterance::SpeechSynthesisUtterance(ScriptExecutionContext& context, const String& text, UtteranceCompletionHandler&& completion)
     : ActiveDOMObject(&context)
-    , m_platformUtterance(PlatformSpeechSynthesisUtterance::create(*this))
+    , m_platformUtterance(PlatformSpeechSynthesisUtterance::create(this))
     , m_completionHandler(WTFMove(completion))
 {
     m_platformUtterance->setText(text);
 }
 
-SpeechSynthesisUtterance::~SpeechSynthesisUtterance()
-{
-    m_platformUtterance->setClient(nullptr);
-}
+SpeechSynthesisUtterance::~SpeechSynthesisUtterance() = default;
 
 SpeechSynthesisVoice* SpeechSynthesisUtterance::voice() const
 {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -50,7 +50,7 @@ public:
 
     virtual ~SpeechSynthesisUtterance();
 
-    // ContextDestructionObserver.
+    // ContextDestructionObserver, PlatformSpeechSynthesisUtteranceClient.
     void ref() const final;
     void deref() const final;
     USING_CAN_MAKE_WEAKPTR(EventTarget);
@@ -78,7 +78,7 @@ public:
 
     PlatformSpeechSynthesisUtterance& platformUtterance() const { return m_platformUtterance.get(); }
 
-    void eventOccurred(const AtomString& type, unsigned long charIndex, unsigned long charLength, const String& name);
+    void eventOccurred(const AtomString& type, unsigned long charIndex, unsigned long charLength, const String& name) final;
     void errorEventOccurred(const AtomString& type, SpeechSynthesisErrorCode);
     void setIsActiveForEventDispatch(bool);
 

--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.cpp
@@ -30,13 +30,13 @@
 
 namespace WebCore {
 
-Ref<PlatformSpeechSynthesisUtterance> PlatformSpeechSynthesisUtterance::create(PlatformSpeechSynthesisUtteranceClient& client)
+Ref<PlatformSpeechSynthesisUtterance> PlatformSpeechSynthesisUtterance::create(PlatformSpeechSynthesisUtteranceClient* client)
 {
     return adoptRef(*new PlatformSpeechSynthesisUtterance(client));
 }
     
-inline PlatformSpeechSynthesisUtterance::PlatformSpeechSynthesisUtterance(PlatformSpeechSynthesisUtteranceClient& client)
-    : m_client(&client)
+inline PlatformSpeechSynthesisUtterance::PlatformSpeechSynthesisUtterance(PlatformSpeechSynthesisUtteranceClient* client)
+    : m_client(client)
 {
 }
     

--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
@@ -29,26 +29,24 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class PlatformSpeechSynthesisUtteranceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PlatformSpeechSynthesisUtteranceClient> : std::true_type { };
-}
-
-namespace WebCore {
     
-class PlatformSpeechSynthesisUtteranceClient : public CanMakeWeakPtr<PlatformSpeechSynthesisUtteranceClient> {
+class PlatformSpeechSynthesisUtteranceClient : public CanMakeWeakPtr<PlatformSpeechSynthesisUtteranceClient>, public AbstractRefCounted {
+public:
+    virtual ~PlatformSpeechSynthesisUtteranceClient() = default;
+    virtual void eventOccurred(const AtomString& type, unsigned long charIndex, unsigned long charLength, const String& name) = 0;
+
+protected:
+    PlatformSpeechSynthesisUtteranceClient() = default;
 };
     
 class PlatformSpeechSynthesisUtterance : public RefCounted<PlatformSpeechSynthesisUtterance> {
 public:
-    WEBCORE_EXPORT static Ref<PlatformSpeechSynthesisUtterance> create(PlatformSpeechSynthesisUtteranceClient&);
+    WEBCORE_EXPORT static Ref<PlatformSpeechSynthesisUtterance> create(PlatformSpeechSynthesisUtteranceClient*);
 
     const String& text() const { return m_text; }
     void setText(const String& text) { m_text = text; }
@@ -75,7 +73,6 @@ public:
     void setStartTime(MonotonicTime startTime) { m_startTime = startTime; }
     
     PlatformSpeechSynthesisUtteranceClient* client() const { return m_client.get(); }
-    void setClient(PlatformSpeechSynthesisUtteranceClient* client) { m_client = client; }
 
 #ifdef __OBJC__
     id wrapper() const { return m_wrapper.get(); }
@@ -83,7 +80,7 @@ public:
 #endif
 
 private:
-    explicit PlatformSpeechSynthesisUtterance(PlatformSpeechSynthesisUtteranceClient&);
+    explicit PlatformSpeechSynthesisUtterance(PlatformSpeechSynthesisUtteranceClient*);
 
     WeakPtr<PlatformSpeechSynthesisUtteranceClient> m_client;
     String m_text;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15758,7 +15758,7 @@ void WebPageProxy::speechSynthesisSetFinishedCallback(CompletionHandler<void()>&
 void WebPageProxy::speechSynthesisSpeak(const String& text, const String& lang, float volume, float rate, float pitch, MonotonicTime, const String& voiceURI, const String& voiceName, const String& voiceLang, bool localService, bool defaultVoice, CompletionHandler<void()>&& completionHandler)
 {
     auto voice = WebCore::PlatformSpeechSynthesisVoice::create(voiceURI, voiceName, voiceLang, localService, defaultVoice);
-    auto utterance = WebCore::PlatformSpeechSynthesisUtterance::create(internals());
+    auto utterance = WebCore::PlatformSpeechSynthesisUtterance::create(nullptr);
     utterance->setText(text);
     utterance->setLang(lang);
     utterance->setVolume(volume);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -222,7 +222,6 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     , EndowmentStateTrackerClient
 #endif
 #if ENABLE(SPEECH_SYNTHESIS)
-    , WebCore::PlatformSpeechSynthesisUtteranceClient
     , WebCore::PlatformSpeechSynthesizerClient
 #endif
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### a979a88aadf788eccd523d5ad9c25287114c862b
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PlatformSpeechSynthesisUtteranceClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303724">https://bugs.webkit.org/show_bug.cgi?id=303724</a>

Reviewed by Ryosuke Niwa.

Drop IsDeprecatedWeakRefSmartPointerException for PlatformSpeechSynthesisUtteranceClient
by making it AbstractRefCounted. Also make it a true virtual interface with a virtual
function that SpeechSynthesisUtterance calls instead of having SpeechSynthesisUtterance
do an unsafe cast from PlatformSpeechSynthesisUtteranceClient to one of its subclasses.
Finally, stop making WebPageProxy::Internals a client. It wasn&apos;t truly a client or the
cast would have failed.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::boundaryEventOccurred):
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::SpeechSynthesisUtterance):
(WebCore::SpeechSynthesisUtterance::~SpeechSynthesisUtterance): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.cpp:
(WebCore::PlatformSpeechSynthesisUtterance::create):
(WebCore::PlatformSpeechSynthesisUtterance::PlatformSpeechSynthesisUtterance):
* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h:
(WebCore::PlatformSpeechSynthesisUtterance::client const):
(WebCore::PlatformSpeechSynthesisUtterance::setClient): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::speechSynthesisSpeak):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/304136@main">https://commits.webkit.org/304136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d79fdcfebef86190368581ecc48d5810fc521a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fb74f4d0-51f9-4632-ae45-a35983a1c9f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6964 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/67ad0c1c-5408-4a92-bf7f-dfaf21463d47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83720 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7384ff75-2b32-4134-b82a-8810a8d317d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5272 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2769 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144870 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6785 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39414 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111604 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5100 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60670 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6836 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35158 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6751 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->