### PR TITLE
[Youtube Shorts] [PiP] Video turns blank while playing in PiP scrolling through shorts

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -115,6 +115,10 @@ RemoteMediaPlayerProxy::RemoteMediaPlayerProxy(RemoteMediaPlayerManagerProxy& ma
     RefPtr player = m_player;
     player->setResourceOwner(resourceOwner);
     player->setPresentationSize(m_configuration.presentationSize);
+#if PLATFORM(COCOA)
+    if (!m_configuration.videoLayerSize.isEmpty())
+        m_layerHostingContextManager->setInitialVideoLayerSize(m_configuration.videoLayerSize);
+#endif
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     player->setPrefersSpatialAudioExperience(m_configuration.prefersSpatialAudioExperience);
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
@@ -55,6 +55,7 @@ struct RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize { };
+    WebCore::FloatSize videoLayerSize { };
     uint64_t logIdentifier { 0 };
     bool shouldUsePersistentCache { false };
     bool isVideo { false };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
@@ -40,6 +40,7 @@ struct WebKit::RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize;
+    WebCore::FloatSize videoLayerSize;
     uint64_t logIdentifier;
     bool shouldUsePersistentCache;
     bool isVideo;

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
@@ -52,6 +52,7 @@ public:
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&, NOESCAPE CompletionHandler<void()>&& postCommitAction);
     WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; }
     void setVideoLayerSizeIfPossible();
+    void setInitialVideoLayerSize(const WebCore::FloatSize&);
 
 private:
     Vector<LayerHostingContextCallback> m_layerHostingContextRequests;

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -52,6 +52,12 @@ void LayerHostingContextManager::requestHostingContext(LayerHostingContextCallba
     m_layerHostingContextRequests.append(WTFMove(completionHandler));
 }
 
+void LayerHostingContextManager::setInitialVideoLayerSize(const WebCore::FloatSize& size)
+{
+    if (!size.isEmpty() && m_videoLayerSize.isEmpty())
+        m_videoLayerSize = size;
+}
+
 std::optional<WebCore::HostingContext> LayerHostingContextManager::createHostingContextIfNeeded(const PlatformLayerContainer& layer, bool canShowWhileLocked)
 {
     bool hadLayer = false;
@@ -75,7 +81,6 @@ std::optional<WebCore::HostingContext> LayerHostingContextManager::createHosting
         hadLayer = true;
     } else if (!layer && m_inlineLayerHostingContext) {
         m_inlineLayerHostingContext = nullptr;
-        m_videoLayerSize = { };
         hadLayer = true;
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -182,6 +182,7 @@ Ref<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRemoteMediaPlay
     proxyConfiguration.documentSecurityOrigin = documentSecurityOrigin;
 
     proxyConfiguration.presentationSize = player.presentationSize();
+    proxyConfiguration.videoLayerSize = player.videoLayerSize();
 
     proxyConfiguration.allowedMediaContainerTypes = player.allowedMediaContainerTypes();
     proxyConfiguration.allowedMediaCodecTypes = player.allowedMediaCodecTypes();


### PR DESCRIPTION
#### b0ee8b3d3d13294d495f8a87434c909262b5da15
<pre>
[Youtube Shorts] [PiP] Video turns blank while playing in PiP scrolling through shorts
<a href="https://bugs.webkit.org/show_bug.cgi?id=303729">https://bugs.webkit.org/show_bug.cgi?id=303729</a>
<a href="https://rdar.apple.com/164577262">rdar://164577262</a>

Reviewed by Jean-Yves Avenard.

When scrolling between YouTube Shorts in PiP, the video goes blank (audio continues).
The bug occurs because videoLayerSize is derived from the platform layer&apos;s frame,
which may be zero when the layer is created. Fix by restoring explicit videoLayerSize
and preserving size across layer transitions instead of resetting it.

This problem seems to occur on a race when we have different resolutions/aspect ratios
between videos being played. As such, this is quite difficult to test either manually
or with layout tests.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::RemoteMediaPlayerProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.h:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm:
(WebKit::LayerHostingContextManager::setInitialVideoLayerSize):
(WebKit::LayerHostingContextManager::createHostingContextIfNeeded):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::createRemoteMediaPlayer):

Canonical link: <a href="https://commits.webkit.org/304722@main">https://commits.webkit.org/304722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8df7a30b22039a9d1f22bbc31de7f19a4023422a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104033 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3951 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115573 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112395 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112743 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6206 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62108 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36314 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71731 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->