### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for NowPlayingManagerClient

### DIFF
--- a/Source/WebCore/platform/NowPlayingManager.cpp
+++ b/Source/WebCore/platform/NowPlayingManager.cpp
@@ -40,8 +40,8 @@ NowPlayingManager::~NowPlayingManager() = default;
 
 void NowPlayingManager::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
-    if (m_client)
-        m_client->didReceiveRemoteControlCommand(type, argument);
+    if (RefPtr client = m_client.get())
+        client->didReceiveRemoteControlCommand(type, argument);
 }
 
 void NowPlayingManager::addClient(NowPlayingManagerClient& client)

--- a/Source/WebCore/platform/NowPlayingManager.h
+++ b/Source/WebCore/platform/NowPlayingManager.h
@@ -28,24 +28,16 @@
 #include <WebCore/NowPlayingInfo.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/RemoteCommandListener.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class NowPlayingManagerClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::NowPlayingManagerClient> : std::true_type { };
-}
 
 namespace WebCore {
 
 class Image;
 struct NowPlayingInfo;
 
-class NowPlayingManagerClient : public CanMakeWeakPtr<NowPlayingManagerClient> {
+class NowPlayingManagerClient : public AbstractRefCountedAndCanMakeWeakPtr<NowPlayingManagerClient> {
 public:
     virtual ~NowPlayingManagerClient() = default;
     virtual void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) = 0;

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -161,7 +161,7 @@ public:
 #endif
 
 protected:
-    MediaSessionManagerInterface(PageIdentifier);
+    explicit MediaSessionManagerInterface(PageIdentifier);
 
     virtual WeakListHashSet<PlatformMediaSessionInterface>& sessions() const = 0;
     virtual Vector<WeakPtr<PlatformMediaSessionInterface>> copySessionsToVector() const = 0;
@@ -201,7 +201,6 @@ protected:
     bool willLog(WTFLogLevel) const;
 
 private:
-
     bool has(PlatformMediaSessionMediaType) const;
 
     std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::WebAudio) + 1> m_restrictions;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -44,7 +44,7 @@ public:
     void forEachMatchingSession(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>& predicate, NOESCAPE const Function<void(PlatformMediaSessionInterface&)>& matchingCallback) final;
 
 protected:
-    PlatformMediaSessionManager(PageIdentifier);
+    explicit PlatformMediaSessionManager(PageIdentifier);
 
     void addSession(PlatformMediaSessionInterface&) override;
     void removeSession(PlatformMediaSessionInterface&) override;
@@ -56,7 +56,6 @@ protected:
     WeakPtr<PlatformMediaSessionInterface> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&, PlatformMediaSessionPlaybackControlsPurpose) final;
 
 private:
-
     mutable WeakListHashSet<PlatformMediaSessionInterface> m_sessions;
 };
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -48,7 +48,13 @@ class WEBCORE_EXPORT MediaSessionManagerCocoa
     , public AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManagerCocoa);
 public:
-    MediaSessionManagerCocoa(PageIdentifier);
+#if PLATFORM(MAC)
+    static Ref<MediaSessionManagerCocoa> create(PageIdentifier);
+#endif
+
+    // NowPlayingManagerClient.
+    void ref() const override { PlatformMediaSessionManager::ref(); }
+    void deref() const override { PlatformMediaSessionManager::deref(); }
     
     static WEBCORE_EXPORT void clearNowPlayingInfo();
     static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo&);
@@ -56,6 +62,8 @@ public:
     static String audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(MediaPlayerPitchCorrectionAlgorithm, bool preservesPitch, double rate);
 
 protected:
+    explicit MediaSessionManagerCocoa(PageIdentifier);
+
     void updateSessionState() override;
     void beginInterruption(PlatformMediaSession::InterruptionType) final;
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -79,7 +79,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerCocoa);
 #if PLATFORM(MAC)
 RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
-    return adoptRef(new MediaSessionManagerCocoa(pageIdentifier));
+    return MediaSessionManagerCocoa::create(pageIdentifier);
+}
+
+Ref<MediaSessionManagerCocoa> MediaSessionManagerCocoa::create(PageIdentifier pageIdentifier)
+{
+    return adoptRef(*new MediaSessionManagerCocoa(pageIdentifier));
 }
 #endif // !PLATFORM(MAC)
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -123,7 +123,12 @@ RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIden
         g_warning("Failed at parsing XML Interface definition: %s", error->message);
         return nullptr;
     }
-    return adoptRef(new MediaSessionManagerGLib(WTFMove(mprisInterface), pageIdentifier));
+    return MediaSessionManagerGLib::create(WTFMove(mprisInterface), pageIdentifier);
+}
+
+Ref<MediaSessionManagerGLib> MediaSessionManagerGLib::create(GRefPtr<GDBusNodeInfo>&& mprisInterface, PageIdentifier pageIdentifier)
+{
+    return adoptRef(*new MediaSessionManagerGLib(WTFMove(mprisInterface), pageIdentifier));
 }
 
 MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface, PageIdentifier pageIdentifier)

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -36,8 +36,12 @@ class MediaSessionManagerGLib
     , private NowPlayingManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManagerGLib);
 public:
-    MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
+    static Ref<MediaSessionManagerGLib> create(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
     ~MediaSessionManagerGLib();
+
+    // NowPlayingManagerClient.
+    void ref() const final { PlatformMediaSessionManager::ref(); }
+    void deref() const final { PlatformMediaSessionManager::deref(); }
 
     void beginInterruption(PlatformMediaSession::InterruptionType) final;
 
@@ -60,6 +64,8 @@ public:
     bool areDBusNotificationsEnabled() const { return m_dbusNotificationsEnabled; }
 
 protected:
+    MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
+
     void scheduleSessionStatusUpdate() final;
     void updateNowPlayingInfo();
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -51,7 +51,7 @@ class WEBCORE_EXPORT MediaSessionManageriOS
     , public AudioSessionInterruptionObserver {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManageriOS);
 public:
-    MediaSessionManageriOS(PageIdentifier);
+    static Ref<MediaSessionManageriOS> create(PageIdentifier);
     virtual ~MediaSessionManageriOS();
 
     bool hasWirelessTargetsAvailable() final;
@@ -64,6 +64,7 @@ public:
     USING_CAN_MAKE_WEAKPTR(MediaSessionHelperClient);
 
 protected:
+    explicit MediaSessionManageriOS(PageIdentifier);
 
 #if !PLATFORM(MACCATALYST)
     void resetRestrictions() override;
@@ -72,7 +73,6 @@ protected:
     void sessionWillBeginPlayback(PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) override;
 
 private:
-
     void configureWirelessTargetMonitoring() final;
     void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) final;
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -47,9 +47,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManageriOS);
 
 RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
-    auto manager = adoptRef(new MediaSessionManageriOS(pageIdentifier));
-    MediaSessionHelper::sharedHelper().addClient(*manager);
+    Ref manager = MediaSessionManageriOS::create(pageIdentifier);
+    MediaSessionHelper::sharedHelper().addClient(manager);
     return manager;
+}
+
+Ref<MediaSessionManageriOS> MediaSessionManageriOS::create(PageIdentifier pageIdentifier)
+{
+    return adoptRef(*new MediaSessionManageriOS(pageIdentifier));
 }
 
 MediaSessionManageriOS::MediaSessionManageriOS(PageIdentifier pageIdentifier)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -141,6 +141,7 @@ public:
     static Ref<GPUConnectionToWebProcess> create(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
     virtual ~GPUConnectionToWebProcess();
 
+    // IPC::Connection::Client, WebCore::NowPlayingManagerClient.
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
@@ -64,8 +64,8 @@ public:
 
     virtual ~RemoteMediaSessionManager();
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    void ref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::ref(); }
+    void deref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::deref(); }
 
 protected:
     RemoteMediaSessionManager(WebPage& topPage, WebPage& localPage);


### PR DESCRIPTION
#### 78682e8e612597c7439e6473d1e441e9e8712a09
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for NowPlayingManagerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=303728">https://bugs.webkit.org/show_bug.cgi?id=303728</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/NowPlayingManager.cpp:
(WebCore::NowPlayingManager::didReceiveRemoteControlCommand):
* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManagerCocoa::create):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManagerGLib::create):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManageriOS::create):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/304125@main">https://commits.webkit.org/304125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13d9b0fe0993972e8a00d15c4f338c61c99d6dc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134539 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86500 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/343f3016-8df1-4cfe-8d51-ce96ce54d442) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102835 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70102 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8bb7c2bf-c4b8-4906-ab57-a5deaf090a4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83632 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e025a1d-165d-41a2-a833-4e0dad8cb0f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2787 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2673 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114401 "Found 4 new API test failures: TestWebKitAPI.CaptionPreferenceTests.MenuItemChangesAfterSelection, TestWebKitAPI.CaptionPreferenceTests.CaptionStyleMenuSelect, TestWebKitAPI.ProcessSwap.PageOverlayLayerPersistence, TestWebKitAPI.CaptionPreferenceTests.ReceievedDidOpenWhenSelected (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144759 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5001 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60531 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35048 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->