### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PreviewConverterProvider

### DIFF
--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -53,7 +53,7 @@ public:
 
     WEBCORE_EXPORT static void setClientForTesting(RefPtr<LegacyPreviewLoaderClient>&&);
 
-    // PreviewConverterClient.
+    // PreviewConverterClient, PreviewConverterProvider.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/platform/PreviewConverter.cpp
+++ b/Source/WebCore/platform/PreviewConverter.cpp
@@ -78,7 +78,7 @@ void PreviewConverter::updateMainResource()
     if (m_state != State::Updating)
         return;
 
-    auto provider = m_provider.get();
+    RefPtr provider = m_provider.get();
     if (!provider) {
         didFailUpdating();
         return;
@@ -280,7 +280,7 @@ void PreviewConverter::delegateDidFailWithError(const ResourceError& error)
     }
 
     ASSERT(m_state == State::Updating);
-    auto provider = m_provider.get();
+    RefPtr provider = m_provider.get();
     if (!provider) {
         didFailConvertingWithError(error);
         return;

--- a/Source/WebCore/platform/PreviewConverterProvider.h
+++ b/Source/WebCore/platform/PreviewConverterProvider.h
@@ -25,20 +25,11 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-struct PreviewConverterProvider;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PreviewConverterProvider> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
-struct PreviewConverterProvider : CanMakeWeakPtr<PreviewConverterProvider> {
+struct PreviewConverterProvider : AbstractRefCountedAndCanMakeWeakPtr<PreviewConverterProvider> {
     virtual ~PreviewConverterProvider() = default;
 
     virtual void provideMainResourceForPreviewConverter(PreviewConverter&, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&&) = 0;


### PR DESCRIPTION
#### 4c5ef40e91e11db69ae06c3e27d21f366d4ce298
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PreviewConverterProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=303725">https://bugs.webkit.org/show_bug.cgi?id=303725</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/ios/LegacyPreviewLoader.h:
* Source/WebCore/platform/PreviewConverter.cpp:
(WebCore::PreviewConverter::updateMainResource):
(WebCore::PreviewConverter::delegateDidFailWithError):
* Source/WebCore/platform/PreviewConverterProvider.h:

Canonical link: <a href="https://commits.webkit.org/304122@main">https://commits.webkit.org/304122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ff1c604d0c6b401d34cb4ec00c08d85cff2c29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86494 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a84250df-89cd-4f8b-8eb0-5193e15b52c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70098 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad5f852a-4f19-494b-b677-d53b20d029af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83616 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d631ac37-6480-4694-863d-3e525ba8b4b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2779 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2668 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144749 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111222 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4998 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60523 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6716 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35040 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->