### PR TITLE
Modernize WTF WARN_UNUSED_RETURN to use C++17 [[nodiscard]]

### DIFF
--- a/Source/JavaScriptCore/API/JSRetainPtr.h
+++ b/Source/JavaScriptCore/API/JSRetainPtr.h
@@ -54,7 +54,7 @@ public:
     T get() const { return m_ptr; }
     
     void clear();
-    T leakRef() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN T leakRef();
 
     T operator->() const { return m_ptr; }
     

--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -587,7 +587,7 @@ void TestAPI::promiseUnhandledRejectionFromUnhandledRejectionCallback()
     JSGlobalContextSetUnhandledRejectionCallback(context, callbackFunction, &exception);
     check(!exception, "setting unhandled rejection callback should not throw");
 
-    callFunction("(function () { Promise.reject(); })");
+    std::ignore = callFunction("(function () { Promise.reject(); })");
     check(!exception && callbackCallCount == 2, "unhandled rejection from unhandled rejection callback should also trigger the callback");
 }
 
@@ -605,10 +605,10 @@ void TestAPI::promiseEarlyHandledRejections()
     JSGlobalContextSetUnhandledRejectionCallback(context, callbackFunction, &exception);
     check(!exception, "setting unhandled rejection callback should not throw");
 
-    callFunction("(function () { const p = Promise.reject(); p.catch(() => {}); })");
+    std::ignore = callFunction("(function () { const p = Promise.reject(); p.catch(() => {}); })");
     check(!callbackCalled, "unhandled rejection callback should not be called for synchronous early-handled rejection");
 
-    callFunction("(function () { const p = Promise.reject(); Promise.resolve().then(() => { p.catch(() => {}); }); })");
+    std::ignore = callFunction("(function () { const p = Promise.reject(); Promise.resolve().then(() => { p.catch(() => {}); }); })");
     check(!callbackCalled, "unhandled rejection callback should not be called for asynchronous early-handled rejection");
 }
 

--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
@@ -135,7 +135,7 @@ private:
         IndexingType indexingType() const { return m_bits >> indexingTypeShift; }
         unsigned vectorLength() const { return m_bits & vectorLengthMask; }
 
-        IndexingTypeAndVectorLength withIndexingType(IndexingType indexingType) WARN_UNUSED_RETURN
+        WARN_UNUSED_RETURN IndexingTypeAndVectorLength withIndexingType(IndexingType indexingType)
         {
             return IndexingTypeAndVectorLength(indexingType, vectorLength());
         }

--- a/Source/JavaScriptCore/heap/Weak.h
+++ b/Source/JavaScriptCore/heap/Weak.h
@@ -81,7 +81,7 @@ public:
 
     inline explicit operator bool() const;
 
-    inline WeakImpl* leakImpl() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN inline WeakImpl* leakImpl();
     WeakImpl* unsafeImpl() const { return impl(); }
     void clear();
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
@@ -142,20 +142,20 @@ void JSGlobalObjectConsoleClient::startConsoleProfile()
 {
     if (m_debuggerAgent) {
         m_profileRestoreBreakpointActiveValue = m_debuggerAgent->breakpointsActive();
-        m_debuggerAgent->setBreakpointsActive(false);
+        std::ignore = m_debuggerAgent->setBreakpointsActive(false);
     }
 
     if (m_scriptProfilerAgent)
-        m_scriptProfilerAgent->startTracking(true);
+        std::ignore = m_scriptProfilerAgent->startTracking(true);
 }
 
 void JSGlobalObjectConsoleClient::stopConsoleProfile()
 {
     if (m_scriptProfilerAgent)
-        m_scriptProfilerAgent->stopTracking();
+        std::ignore = m_scriptProfilerAgent->stopTracking();
 
     if (m_debuggerAgent)
-        m_debuggerAgent->setBreakpointsActive(m_profileRestoreBreakpointActiveValue);
+        std::ignore = m_debuggerAgent->setBreakpointsActive(m_profileRestoreBreakpointActiveValue);
 }
 
 void JSGlobalObjectConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -238,8 +238,8 @@ void JSGlobalObjectInspectorController::frontendInitialized()
     if (m_pauseAfterInitialization) {
         m_pauseAfterInitialization = false;
 
-        ensureDebuggerAgent().enable();
-        ensureDebuggerAgent().pause();
+        std::ignore = ensureDebuggerAgent().enable();
+        std::ignore = ensureDebuggerAgent().pause();
     }
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
@@ -57,7 +57,7 @@ void InspectorAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     m_pendingEvaluateTestCommands.clear();
 
-    disable();
+    std::ignore = disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorAgent::enable()

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -58,7 +58,7 @@ void InspectorConsoleAgent::didCreateFrontendAndBackend()
 
 void InspectorConsoleAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 void InspectorConsoleAgent::discardValues()

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1174,7 +1174,7 @@ void InspectorDebuggerAgent::didBecomeIdle()
     m_conditionToDispatchResumed = ShouldDispatchResumed::No;
 
     if (m_enablePauseWhenIdle)
-        pause();
+        std::ignore = pause();
 }
 
 Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setPauseOnDebuggerStatements(bool enabled, RefPtr<JSON::Object>&& options)
@@ -1856,7 +1856,7 @@ void InspectorDebuggerAgent::breakProgram(DebuggerFrontendDispatcher::Reason rea
 void InspectorDebuggerAgent::clearInspectorBreakpointState()
 {
     for (auto& protocolBreakpointID : copyToVector(m_debuggerBreakpointsForProtocolBreakpointID.keys()))
-        removeBreakpoint(protocolBreakpointID);
+        std::ignore = removeBreakpoint(protocolBreakpointID);
 
     m_protocolBreakpointForProtocolBreakpointID.clear();
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -59,7 +59,7 @@ void InspectorHeapAgent::didCreateFrontendAndBackend()
 
 void InspectorHeapAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorHeapAgent::enable()

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -454,7 +454,7 @@ void InspectorRuntimeAgent::willDestroyFrontendAndBackend(DisconnectReason reaso
     if (reason != DisconnectReason::InspectedTargetDestroyed && m_isTypeProfilingEnabled)
         setTypeProfilerEnabledState(false);
 
-    disable();
+    std::ignore = disable();
 }
 
 Protocol::ErrorStringOr<void> InspectorRuntimeAgent::enableTypeProfiler()

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -124,9 +124,9 @@ public:
         return *this;
     }
 
-    inline constexpr RegisterSet buildAndValidate() const WARN_UNUSED_RETURN;
-    inline constexpr RegisterSet buildWithLowerBits() const WARN_UNUSED_RETURN;
-    inline constexpr ScalarRegisterSet buildScalarRegisterSet() const WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN inline constexpr RegisterSet buildAndValidate() const;
+    WARN_UNUSED_RETURN inline constexpr RegisterSet buildWithLowerBits() const;
+    WARN_UNUSED_RETURN inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
     inline constexpr size_t numberOfSetRegisters() const;
     inline size_t numberOfSetGPRs() const;
     inline size_t numberOfSetFPRs() const;
@@ -302,7 +302,7 @@ public:
         return *this;
     }
 
-    inline constexpr ScalarRegisterSet buildScalarRegisterSet() const WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
 
     template<typename Func>
     inline constexpr void forEach(const Func& func) const
@@ -479,7 +479,7 @@ public:
     inline uint64_t bitsForDebugging() const { return m_bits.storage()[0]; }
     friend constexpr bool operator==(const ScalarRegisterSet&, const ScalarRegisterSet&) = default;
 
-    inline constexpr RegisterSet toRegisterSet() const WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN inline constexpr RegisterSet toRegisterSet() const
     {
         RegisterSet result;
         m_bits.forEachSetBit(

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -512,7 +512,7 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
                 // The memory will call back to our refreshAfterWasmMemoryGrow().
                 RefPtr<Wasm::Memory> memory = m_associatedWasmMemory.get();
                 if (memory) {
-                    memory->grow(vm, PageCount(newPageCount.pageCount() - oldPageCount.pageCount()));
+                    std::ignore = memory->grow(vm, PageCount(newPageCount.pageCount() - oldPageCount.pageCount()));
                     return deltaByteLength;
                 }
             }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
 }
 
 template<typename CharacterType>
-inline static WARN_UNUSED_RETURN size_t decodeHexImpl(std::span<CharacterType> span, std::span<uint8_t> result)
+WARN_UNUSED_RETURN inline static size_t decodeHexImpl(std::span<CharacterType> span, std::span<uint8_t> result)
 {
     ASSERT(span.size() == result.size() * 2);
 

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1028,7 +1028,7 @@ protected:
         
     // Call this if you want setIndexQuickly to succeed and you're sure that
     // the array is contiguous.
-    bool WARN_UNUSED_RETURN ensureLength(VM& vm, unsigned length)
+    WARN_UNUSED_RETURN bool ensureLength(VM& vm, unsigned length)
     {
         RELEASE_ASSERT(length <= MAX_STORAGE_VECTOR_LENGTH);
         ASSERT(hasContiguous(indexingType()) || hasInt32(indexingType()) || hasDouble(indexingType()) || hasUndecided(indexingType()));

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -115,7 +115,7 @@ public:
     // Find a value in the table.
     std::tuple<PropertyOffset, unsigned> get(const KeyType&);
     // Add a value to the table
-    std::tuple<PropertyOffset, unsigned, bool> WARN_UNUSED_RETURN add(VM&, const ValueType& entry);
+    WARN_UNUSED_RETURN std::tuple<PropertyOffset, unsigned, bool> add(VM&, const ValueType& entry);
     // Remove a value from the table.
     std::tuple<PropertyOffset, unsigned> take(VM&, const KeyType&);
     PropertyOffset updateAttributeIfExists(const KeyType&, unsigned attributes);
@@ -355,7 +355,7 @@ inline std::tuple<PropertyOffset, unsigned> PropertyTable::get(const KeyType& ke
     return std::tuple { result.offset, result.attributes };
 }
 
-inline std::tuple<PropertyOffset, unsigned, bool> WARN_UNUSED_RETURN PropertyTable::add(VM& vm, const ValueType& entry)
+WARN_UNUSED_RETURN inline std::tuple<PropertyOffset, unsigned, bool> PropertyTable::add(VM& vm, const ValueType& entry)
 {
     ASSERT(!m_deletedOffsets || !m_deletedOffsets->contains(entry.offset()));
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -836,7 +836,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 // Tables
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -861,7 +861,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableSet(unsigned tableIndex, Value 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
 {
     ASSERT(dstOffset.type() == TypeKind::I32);
     ASSERT(srcOffset.type() == TypeKind::I32);
@@ -888,7 +888,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableInit(unsigned elementIndex, uns
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addElemDrop(unsigned elementIndex)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addElemDrop(unsigned elementIndex)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -900,7 +900,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addElemDrop(unsigned elementIndex)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableSize(unsigned tableIndex, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSize(unsigned tableIndex, Value& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -913,7 +913,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableSize(unsigned tableIndex, Value
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result)
 {
     ASSERT(delta.type() == TypeKind::I32);
 
@@ -929,7 +929,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGrow(unsigned tableIndex, Value
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
 {
     ASSERT(offset.type() == TypeKind::I32);
     ASSERT(count.type() == TypeKind::I32);
@@ -952,7 +952,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableFill(unsigned tableIndex, Value
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
 {
     ASSERT(dstOffset.type() == TypeKind::I32);
     ASSERT(srcOffset.type() == TypeKind::I32);
@@ -979,7 +979,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableCopy(unsigned dstTableIndex, un
 
 // Locals
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::getLocal(uint32_t localIndex, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::getLocal(uint32_t localIndex, Value& result)
 {
     // Currently, we load locals as temps, which basically prevents register allocation of locals.
     // This is probably not ideal, we have infrastructure to support binding locals to registers, but
@@ -992,7 +992,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::getLocal(uint32_t localIndex, Value& re
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::setLocal(uint32_t localIndex, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::setLocal(uint32_t localIndex, Value value)
 {
     if (!value.isConst())
         loadIfNecessary(value);
@@ -1004,7 +1004,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setLocal(uint32_t localIndex, Value val
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::teeLocal(uint32_t localIndex, Value value, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::teeLocal(uint32_t localIndex, Value value, Value& result)
 {
     auto type = m_parser->typeOfLocal(localIndex);
     Value local = Value::fromLocal(type.kind, localIndex);
@@ -1098,7 +1098,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return Address(pointerLocation.asGPR(), static_cast<int32_t>(uoffset));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addGrowMemory(Value delta, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addGrowMemory(Value delta, Value& result)
 {
     Vector<Value, 8> arguments = { instanceValue(), delta };
     result = topValue(TypeKind::I32);
@@ -1110,7 +1110,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addGrowMemory(Value delta, Value& resul
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCurrentMemory(Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCurrentMemory(Value& result)
 {
     result = topValue(TypeKind::I32);
     Location resultLocation = allocate(result);
@@ -1126,7 +1126,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCurrentMemory(Value& result)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryFill(Value dstAddress, Value targetValue, Value count)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryFill(Value dstAddress, Value targetValue, Value count)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(targetValue.type() == TypeKind::I32);
@@ -1149,7 +1149,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryFill(Value dstAddress, Value t
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryCopy(Value dstAddress, Value srcAddress, Value count)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryCopy(Value dstAddress, Value srcAddress, Value count)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(srcAddress.type() == TypeKind::I32);
@@ -1172,7 +1172,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryCopy(Value dstAddress, Value s
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(srcAddress.type() == TypeKind::I32);
@@ -1196,7 +1196,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addMemoryInit(unsigned dataSegmentIndex
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addDataDrop(unsigned dataSegmentIndex)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 {
     Vector<Value, 8> arguments = { instanceValue(), Value::fromI32(dataSegmentIndex) };
     emitCCall(&operationWasmDataDrop, arguments);
@@ -1207,7 +1207,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 
 // Atomics
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -1222,7 +1222,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))) [[unlikely]] {
@@ -1238,7 +1238,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicStore(ExtAtomicOpType storeOp, Ty
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
@@ -1256,7 +1256,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Typ
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
@@ -1275,7 +1275,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicCompareExchange(ExtAtomicOpType o
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1298,7 +1298,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicWait(ExtAtomicOpType op, Expressi
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1316,7 +1316,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicNotify(ExtAtomicOpType op, Expres
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::atomicFence(ExtAtomicOpType, uint8_t)
+WARN_UNUSED_RETURN PartialResult BBQJIT::atomicFence(ExtAtomicOpType, uint8_t)
 {
     m_jit.memoryFence();
     return { };
@@ -1419,7 +1419,7 @@ FloatingPointRange BBQJIT::lookupTruncationRange(TruncationKind truncationKind)
     return FloatingPointRange { min, max, closedLowerEndpoint };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
 {
     ScratchScope<0, 2> scratches(*this);
 
@@ -1465,7 +1465,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::truncTrapping(OpType truncationOp, Valu
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
 {
     ScratchScope<0, 2> scratches(*this);
 
@@ -1605,21 +1605,21 @@ void BBQJIT::pushArrayNewFromSegment(ArraySegmentOperation operation, uint32_t t
     emitThrowOnNullReference(exceptionType, resultLocation);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
     pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::BadArrayNewInitData, result);
     LOG_INSTRUCTION("ArrayNewData", typeIndex, dataIndex, arraySize, offset, RESULT(result));
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
     pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::BadArrayNewInitElem, result);
     LOG_INSTRUCTION("ArrayNewElem", typeIndex, elemSegmentIndex, arraySize, offset, RESULT(result));
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayCopy(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression typedSrc, ExpressionType srcOffset, ExpressionType size)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayCopy(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression typedSrc, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     auto src = typedSrc.value();
@@ -1664,7 +1664,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayCopy(uint32_t dstTypeIndex, Typ
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayInitElem(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitElem(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     if (dst.isConst()) {
@@ -1703,7 +1703,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayInitElem(uint32_t dstTypeIndex,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayInitData(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitData(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     if (dst.isConst()) {
@@ -1742,7 +1742,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayInitData(uint32_t dstTypeIndex,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         reference
@@ -1754,7 +1754,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addAnyConvertExtern(ExpressionType refe
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addExternConvertAny(ExpressionType reference, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addExternConvertAny(ExpressionType reference, ExpressionType& result)
 {
     auto referenceLocation = reference.isConst() ? Location::none() : loadIfNecessary(reference);
     consume(reference);
@@ -1771,7 +1771,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addExternConvertAny(ExpressionType refe
 }
 
 // Basic operators
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSelect(Value condition, Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSelect(Value condition, Value lhs, Value rhs, Value& result)
 {
     if (condition.isConst()) {
         Value src = condition.asI32() ? lhs : rhs;
@@ -1845,7 +1845,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSelect(Value condition, Value lhs, V
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Add(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Add", TypeKind::I32,
@@ -1859,7 +1859,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Add(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Add(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Add", TypeKind::F32,
@@ -1875,7 +1875,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Add(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Add(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Add", TypeKind::F64,
@@ -1891,7 +1891,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Sub(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Sub", TypeKind::I32,
@@ -1910,7 +1910,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Sub(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Sub", TypeKind::F32,
@@ -1933,7 +1933,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Sub(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Sub", TypeKind::F64,
@@ -1956,7 +1956,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Mul(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Mul", TypeKind::I32,
@@ -1974,7 +1974,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Mul(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Mul(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Mul", TypeKind::F32,
@@ -1990,7 +1990,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Mul(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Mul(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Mul", TypeKind::F64,
@@ -2045,7 +2045,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     return rhs;
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32DivS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2062,7 +2062,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32DivS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64DivS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2079,7 +2079,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64DivS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32DivU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2096,7 +2096,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32DivU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64DivU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2113,7 +2113,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64DivU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32RemS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2130,7 +2130,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32RemS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64RemS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2147,7 +2147,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64RemS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32RemU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2164,7 +2164,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32RemU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64RemU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2181,7 +2181,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64RemU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Div(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Div(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Div", TypeKind::F32,
@@ -2197,7 +2197,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Div(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Div(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Div(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Div", TypeKind::F64,
@@ -2281,7 +2281,7 @@ void BBQJIT::emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result)
 #endif
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Min(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Min(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Min", TypeKind::F32,
@@ -2297,7 +2297,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Min(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Min(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Min(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Min", TypeKind::F64,
@@ -2313,7 +2313,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Min(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Max(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Max(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Max", TypeKind::F32,
@@ -2329,7 +2329,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Max(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Max(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Max(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Max", TypeKind::F64,
@@ -2345,7 +2345,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Max(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32And(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32And", TypeKind::I32,
@@ -2359,7 +2359,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32And(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Xor(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Xor", TypeKind::I32,
@@ -2373,7 +2373,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Or(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Or", TypeKind::I32,
@@ -2395,7 +2395,7 @@ void BBQJIT::moveShiftAmountIfNecessary(Location& rhsLocation)
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Shl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Shl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2417,7 +2417,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ShrS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2439,7 +2439,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ShrU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2461,7 +2461,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2501,7 +2501,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotr(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2523,7 +2523,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Rotr(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Clz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Clz", TypeKind::I32,
@@ -2534,7 +2534,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Clz(Value operand, Value& result)
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Ctz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Ctz", TypeKind::I32,
@@ -2565,102 +2565,102 @@ PartialResult BBQJIT::emitCompareI32(const char* opcode, Value& lhs, Value& rhs,
 #define RELOP_AS_LAMBDA(op) [](auto lhs, auto rhs) -> auto { return lhs op rhs; }
 #define TYPED_RELOP_AS_LAMBDA(type, op) [](auto lhs, auto rhs) -> auto { return static_cast<type>(lhs) op static_cast<type>(rhs); }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Eq(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32Eq", lhs, rhs, result, RelationalCondition::Equal, RELOP_AS_LAMBDA( == ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Eq(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64Eq", lhs, rhs, result, RelationalCondition::Equal, RELOP_AS_LAMBDA( == ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Ne(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32Ne", lhs, rhs, result, RelationalCondition::NotEqual, RELOP_AS_LAMBDA( != ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Ne(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64Ne", lhs, rhs, result, RelationalCondition::NotEqual, RELOP_AS_LAMBDA( != ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32LtS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LtS", lhs, rhs, result, RelationalCondition::LessThan, RELOP_AS_LAMBDA( < ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64LtS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LtS", lhs, rhs, result, RelationalCondition::LessThan, RELOP_AS_LAMBDA( < ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32LeS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LeS", lhs, rhs, result, RelationalCondition::LessThanOrEqual, RELOP_AS_LAMBDA( <= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64LeS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LeS", lhs, rhs, result, RelationalCondition::LessThanOrEqual, RELOP_AS_LAMBDA( <= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32GtS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GtS", lhs, rhs, result, RelationalCondition::GreaterThan, RELOP_AS_LAMBDA( > ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64GtS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GtS", lhs, rhs, result, RelationalCondition::GreaterThan, RELOP_AS_LAMBDA( > ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32GeS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GeS", lhs, rhs, result, RelationalCondition::GreaterThanOrEqual, RELOP_AS_LAMBDA( >= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64GeS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GeS", lhs, rhs, result, RelationalCondition::GreaterThanOrEqual, RELOP_AS_LAMBDA( >= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32LtU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LtU", lhs, rhs, result, RelationalCondition::Below, TYPED_RELOP_AS_LAMBDA(uint32_t, <));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64LtU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LtU", lhs, rhs, result, RelationalCondition::Below, TYPED_RELOP_AS_LAMBDA(uint64_t, <));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32LeU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LeU", lhs, rhs, result, RelationalCondition::BelowOrEqual, TYPED_RELOP_AS_LAMBDA(uint32_t, <=));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64LeU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LeU", lhs, rhs, result, RelationalCondition::BelowOrEqual, TYPED_RELOP_AS_LAMBDA(uint64_t, <=));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32GtU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GtU", lhs, rhs, result, RelationalCondition::Above, TYPED_RELOP_AS_LAMBDA(uint32_t, >));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64GtU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GtU", lhs, rhs, result, RelationalCondition::Above, TYPED_RELOP_AS_LAMBDA(uint64_t, >));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32GeU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GeU", lhs, rhs, result, RelationalCondition::AboveOrEqual, TYPED_RELOP_AS_LAMBDA(uint32_t, >=));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64GeU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GeU", lhs, rhs, result, RelationalCondition::AboveOrEqual, TYPED_RELOP_AS_LAMBDA(uint64_t, >=));
 }
@@ -2697,62 +2697,62 @@ PartialResult BBQJIT::emitCompareF64(const char* opcode, Value& lhs, Value& rhs,
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Eq(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Eq", lhs, rhs, result, DoubleCondition::DoubleEqualAndOrdered, RELOP_AS_LAMBDA( == ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Eq(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Eq", lhs, rhs, result, DoubleCondition::DoubleEqualAndOrdered, RELOP_AS_LAMBDA( == ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ne(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Ne", lhs, rhs, result, DoubleCondition::DoubleNotEqualOrUnordered, RELOP_AS_LAMBDA( != ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ne(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Ne", lhs, rhs, result, DoubleCondition::DoubleNotEqualOrUnordered, RELOP_AS_LAMBDA( != ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Lt(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Lt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Lt", lhs, rhs, result, DoubleCondition::DoubleLessThanAndOrdered, RELOP_AS_LAMBDA( < ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Lt(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Lt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Lt", lhs, rhs, result, DoubleCondition::DoubleLessThanAndOrdered, RELOP_AS_LAMBDA( < ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Le(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Le(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Le", lhs, rhs, result, DoubleCondition::DoubleLessThanOrEqualAndOrdered, RELOP_AS_LAMBDA( <= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Le(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Le(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Le", lhs, rhs, result, DoubleCondition::DoubleLessThanOrEqualAndOrdered, RELOP_AS_LAMBDA( <= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Gt(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Gt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Gt", lhs, rhs, result, DoubleCondition::DoubleGreaterThanAndOrdered, RELOP_AS_LAMBDA( > ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Gt(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Gt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Gt", lhs, rhs, result, DoubleCondition::DoubleGreaterThanAndOrdered, RELOP_AS_LAMBDA( > ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ge(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ge(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Ge", lhs, rhs, result, DoubleCondition::DoubleGreaterThanOrEqualAndOrdered, RELOP_AS_LAMBDA( >= ));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ge(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ge(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Ge", lhs, rhs, result, DoubleCondition::DoubleGreaterThanOrEqualAndOrdered, RELOP_AS_LAMBDA( >= ));
 }
@@ -2771,7 +2771,7 @@ PartialResult BBQJIT::addI32Extend8S(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Extend16S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Extend16S", TypeKind::I32,
@@ -2782,7 +2782,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Extend16S(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Eqz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Eqz", TypeKind::I32,
@@ -2793,7 +2793,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Eqz(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Popcnt(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Popcnt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Popcnt", TypeKind::I32,
@@ -2818,7 +2818,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32Popcnt(Value operand, Value& resu
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Popcnt(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Popcnt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Popcnt", TypeKind::I64,
@@ -2843,7 +2843,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Popcnt(Value operand, Value& resu
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ReinterpretF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ReinterpretF32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32ReinterpretF32", TypeKind::I32,
@@ -2854,7 +2854,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI32ReinterpretF32(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ReinterpretI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ReinterpretI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ReinterpretI32", TypeKind::F32,
@@ -2865,7 +2865,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ReinterpretI32(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32DemoteF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32DemoteF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32DemoteF64", TypeKind::F32,
@@ -2876,7 +2876,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32DemoteF64(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64PromoteF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64PromoteF32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64PromoteF32", TypeKind::F64,
@@ -2887,7 +2887,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64PromoteF32(Value operand, Value& 
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Copysign(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Copysign(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Copysign", TypeKind::F64,
@@ -2914,7 +2914,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Copysign(Value lhs, Value rhs, Va
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI32", TypeKind::F32,
@@ -2925,7 +2925,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI32", TypeKind::F64,
@@ -2936,7 +2936,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Copysign(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Copysign(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Copysign", TypeKind::F32,
@@ -2963,7 +2963,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Copysign(Value lhs, Value rhs, Va
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Abs(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Abs(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Abs", TypeKind::F32,
@@ -2979,7 +2979,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Abs(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Abs(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Abs(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Abs", TypeKind::F64,
@@ -2995,7 +2995,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Abs(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Sqrt(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sqrt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Sqrt", TypeKind::F32,
@@ -3006,7 +3006,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Sqrt(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Sqrt(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sqrt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Sqrt", TypeKind::F64,
@@ -3017,7 +3017,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Sqrt(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Neg(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Neg(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Neg", TypeKind::F32,
@@ -3034,7 +3034,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Neg(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Neg(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Neg(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Neg", TypeKind::F64,
@@ -3051,54 +3051,54 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Neg(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32TruncSF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncSF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncSF32, operand, result, Types::I32, Types::F32);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32TruncSF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncSF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncSF64, operand, result, Types::I32, Types::F64);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32TruncUF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncUF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncUF32, operand, result, Types::I32, Types::F32);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI32TruncUF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncUF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncUF64, operand, result, Types::I32, Types::F64);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64TruncSF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncSF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncSF32, operand, result, Types::I64, Types::F32);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64TruncSF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncSF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncSF64, operand, result, Types::I64, Types::F64);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64TruncUF32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncUF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncUF32, operand, result, Types::I64, Types::F32);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64TruncUF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncUF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncUF64, operand, result, Types::I64, Types::F64);
 }
 
 // References
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefEq(Value ref0, Value ref1, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefEq(Value ref0, Value ref1, Value& result)
 {
     return addI64Eq(ref0, ref1, result);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefFunc(FunctionSpaceIndex index, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefFunc(FunctionSpaceIndex index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     TypeKind returnType = TypeKind::Ref;
@@ -3135,7 +3135,7 @@ void BBQJIT::emitEntryTierUpCheck()
 }
 
 // Control flow
-ControlData WARN_UNUSED_RETURN BBQJIT::addTopLevel(BlockSignature signature)
+WARN_UNUSED_RETURN ControlData BBQJIT::addTopLevel(BlockSignature signature)
 {
     if (Options::verboseBBQJITInstructions()) [[unlikely]] {
         auto nameSection = m_info.nameSection;
@@ -3376,7 +3376,7 @@ MacroAssembler::Label BBQJIT::addLoopOSREntrypoint()
     return label;
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
 {
     result = ControlData(*this, BlockType::Block, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount());
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
@@ -3534,7 +3534,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 #endif
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex)
 {
     result = ControlData(*this, BlockType::Loop, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount());
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
@@ -3552,7 +3552,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addLoop(BlockSignature signature, Stack
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     RegisterSet liveScratchGPRs;
     Location conditionLocation;
@@ -3579,7 +3579,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addIf(Value condition, BlockSignature s
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addElse(ControlData& data, Stack& expressionStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addElse(ControlData& data, Stack& expressionStack)
 {
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
     ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
@@ -3604,7 +3604,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addElse(ControlData& data, Stack& expre
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addElseToUnreachable(ControlData& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addElseToUnreachable(ControlData& data)
 {
     // We want to flush or consume all values on the stack to reset the allocator
     // state entering the else block.
@@ -3629,7 +3629,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addElseToUnreachable(ControlData& data)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
 {
     m_usesExceptions = true;
     ++m_tryCatchDepth;
@@ -3645,7 +3645,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTry(BlockSignature signature, Stack&
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
 {
     m_usesExceptions = true;
     ++m_tryCatchDepth;
@@ -3674,7 +3674,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTryTable(BlockSignature signature, S
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3698,7 +3698,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCatch(unsigned exceptionIndex, const
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results)
 {
     m_usesExceptions = true;
     unbindAllRegisters();
@@ -3720,7 +3720,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchToUnreachable(unsigned exceptio
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchAll(Stack& expressionStack, ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAll(Stack& expressionStack, ControlType& data)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3744,7 +3744,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchAll(Stack& expressionStack, Con
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchAllToUnreachable(ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAllToUnreachable(ControlType& data)
 {
     m_usesExceptions = true;
     unbindAllRegisters();
@@ -3766,12 +3766,12 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCatchAllToUnreachable(ControlType& d
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addDelegate(ControlType& target, ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addDelegate(ControlType& target, ControlType& data)
 {
     return addDelegateToUnreachable(target, data);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addDelegateToUnreachable(ControlType& target, ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addDelegateToUnreachable(ControlType& target, ControlType& data)
 {
     unsigned depth = 0;
     if (ControlType::isTry(target))
@@ -3785,7 +3785,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addDelegateToUnreachable(ControlType& t
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&)
 {
 
     LOG_INSTRUCTION("Throw", arguments);
@@ -3820,7 +3820,7 @@ void BBQJIT::prepareForExceptions()
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addReturn(const ControlData& data, const Stack& returnValues)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addReturn(const ControlData& data, const Stack& returnValues)
 {
     CallInformation wasmCallInfo = wasmCallingConvention().callInformationFor(*data.signature().m_signature, CallRole::Callee);
 
@@ -3857,7 +3857,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addReturn(const ControlData& data, cons
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBranch(ControlData& target, Value condition, Stack& results)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranch(ControlData& target, Value condition, Stack& results)
 {
     if (condition.isConst() && !condition.asI32()) // If condition is known to be false, this is a no-op.
         return { };
@@ -3894,7 +3894,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addBranch(ControlData& target, Value co
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results)
 {
     ASSERT(condition.type() == TypeKind::I32);
 
@@ -3974,12 +3974,12 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSwitch(Value condition, const Vector
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::endBlock(ControlEntry& entry, Stack& stack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::endBlock(ControlEntry& entry, Stack& stack)
 {
     return addEndToUnreachable(entry, stack, false);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable)
 {
     ControlData& entryData = entry.controlData;
 
@@ -4058,7 +4058,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addEndToUnreachable(ControlEntry& entry
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::endTopLevel(BlockSignature, const Stack&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::endTopLevel(BlockSignature, const Stack&)
 {
     int frameSize = stackCheckSize();
     CCallHelpers& jit = m_jit;
@@ -4432,7 +4432,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const TypeDefin
 }
 
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCall(unsigned callProfileIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCall(unsigned callProfileIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     JIT_COMMENT(m_jit, "calling functionIndexSpace: ", functionIndexSpace, ConditionalDump(!m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace), " functionIndex: ", functionIndexSpace - m_info.importFunctionCount()));
@@ -4698,7 +4698,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
         consume(value);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value calleeIndex = args.takeLast();
@@ -4812,14 +4812,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCallIndirect(unsigned callProfileInd
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addUnreachable()
+WARN_UNUSED_RETURN PartialResult BBQJIT::addUnreachable()
 {
     LOG_INSTRUCTION("Unreachable");
     emitThrowException(ExceptionType::Unreachable);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCrash()
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCrash()
 {
     m_jit.breakpoint();
     return { };
@@ -4967,7 +4967,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, operand);
 
@@ -5236,7 +5236,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, left, right);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1105,29 +1105,29 @@ public:
     Value instanceValue();
 
     // Tables
-    PartialResult WARN_UNUSED_RETURN addTableGet(unsigned tableIndex, Value index, Value& result);
+    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned tableIndex, Value index, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addTableSet(unsigned tableIndex, Value index, Value value);
+    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned tableIndex, Value index, Value value);
 
-    PartialResult WARN_UNUSED_RETURN addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
-    PartialResult WARN_UNUSED_RETURN addElemDrop(unsigned elementIndex);
+    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned elementIndex);
 
-    PartialResult WARN_UNUSED_RETURN addTableSize(unsigned tableIndex, Value& result);
+    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned tableIndex, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result);
+    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addTableFill(unsigned tableIndex, Value offset, Value fill, Value count);
+    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned tableIndex, Value offset, Value fill, Value count);
 
-    PartialResult WARN_UNUSED_RETURN addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length);
+    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length);
 
     // Locals
 
-    PartialResult WARN_UNUSED_RETURN getLocal(uint32_t localIndex, Value& result);
+    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t localIndex, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN setLocal(uint32_t localIndex, Value value);
+    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t localIndex, Value value);
 
-    PartialResult WARN_UNUSED_RETURN teeLocal(uint32_t localIndex, Value, Value& result);
+    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t localIndex, Value, Value& result);
 
     // Globals
 
@@ -1135,12 +1135,12 @@ public:
 
     Value exception(const ControlData& control);
 
-    PartialResult WARN_UNUSED_RETURN getGlobal(uint32_t index, Value& result);
+    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, Value& result);
 
     void emitWriteBarrier(GPRReg cellGPR);
     void emitMutatorFence();
 
-    PartialResult WARN_UNUSED_RETURN setGlobal(uint32_t index, Value value);
+    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, Value value);
 
     // Memory
 
@@ -1268,7 +1268,7 @@ public:
         "I64Load8S", "I64Load8U", "I64Load16S", "I64Load16U", "I64Load32S", "I64Load32U"
     };
 
-    PartialResult WARN_UNUSED_RETURN load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset);
 
     inline uint32_t sizeOfStoreOp(StoreOpType op)
     {
@@ -1296,19 +1296,19 @@ public:
         "I64Store8", "I64Store16", "I64Store32",
     };
 
-    PartialResult WARN_UNUSED_RETURN store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN addGrowMemory(Value delta, Value& result);
+    WARN_UNUSED_RETURN PartialResult addGrowMemory(Value delta, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addCurrentMemory(Value& result);
+    WARN_UNUSED_RETURN PartialResult addCurrentMemory(Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addMemoryFill(Value dstAddress, Value targetValue, Value count);
+    WARN_UNUSED_RETURN PartialResult addMemoryFill(Value dstAddress, Value targetValue, Value count);
 
-    PartialResult WARN_UNUSED_RETURN addMemoryCopy(Value dstAddress, Value srcAddress, Value count);
+    WARN_UNUSED_RETURN PartialResult addMemoryCopy(Value dstAddress, Value srcAddress, Value count);
 
-    PartialResult WARN_UNUSED_RETURN addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length);
+    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length);
 
-    PartialResult WARN_UNUSED_RETURN addDataDrop(unsigned dataSegmentIndex);
+    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned dataSegmentIndex);
 
     // Atomics
 
@@ -1335,27 +1335,27 @@ public:
     template<typename Functor>
     void emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location old, Location cur, const Functor& functor);
 
-    Value WARN_UNUSED_RETURN emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset);
+    WARN_UNUSED_RETURN Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset);
 
     void emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset);
 
     Value emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location pointer, Value value, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset);
 
-    Value WARN_UNUSED_RETURN emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset);
+    WARN_UNUSED_RETURN Value emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset);
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset);
 
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType, uint8_t);
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 
     // Saturated truncation.
 
@@ -1383,16 +1383,16 @@ public:
 
     void truncInBounds(TruncationKind truncationKind, Location operandLocation, Location resultLocation, FPRReg scratch1FPR, FPRReg scratch2FPR);
 
-    PartialResult WARN_UNUSED_RETURN truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
 
 
     // GC
-    PartialResult WARN_UNUSED_RETURN addRefI31(ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addI31GetS(TypedExpression value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression value, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addI31GetU(TypedExpression value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression value, ExpressionType& result);
 
     const Ref<TypeDefinition> getTypeDefinition(uint32_t typeIndex);
 
@@ -1407,62 +1407,62 @@ public:
     Value marshallToI64(Value value);
 
     void emitAllocateGCArrayUninitialized(GPRReg result, uint32_t typeIndex, ExpressionType size, GPRReg scratchGPR, GPRReg scratchGPR2);
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result);
 
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
     void pushArrayNewFromSegment(ArraySegmentOperation operation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType exceptionType, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
 
     void emitArrayStoreElementUnchecked(StorageType elementType, GPRReg payloadGPR, Location index, Value value, bool preserveIndex = false);
     void emitArrayStoreElementUnchecked(StorageType elementType, GPRReg payloadGPR, Value index, Value value);
     void emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value index, Value value);
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
 
     void emitArrayGetPayload(StorageType, GPRReg arrayGPR, GPRReg payloadGPR);
 
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
 
-    PartialResult WARN_UNUSED_RETURN addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addArrayFill(uint32_t typeIndex, TypedExpression arrayref, ExpressionType offset, ExpressionType value, ExpressionType size);
+    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t typeIndex, TypedExpression arrayref, ExpressionType offset, ExpressionType value, ExpressionType size);
 
-    PartialResult WARN_UNUSED_RETURN addArrayCopy(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size);
+    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size);
 
-    PartialResult WARN_UNUSED_RETURN addArrayInitElem(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size);
+    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size);
 
-    PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size);
+    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size);
 
     // Returns true if a writeBarrier/mutatorFence is needed.
-    bool WARN_UNUSED_RETURN emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
+    WARN_UNUSED_RETURN bool emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
 
     void emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIndex, GPRReg scratchGPR, GPRReg scratchGPR2);
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result);
+    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addStructGet(ExtGCOpType structGetKind, TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value& result);
+    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addStructSet(TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value value);
+    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value value);
 
     enum class CastKind { Test, Cast };
     void emitRefTestOrCast(CastKind, const TypedExpression&, GPRReg, bool allowNull, int32_t toHeapType, JumpList& failureCases);
 
-    PartialResult WARN_UNUSED_RETURN addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
-    PartialResult WARN_UNUSED_RETURN addSelect(Value condition, Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addSelect(Value condition, Value lhs, Value rhs, Value& result);
 
     template<typename Fold, typename RegReg, typename RegImm>
     inline PartialResult binary(const char* opcode, TypeKind resultType, Value& lhs, Value& rhs, Value& result, Fold fold, RegReg regReg, RegImm regImm)
@@ -1588,29 +1588,29 @@ public:
                 regStatement /* Lambda to be called when both operands are registers. */ \
             });
 
-    PartialResult WARN_UNUSED_RETURN addI32Add(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Add(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Add(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Add(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Add(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Add(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Add(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Add(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Sub(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Sub(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Sub(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Sub(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Sub(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Sub(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Sub(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Sub(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Mul(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Mul(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Mul(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Mul(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Mul(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Mul(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Mul(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Mul(Value lhs, Value rhs, Value& result);
 
     template<typename Func>
     void addLatePath(WasmOrigin, Func&&);
@@ -1629,25 +1629,25 @@ public:
     template<typename IntType>
     Value checkConstantDivision(const Value& lhs, const Value& rhs);
 
-    PartialResult WARN_UNUSED_RETURN addI32DivS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32DivS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64DivS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64DivS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32DivU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32DivU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64DivU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64DivU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32RemS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32RemS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64RemS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64RemS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32RemU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32RemU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64RemU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64RemU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Div(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Div(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Div(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Div(Value lhs, Value rhs, Value& result);
 
     enum class MinOrMax { Min, Max };
 
@@ -1668,13 +1668,13 @@ public:
             return std::max<FloatType>(left, right);
     }
 
-    PartialResult WARN_UNUSED_RETURN addF32Min(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Min(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Min(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Min(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Max(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Max(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Max(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Max(Value lhs, Value rhs, Value& result);
 
     inline float floatCopySign(float lhs, float rhs)
     {
@@ -1696,241 +1696,241 @@ public:
         return std::bit_cast<double>(lhsAsInt64);
     }
 
-    PartialResult WARN_UNUSED_RETURN addI32And(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32And(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64And(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64And(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Xor(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Xor(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Xor(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Xor(Value lhs, Value rhs, Value& result);
 
 
-    PartialResult WARN_UNUSED_RETURN addI32Or(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Or(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Or(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Or(Value lhs, Value rhs, Value& result);
 
     void moveShiftAmountIfNecessary(Location& rhsLocation);
 
-    PartialResult WARN_UNUSED_RETURN addI32Shl(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Shl(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Shl(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Shl(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32ShrS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32ShrS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64ShrS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64ShrS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32ShrU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32ShrU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64ShrU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64ShrU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Rotl(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Rotl(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Rotl(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Rotl(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Rotr(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Rotr(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Rotr(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Rotr(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Clz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Clz(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Clz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Clz(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Ctz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Ctz(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Ctz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Ctz(Value operand, Value& result);
 
     PartialResult emitCompareI32(const char* opcode, Value& lhs, Value& rhs, Value& result, RelationalCondition condition, bool (*comparator)(int32_t lhs, int32_t rhs));
 
     PartialResult emitCompareI64(const char* opcode, Value& lhs, Value& rhs, Value& result, RelationalCondition condition, bool (*comparator)(int64_t lhs, int64_t rhs));
 
-    PartialResult WARN_UNUSED_RETURN addI32Eq(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Eq(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Eq(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Eq(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Ne(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Ne(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Ne(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Ne(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32LtS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32LtS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64LtS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64LtS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32LeS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32LeS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64LeS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64LeS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32GtS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32GtS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64GtS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64GtS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32GeS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32GeS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64GeS(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64GeS(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32LtU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32LtU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64LtU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64LtU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32LeU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32LeU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64LeU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64LeU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32GtU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32GtU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64GtU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64GtU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32GeU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32GeU(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64GeU(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64GeU(Value lhs, Value rhs, Value& result);
 
     PartialResult emitCompareF32(const char* opcode, Value& lhs, Value& rhs, Value& result, DoubleCondition condition, bool (*comparator)(float lhs, float rhs));
 
     PartialResult emitCompareF64(const char* opcode, Value& lhs, Value& rhs, Value& result, DoubleCondition condition, bool (*comparator)(double lhs, double rhs));
 
-    PartialResult WARN_UNUSED_RETURN addF32Eq(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Eq(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Eq(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Eq(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Ne(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Ne(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Ne(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Ne(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Lt(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Lt(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Lt(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Lt(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Le(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Le(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Le(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Le(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Gt(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Gt(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Gt(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Gt(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Ge(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Ge(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Ge(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Ge(Value lhs, Value rhs, Value& result);
 
     PartialResult addI32WrapI64(Value operand, Value& result);
 
     PartialResult addI32Extend8S(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Extend16S(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Extend16S(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Extend8S(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Extend8S(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Extend16S(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Extend16S(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Extend32S(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Extend32S(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64ExtendSI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64ExtendUI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Eqz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Eqz(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Eqz(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Eqz(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32Popcnt(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32Popcnt(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64Popcnt(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64Popcnt(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32ReinterpretF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64ReinterpretF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32ReinterpretI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64ReinterpretI64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32DemoteF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64PromoteF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Copysign(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Copysign(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Copysign(Value lhs, Value rhs, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Copysign(Value lhs, Value rhs, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Floor(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Floor(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Floor(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Floor(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Ceil(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Ceil(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Ceil(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Ceil(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Abs(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Abs(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Abs(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Abs(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Sqrt(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Sqrt(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Sqrt(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Sqrt(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Neg(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Neg(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Neg(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Neg(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Nearest(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Nearest(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Nearest(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Nearest(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF32Trunc(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF32Trunc(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addF64Trunc(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addF64Trunc(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF32(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF64(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(Value operand, Value& result);
 
     // References
 
-    PartialResult WARN_UNUSED_RETURN addRefIsNull(Value operand, Value& result);
+    WARN_UNUSED_RETURN PartialResult addRefIsNull(Value operand, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addRefAsNonNull(Value value, Value& result);
+    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(Value value, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addRefEq(Value ref0, Value ref1, Value& result);
+    WARN_UNUSED_RETURN PartialResult addRefEq(Value ref0, Value ref1, Value& result);
 
-    PartialResult WARN_UNUSED_RETURN addRefFunc(FunctionSpaceIndex index, Value& result);
+    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, Value& result);
 
     void emitEntryTierUpCheck();
 
     // Control flow
-    ControlData WARN_UNUSED_RETURN addTopLevel(BlockSignature signature);
+    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature signature);
 
     bool hasLoops() const;
 
     MacroAssembler::Label addLoopOSREntrypoint();
 
-    PartialResult WARN_UNUSED_RETURN addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
 
     B3::Type toB3Type(Type type);
 
@@ -1942,16 +1942,16 @@ public:
 
     void emitLoopTierUpCheckAndOSREntryData(const ControlData&, Stack& enclosingStack, unsigned loopIndex);
 
-    PartialResult WARN_UNUSED_RETURN addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex);
+    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex);
 
-    PartialResult WARN_UNUSED_RETURN addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack);
 
-    PartialResult WARN_UNUSED_RETURN addElse(ControlData& data, Stack& expressionStack);
+    WARN_UNUSED_RETURN PartialResult addElse(ControlData& data, Stack& expressionStack);
 
-    PartialResult WARN_UNUSED_RETURN addElseToUnreachable(ControlData& data);
+    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData& data);
 
-    PartialResult WARN_UNUSED_RETURN addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
 
     void emitCatchPrologue();
 
@@ -1960,43 +1960,43 @@ public:
     void emitCatchImpl(ControlData& dataCatch, const TypeDefinition& exceptionSignature, ResultList& results);
     void emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTarget&);
 
-    PartialResult WARN_UNUSED_RETURN addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results);
+    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results);
 
-    PartialResult WARN_UNUSED_RETURN addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results);
+    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results);
 
-    PartialResult WARN_UNUSED_RETURN addCatchAll(Stack& expressionStack, ControlType& data);
+    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack& expressionStack, ControlType& data);
 
-    PartialResult WARN_UNUSED_RETURN addCatchAllToUnreachable(ControlType& data);
+    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType& data);
 
-    PartialResult WARN_UNUSED_RETURN addDelegate(ControlType& target, ControlType& data);
+    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType& target, ControlType& data);
 
-    PartialResult WARN_UNUSED_RETURN addDelegateToUnreachable(ControlType& target, ControlType& data);
+    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType& target, ControlType& data);
 
-    PartialResult WARN_UNUSED_RETURN addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&);
+    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&);
 
-    PartialResult WARN_UNUSED_RETURN addRethrow(unsigned, ControlType& data);
+    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType& data);
 
-    PartialResult WARN_UNUSED_RETURN addThrowRef(ExpressionType exception, Stack&);
+    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType exception, Stack&);
 
     void prepareForExceptions();
 
-    PartialResult WARN_UNUSED_RETURN addReturn(const ControlData& data, const Stack& returnValues);
+    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData& data, const Stack& returnValues);
 
-    PartialResult WARN_UNUSED_RETURN addBranch(ControlData& target, Value condition, Stack& results);
+    WARN_UNUSED_RETURN PartialResult addBranch(ControlData& target, Value condition, Stack& results);
 
-    PartialResult WARN_UNUSED_RETURN addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result);
 
-    PartialResult WARN_UNUSED_RETURN addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
+    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
 
-    PartialResult WARN_UNUSED_RETURN addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results);
+    WARN_UNUSED_RETURN PartialResult addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results);
 
-    PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry& entry, Stack& stack);
+    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry& entry, Stack& stack);
 
-    PartialResult WARN_UNUSED_RETURN addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable = true);
+    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable = true);
 
     int alignedFrameSize(int frameSize) const;
 
-    PartialResult WARN_UNUSED_RETURN endTopLevel(BlockSignature, const Stack&);
+    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&);
 
     enum BranchFoldResult {
         BranchAlwaysTaken,
@@ -2004,15 +2004,15 @@ public:
         BranchNotFolded
     };
 
-    BranchFoldResult WARN_UNUSED_RETURN tryFoldFusedBranchCompare(OpType, ExpressionType);
-    Jump WARN_UNUSED_RETURN emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
-    BranchFoldResult WARN_UNUSED_RETURN tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
-    Jump WARN_UNUSED_RETURN emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
+    WARN_UNUSED_RETURN BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType);
+    WARN_UNUSED_RETURN Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
+    WARN_UNUSED_RETURN BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
 
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
 
     // Flush a value to its canonical slot.
     void flushValue(Value value);
@@ -2046,18 +2046,18 @@ public:
     void emitCCall(Func function, const Vector<Value, N>& arguments, Value& result);
 
     void emitTailCall(FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments);
-    PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType = CallType::Call);
 
     void emitIndirectCall(const char* opcode, unsigned callProfileIndex, const Value& callee, GPRReg importableFunction, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results);
     void emitIndirectTailCall(const char* opcode, const Value& callee, GPRReg importableFunction, const TypeDefinition& signature, ArgumentList& arguments);
 
-    PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
 
-    PartialResult WARN_UNUSED_RETURN addCallRef(unsigned, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
 
-    PartialResult WARN_UNUSED_RETURN addUnreachable();
+    WARN_UNUSED_RETURN PartialResult addUnreachable();
 
-    PartialResult WARN_UNUSED_RETURN addCrash();
+    WARN_UNUSED_RETURN PartialResult addCrash();
 
     ALWAYS_INLINE void willParseOpcode();
 
@@ -2111,7 +2111,7 @@ public:
 
     void emitVectorMul(SIMDInfo info, Location left, Location right, Location result);
 
-    PartialResult WARN_UNUSED_RETURN fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result);
+    WARN_UNUSED_RETURN PartialResult fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result);
 
     PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -209,7 +209,7 @@ Value BBQJIT::instanceValue()
 }
 
 // Tables
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -233,7 +233,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGet(unsigned tableIndex, Value 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::getGlobal(uint32_t index, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -303,7 +303,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::getGlobal(uint32_t index, Value& result
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -398,7 +398,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
 
 // Memory
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -498,7 +498,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
@@ -776,7 +776,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location o
     m_jit.branchTest32(ResultCondition::NonZero, wasmScratchGPR2).linkTo(reloopLabel, &m_jit);
 }
 
-Value WARN_UNUSED_RETURN BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1065,7 +1065,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
     return result;
 }
 
-Value WARN_UNUSED_RETURN BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Location pointer, Value expected, Value value, uint32_t uoffset)
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Location pointer, Value expected, Value value, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1211,7 +1211,7 @@ void BBQJIT::truncInBounds(TruncationKind truncationKind, Location operandLocati
 }
 
 // GC
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
 {
     if (value.isConst()) {
         uint32_t lo32 = (value.asI32() << 1) >> 1;
@@ -1234,7 +1234,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, Express
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1266,7 +1266,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetS(TypedExpression typedValue, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1329,7 +1329,7 @@ Value BBQJIT::marshallToI64(Value value)
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
 {
     result = topValue(TypeKind::Arrayref);
 
@@ -1350,7 +1350,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNew(uint32_t typeIndex, Express
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
 {
     // Allocate an uninitialized array whose length matches the argument count
     // FIXME: inline the allocation.
@@ -1394,7 +1394,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewFixed(uint32_t typeIndex, Ar
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1411,7 +1411,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewDefault(uint32_t typeIndex, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     StorageType elementType = getArrayElementType(typeIndex);
@@ -1664,7 +1664,7 @@ void BBQJIT::emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value ind
     consume(value);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1700,7 +1700,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArraySet(uint32_t typeIndex, TypedEx
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1724,7 +1724,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1838,7 +1838,7 @@ bool BBQJIT::emitStructSet(GPRReg structGPR, const StructType& structType, uint3
     return isRefType(storageType.unpacked());
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
 {
 
     Vector<Value, 8> arguments = {
@@ -1867,7 +1867,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1904,7 +1904,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, Argume
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
 {
     auto structValue = typedStruct.value();
     TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
@@ -1975,7 +1975,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
 {
     auto structValue = typedStruct.value();
     if (structValue.isConst()) {
@@ -2003,7 +2003,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructSet(TypedExpression typedStruc
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -2023,7 +2023,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefCast(TypedExpression reference, b
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -2040,7 +2040,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefTest(TypedExpression reference, b
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Add", TypeKind::I64,
@@ -2056,7 +2056,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Sub", TypeKind::I64,
@@ -2080,7 +2080,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Mul", TypeKind::I64,
@@ -2101,7 +2101,7 @@ void BBQJIT::emitThrowOnNullReference(ExceptionType type, Location ref)
     recordJumpToThrowException(type, m_jit.branch32(MacroAssembler::Equal, ref.asGPRhi(), TrustedImm32(JSValue::NullTag)));
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64And", TypeKind::I64,
@@ -2118,7 +2118,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64And(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Xor", TypeKind::I64,
@@ -2135,7 +2135,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Or", TypeKind::I64,
@@ -2152,7 +2152,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Or(Value lhs, Value rhs, Value& r
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
 {
     auto emitI64Shl = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2193,7 +2193,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
 {
     auto emitI64ShrS = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2237,7 +2237,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
 {
     auto emitI64ShrU = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2280,7 +2280,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2297,7 +2297,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2350,7 +2350,7 @@ void BBQJIT::rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsL
     zero.link(&m_jit);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Clz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Clz", TypeKind::I64,
@@ -2361,7 +2361,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Clz(Value operand, Value& result)
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Ctz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Ctz", TypeKind::I64,
@@ -2399,7 +2399,7 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend8S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend8S", TypeKind::I64,
@@ -2412,7 +2412,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend8S(Value operand, Value& re
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend16S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend16S", TypeKind::I64,
@@ -2425,7 +2425,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend16S(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend32S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend32S", TypeKind::I64,
@@ -2438,7 +2438,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend32S(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendSI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendSI32", TypeKind::I64,
@@ -2451,7 +2451,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendSI32(Value operand, Value& 
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendUI32", TypeKind::I64,
@@ -2464,7 +2464,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendUI32(Value operand, Value& 
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Eqz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Eqz", TypeKind::I32,
@@ -2476,7 +2476,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Eqz(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ReinterpretF64", TypeKind::I64,
@@ -2487,7 +2487,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ReinterpretF64(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ReinterpretI64", TypeKind::F64,
@@ -2498,7 +2498,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ReinterpretI64(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI32", TypeKind::F32,
@@ -2509,7 +2509,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI64", TypeKind::F32,
@@ -2522,7 +2522,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI64", TypeKind::F32,
@@ -2535,7 +2535,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI32", TypeKind::F64,
@@ -2546,7 +2546,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI64", TypeKind::F64,
@@ -2559,7 +2559,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI64", TypeKind::F64,
@@ -2572,7 +2572,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Floor(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Floor", TypeKind::F32,
@@ -2585,7 +2585,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Floor(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Floor(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Floor", TypeKind::F64,
@@ -2598,7 +2598,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Floor(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ceil(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Ceil", TypeKind::F32,
@@ -2611,7 +2611,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ceil(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ceil(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Ceil", TypeKind::F64,
@@ -2624,7 +2624,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ceil(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Nearest(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Nearest", TypeKind::F32,
@@ -2637,7 +2637,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Nearest(Value operand, Value& res
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Nearest(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Nearest", TypeKind::F64,
@@ -2650,7 +2650,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Nearest(Value operand, Value& res
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Trunc(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Trunc", TypeKind::F32,
@@ -2663,7 +2663,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Trunc(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Trunc(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Trunc", TypeKind::F64,
@@ -2678,7 +2678,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Trunc(Value operand, Value& resul
 
 // References
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefIsNull(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
 {
     EMIT_UNARY(
         "RefIsNull", TypeKind::I32,
@@ -2690,7 +2690,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefIsNull(Value operand, Value& resu
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefAsNonNull(Value value, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -2909,7 +2909,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addThrowRef(Value exception, Stack&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
 {
     LOG_INSTRUCTION("ThrowRef", exception);
 
@@ -2935,7 +2935,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addThrowRef(Value exception, Stack&)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRethrow(unsigned, ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
 {
     LOG_INSTRUCTION("Rethrow", exception(data));
 
@@ -2950,7 +2950,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRethrow(unsigned, ControlType& data)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
 {
     if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
         // If branch is known to be not-taken, exit early.
@@ -3014,7 +3014,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchNull(ControlData& data, Expres
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
 {
     Value condition;
     if (reference.isConst()) {
@@ -3073,67 +3073,67 @@ void BBQJIT::notifyFunctionUsesSIMD()
     m_usesSIMD = false;
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStore(ExpressionType, ExpressionType, uint32_t)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType, ExpressionType, uint32_t)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
@@ -3150,49 +3150,49 @@ ExpressionType BBQJIT::addConstant(v128_t)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addExtractLane(SIMDInfo, uint8_t, Value, Value&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addExtractLane(SIMDInfo, uint8_t, Value, Value&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
@@ -3470,7 +3470,7 @@ void BBQJIT::emitLoad(TypeKind type, Location src, Location dst)
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -161,7 +161,7 @@ Value BBQJIT::instanceValue()
 }
 
 // Tables
-PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -183,7 +183,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addTableGet(unsigned tableIndex, Value 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::getGlobal(uint32_t index, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -250,7 +250,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::getGlobal(uint32_t index, Value& result
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -340,7 +340,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
 
 // Memory
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -432,7 +432,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
@@ -631,7 +631,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
 #endif
 }
 
-Value WARN_UNUSED_RETURN BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1187,7 +1187,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
     return result;
 }
 
-Value WARN_UNUSED_RETURN BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset)
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1337,7 +1337,7 @@ void BBQJIT::truncInBounds(TruncationKind truncationKind, Location operandLocati
 }
 
 // GC
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
 {
     if (value.isConst()) {
         uint32_t lo32 = (value.asI32() << 1) >> 1;
@@ -1360,7 +1360,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, Express
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1392,7 +1392,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetS(TypedExpression typedValue, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1501,7 +1501,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
     } });
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
 {
     GPRReg resultGPR;
     {
@@ -1553,7 +1553,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNew(uint32_t typeIndex, Express
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
 {
     GPRReg resultGPR;
     {
@@ -1585,7 +1585,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewFixed(uint32_t typeIndex, Ar
 }
 
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
 {
     StorageType elementType = getArrayElementType(typeIndex);
     // FIXME: We don't have a good way to fill V128s yet so just make a call.
@@ -1641,7 +1641,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewDefault(uint32_t typeIndex, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     StorageType elementType = getArrayElementType(typeIndex);
@@ -1830,7 +1830,7 @@ void BBQJIT::emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value ind
     consume(value);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1868,7 +1868,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArraySet(uint32_t typeIndex, TypedEx
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1892,7 +1892,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -2014,7 +2014,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
     }});
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
 {
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     GPRReg resultGPR;
@@ -2060,7 +2060,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
 {
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     GPRReg resultGPR;
@@ -2100,7 +2100,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, Argume
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
 {
     auto structValue = typedStruct.value();
     TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
@@ -2187,7 +2187,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
 {
     auto structValue = typedStruct.value();
     if (structValue.isConst()) {
@@ -2338,7 +2338,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
     doneCases.link(m_jit);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefCast(TypedExpression typedValue, bool allowNull, int32_t toHeapType, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression typedValue, bool allowNull, int32_t toHeapType, ExpressionType& result)
 {
     auto value = typedValue.value();
     Location valueLocation;
@@ -2362,7 +2362,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefCast(TypedExpression typedValue, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefTest(TypedExpression typedValue, bool allowNull, int32_t toHeapType, bool shouldNegate, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression typedValue, bool allowNull, int32_t toHeapType, bool shouldNegate, ExpressionType& result)
 {
     auto value = typedValue.value();
     Location valueLocation;
@@ -2393,7 +2393,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefTest(TypedExpression typedValue, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Add", TypeKind::I64,
@@ -2412,7 +2412,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Sub", TypeKind::I64,
@@ -2431,7 +2431,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Mul", TypeKind::I64,
@@ -2461,7 +2461,7 @@ void BBQJIT::emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset
     emitThrowOnNullReference(ExceptionType::NullAccess, ref);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64And", TypeKind::I64,
@@ -2475,7 +2475,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64And(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Xor", TypeKind::I64,
@@ -2489,7 +2489,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Or", TypeKind::I64,
@@ -2503,7 +2503,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Or(Value lhs, Value rhs, Value& r
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2525,7 +2525,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2547,7 +2547,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2569,7 +2569,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2609,7 +2609,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2631,7 +2631,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Rotr(Value lhs, Value rhs, Value&
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Clz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Clz", TypeKind::I64,
@@ -2642,7 +2642,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Clz(Value operand, Value& result)
     );
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Ctz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Ctz", TypeKind::I64,
@@ -2681,7 +2681,7 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend8S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend8S", TypeKind::I64,
@@ -2692,7 +2692,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend8S(Value operand, Value& re
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend16S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend16S", TypeKind::I64,
@@ -2703,7 +2703,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend16S(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend32S(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend32S", TypeKind::I64,
@@ -2714,7 +2714,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Extend32S(Value operand, Value& r
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendSI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendSI32", TypeKind::I64,
@@ -2725,7 +2725,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendSI32(Value operand, Value& 
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendUI32", TypeKind::I64,
@@ -2736,7 +2736,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ExtendUI32(Value operand, Value& 
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Eqz(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Eqz", TypeKind::I32,
@@ -2747,7 +2747,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Eqz(Value operand, Value& result)
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ReinterpretF64", TypeKind::I64,
@@ -2758,7 +2758,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64ReinterpretF64(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ReinterpretI64", TypeKind::F64,
@@ -2769,7 +2769,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ReinterpretI64(Value operand, Val
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI32", TypeKind::F32,
@@ -2780,7 +2780,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI64", TypeKind::F32,
@@ -2791,7 +2791,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertSI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI64", TypeKind::F32,
@@ -2806,7 +2806,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI32(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI32", TypeKind::F64,
@@ -2817,7 +2817,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI32(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI64", TypeKind::F64,
@@ -2828,7 +2828,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertSI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI64(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI64", TypeKind::F64,
@@ -2843,7 +2843,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI64(Value operand, Value&
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Floor(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Floor", TypeKind::F32,
@@ -2854,7 +2854,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Floor(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Floor(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Floor", TypeKind::F64,
@@ -2865,7 +2865,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Floor(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ceil(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Ceil", TypeKind::F32,
@@ -2876,7 +2876,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Ceil(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ceil(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Ceil", TypeKind::F64,
@@ -2887,7 +2887,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Ceil(Value operand, Value& result
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Nearest(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Nearest", TypeKind::F32,
@@ -2898,7 +2898,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Nearest(Value operand, Value& res
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Nearest(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Nearest", TypeKind::F64,
@@ -2909,7 +2909,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Nearest(Value operand, Value& res
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Trunc(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Trunc", TypeKind::F32,
@@ -2920,7 +2920,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Trunc(Value operand, Value& resul
     )
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Trunc(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Trunc", TypeKind::F64,
@@ -2933,7 +2933,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Trunc(Value operand, Value& resul
 
 // References
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefIsNull(Value operand, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
 {
     EMIT_UNARY(
         "RefIsNull", TypeKind::I32,
@@ -2946,7 +2946,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefIsNull(Value operand, Value& resu
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRefAsNonNull(Value value, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -3154,7 +3154,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addThrowRef(Value exception, Stack&)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
 {
     LOG_INSTRUCTION("ThrowRef", exception);
 
@@ -3181,7 +3181,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addThrowRef(Value exception, Stack&)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addRethrow(unsigned, ControlType& data)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
 {
     LOG_INSTRUCTION("Rethrow", exception(data));
 
@@ -3196,7 +3196,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRethrow(unsigned, ControlType& data)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
 {
     if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
         // If branch is known to be not-taken, exit early.
@@ -3261,7 +3261,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchNull(ControlData& data, Expres
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
 {
     Value condition;
     if (reference.isConst()) {
@@ -3332,7 +3332,7 @@ void BBQJIT::notifyFunctionUsesSIMD()
     m_usesSIMD = true;
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoad(ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), [&](auto location) -> Value {
         consume(pointer);
@@ -3345,7 +3345,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoad(ExpressionType pointer, uin
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t uoffset)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t uoffset)
 {
     emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), [&](auto location) -> void {
         Location valueLocation = loadIfNecessary(value);
@@ -3357,7 +3357,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStore(ExpressionType value, Expr
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionType value, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -3432,7 +3432,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionT
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result)
 {
 #if CPU(X86_64)
     ScratchScope<0, 1> scratches(*this);
@@ -3490,7 +3490,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShuffle(v128_t imm, ExpressionTy
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMDInfo info, ExpressionType src, ExpressionType shift, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMDInfo info, ExpressionType src, ExpressionType shift, ExpressionType& result)
 {
 #if CPU(X86_64)
     // Clobber and preserve RCX on x86, since we need it to do shifts.
@@ -3570,7 +3570,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMD
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
 {
     ASSERT(info.signMode != SIMDSignMode::None);
 
@@ -3591,7 +3591,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIM
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     Width width;
     switch (op) {
@@ -3644,7 +3644,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result)
 {
     Width width;
     switch (op) {
@@ -3695,7 +3695,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, E
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane)
 {
     Width width;
     switch (op) {
@@ -3742,7 +3742,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     SIMDLane lane;
     SIMDSignMode signMode;
@@ -3791,7 +3791,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, op == SIMDLaneOperation::LoadPad32 ? sizeof(float) : sizeof(double), [&](auto location) -> Value {
         consume(pointer);
@@ -3825,7 +3825,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
         m_jit.materializeVector(value, result.asFPR());
 }
 
-ExpressionType WARN_UNUSED_RETURN BBQJIT::addConstant(v128_t value)
+WARN_UNUSED_RETURN ExpressionType BBQJIT::addConstant(v128_t value)
 {
     // We currently don't track constant Values for V128s, since folding them seems like a lot of work that might not be worth it.
     // Maybe we can look into this eventually?
@@ -3838,7 +3838,7 @@ ExpressionType WARN_UNUSED_RETURN BBQJIT::addConstant(v128_t value)
 
 // SIMD generated
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -3854,7 +3854,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addExtractLane(SIMDInfo info, uint8_t l
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
 {
     Location vectorLocation = loadIfNecessary(vector);
     Location scalarLocation;
@@ -3884,7 +3884,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addReplaceLane(SIMDInfo info, uint8_t l
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -3991,7 +3991,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDIn
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -4179,7 +4179,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDIn
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDBitwiseSelect(ExpressionType left, ExpressionType right, ExpressionType selector, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType left, ExpressionType right, ExpressionType selector, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4205,7 +4205,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDBitwiseSelect(ExpressionType lef
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDRelOp(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, B3::Air::Arg relOp, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, B3::Air::Arg relOp, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4298,7 +4298,7 @@ void BBQJIT::emitVectorMul(SIMDInfo info, Location left, Location right, Locatio
         m_jit.vectorMul(info, left.asFPR(), right.asFPR(), result.asFPR());
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result)
 {
     ASSERT(isX86());
     // Let each byte mask be 112 (0x70) then after VectorAddSat
@@ -4314,7 +4314,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Locat
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4464,7 +4464,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDI
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType mul1, ExpressionType mul2, ExpressionType addend, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType mul1, ExpressionType mul2, ExpressionType addend, ExpressionType& result)
 {
     Location mul1Location = loadIfNecessary(mul1);
     Location mul2Location = loadIfNecessary(mul2);
@@ -4900,7 +4900,7 @@ void BBQJIT::emitMove(StorageType type, Value src, Address dst)
         emitStore(type, srcLocation, dst);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -184,7 +184,7 @@ public:
 
 protected:
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_parser->offset() + m_offsetInSource), ": "_s, makeString(args)...));
@@ -248,19 +248,19 @@ public:
 
     PartialResult addDrop(ExpressionType) CONST_EXPR_STUB
     PartialResult addLocal(Type, uint32_t) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addTableGet(unsigned, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableSet(unsigned, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addElemDrop(unsigned) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableSize(unsigned, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN getLocal(uint32_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN setLocal(uint32_t, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN teeLocal(uint32_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN getGlobal(uint32_t index, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result)
     {
         // Note that this check works for table initializers too, because no globals are registered when the table section is read and the count is 0.
         WASM_COMPILE_FAIL_IF(index >= m_info.globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info.globals.size());
@@ -276,26 +276,26 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN setGlobal(uint32_t, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN load(LoadOpType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN store(StoreOpType, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addGrowMemory(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCurrentMemory(ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addMemoryFill(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addDataDrop(unsigned) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType, uint8_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN truncTrapping(OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult truncTrapping(OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addRefI31(ExpressionType value, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             JSValue i31 = JSValue((((static_cast<int32_t>(value.getValue()) & 0x7fffffff) << 1) >> 1));
@@ -305,8 +305,8 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addI31GetS(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI31GetS(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI31GetU(ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
     ExpressionType createNewArray(WebAssemblyGCStructure* structure, uint32_t size, ExpressionType value)
     {
@@ -321,7 +321,7 @@ public:
         return ConstExprValue(result);
     }
 
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -331,7 +331,7 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -349,7 +349,7 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -372,15 +372,15 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
-    PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
+    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayLen(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
+    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
 
     ExpressionType createNewStruct(uint32_t typeIndex)
     {
@@ -392,7 +392,7 @@ public:
         return ConstExprValue(result);
     }
 
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -402,7 +402,7 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -419,12 +419,12 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType, bool, int32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             if (reference.type() == ConstExprValue::Numeric)
@@ -438,184 +438,184 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result)
     {
         result = reference;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addI32Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI32Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs + rhs;
         return { };
     }
-    PartialResult WARN_UNUSED_RETURN addI64Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI64Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs + rhs;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addF32Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addI32Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI32Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs - rhs;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addI64Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI64Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs - rhs;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addF32Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addI32Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI32Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs * rhs;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addI64Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addI64Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs * rhs;
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addF32Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     PartialResult addI32WrapI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
     PartialResult addI32Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Extend32S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64ExtendSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64ExtendUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32ReinterpretF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64ReinterpretF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32ReinterpretI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64ReinterpretI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32DemoteF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64PromoteF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF32Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addF64Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRefIsNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRefAsNonNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRefEq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Extend32S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF32Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addF64Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
+    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             JSValue wrapper = m_instance->getFunctionWrapper(index);
@@ -634,33 +634,33 @@ public:
         return ControlData(signature);
     }
 
-    PartialResult WARN_UNUSED_RETURN addBlock(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addIf(ExpressionType, BlockSignature, Stack&, ControlData&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addElse(ControlData&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addElseToUnreachable(ControlData&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTry(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addTryTable(BlockSignature, Stack&, const Vector<CatchHandler>&, ControlType&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCatchAll(Stack&, ControlType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCatchAllToUnreachable(ControlType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addDelegate(ControlType&, ControlType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addDelegateToUnreachable(ControlType&, ControlType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addThrow(unsigned, ArgumentList&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addRethrow(unsigned, ControlType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addThrowRef(ExpressionType, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addReturn(const ControlData&, const Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addBranch(ControlData&, ExpressionType, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlData&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack&, const Vector<CatchHandler>&, ControlType&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addThrow(unsigned, ArgumentList&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry& entry, Stack& expressionStack)
+    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry& entry, Stack& expressionStack)
     {
         ASSERT(expressionStack.size() == 1);
         ASSERT_UNUSED(entry, ControlType::isTopLevel(entry.controlData));
@@ -668,9 +668,9 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addEndToUnreachable(ControlEntry&, Stack&, bool = true) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, Stack&, bool = true) CONST_EXPR_STUB
 
-    PartialResult WARN_UNUSED_RETURN endTopLevel(BlockSignature, const Stack&)
+    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&)
     {
         // Some opcodes like "nop" are not detectable by an error stub because the context
         // doesn't get called by the parser. This flag is set by didParseOpcode() to signal
@@ -679,41 +679,41 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addUnreachable() CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addCrash() CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addUnreachable() CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addCrash() CONST_EXPR_STUB
     bool usesSIMD() { return false; }
     void notifyFunctionUsesSIMD() { }
-    PartialResult WARN_UNUSED_RETURN addSIMDLoad(ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDStore(ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    ExpressionType WARN_UNUSED_RETURN addConstant(v128_t vector)
+    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t vector)
     {
         RELEASE_ASSERT(Options::useWasmSIMD());
         if (m_mode == Mode::Evaluate)
             return ConstExprValue(vector);
         return { };
     }
-    PartialResult WARN_UNUSED_RETURN addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 #if ENABLE(B3_JIT)
-    PartialResult WARN_UNUSED_RETURN addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&) CONST_EXPR_STUB
 #endif
-    PartialResult WARN_UNUSED_RETURN addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    PartialResult WARN_UNUSED_RETURN addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    WARN_UNUSED_RETURN PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
     void dump(const ControlStack&, const Stack*) { }
     ALWAYS_INLINE void willParseOpcode() { }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -153,8 +153,8 @@ public:
 
     FunctionParser(Context&, std::span<const uint8_t> function, const TypeDefinition&, const ModuleInformation&);
 
-    Result WARN_UNUSED_RETURN parse();
-    Result WARN_UNUSED_RETURN parseConstantExpression();
+    WARN_UNUSED_RETURN Result parse();
+    WARN_UNUSED_RETURN Result parseConstantExpression();
 
     OpType currentOpcode() const { return m_currentOpcode; }
     uint32_t currentExtendedOpcode() const { return m_currentExtOp; }
@@ -205,25 +205,25 @@ public:
 private:
     static constexpr bool verbose = false;
 
-    PartialResult WARN_UNUSED_RETURN parseBody();
-    PartialResult WARN_UNUSED_RETURN parseExpression();
-    PartialResult WARN_UNUSED_RETURN parseUnreachableExpression();
-    PartialResult WARN_UNUSED_RETURN unifyControl(ArgumentList&, unsigned level);
-    PartialResult WARN_UNUSED_RETURN checkLocalInitialized(uint32_t);
-    PartialResult WARN_UNUSED_RETURN checkExpressionStack(const ControlType&, bool forceSignature = false);
+    WARN_UNUSED_RETURN PartialResult parseBody();
+    WARN_UNUSED_RETURN PartialResult parseExpression();
+    WARN_UNUSED_RETURN PartialResult parseUnreachableExpression();
+    WARN_UNUSED_RETURN PartialResult unifyControl(ArgumentList&, unsigned level);
+    WARN_UNUSED_RETURN PartialResult checkLocalInitialized(uint32_t);
+    WARN_UNUSED_RETURN PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
 
     enum BranchConditionalityTag {
         Unconditional,
         Conditional
     };
 
-    PartialResult WARN_UNUSED_RETURN checkBranchTarget(const ControlType&, BranchConditionalityTag);
+    WARN_UNUSED_RETURN PartialResult checkBranchTarget(const ControlType&, BranchConditionalityTag);
 
-    PartialResult WARN_UNUSED_RETURN parseImmLaneIdx(uint8_t laneCount, uint8_t&);
-    PartialResult WARN_UNUSED_RETURN parseBlockSignature(const ModuleInformation&, BlockSignature&);
-    PartialResult WARN_UNUSED_RETURN parseReftypeSignature(const ModuleInformation&, BlockSignature&);
+    WARN_UNUSED_RETURN PartialResult parseImmLaneIdx(uint8_t laneCount, uint8_t&);
+    WARN_UNUSED_RETURN PartialResult parseBlockSignature(const ModuleInformation&, BlockSignature&);
+    WARN_UNUSED_RETURN PartialResult parseReftypeSignature(const ModuleInformation&, BlockSignature&);
 
-    PartialResult WARN_UNUSED_RETURN parseNestedBlocksEagerly(bool&);
+    WARN_UNUSED_RETURN PartialResult parseNestedBlocksEagerly(bool&);
     void switchToBlock(ControlType&&, Stack&&);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do { \
@@ -233,90 +233,88 @@ private:
     } while (0)
 
     using UnaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN unaryCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
-    PartialResult WARN_UNUSED_RETURN unaryCompareCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult unaryCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult unaryCompareCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
     using BinaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN binaryCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
-    PartialResult WARN_UNUSED_RETURN binaryCompareCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
+    WARN_UNUSED_RETURN PartialResult binaryCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
+    WARN_UNUSED_RETURN PartialResult binaryCompareCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
 
-    PartialResult WARN_UNUSED_RETURN store(Type memoryType);
-    PartialResult WARN_UNUSED_RETURN load(Type memoryType);
+    WARN_UNUSED_RETURN PartialResult store(Type memoryType);
+    WARN_UNUSED_RETURN PartialResult load(Type memoryType);
 
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, Type returnType, Type operandType);
 
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType, Type memoryType);
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType, Type memoryType);
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType, Type memoryType);
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType, Type memoryType);
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, Type memoryType);
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType);
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType);
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type memoryType);
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type memoryType);
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type memoryType);
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type memoryType);
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, Type memoryType);
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType);
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType);
 
 #if ENABLE(B3_JIT)
     template<bool isReachable, typename = void>
-    PartialResult
-    WARN_UNUSED_RETURN
-    simd(SIMDLaneOperation, SIMDLane, SIMDSignMode, B3::Air::Arg optionalRelation = { });
+    WARN_UNUSED_RETURN PartialResult simd(SIMDLaneOperation, SIMDLane, SIMDSignMode, B3::Air::Arg optionalRelation = { });
 #endif
 
-    PartialResult WARN_UNUSED_RETURN parseTableIndex(unsigned&);
-    PartialResult WARN_UNUSED_RETURN parseElementIndex(unsigned&);
-    PartialResult WARN_UNUSED_RETURN parseDataSegmentIndex(unsigned&);
+    WARN_UNUSED_RETURN PartialResult parseTableIndex(unsigned&);
+    WARN_UNUSED_RETURN PartialResult parseElementIndex(unsigned&);
+    WARN_UNUSED_RETURN PartialResult parseDataSegmentIndex(unsigned&);
 
-    PartialResult WARN_UNUSED_RETURN parseIndexForLocal(uint32_t&);
-    PartialResult WARN_UNUSED_RETURN parseIndexForGlobal(uint32_t&);
-    PartialResult WARN_UNUSED_RETURN parseFunctionIndex(FunctionSpaceIndex&);
-    PartialResult WARN_UNUSED_RETURN parseExceptionIndex(uint32_t&);
-    PartialResult WARN_UNUSED_RETURN parseBranchTarget(uint32_t&, uint32_t = 0);
-    PartialResult WARN_UNUSED_RETURN parseDelegateTarget(uint32_t&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult parseIndexForLocal(uint32_t&);
+    WARN_UNUSED_RETURN PartialResult parseIndexForGlobal(uint32_t&);
+    WARN_UNUSED_RETURN PartialResult parseFunctionIndex(FunctionSpaceIndex&);
+    WARN_UNUSED_RETURN PartialResult parseExceptionIndex(uint32_t&);
+    WARN_UNUSED_RETURN PartialResult parseBranchTarget(uint32_t&, uint32_t = 0);
+    WARN_UNUSED_RETURN PartialResult parseDelegateTarget(uint32_t&, uint32_t);
 
     struct TableInitImmediates {
         unsigned elementIndex;
         unsigned tableIndex;
     };
-    PartialResult WARN_UNUSED_RETURN parseTableInitImmediates(TableInitImmediates&);
+    WARN_UNUSED_RETURN PartialResult parseTableInitImmediates(TableInitImmediates&);
 
     struct TableCopyImmediates {
         unsigned srcTableIndex;
         unsigned dstTableIndex;
     };
-    PartialResult WARN_UNUSED_RETURN parseTableCopyImmediates(TableCopyImmediates&);
+    WARN_UNUSED_RETURN PartialResult parseTableCopyImmediates(TableCopyImmediates&);
 
     struct AnnotatedSelectImmediates {
         unsigned sizeOfAnnotationVector;
         Type targetType;
     };
-    PartialResult WARN_UNUSED_RETURN parseAnnotatedSelectImmediates(AnnotatedSelectImmediates&);
+    WARN_UNUSED_RETURN PartialResult parseAnnotatedSelectImmediates(AnnotatedSelectImmediates&);
 
-    PartialResult WARN_UNUSED_RETURN parseMemoryFillImmediate();
-    PartialResult WARN_UNUSED_RETURN parseMemoryCopyImmediates();
+    WARN_UNUSED_RETURN PartialResult parseMemoryFillImmediate();
+    WARN_UNUSED_RETURN PartialResult parseMemoryCopyImmediates();
 
     struct MemoryInitImmediates {
         unsigned dataSegmentIndex;
         unsigned unused;
     };
-    PartialResult WARN_UNUSED_RETURN parseMemoryInitImmediates(MemoryInitImmediates&);
+    WARN_UNUSED_RETURN PartialResult parseMemoryInitImmediates(MemoryInitImmediates&);
 
-    PartialResult WARN_UNUSED_RETURN parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation);
-    PartialResult WARN_UNUSED_RETURN parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, ASCIILiteral operation);
+    WARN_UNUSED_RETURN PartialResult parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation);
+    WARN_UNUSED_RETURN PartialResult parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, ASCIILiteral operation);
 
     struct StructTypeIndexAndFieldIndex {
         uint32_t structTypeIndex;
         uint32_t fieldIndex;
     };
-    PartialResult WARN_UNUSED_RETURN parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation);
+    WARN_UNUSED_RETURN PartialResult parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation);
 
     struct StructFieldManipulation {
         StructTypeIndexAndFieldIndex indices;
         TypedExpression structReference;
         FieldType field;
     };
-    PartialResult WARN_UNUSED_RETURN parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation);
+    WARN_UNUSED_RETURN PartialResult parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation);
 
 #define WASM_TRY_ADD_TO_CONTEXT(add_expression) WASM_FAIL_IF_HELPER_FAILS(m_context.add_expression)
 
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN validationFail(const Args&... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult validationFail(const Args&... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate())
@@ -328,7 +326,7 @@ private:
     }
 
     template <typename Arg>
-    String WARN_UNUSED_RETURN validationFailHelper(const Arg& arg) const
+    WARN_UNUSED_RETURN String validationFailHelper(const Arg& arg) const
     {
         if constexpr (std::is_same<Arg, Type>())
             return typeToStringModuleRelative(arg);
@@ -378,8 +376,8 @@ private:
     // FIXME add a macro as above for WASM_TRY_APPEND_TO_CONTROL_STACK https://bugs.webkit.org/show_bug.cgi?id=165862
 
     void addReferencedFunctions(const Element&);
-    PartialResult WARN_UNUSED_RETURN parseArrayTypeDefinition(ASCIILiteral, bool, uint32_t&, FieldType&, Type&);
-    PartialResult WARN_UNUSED_RETURN parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockSignature&);
+    WARN_UNUSED_RETURN PartialResult parseArrayTypeDefinition(ASCIILiteral, bool, uint32_t&, FieldType&, Type&);
+    WARN_UNUSED_RETURN PartialResult parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockSignature&);
 
     Context& m_context;
     Stack m_expressionStack;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -219,10 +219,10 @@ public:
     using ArgumentList = FunctionParser<IPIntGenerator>::ArgumentList;
 
     static ExpressionType emptyExpression() { return { }; };
-    PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
 
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -234,299 +234,299 @@ public:
 
     std::unique_ptr<FunctionIPIntMetadataGenerator> finalize();
 
-    PartialResult WARN_UNUSED_RETURN addArguments(const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN addLocal(Type, uint32_t);
+    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
     Value addConstant(Type, uint64_t);
 
     // SIMD
 
     bool usesSIMD() { return m_usesSIMD; }
     void notifyFunctionUsesSIMD() { ASSERT(Options::useWasmSIMD()); m_usesSIMD = true; }
-    PartialResult WARN_UNUSED_RETURN addSIMDLoad(ExpressionType, uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDStore(ExpressionType, ExpressionType, uint32_t);
-    PartialResult WARN_UNUSED_RETURN addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t);
+    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
 
     ExpressionType addConstant(v128_t);
 
     // SIMD generated
 
-    PartialResult WARN_UNUSED_RETURN addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 #if ENABLE(B3_JIT)
-    PartialResult WARN_UNUSED_RETURN addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&);
 #endif
-    PartialResult WARN_UNUSED_RETURN addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     // References
 
-    PartialResult WARN_UNUSED_RETURN addRefIsNull(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefFunc(FunctionSpaceIndex, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefAsNonNull(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
 
-    PartialResult WARN_UNUSED_RETURN addTableGet(unsigned, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addTableSet(unsigned, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addElemDrop(unsigned);
-    PartialResult WARN_UNUSED_RETURN addTableSize(unsigned, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
 
     // Locals
 
-    PartialResult WARN_UNUSED_RETURN getLocal(uint32_t index, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN setLocal(uint32_t, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
 
-    PartialResult WARN_UNUSED_RETURN getGlobal(uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN setGlobal(uint32_t, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t, ExpressionType);
 
     // Memory
 
-    PartialResult WARN_UNUSED_RETURN load(LoadOpType, ExpressionType, ExpressionType&, uint64_t);
-    PartialResult WARN_UNUSED_RETURN store(StoreOpType, ExpressionType, ExpressionType, uint64_t);
-    PartialResult WARN_UNUSED_RETURN addGrowMemory(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addCurrentMemory(ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addMemoryFill(ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addMemoryCopy(ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addDataDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint64_t);
+    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint64_t);
+    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
 
     // Atomics
 
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t);
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t);
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
 
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType, uint8_t);
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 
     // Saturated truncation
 
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type);
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type);
 
     // GC
 
-    PartialResult WARN_UNUSED_RETURN addRefI31(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI31GetS(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t, ArgumentList&, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t, ArgumentList&, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType, bool, int32_t, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI31GetS(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI31GetU(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t, ArgumentList&, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayLen(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t, ArgumentList&, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType, ExpressionType&);
 
     // Basic operators
 
-    PartialResult WARN_UNUSED_RETURN addI32DivS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32RemS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32DivU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32RemU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64DivS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64RemS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64DivU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64RemU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Ctz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Popcnt(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Popcnt(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Nearest(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Nearest(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Trunc(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Trunc(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32TruncSF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32TruncUF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64TruncSF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64TruncUF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Ceil(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Mul(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Sub(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Le(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32DemoteF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Ne(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Lt(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Min(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Max(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Min(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Max(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Mul(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Div(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Clz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Copysign(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32ReinterpretI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Ne(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Gt(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Sqrt(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Ge(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64GtS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64GtU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Div(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Add(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32LeU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32LeS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Ne(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Clz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Neg(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32And(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32LtU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Rotr(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Abs(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32LtS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Eq(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Copysign(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Rotl(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Lt(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Eq(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Le(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Ge(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32ShrU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32ShrS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32GeU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Ceil(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32GeS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Shl(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Floor(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Xor(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Abs(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Mul(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Sub(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32ReinterpretF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Add(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Sub(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Or(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64LtU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64LtS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64ConvertSI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Xor(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64GeU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Mul(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Sub(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64PromoteF32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Add(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64GeS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64ExtendUI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Ne(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64ReinterpretI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Eq(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Eq(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Floor(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32ConvertSI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64And(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Or(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Ctz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Eqz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Eqz(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64ReinterpretF64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32ConvertUI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64ConvertUI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64ShrS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64ShrU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Sqrt(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Shl(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF32Gt(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32WrapI64(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Rotl(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Rotr(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32GtU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64ExtendSI32(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Extend8S(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32Extend16S(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Extend8S(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Extend16S(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Extend32S(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI32GtS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addF64Neg(ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64LeU(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64LeS(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addI64Add(ExpressionType, ExpressionType, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Ctz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Popcnt(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Popcnt(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Nearest(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Nearest(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Trunc(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Trunc(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Ceil(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Mul(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Sub(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Clz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Sqrt(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Clz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Neg(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Abs(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Ceil(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Floor(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Abs(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Sub(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Add(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Mul(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Floor(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Ctz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Eqz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Eqz(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Sqrt(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32WrapI64(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Extend8S(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32Extend16S(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Extend8S(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Extend16S(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Extend32S(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addF64Neg(ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addI64Add(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     // Control flow
 
-    ControlType WARN_UNUSED_RETURN addTopLevel(BlockSignature);
-    PartialResult WARN_UNUSED_RETURN addBlock(BlockSignature, Stack&, ControlType&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t);
-    PartialResult WARN_UNUSED_RETURN addIf(ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addElse(ControlType&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addElseToUnreachable(ControlType&);
+    WARN_UNUSED_RETURN ControlType addTopLevel(BlockSignature);
+    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t);
+    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addElse(ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlType&);
 
-    PartialResult WARN_UNUSED_RETURN addTry(BlockSignature, Stack&, ControlType&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchAll(Stack&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addCatchAllToUnreachable(ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegate(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegateToUnreachable(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrow(unsigned, ArgumentList&, Stack&);
-    PartialResult WARN_UNUSED_RETURN addRethrow(unsigned, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrowRef(ExpressionType, Stack&);
+    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrow(unsigned, ArgumentList&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType, Stack&);
 
-    PartialResult WARN_UNUSED_RETURN addReturn(const ControlType&, const Stack&);
-    PartialResult WARN_UNUSED_RETURN addBranch(ControlType&, ExpressionType, const Stack&);
-    PartialResult WARN_UNUSED_RETURN addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool);
-    PartialResult WARN_UNUSED_RETURN addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, const Stack&);
-    PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addReturn(const ControlType&, const Stack&);
+    WARN_UNUSED_RETURN PartialResult addBranch(ControlType&, ExpressionType, const Stack&);
+    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool);
+    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, const Stack&);
+    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack&);
     void endTryTable(ControlType& data);
-    PartialResult WARN_UNUSED_RETURN addEndToUnreachable(ControlEntry&, Stack&);
+    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, Stack&);
 
-    PartialResult WARN_UNUSED_RETURN endTopLevel(BlockSignature, const Stack&);
+    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&);
 
     // Fused comparison stubs (TODO: make use of these for better codegen)
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
 
-    PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addUnreachable();
-    PartialResult WARN_UNUSED_RETURN addCrash();
+    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addUnreachable();
+    WARN_UNUSED_RETURN PartialResult addCrash();
 
     void setParser(FunctionParser<IPIntGenerator>* parser) { m_parser = parser; };
     size_t getCurrentInstructionLength()
@@ -684,7 +684,7 @@ IPIntGenerator::IPIntGenerator(ModuleInformation& info, FunctionCodeIndex functi
 {
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDrop(ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDrop(ExpressionType)
 {
     changeStackSize(-1);
     return { };
@@ -699,68 +699,68 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
 
 // SIMD
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&)
 {
     changeStackSize(0); // Pop address, push v128 value (net change = 0)
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset)
 {
     changeStackSize(-2); // Pop address and v128 value
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
@@ -771,48 +771,48 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // 3 operands, 1 result
     return { };
 }
 
 #if ENABLE(B3_JIT)
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 #endif
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1); // Pop two v128 values, push one v128 value
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // Pop three v128 values, push one v128 value
     return { };
@@ -820,24 +820,24 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOpera
 
 // References
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefIsNull(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefIsNull(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefFunc(FunctionSpaceIndex index, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefFunc(FunctionSpaceIndex index, ExpressionType&)
 {
     changeStackSize(1);
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefAsNonNull(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefAsNonNull(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefEq(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefEq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -845,20 +845,20 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefEq(ExpressionType, Expres
 
 // Tables
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableGet(unsigned index, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableGet(unsigned index, ExpressionType, ExpressionType&)
 {
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableSet(unsigned index, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableSet(unsigned index, ExpressionType, ExpressionType)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableInitMetadata table {
@@ -870,20 +870,20 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableInit(unsigned elementIn
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElemDrop(unsigned elementIndex)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElemDrop(unsigned elementIndex)
 {
     m_metadata->addLEB128ConstantInt32AndLength(elementIndex, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableSize(unsigned tableIndex, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableSize(unsigned tableIndex, ExpressionType&)
 {
     changeStackSize(1);
     m_metadata->addLEB128ConstantInt32AndLength(tableIndex, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableGrow(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableGrow(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     IPInt::TableGrowMetadata table {
@@ -894,7 +894,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableGrow(unsigned tableInde
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableFill(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableFill(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableFillMetadata table {
@@ -905,7 +905,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableFill(unsigned tableInde
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableCopyMetadata table {
@@ -919,7 +919,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableCopy(unsigned dstTableI
 
 // Locals and Globals
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArguments(const TypeDefinition &signature)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArguments(const TypeDefinition &signature)
 {
     auto sig = signature.as<FunctionSignature>();
     const CallInformation callCC = wasmCallingConvention().callInformationFor(*sig, CallRole::Callee);
@@ -989,7 +989,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArguments(const TypeDefiniti
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addLocal(Type localType, uint32_t count)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLocal(Type localType, uint32_t count)
 {
     // push 0x00 or 0xff (for bit hacks) to the metadata depending on if we have a primitive or a reference
     if (isRefType(localType)) {
@@ -1012,7 +1012,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addLocal(Type localType, uint32
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::getLocal(uint32_t, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::getLocal(uint32_t, ExpressionType&)
 {
     // Local indices are usually very small, so we decode them on the fly
     // instead of generating metadata.
@@ -1020,7 +1020,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::getLocal(uint32_t, ExpressionTy
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::setLocal(uint32_t, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::setLocal(uint32_t, ExpressionType)
 {
     // Local indices are usually very small, so we decode them on the fly
     // instead of generating metadata.
@@ -1028,12 +1028,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::setLocal(uint32_t, ExpressionTy
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::teeLocal(uint32_t, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::teeLocal(uint32_t, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::getGlobal(uint32_t index, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::getGlobal(uint32_t index, ExpressionType&)
 {
     changeStackSize(1);
     const Wasm::GlobalInformation& global = m_info.globals[index];
@@ -1047,7 +1047,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::getGlobal(uint32_t index, Expre
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::setGlobal(uint32_t index, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::setGlobal(uint32_t index, ExpressionType)
 {
     changeStackSize(-1);
     const Wasm::GlobalInformation& global = m_info.globals[index];
@@ -1063,7 +1063,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::setGlobal(uint32_t index, Expre
 
 // Loads and Stores
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint64_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint64_t offset)
 {
     if (m_info.memory.isMemory64())
         m_metadata->addLEB128ConstantInt64AndLength(offset, getCurrentInstructionLength());
@@ -1072,7 +1072,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::load(LoadOpType, ExpressionType
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::store(StoreOpType, ExpressionType, ExpressionType, uint64_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::store(StoreOpType, ExpressionType, ExpressionType, uint64_t offset)
 {
     changeStackSize(-2);
     if (m_info.memory.isMemory64())
@@ -1084,39 +1084,39 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::store(StoreOpType, ExpressionTy
 
 // Memories
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCurrentMemory(ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCurrentMemory(ExpressionType&)
 {
     changeStackSize(1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDataDrop(unsigned dataIndex)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDataDrop(unsigned dataIndex)
 {
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
     return { };
@@ -1124,48 +1124,48 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDataDrop(unsigned dataIndex)
 
 // Atomics
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
 {
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
 {
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
@@ -1173,22 +1173,22 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, ui
 
 // GC
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefI31(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefI31(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI31GetS(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI31GetS(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI31GetU(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI31GetU(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNew(uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNew(uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
         index,
@@ -1198,7 +1198,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNew(uint32_t index, Exp
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewData(uint32_t index, uint32_t dataSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewData(uint32_t index, uint32_t dataSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewDataMetadata>({
         index,
@@ -1209,7 +1209,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewData(uint32_t index,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewElem(uint32_t index, uint32_t elemSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewElem(uint32_t index, uint32_t elemSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewElemMetadata>({
         index,
@@ -1220,7 +1220,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewElem(uint32_t index,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewFixed(uint32_t index, ArgumentList& args, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewFixed(uint32_t index, ArgumentList& args, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewFixedMetadata>({
         index,
@@ -1231,7 +1231,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewFixed(uint32_t index
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
         index,
@@ -1240,7 +1240,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewDefault(uint32_t ind
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayGet(ExtGCOpType, uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayGet(ExtGCOpType, uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
         index,
@@ -1250,7 +1250,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayGet(ExtGCOpType, uint32
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArraySet(uint32_t index, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArraySet(uint32_t index, ExpressionType, ExpressionType, ExpressionType)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
         index,
@@ -1260,13 +1260,13 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArraySet(uint32_t index, Exp
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayLen(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayLen(ExpressionType, ExpressionType&)
 {
     // no metadata
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayFillMetadata>({
@@ -1275,7 +1275,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayFill(uint32_t, Expressi
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-5);
     m_metadata->appendMetadata<IPInt::ArrayCopyMetadata>({
@@ -1284,7 +1284,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayCopy(uint32_t, Expressi
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t elemSegmentIndex, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t elemSegmentIndex, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayInitDataMetadata>({
@@ -1294,7 +1294,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayInitElem(uint32_t, Expr
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t dataSegmentIndex, ExpressionType, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t dataSegmentIndex, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayInitDataMetadata>({
@@ -1304,7 +1304,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayInitData(uint32_t, Expr
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNew(uint32_t index, ArgumentList&, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNew(uint32_t index, ArgumentList&, ExpressionType&)
 {
     const StructType& type = *m_info.typeSignatures[index]->expand().as<StructType>();
     m_metadata->appendMetadata<IPInt::StructNewMetadata>({
@@ -1316,7 +1316,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNew(uint32_t index, Ar
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNewDefault(uint32_t index, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNewDefault(uint32_t index, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::StructNewDefaultMetadata>({
         index,
@@ -1326,7 +1326,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNewDefault(uint32_t in
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::StructGetSetMetadata>({
         fieldIndex,
@@ -1335,7 +1335,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructGet(ExtGCOpType, Expre
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructSet(ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructSet(ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType)
 {
     m_metadata->appendMetadata<IPInt::StructGetSetMetadata>({
         fieldIndex,
@@ -1345,7 +1345,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructSet(ExpressionType, co
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -1354,7 +1354,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefTest(ExpressionType, bool
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -1363,97 +1363,97 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRefCast(ExpressionType, bool
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addAnyConvertExtern(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addAnyConvertExtern(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addExternConvertAny(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addExternConvertAny(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Integer Arithmetic
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Add(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Add(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Sub(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Sub(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Mul(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Mul(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32DivS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32DivS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32DivU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32DivU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64DivS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64DivS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64DivU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64DivU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32RemS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32RemS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32RemU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32RemU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64RemS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64RemS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64RemU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64RemU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1461,177 +1461,177 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64RemU(ExpressionType, Expr
 
 // Bitwise Operations
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32And(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32And(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64And(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64And(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Xor(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Xor(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Xor(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Xor(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Or(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Or(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Or(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Or(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Shl(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Shl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32ShrU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ShrU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32ShrS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ShrS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Shl(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Shl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64ShrU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ShrU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64ShrS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ShrS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Rotl(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Rotl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Rotl(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Rotl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Rotr(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Rotr(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Rotr(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Rotr(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Popcnt(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Popcnt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Popcnt(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Popcnt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Clz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Clz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Clz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Clz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Ctz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Ctz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Ctz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Ctz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Floating-Point Arithmetic
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Add(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Add(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Sub(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Sub(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Mul(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Mul(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Div(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Div(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Div(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Div(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1639,303 +1639,303 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Div(ExpressionType, Expre
 
 // Other Floating-Point Instructions
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Min(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Min(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Max(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Max(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Min(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Min(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Max(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Max(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Nearest(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Nearest(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Nearest(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Nearest(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Floor(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Floor(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Floor(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Floor(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Ceil(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ceil(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Ceil(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ceil(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Copysign(ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Copysign(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Copysign(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Sqrt(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Copysign(ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Sqrt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Sqrt(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Sqrt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Neg(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Neg(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Neg(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Neg(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Abs(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Abs(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Abs(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Abs(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Integer Comparisons
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Eq(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Ne(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32LtS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32LtU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32LeS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32LeU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32GtS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32GtU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32GeU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32GeS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Eqz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Eqz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Eq(ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Ne(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64GtS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64GtU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64GeS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64GeU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64LtS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64LtU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64LeS(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64LeU(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Eqz(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LeU(ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Eqz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Floating-Point Comparisons
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Eq(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Ne(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Lt(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Lt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Le(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Le(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Gt(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Gt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Ge(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ge(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Eq(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Ne(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Lt(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Lt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Le(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Le(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Gt(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Gt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Ge(ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ge(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1943,94 +1943,94 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Ge(ExpressionType, Expres
 
 // Integer Extension
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64ExtendSI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ExtendSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64ExtendUI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ExtendUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Extend8S(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Extend8S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32Extend16S(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Extend16S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Extend8S(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend8S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Extend16S(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend16S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64Extend32S(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend32S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Truncation
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64Trunc(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Trunc(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32Trunc(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Trunc(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32TruncSF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncSF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32TruncSF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncSF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32TruncUF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncUF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32TruncUF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncUF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncSF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncSF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncSF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncSF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
 {
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
@@ -2038,77 +2038,77 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, Expr
 
 // Conversions
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32WrapI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32WrapI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32DemoteF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32DemoteF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64PromoteF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64PromoteF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32ReinterpretI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ReinterpretI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI32ReinterpretF32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ReinterpretF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64ReinterpretI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ReinterpretI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64ReinterpretF64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ReinterpretF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32ConvertSI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32ConvertUI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32ConvertSI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertSI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF32ConvertUI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertUI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64ConvertSI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64ConvertUI32(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64ConvertSI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertSI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addF64ConvertUI64(ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertUI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
@@ -2195,19 +2195,19 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     control.m_exitTarget = loc;
 }
 
-IPIntGenerator::ControlType WARN_UNUSED_RETURN IPIntGenerator::addTopLevel(BlockSignature signature)
+WARN_UNUSED_RETURN IPIntGenerator::ControlType IPIntGenerator::addTopLevel(BlockSignature signature)
 {
     return ControlType(signature, 0, BlockType::TopLevel);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBlock(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBlock(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     splitStack(signature, oldStack, newStack);
     block = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::Block);
@@ -2234,7 +2234,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBlock(BlockSignature signatu
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addLoop(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack, uint32_t loopIndex)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLoop(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack, uint32_t loopIndex)
 {
     splitStack(signature, oldStack, newStack);
     block = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::Loop);
@@ -2265,7 +2265,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addLoop(BlockSignature signatur
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addIf(ExpressionType, BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addIf(ExpressionType, BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     splitStack(signature, oldStack, newStack);
     changeStackSize(-1);
@@ -2292,12 +2292,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addIf(ExpressionType, BlockSign
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElse(ControlType& block, Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElse(ControlType& block, Stack&)
 {
     return addElseToUnreachable(block);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElseToUnreachable(ControlType& block)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElseToUnreachable(ControlType& block)
 {
     auto blockSignature = block.signature();
     const FunctionSignature& signature = *blockSignature.m_signature;
@@ -2335,7 +2335,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addElseToUnreachable(ControlTyp
 
 // Exception Handling
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTry(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTry(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     m_tryDepth++;
     m_maxTryDepth = std::max(m_maxTryDepth, m_tryDepth.value());
@@ -2366,7 +2366,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTry(BlockSignature signature
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
 {
     splitStack(signature, enclosingStack, newStack);
     result = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::TryTable);
@@ -2434,13 +2434,13 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     tryBlock = WTFMove(catchBlock);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack&, ControlType& block, ResultList& results)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack&, ControlType& block, ResultList& results)
 {
 
     return addCatchToUnreachable(exceptionIndex, exceptionSignature, block, results);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& block, ResultList& results)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& block, ResultList& results)
 {
     if (ControlType::isTry(block))
         convertTryToCatch(block, CatchKind::Catch);
@@ -2476,12 +2476,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatchToUnreachable(unsigned 
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatchAll(Stack&, ControlType& block)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchAll(Stack&, ControlType& block)
 {
     return addCatchAllToUnreachable(block);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatchAllToUnreachable(ControlType& block)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchAllToUnreachable(ControlType& block)
 {
     UNUSED_PARAM(block);
     if (ControlType::isTry(block))
@@ -2515,12 +2515,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCatchAllToUnreachable(Contro
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDelegate(ControlType& target, ControlType& data)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDelegate(ControlType& target, ControlType& data)
 {
     return addDelegateToUnreachable(target, data);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDelegateToUnreachable(ControlType& target, ControlType& data)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDelegateToUnreachable(ControlType& target, ControlType& data)
 {
     UNUSED_PARAM(target);
     UNUSED_PARAM(data);
@@ -2547,7 +2547,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDelegateToUnreachable(Contro
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, Stack&)
 {
     IPInt::ThrowMetadata mdThrow {
         .exceptionIndex = safeCast<uint32_t>(exceptionIndex)
@@ -2557,7 +2557,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addThrow(unsigned exceptionInde
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRethrow(unsigned, ControlType& catchBlock)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRethrow(unsigned, ControlType& catchBlock)
 {
     m_usesRethrow = true;
 
@@ -2571,7 +2571,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addRethrow(unsigned, ControlTyp
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addThrowRef(ExpressionType, Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrowRef(ExpressionType, Stack&)
 {
     changeStackSize(-1);
     return { };
@@ -2579,12 +2579,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addThrowRef(ExpressionType, Sta
 
 // Control Flow Branches
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addReturn(const ControlType&, const Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addReturn(const ControlType&, const Stack&)
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranch(ControlType& block, ExpressionType, const Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranch(ControlType& block, ExpressionType, const Stack&)
 {
     bool isBrIf = (m_parser->currentOpcode() == OpType::BrIf);
     if (isBrIf)
@@ -2608,7 +2608,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranch(ControlType& block, E
 
     return { };
 }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, Stack&, bool shouldNegate, ExpressionType&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, Stack&, bool shouldNegate, ExpressionType&)
 {
     // We don't need shouldNegate in the metadata since it's in the opcode
 
@@ -2636,7 +2636,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranchNull(ControlType& bloc
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -2659,7 +2659,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addBranchCast(ControlType& bloc
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, const Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, const Stack&)
 {
     changeStackSize(-1);
     IPInt::SwitchMetadata mdSwitch {
@@ -2690,7 +2690,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSwitch(ExpressionType, const
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::endBlock(ControlEntry& entry, Stack& stack)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::endBlock(ControlEntry& entry, Stack& stack)
 {
     return addEndToUnreachable(entry, stack);
 }
@@ -2734,7 +2734,7 @@ void IPIntGenerator::endTryTable(ControlType& data)
     }
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
 {
     auto blockSignature = entry.controlData.signature();
     const auto& signature = *blockSignature.m_signature;
@@ -3004,7 +3004,7 @@ void IPIntGenerator::addTailCallCommonData(const FunctionSignature&, const CallI
     m_metadata->appendMetadata(stackArgumentsAndResultsInBytes);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *type.as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3050,7 +3050,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileInd
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3101,7 +3101,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callPr
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3150,12 +3150,12 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfile
 
 // Traps
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addUnreachable()
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addUnreachable()
 {
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCrash()
+WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCrash()
 {
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmNameSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmNameSectionParser.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    Result WARN_UNUSED_RETURN parse();
+    WARN_UNUSED_RETURN Result parse();
     
 private:
     const ModuleInformation& m_info;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -365,7 +365,7 @@ public:
     enum class CastKind { Cast, Test };
 
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -417,19 +417,19 @@ public:
     // SIMD
     bool usesSIMD() { return m_info.usesSIMD(m_functionIndex); }
     void notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
-    PartialResult WARN_UNUSED_RETURN addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
 
-    ExpressionType WARN_UNUSED_RETURN addConstant(v128_t value)
+    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t value)
     {
         return push(m_currentBlock->appendNew<Const128Value>(m_proc, origin(), value));
     }
@@ -635,153 +635,153 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addInlinedArguments(const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN addArguments(const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN addLocal(Type, uint32_t);
+    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addInlinedArguments(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
     ExpressionType addConstant(Type, uint64_t);
 
     // References
-    PartialResult WARN_UNUSED_RETURN addRefIsNull(ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefAsNonNull(TypedExpression, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
-    PartialResult WARN_UNUSED_RETURN addTableGet(unsigned, ExpressionType index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableSet(unsigned, ExpressionType index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
-    PartialResult WARN_UNUSED_RETURN addElemDrop(unsigned);
-    PartialResult WARN_UNUSED_RETURN addTableSize(unsigned, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
     // Locals
-    PartialResult WARN_UNUSED_RETURN getLocal(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN setLocal(uint32_t index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
-    PartialResult WARN_UNUSED_RETURN getGlobal(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN setGlobal(uint32_t index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, ExpressionType value);
 
     // Memory
-    PartialResult WARN_UNUSED_RETURN load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN addGrowMemory(ExpressionType delta, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addCurrentMemory(ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
-    PartialResult WARN_UNUSED_RETURN addDataDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
 
     // Atomics
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
 
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType, uint8_t flags);
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
 
     // Saturated truncation.
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
 
     // GC
-    PartialResult WARN_UNUSED_RETURN addRefI31(ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addI31GetS(TypedExpression ref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addI31GetU(TypedExpression ref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addArrayLen(TypedExpression arrayref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
 #define X(name, opcode, short, idx, ...) \
-    PartialResult WARN_UNUSED_RETURN add##name(ExpressionType arg, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType arg, ExpressionType& result);
     FOR_EACH_WASM_UNARY_OP(X)
 #undef X
 #define X(name, opcode, short, idx, ...) \
-    PartialResult WARN_UNUSED_RETURN add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
     FOR_EACH_WASM_BINARY_OP(X)
 #undef X
 
-    PartialResult WARN_UNUSED_RETURN addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
 
     // Control flow
-    ControlData WARN_UNUSED_RETURN addTopLevel(BlockSignature);
-    PartialResult WARN_UNUSED_RETURN addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
-    PartialResult WARN_UNUSED_RETURN addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addElse(ControlData&, const Stack&);
-    PartialResult WARN_UNUSED_RETURN addElseToUnreachable(ControlData&);
+    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature);
+    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
+    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, const Stack&);
+    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&);
 
-    PartialResult WARN_UNUSED_RETURN addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchAll(Stack&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addCatchAllToUnreachable(ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegate(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegateToUnreachable(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
-    PartialResult WARN_UNUSED_RETURN addRethrow(unsigned, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrowRef(TypedExpression exception, Stack&);
+    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
+    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrowRef(TypedExpression exception, Stack&);
 
-    PartialResult WARN_UNUSED_RETURN addInlinedReturn(const auto& returnValues);
+    WARN_UNUSED_RETURN PartialResult addInlinedReturn(const auto& returnValues);
 
-    PartialResult WARN_UNUSED_RETURN addReturn(const ControlData&, const Stack& returnValues);
-    PartialResult WARN_UNUSED_RETURN addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
-    PartialResult WARN_UNUSED_RETURN addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
-    PartialResult WARN_UNUSED_RETURN addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
-    PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry&, Stack& expressionStack);
-    PartialResult WARN_UNUSED_RETURN addEndToUnreachable(ControlEntry&, const Stack& = { });
+    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack& returnValues);
+    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
+    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
+    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
+    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack& expressionStack);
+    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
 
-    PartialResult WARN_UNUSED_RETURN endTopLevel(BlockSignature, const Stack&) { return { }; }
+    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
 
     // Fused comparison stubs (B3 will do this for us later).
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
-    PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addUnreachable();
-    PartialResult WARN_UNUSED_RETURN addCrash();
+    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addUnreachable();
+    WARN_UNUSED_RETURN PartialResult addCrash();
 
     using ValueResults = Vector<Value*, 16>;
     void fillCallResults(Value* callResult, const TypeDefinition& signature, ValueResults&);
-    PartialResult WARN_UNUSED_RETURN emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
 
     Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
     auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     InliningNode* canInline(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex) const;
-    PartialResult WARN_UNUSED_RETURN emitInlineDirectCall(InliningNode*, FunctionCodeIndex calleeIndex, const TypeDefinition&, const ArgumentList& args, ValueResults&);
+    WARN_UNUSED_RETURN PartialResult emitInlineDirectCall(InliningNode*, FunctionCodeIndex calleeIndex, const TypeDefinition&, const ArgumentList& args, ValueResults&);
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
@@ -881,10 +881,10 @@ private:
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
     bool emitArraySetUncheckedWithoutWriteBarrier(uint32_t, Value*, Value*, Value*);
     // Returns true if a writeBarrier/mutatorFence is needed.
-    bool WARN_UNUSED_RETURN emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
-    Value* WARN_UNUSED_RETURN allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
+    WARN_UNUSED_RETURN bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
+    WARN_UNUSED_RETURN Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
-    ExpressionType WARN_UNUSED_RETURN pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
+    WARN_UNUSED_RETURN ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
     void emitRefTestOrCast(CastKind, TypedExpression, bool, int32_t, bool, ExpressionType&);
     template <typename Generator>
     void emitCheckOrBranchForCast(CastKind, Value*, const Generator&, BasicBlock*);
@@ -895,8 +895,8 @@ private:
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
-    int32_t WARN_UNUSED_RETURN fixupPointerPlusOffset(Value*&, uint32_t);
-    Value* WARN_UNUSED_RETURN fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
+    WARN_UNUSED_RETURN int32_t fixupPointerPlusOffset(Value*&, uint32_t);
+    WARN_UNUSED_RETURN Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
 
     void restoreWasmContextInstance(BasicBlock*, Value*);
     void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, BasicBlock*);
@@ -2925,7 +2925,7 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-bool WARN_UNUSED_RETURN OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
+WARN_UNUSED_RETURN bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     structValue = pointerOfWasmRef(structValue);
     auto fieldType = structType.field(fieldIndex).type;
@@ -5250,7 +5250,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
     return { };
 }
 
-auto WARN_UNUSED_RETURN OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
+WARN_UNUSED_RETURN auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
 {
     TRACE_CF("THROW_REF");
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -361,7 +361,7 @@ public:
     enum class CastKind { Cast, Test };
 
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -418,19 +418,19 @@ public:
     // SIMD
     bool usesSIMD() { return m_info.usesSIMD(m_functionIndex); }
     void notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
-    PartialResult WARN_UNUSED_RETURN addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
 
-    ExpressionType WARN_UNUSED_RETURN addConstant(v128_t value)
+    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t value)
     {
         return push(m_currentBlock->appendNew<Const128Value>(m_proc, origin(), value));
     }
@@ -636,153 +636,153 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addInlinedArguments(const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN addArguments(const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN addLocal(Type, uint32_t);
+    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addInlinedArguments(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
     ExpressionType addConstant(Type, uint64_t);
 
     // References
-    PartialResult WARN_UNUSED_RETURN addRefIsNull(ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefAsNonNull(TypedExpression, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
-    PartialResult WARN_UNUSED_RETURN addTableGet(unsigned, ExpressionType index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableSet(unsigned, ExpressionType index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
-    PartialResult WARN_UNUSED_RETURN addElemDrop(unsigned);
-    PartialResult WARN_UNUSED_RETURN addTableSize(unsigned, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
     // Locals
-    PartialResult WARN_UNUSED_RETURN getLocal(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN setLocal(uint32_t index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
-    PartialResult WARN_UNUSED_RETURN getGlobal(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN setGlobal(uint32_t index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, ExpressionType value);
 
     // Memory
-    PartialResult WARN_UNUSED_RETURN load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN addGrowMemory(ExpressionType delta, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addCurrentMemory(ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
-    PartialResult WARN_UNUSED_RETURN addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
-    PartialResult WARN_UNUSED_RETURN addDataDrop(unsigned);
+    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
+    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
+    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
 
     // Atomics
-    PartialResult WARN_UNUSED_RETURN atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
 
-    PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType, uint8_t flags);
+    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
 
     // Saturated truncation.
-    PartialResult WARN_UNUSED_RETURN truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
+    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
 
     // GC
-    PartialResult WARN_UNUSED_RETURN addRefI31(ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addI31GetS(TypedExpression ref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addI31GetU(TypedExpression ref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addArrayLen(TypedExpression arrayref, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t index, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
-    PartialResult WARN_UNUSED_RETURN addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
+    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
 #define X(name, opcode, short, idx, ...) \
-    PartialResult WARN_UNUSED_RETURN add##name(ExpressionType arg, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType arg, ExpressionType& result);
     FOR_EACH_WASM_UNARY_OP(X)
 #undef X
 #define X(name, opcode, short, idx, ...) \
-    PartialResult WARN_UNUSED_RETURN add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
     FOR_EACH_WASM_BINARY_OP(X)
 #undef X
 
-    PartialResult WARN_UNUSED_RETURN addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
+    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
 
     // Control flow
-    ControlData WARN_UNUSED_RETURN addTopLevel(BlockSignature);
-    PartialResult WARN_UNUSED_RETURN addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
-    PartialResult WARN_UNUSED_RETURN addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addElse(ControlData&, const Stack&);
-    PartialResult WARN_UNUSED_RETURN addElseToUnreachable(ControlData&);
+    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature);
+    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
+    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, const Stack&);
+    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&);
 
-    PartialResult WARN_UNUSED_RETURN addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    PartialResult WARN_UNUSED_RETURN addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
-    PartialResult WARN_UNUSED_RETURN addCatchAll(Stack&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addCatchAllToUnreachable(ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegate(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addDelegateToUnreachable(ControlType&, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
-    PartialResult WARN_UNUSED_RETURN addRethrow(unsigned, ControlType&);
-    PartialResult WARN_UNUSED_RETURN addThrowRef(TypedExpression exception, Stack&);
+    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
+    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
+    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
+    WARN_UNUSED_RETURN PartialResult addThrowRef(TypedExpression exception, Stack&);
 
-    PartialResult WARN_UNUSED_RETURN addInlinedReturn(const auto& returnValues);
+    WARN_UNUSED_RETURN PartialResult addInlinedReturn(const auto& returnValues);
 
-    PartialResult WARN_UNUSED_RETURN addReturn(const ControlData&, const Stack& returnValues);
-    PartialResult WARN_UNUSED_RETURN addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
-    PartialResult WARN_UNUSED_RETURN addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
-    PartialResult WARN_UNUSED_RETURN addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
-    PartialResult WARN_UNUSED_RETURN addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
-    PartialResult WARN_UNUSED_RETURN endBlock(ControlEntry&, Stack& expressionStack);
-    PartialResult WARN_UNUSED_RETURN addEndToUnreachable(ControlEntry&, const Stack& = { });
+    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack& returnValues);
+    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
+    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
+    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
+    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
+    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack& expressionStack);
+    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
 
-    PartialResult WARN_UNUSED_RETURN endTopLevel(BlockSignature, const Stack&) { return { }; }
+    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
 
     // Fused comparison stubs (B3 will do this for us later).
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    PartialResult WARN_UNUSED_RETURN addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
-    PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN addUnreachable();
-    PartialResult WARN_UNUSED_RETURN addCrash();
+    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult addUnreachable();
+    WARN_UNUSED_RETURN PartialResult addCrash();
 
     using ValueResults = Vector<Value*, 16>;
     void fillCallResults(Value* callResult, const TypeDefinition& signature, ValueResults&);
-    PartialResult WARN_UNUSED_RETURN emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ValueResults&, CallType = CallType::Call);
-    PartialResult WARN_UNUSED_RETURN emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    WARN_UNUSED_RETURN PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
 
     Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
     auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     bool canInline(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex) const;
-    PartialResult WARN_UNUSED_RETURN emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ValueResults&);
+    WARN_UNUSED_RETURN PartialResult emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ValueResults&);
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
@@ -881,10 +881,10 @@ private:
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
     bool emitArraySetUncheckedWithoutWriteBarrier(uint32_t, Value*, Value*, Value*);
     // Returns true if a writeBarrier/mutatorFence is needed.
-    bool WARN_UNUSED_RETURN emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
-    Value* WARN_UNUSED_RETURN allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
+    WARN_UNUSED_RETURN bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
+    WARN_UNUSED_RETURN Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
-    ExpressionType WARN_UNUSED_RETURN pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
+    WARN_UNUSED_RETURN ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
     void emitRefTestOrCast(CastKind, TypedExpression, bool, int32_t, bool, ExpressionType&);
     template <typename Generator>
     void emitCheckOrBranchForCast(CastKind, Value*, const Generator&, BasicBlock*);
@@ -895,8 +895,8 @@ private:
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
-    int32_t WARN_UNUSED_RETURN fixupPointerPlusOffset(Value*&, uint32_t);
-    Value* WARN_UNUSED_RETURN fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
+    WARN_UNUSED_RETURN int32_t fixupPointerPlusOffset(Value*&, uint32_t);
+    WARN_UNUSED_RETURN Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
 
     void restoreWasmContextInstance(BasicBlock*, Value*);
     void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, BasicBlock*);
@@ -3032,7 +3032,7 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-bool WARN_UNUSED_RETURN OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
+WARN_UNUSED_RETURN bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     structValue = pointerOfWasmRef(structValue);
     auto fieldType = structType.field(fieldIndex).type;
@@ -5326,7 +5326,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
     return { };
 }
 
-auto WARN_UNUSED_RETURN OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
+WARN_UNUSED_RETURN auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
 {
     TRACE_CF("THROW_REF");
 

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -75,35 +75,35 @@ protected:
 
     explicit ParserBase(std::span<const uint8_t>);
 
-    bool WARN_UNUSED_RETURN consumeCharacter(char);
-    bool WARN_UNUSED_RETURN consumeString(const char*);
-    bool WARN_UNUSED_RETURN consumeUTF8String(Name&, size_t);
+    WARN_UNUSED_RETURN bool consumeCharacter(char);
+    WARN_UNUSED_RETURN bool consumeString(const char*);
+    WARN_UNUSED_RETURN bool consumeUTF8String(Name&, size_t);
 
-    bool WARN_UNUSED_RETURN parseVarUInt1(uint8_t&);
-    bool WARN_UNUSED_RETURN parseInt7(int8_t&);
-    bool WARN_UNUSED_RETURN peekInt7(int8_t&);
-    bool WARN_UNUSED_RETURN parseUInt7(uint8_t&);
-    bool WARN_UNUSED_RETURN peekUInt8(uint8_t&);
-    bool WARN_UNUSED_RETURN parseUInt8(uint8_t&);
-    bool WARN_UNUSED_RETURN parseUInt32(uint32_t&);
-    bool WARN_UNUSED_RETURN parseUInt64(uint64_t&);
-    bool WARN_UNUSED_RETURN parseImmByteArray16(v128_t&);
-    bool WARN_UNUSED_RETURN parseVarUInt32(uint32_t&);
-    bool WARN_UNUSED_RETURN peekVarUInt32(uint32_t&);
-    bool WARN_UNUSED_RETURN parseVarUInt64(uint64_t&);
+    WARN_UNUSED_RETURN bool parseVarUInt1(uint8_t&);
+    WARN_UNUSED_RETURN bool parseInt7(int8_t&);
+    WARN_UNUSED_RETURN bool peekInt7(int8_t&);
+    WARN_UNUSED_RETURN bool parseUInt7(uint8_t&);
+    WARN_UNUSED_RETURN bool peekUInt8(uint8_t&);
+    WARN_UNUSED_RETURN bool parseUInt8(uint8_t&);
+    WARN_UNUSED_RETURN bool parseUInt32(uint32_t&);
+    WARN_UNUSED_RETURN bool parseUInt64(uint64_t&);
+    WARN_UNUSED_RETURN bool parseImmByteArray16(v128_t&);
+    WARN_UNUSED_RETURN bool parseVarUInt32(uint32_t&);
+    WARN_UNUSED_RETURN bool peekVarUInt32(uint32_t&);
+    WARN_UNUSED_RETURN bool parseVarUInt64(uint64_t&);
 
-    bool WARN_UNUSED_RETURN parseVarInt32(int32_t&);
-    bool WARN_UNUSED_RETURN parseVarInt64(int64_t&);
+    WARN_UNUSED_RETURN bool parseVarInt32(int32_t&);
+    WARN_UNUSED_RETURN bool parseVarInt64(int64_t&);
 
-    bool WARN_UNUSED_RETURN parseValueType(const ModuleInformation&, Type&);
-    bool WARN_UNUSED_RETURN parseRefType(const ModuleInformation&, Type&);
-    bool WARN_UNUSED_RETURN parseExternalKind(ExternalKind&);
-    bool WARN_UNUSED_RETURN parseHeapType(const ModuleInformation&, int32_t&);
+    WARN_UNUSED_RETURN bool parseValueType(const ModuleInformation&, Type&);
+    WARN_UNUSED_RETURN bool parseRefType(const ModuleInformation&, Type&);
+    WARN_UNUSED_RETURN bool parseExternalKind(ExternalKind&);
+    WARN_UNUSED_RETURN bool parseHeapType(const ModuleInformation&, int32_t&);
 
     size_t m_offset = 0;
 
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...));

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -69,7 +69,7 @@ public:
     String errorMessage() const { return crossThreadCopy(m_errorMessage); }
     CompilationError error() const { return m_error; }
 
-    bool WARN_UNUSED_RETURN failed() const { return !m_errorMessage.isNull(); }
+    WARN_UNUSED_RETURN bool failed() const { return !m_errorMessage.isNull(); }
     virtual bool hasWork() const = 0;
     virtual void work() = 0;
     virtual bool multiThreaded() const = 0;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1408,10 +1408,10 @@ auto SectionParser::parseCustom() -> PartialResult
             dataLogLnIf(Options::dumpWasmWarnings(), "Could not parse name section: ", nameSection.error());
     } else if (WTF::Unicode::equal("metadata.code.branch_hint"_span8, section.name.span())) {
         BranchHintsSectionParser branchHintsSectionParser(section.payload, m_info);
-        branchHintsSectionParser.parse();
+        std::ignore = branchHintsSectionParser.parse();
     } else if (WTF::Unicode::equal("sourceMappingURL"_span8, section.name.span())) {
         SourceMappingURLSectionParser sourceMappingURLSectionParser(section.payload, m_info);
-        sourceMappingURLSectionParser.parse();
+        std::ignore = sourceMappingURLSectionParser.parse();
     }
 
     m_info->customSections.append(WTFMove(section));

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -45,15 +45,15 @@ public:
     {
     }
 
-#define WASM_SECTION_DECLARE_PARSER(NAME, ID, ORDERING, DESCRIPTION) PartialResult WARN_UNUSED_RETURN parse ## NAME();
+#define WASM_SECTION_DECLARE_PARSER(NAME, ID, ORDERING, DESCRIPTION) WARN_UNUSED_RETURN PartialResult parse ## NAME();
     FOR_EACH_KNOWN_WASM_SECTION(WASM_SECTION_DECLARE_PARSER)
 #undef WASM_SECTION_DECLARE_PARSER
 
-    PartialResult WARN_UNUSED_RETURN parseCustom();
+    WARN_UNUSED_RETURN PartialResult parseCustom();
 
 private:
     template <typename ...Args>
-    NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
+    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
         if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate()) [[unlikely]]
@@ -62,34 +62,34 @@ private:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offset + m_offsetInSource), ": "_s, makeString(args)...));
     }
 
-    PartialResult WARN_UNUSED_RETURN parseGlobalType(GlobalInformation&);
-    PartialResult WARN_UNUSED_RETURN parseMemoryHelper(bool isImport);
-    PartialResult WARN_UNUSED_RETURN parseTableHelper(bool isImport);
+    WARN_UNUSED_RETURN PartialResult parseGlobalType(GlobalInformation&);
+    WARN_UNUSED_RETURN PartialResult parseMemoryHelper(bool isImport);
+    WARN_UNUSED_RETURN PartialResult parseTableHelper(bool isImport);
     enum class LimitsType { Memory, Table };
     template <LimitsType T>
-    PartialResult WARN_UNUSED_RETURN parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
-    PartialResult WARN_UNUSED_RETURN parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
-    PartialResult WARN_UNUSED_RETURN parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
+    WARN_UNUSED_RETURN PartialResult parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
+    WARN_UNUSED_RETURN PartialResult parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
+    WARN_UNUSED_RETURN PartialResult parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
 
-    PartialResult WARN_UNUSED_RETURN parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
-    PartialResult WARN_UNUSED_RETURN parsePackedType(PackedType&);
-    PartialResult WARN_UNUSED_RETURN parseStorageType(StorageType&);
-    PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
-    PartialResult WARN_UNUSED_RETURN parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
-    PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
-    PartialResult WARN_UNUSED_RETURN parseSubtype(uint32_t position, RefPtr<TypeDefinition>&, Vector<TypeIndex>&, bool);
+    WARN_UNUSED_RETURN PartialResult parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
+    WARN_UNUSED_RETURN PartialResult parsePackedType(PackedType&);
+    WARN_UNUSED_RETURN PartialResult parseStorageType(StorageType&);
+    WARN_UNUSED_RETURN PartialResult parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
+    WARN_UNUSED_RETURN PartialResult parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
+    WARN_UNUSED_RETURN PartialResult parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
+    WARN_UNUSED_RETURN PartialResult parseSubtype(uint32_t position, RefPtr<TypeDefinition>&, Vector<TypeIndex>&, bool);
 
-    PartialResult WARN_UNUSED_RETURN validateElementTableIdx(uint32_t, Type);
-    PartialResult WARN_UNUSED_RETURN parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
-    PartialResult WARN_UNUSED_RETURN parseElementKind(uint8_t& elementKind);
-    PartialResult WARN_UNUSED_RETURN parseIndexCountForElementSection(uint32_t&, const unsigned);
-    PartialResult WARN_UNUSED_RETURN parseElementSegmentVectorOfExpressions(Type, Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
-    PartialResult WARN_UNUSED_RETURN parseElementSegmentVectorOfIndexes(Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
+    WARN_UNUSED_RETURN PartialResult validateElementTableIdx(uint32_t, Type);
+    WARN_UNUSED_RETURN PartialResult parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
+    WARN_UNUSED_RETURN PartialResult parseElementKind(uint8_t& elementKind);
+    WARN_UNUSED_RETURN PartialResult parseIndexCountForElementSection(uint32_t&, const unsigned);
+    WARN_UNUSED_RETURN PartialResult parseElementSegmentVectorOfExpressions(Type, Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
+    WARN_UNUSED_RETURN PartialResult parseElementSegmentVectorOfIndexes(Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
 
-    PartialResult WARN_UNUSED_RETURN parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
+    WARN_UNUSED_RETURN PartialResult parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
 
     static bool checkStructuralSubtype(const TypeDefinition&, const TypeDefinition&);
-    PartialResult WARN_UNUSED_RETURN checkSubtypeValidity(const TypeDefinition&);
+    WARN_UNUSED_RETURN PartialResult checkSubtypeValidity(const TypeDefinition&);
 
     size_t m_offsetInSource;
     const Ref<ModuleInformation> m_info;

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -71,7 +71,7 @@ ALWAYS_INLINE std::optional<uint8_t> parseUInt7(const uint8_t* data, size_t& off
 }
 
 template <typename ...Args>
-NEVER_INLINE auto WARN_UNUSED_RETURN StreamingParser::fail(Args... args) -> State
+WARN_UNUSED_RETURN NEVER_INLINE auto StreamingParser::fail(Args... args) -> State
 {
     using namespace FailureHelper; // See ADL comment in namespace above.
     m_errorMessage = makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...);

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -107,7 +107,7 @@ private:
     Expected<uint32_t, State> consumeVarUInt32(std::span<const uint8_t> bytes, size_t&, IsEndOfStream);
 
     void moveToStateIfNotFailed(State);
-    template <typename ...Args> NEVER_INLINE State WARN_UNUSED_RETURN fail(Args...);
+    template <typename ...Args> WARN_UNUSED_RETURN NEVER_INLINE State fail(Args...);
 
     State failOnState(State);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -59,7 +59,7 @@ public:
     std::optional<uint32_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
     uint32_t allocatedLength() const { return m_table->allocatedLength(length()); }
-    std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue);
     JSValue get(JSGlobalObject*, uint32_t);
     void set(uint32_t, JSValue);
     void set(JSGlobalObject*, uint32_t, JSValue);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2665,7 +2665,7 @@ public:
         m_currentAlternativeIndex = newAlternativeIndex;
     }
 
-    std::optional<ErrorCode> WARN_UNUSED_RETURN emitDisjunction(PatternDisjunction* disjunction, CheckedUint32 inputCountAlreadyChecked, unsigned parenthesesInputCountAlreadyChecked, MatchDirection matchDirection = Forward)
+    WARN_UNUSED_RETURN std::optional<ErrorCode> emitDisjunction(PatternDisjunction* disjunction, CheckedUint32 inputCountAlreadyChecked, unsigned parenthesesInputCountAlreadyChecked, MatchDirection matchDirection = Forward)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1768,7 +1768,7 @@ public:
         return m_error;
     }
 
-    ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;

--- a/Source/WTF/wtf/AllocSpanMixin.h
+++ b/Source/WTF/wtf/AllocSpanMixin.h
@@ -49,7 +49,7 @@ public:
 
     std::span<const T> span() const LIFETIME_BOUND { return m_span; }
     std::span<T> mutableSpan() LIFETIME_BOUND { return m_span; }
-    std::span<T> leakSpan() WARN_UNUSED_RETURN { return std::exchange(m_span, std::span<T> { }); }
+    WARN_UNUSED_RETURN std::span<T> leakSpan() { return std::exchange(m_span, std::span<T> { }); }
 
     T& operator[](size_t i) LIFETIME_BOUND { return m_span[i]; }
     const T& operator[](size_t i) const LIFETIME_BOUND { return m_span[i]; }

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -289,7 +289,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return (lhs ^ rhs) >= 0;
     }
 
-    static inline bool add(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
@@ -316,7 +316,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool sub(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
@@ -342,7 +342,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool multiply(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
     {
 #if USE(MUL_OVERFLOW)
         // Don't use the builtin if the int128 type is WTF::[U]Int128Impl.
@@ -383,7 +383,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool divide(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
     {
         if (!rhs)
             return false;
@@ -398,7 +398,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
 
 template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, false, false> {
     // LHS and RHS are unsigned types so bounds checks are nice and easy
-    static inline bool add(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
 #if !HAVE(INT128_T)
@@ -418,7 +418,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool sub(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
 #if !HAVE(INT128_T)
@@ -438,7 +438,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool multiply(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
     {
 #if USE(MUL_OVERFLOW)
         // Don't use the builtin if the int128 type is WTF::Int128Impl.
@@ -466,7 +466,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    static inline bool divide(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
     {
         if (!rhs)
             return false;

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -424,7 +424,7 @@
 /* WARN_UNUSED_RETURN */
 
 #if !defined(WARN_UNUSED_RETURN)
-#define WARN_UNUSED_RETURN __attribute__((__warn_unused_result__))
+#define WARN_UNUSED_RETURN [[nodiscard]] // NOLINT: check-webkit-style does not understand annotations.
 #endif
 
 /* DEBUGGER_ANNOTATION_MARKER */

--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -85,7 +85,7 @@ public:
 
     explicit operator bool() const { return !!m_function; }
 
-    Impl* leak() WARN_UNUSED_RETURN { return m_function.leak(); }
+    WARN_UNUSED_RETURN Impl* leak() { return m_function.leak(); }
 
     Out operator()(In... in)
     {

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -193,7 +193,7 @@ WTF_EXPORT_PRIVATE bool deleteNonEmptyDirectory(const String&);
 WTF_EXPORT_PRIVATE String realPath(const String&);
 
 WTF_EXPORT_PRIVATE bool isSafeToUseMemoryMapForPath(const String&);
-WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool makeSafeToUseMemoryMapForPath(const String&);
+WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool makeSafeToUseMemoryMapForPath(const String&);
 
 WTF_EXPORT_PRIVATE std::optional<MappedFileData> mapFile(const String& path, MappedFileMode);
 

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -127,7 +127,7 @@ public:
         return *this;
     }
 
-    Impl* leak() WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN Impl* leak()
     {
         return m_callableWrapper.release();
     }

--- a/Source/WTF/wtf/LEBDecoder.h
+++ b/Source/WTF/wtf/LEBDecoder.h
@@ -51,7 +51,7 @@ constexpr unsigned lastByteMask()
 }
 
 template<typename T>
-inline bool WARN_UNUSED_RETURN decodeUInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
+WARN_UNUSED_RETURN inline bool decodeUInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
 {
     static_assert(std::is_unsigned_v<T>);
     if (bytes.size() <= offset)
@@ -73,7 +73,7 @@ inline bool WARN_UNUSED_RETURN decodeUInt(std::span<const uint8_t> bytes, size_t
 }
 
 template<typename T>
-inline bool WARN_UNUSED_RETURN decodeInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
+WARN_UNUSED_RETURN inline bool decodeInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
 {
     static_assert(std::is_signed_v<T>);
     if (bytes.size() <= offset)
@@ -115,22 +115,22 @@ inline bool WARN_UNUSED_RETURN decodeInt(std::span<const uint8_t> bytes, size_t&
     return true;
 }
 
-inline bool WARN_UNUSED_RETURN decodeUInt32(std::span<const uint8_t> bytes, size_t& offset, uint32_t& result)
+WARN_UNUSED_RETURN inline bool decodeUInt32(std::span<const uint8_t> bytes, size_t& offset, uint32_t& result)
 {
     return decodeUInt<uint32_t>(bytes, offset, result);
 }
 
-inline bool WARN_UNUSED_RETURN decodeUInt64(std::span<const uint8_t> bytes, size_t& offset, uint64_t& result)
+WARN_UNUSED_RETURN inline bool decodeUInt64(std::span<const uint8_t> bytes, size_t& offset, uint64_t& result)
 {
     return decodeUInt<uint64_t>(bytes, offset, result);
 }
 
-inline bool WARN_UNUSED_RETURN decodeInt32(std::span<const uint8_t> bytes, size_t& offset, int32_t& result)
+WARN_UNUSED_RETURN inline bool decodeInt32(std::span<const uint8_t> bytes, size_t& offset, int32_t& result)
 {
     return decodeInt<int32_t>(bytes, offset, result);
 }
 
-inline bool WARN_UNUSED_RETURN decodeInt64(std::span<const uint8_t> bytes, size_t& offset, int64_t& result)
+WARN_UNUSED_RETURN inline bool decodeInt64(std::span<const uint8_t> bytes, size_t& offset, int64_t& result)
 {
     return decodeInt<int64_t>(bytes, offset, result);
 }

--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -51,7 +51,7 @@ public:
 
     mach_port_t sendRight() const LIFETIME_BOUND { return m_port; }
 
-    WTF_EXPORT_PRIVATE mach_port_t leakSendRight() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE mach_port_t leakSendRight();
 
 private:
     explicit MachSendRight(mach_port_t);

--- a/Source/WTF/wtf/MallocCommon.h
+++ b/Source/WTF/wtf/MallocCommon.h
@@ -35,7 +35,7 @@ public:
     TryMallocReturnValue(void*);
     TryMallocReturnValue(TryMallocReturnValue&&);
     ~TryMallocReturnValue();
-    template<typename T> bool getValue(T*&) WARN_UNUSED_RETURN;
+    template<typename T> WARN_UNUSED_RETURN bool getValue(T*&);
 private:
     void operator=(TryMallocReturnValue&&) = delete;
     mutable void* m_data;

--- a/Source/WTF/wtf/MallocPtr.h
+++ b/Source/WTF/wtf/MallocPtr.h
@@ -62,7 +62,7 @@ public:
         return m_ptr;
     }
 
-    T *leakPtr() WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN T* leakPtr()
     {
         return std::exchange(m_ptr, nullptr);
     }

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -58,7 +58,7 @@ public:
 #if HAVE(MMAP)
     explicit MappedFileData(MmapSpan<uint8_t>&&);
 
-    std::span<uint8_t> leakHandle() WARN_UNUSED_RETURN { return m_fileData.leakSpan(); }
+    WARN_UNUSED_RETURN std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
     explicit operator bool() const { return !!m_fileData; }
     size_t size() const { return m_fileData.span().size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }

--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -59,7 +59,7 @@ template<typename T, typename arcEnabled = ARCEnabled> struct DefaultOSObjectRet
     }
 };
 
-template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> OSObjectPtr<T, RetainTraits> adoptOSObject(T) WARN_UNUSED_RETURN;
+template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> WARN_UNUSED_RETURN OSObjectPtr<T, RetainTraits> adoptOSObject(T);
 
 template<typename T, typename RetainTraits> class OSObjectPtr {
 public:
@@ -140,12 +140,12 @@ public:
         std::swap(m_ptr, other.m_ptr);
     }
 
-    T leakRef() WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN T leakRef()
     {
         return std::exchange(m_ptr, nullptr);
     }
 
-    friend OSObjectPtr adoptOSObject<T, RetainTraits>(T) WARN_UNUSED_RETURN;
+    friend OSObjectPtr adoptOSObject<T, RetainTraits>(T);
 
 private:
     struct AdoptOSObject { };

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -141,13 +141,13 @@ public:
     operator T&() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     bool operator!() const { ASSERT(m_ptr); return !*m_ptr; }
 
-    template<typename X, typename Y, typename Z> Ref<T, PtrTraits, RefDerefTraits> replace(Ref<X, Y, Z>&&) WARN_UNUSED_RETURN;
+    template<typename X, typename Y, typename Z> WARN_UNUSED_RETURN Ref<T, PtrTraits, RefDerefTraits> replace(Ref<X, Y, Z>&&);
 
     // The following function is deprecated.
     Ref copyRef() && = delete;
-    Ref copyRef() const & WARN_UNUSED_RETURN { return Ref(*m_ptr); }
+    WARN_UNUSED_RETURN Ref copyRef() const & { return Ref(*m_ptr); }
 
-    T& leakRef() WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN T& leakRef()
     {
         ASSERT(m_ptr);
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -70,7 +70,7 @@ public:
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
-    T* leakRef() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN T* leakRef();
 
     T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
@@ -94,7 +94,7 @@ public:
     template<typename X, typename Y, typename Z> void swap(RefPtr<X, Y, Z>&);
 
     RefPtr copyRef() && = delete;
-    RefPtr copyRef() const & WARN_UNUSED_RETURN { return RefPtr(m_ptr); }
+    WARN_UNUSED_RETURN RefPtr copyRef() const & { return RefPtr(m_ptr); }
 
 private:
     void unspecifiedBoolTypeInstance() const { }

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -73,9 +73,9 @@ template<typename T> class RetainPtr;
 template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
 template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
 
-template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+template<typename T> WARN_UNUSED_RETURN constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT);
 
-template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+template<typename T> WARN_UNUSED_RETURN constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT);
 
 template<typename T> class RetainPtr {
 public:
@@ -108,12 +108,12 @@ public:
     void clear();
 
     template<typename U = StorageType>
-    std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
+    WARN_UNUSED_RETURN std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED {
         return std::exchange(m_ptr, nullptr);
     }
 
     template<typename U = StorageType>
-    std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
+    WARN_UNUSED_RETURN std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED {
         return std::exchange(m_ptr, nullptr);
     }
 
@@ -142,9 +142,9 @@ public:
 
     void swap(RetainPtr&);
 
-    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptCF(U CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptCF(U CF_RELEASES_ARGUMENT);
 
-    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT);
 
 private:
     enum AdoptTag { Adopt };
@@ -183,7 +183,7 @@ private:
 template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
 
 // Helper function for creating a RetainPtr using template argument deduction.
-template<typename T> RetainPtr<RetainPtrType<T>> retainPtr(T) WARN_UNUSED_RETURN;
+template<typename T> WARN_UNUSED_RETURN RetainPtr<RetainPtrType<T>> retainPtr(T);
 
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {

--- a/Source/WTF/wtf/Scope.h
+++ b/Source/WTF/wtf/Scope.h
@@ -68,7 +68,7 @@ private:
 };
 
 
-template<typename ExitFunction> ScopeExit<ExitFunction> makeScopeExit(ExitFunction&&) WARN_UNUSED_RETURN;
+template<typename ExitFunction> WARN_UNUSED_RETURN ScopeExit<ExitFunction> makeScopeExit(ExitFunction&&);
 template<typename ExitFunction>
 ScopeExit<ExitFunction> makeScopeExit(ExitFunction&& exitFunction)
 {

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -132,13 +132,13 @@ public:
     }
 
     // Relinquishes the owned reference as a raw pointer. GRefPtr<T> is empty afterwards.
-    T* /* (transfer full) */ leakRef() WARN_UNUSED_RETURN
+    WARN_UNUSED_RETURN T* /* (transfer full) */ leakRef()
     {
         return std::exchange(m_ptr, nullptr);
     }
 
     // Increments the reference count.
-    T* /* (transfer full) */ ref() WARN_UNUSED_RETURN {
+    WARN_UNUSED_RETURN T* /* (transfer full) */ ref() {
         return RefDerefTraits::refIfNotNull(m_ptr);
     }
 

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -43,11 +43,11 @@ public:
     size_t length() const { return m_buffer.size(); }
     size_t currentOffset() const { return static_cast<size_t>(std::distance(m_buffer.begin(), m_bufferPosition)); }
     
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool rewind(size_t);
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool rewind(size_t);
 
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool verifyChecksum();
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool verifyChecksum();
 
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool decodeFixedLengthData(std::span<uint8_t>);
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool decodeFixedLengthData(std::span<uint8_t>);
 
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<bool>&);
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<uint8_t>&);
@@ -90,10 +90,10 @@ public:
         return numElements <= std::numeric_limits<size_t>::max() / sizeof(T) && bufferIsLargeEnoughToContain(numElements * sizeof(T));
     }
 
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN std::span<const uint8_t> bufferPointerForDirectRead(size_t numBytes);
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE std::span<const uint8_t> bufferPointerForDirectRead(size_t numBytes);
 
 private:
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContain(size_t) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool bufferIsLargeEnoughToContain(size_t) const;
     template<typename Type> Decoder& decodeNumber(std::optional<Type>&);
 
     const std::span<const uint8_t> m_buffer;

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -324,7 +324,7 @@ inline std::strong_ordering codePointCompare(const AtomString& a, const AtomStri
     return codePointCompare(a.string(), b.string());
 }
 
-ALWAYS_INLINE String WARN_UNUSED_RETURN makeStringByReplacingAll(const AtomString& string, char16_t target, char16_t replacement)
+WARN_UNUSED_RETURN ALWAYS_INLINE String makeStringByReplacingAll(const AtomString& string, char16_t target, char16_t replacement)
 {
     return makeStringByReplacingAll(string.string(), target, replacement);
 }

--- a/Source/WTF/wtf/text/MakeString.h
+++ b/Source/WTF/wtf/text/MakeString.h
@@ -149,7 +149,7 @@ AtomString makeAtomString(StringTypes... strings)
     return result;
 }
 
-inline String WARN_UNUSED_RETURN makeStringByInserting(StringView originalString, StringView stringToInsert, unsigned position)
+WARN_UNUSED_RETURN inline String makeStringByInserting(StringView originalString, StringView stringToInsert, unsigned position)
 {
     return makeString(originalString.left(position), stringToInsert, originalString.substring(position));
 }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -1378,31 +1378,31 @@ inline bool String::containsIgnoringASCIICase(StringView string, unsigned start)
     return findIgnoringASCIICase(string, start) != notFound;
 }
 
-inline String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, StringView target, StringView replacement)
+WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, StringView target, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-inline String WARN_UNUSED_RETURN makeStringByReplacing(const String& string, unsigned start, unsigned length, StringView replacement)
+WARN_UNUSED_RETURN inline String makeStringByReplacing(const String& string, unsigned start, unsigned length, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(start, length, replacement) };
     return string;
 }
 
-inline String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, char16_t target, StringView replacement)
+WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, char16_t target, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN makeStringByReplacingAll(StringView, char16_t target, char16_t replacement);
-WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN makeStringBySimplifyingNewLinesSlowCase(const String&, unsigned firstCarriageReturnOffset);
+WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringByReplacingAll(StringView, char16_t target, char16_t replacement);
+WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringBySimplifyingNewLinesSlowCase(const String&, unsigned firstCarriageReturnOffset);
 
-inline String WARN_UNUSED_RETURN makeStringBySimplifyingNewLines(const String& string)
+WARN_UNUSED_RETURN inline String makeStringBySimplifyingNewLines(const String& string)
 {
     auto firstCarriageReturn = string.find('\r');
     if (firstCarriageReturn == notFound)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -191,27 +191,27 @@ public:
     bool endsWith(char character) const { return endsWith(static_cast<char16_t>(character)); }
     bool hasInfixEndingAt(StringView suffix, unsigned end) const;
 
-    String WARN_UNUSED_RETURN substring(unsigned position, unsigned length = MaxLength) const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN substringSharingImpl(unsigned position, unsigned length = MaxLength) const;
-    String WARN_UNUSED_RETURN left(unsigned length) const { return substring(0, length); }
-    String WARN_UNUSED_RETURN right(unsigned length) const { return substring(this->length() - length, length); }
+    WARN_UNUSED_RETURN String substring(unsigned position, unsigned length = MaxLength) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String substringSharingImpl(unsigned position, unsigned length = MaxLength) const;
+    WARN_UNUSED_RETURN String left(unsigned length) const { return substring(0, length); }
+    WARN_UNUSED_RETURN String right(unsigned length) const { return substring(this->length() - length, length); }
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToASCIILowercase() const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToASCIIUppercase() const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToLowercaseWithoutLocale() const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned) const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToUppercaseWithoutLocale() const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToASCIILowercase() const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToASCIIUppercase() const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocale() const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocale() const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace(CodeUnitMatchFunction) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String simplifyWhiteSpace(CodeUnitMatchFunction) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN trim(CodeUnitMatchFunction) const;
-    template<typename Predicate> String WARN_UNUSED_RETURN removeCharacters(const Predicate&) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String trim(CodeUnitMatchFunction) const;
+    template<typename Predicate> WARN_UNUSED_RETURN String removeCharacters(const Predicate&) const;
 
     // Returns the string with case folded for case insensitive comparison.
     // Use convertToASCIILowercase instead if ASCII case insensitive comparison is desired.
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN foldCase() const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String foldCase() const;
 
     // Returns an uninitialized string. The characters needs to be written
     // into the buffer returned in data before the returned string is used.
@@ -221,18 +221,18 @@ public:
     using SplitFunctor = WTF::Function<void(StringView)>;
 
     WTF_EXPORT_PRIVATE void split(char16_t separator, NOESCAPE const SplitFunctor&) const;
-    WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN split(char16_t separator) const;
-    WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN split(StringView separator) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> split(char16_t separator) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> split(StringView separator) const;
 
     WTF_EXPORT_PRIVATE void splitAllowingEmptyEntries(char16_t separator, NOESCAPE const SplitFunctor&) const;
-    WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(char16_t separator) const;
-    WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(StringView separator) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(char16_t separator) const;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(StringView separator) const;
 
     WTF_EXPORT_PRIVATE double toDouble(bool* ok = nullptr) const;
     WTF_EXPORT_PRIVATE float toFloat(bool* ok = nullptr) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN isolatedCopy() const &;
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN isolatedCopy() &&;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String isolatedCopy() const &;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String isolatedCopy() &&;
 
     WTF_EXPORT_PRIVATE bool isSafeToSendToAnotherThread() const;
 
@@ -465,21 +465,21 @@ inline char16_t String::characterAt(unsigned index) const
     return m_impl->at(index);
 }
 
-inline String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, char16_t target, char16_t replacement)
+WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, char16_t target, char16_t replacement)
 {
     if (auto impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-ALWAYS_INLINE String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, char16_t target, ASCIILiteral literal)
+WARN_UNUSED_RETURN ALWAYS_INLINE String makeStringByReplacingAll(const String& string, char16_t target, ASCIILiteral literal)
 {
     if (auto impl = string.impl())
         return String { impl->replace(target, literal.span8()) };
     return string;
 }
 
-WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN makeStringByRemoving(const String&, unsigned position, unsigned lengthToRemove);
+WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringByRemoving(const String&, unsigned position, unsigned lengthToRemove);
 
 WTF_EXPORT_PRIVATE String makeStringByJoining(std::span<const String> strings, const String& separator);
 

--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -83,7 +83,7 @@ public:
         return UnixFileDescriptor { m_value, Duplicate };
     }
 
-    int release() WARN_UNUSED_RETURN { return std::exchange(m_value, -1); }
+    WARN_UNUSED_RETURN int release() { return std::exchange(m_value, -1); }
 
 private:
     int m_value { -1 };

--- a/Source/WTF/wtf/win/GDIObject.h
+++ b/Source/WTF/wtf/win/GDIObject.h
@@ -49,7 +49,7 @@ public:
     T get() const { return m_object; }
 
     void clear();
-    T leak() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN T leak();
 
     bool operator!() const { return !m_object; }
 

--- a/Source/WTF/wtf/win/Win32Handle.h
+++ b/Source/WTF/wtf/win/Win32Handle.h
@@ -46,7 +46,7 @@ public:
 
     HANDLE get() const { return m_handle; }
 
-    WTF_EXPORT_PRIVATE HANDLE leak() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE HANDLE leak();
 
     struct IPCData {
         uintptr_t handle;

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -86,7 +86,7 @@ public:
     WEBCORE_EXPORT IDBKeyData isolatedCopy() const;
 
     WEBCORE_EXPORT void encode(KeyedEncoder&) const;
-    WEBCORE_EXPORT static WARN_UNUSED_RETURN bool decode(KeyedDecoder&, IDBKeyData&);
+    WARN_UNUSED_RETURN WEBCORE_EXPORT static bool decode(KeyedDecoder&, IDBKeyData&);
 
     void setArrayValue(const Vector<IDBKeyData>&);
     void setBinaryValue(const ThreadSafeDataBuffer&);

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -289,7 +289,7 @@ RefPtr<SharedBuffer> serializeIDBKeyData(const IDBKeyData& key)
     return SharedBuffer::create(WTFMove(data));
 }
 
-static WARN_UNUSED_RETURN bool decodeKey(std::span<const uint8_t>& data, IDBKeyData& result)
+WARN_UNUSED_RETURN static bool decodeKey(std::span<const uint8_t>& data, IDBKeyData& result)
 {
     if (data.empty())
         return false;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -118,7 +118,7 @@ bool GStreamerRtpTransceiverBackend::stopped() const
     return m_isStopped;
 }
 
-static inline WARN_UNUSED_RETURN ExceptionOr<GRefPtr<GstCaps>> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, const String& msid)
+WARN_UNUSED_RETURN static inline ExceptionOr<GRefPtr<GstCaps>> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, const String& msid)
 {
     if (!codec.mimeType.startsWith("video/"_s) && !codec.mimeType.startsWith("audio/"_s))
         return Exception { ExceptionCode::InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -121,7 +121,7 @@ private:
 
     RefPtr<DeprecatedCSSOMValue> wrapForDeprecatedCSSOM(CSSValue*);
 
-    virtual bool willMutate() WARN_UNUSED_RETURN { return true; }
+    WARN_UNUSED_RETURN virtual bool willMutate() { return true; }
     virtual void didMutate(MutationType) { }
 };
 
@@ -148,7 +148,7 @@ private:
 
     CSSRule* parentRule() const final;
 
-    bool willMutate() final WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool willMutate() final;
     void didMutate(MutationType) final;
     OptionalOrReference<CSSParserContext> cssParserContext() const final;
 
@@ -169,7 +169,7 @@ private:
     CSSStyleSheet* parentStyleSheet() const final;
     StyledElement* parentElement() const final { return m_parentElement.get(); }
 
-    bool willMutate() final WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool willMutate() final;
     void didMutate(MutationType) final;
     OptionalOrReference<CSSParserContext> cssParserContext() const final;
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -73,7 +73,7 @@ protected:
     RefPtr<DeprecatedCSSOMValue> wrapForDeprecatedCSSOM(CSSValue*);
 
     enum class MutationType : uint8_t { NoChanges, StyleAttributeChanged, PropertyChanged };
-    bool willMutate() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool willMutate();
     void didMutate(MutationType);
 
     // CSSPropertyID versions of the CSSOM functions to support bindings.

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -71,7 +71,7 @@ struct UnevaluatedCalcBase {
     ~UnevaluatedCalcBase();
 
     Ref<CSSCalc::Value> protectedCalc() const;
-    CSSCalc::Value& leakRef() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN CSSCalc::Value& leakRef();
 
     bool requiresConversionData() const;
 

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -52,7 +52,7 @@ public:
     void clear();
 
     // We do not introduce a && version since it might break the register/unregister balance.
-    WEBCORE_EXPORT URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() const;
+    WARN_UNUSED_RETURN WEBCORE_EXPORT URLKeepingBlobAlive isolatedCopy() const;
 
 private:
     void registerBlobURLHandleIfNecessary();

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -109,7 +109,7 @@ void HTMLResourcePreloader::preload(std::unique_ptr<PreloadRequest> preload)
     if (!MQ::MediaQueryEvaluator { screenAtom(), *document, document->renderStyle() }.evaluate(queries))
         return;
 
-    document->protectedCachedResourceLoader()->preload(preload->resourceType(), preload->resourceRequest(*document));
+    std::ignore = document->protectedCachedResourceLoader()->preload(preload->resourceType(), preload->resourceRequest(*document));
 }
 
 }

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -136,7 +136,7 @@ private:
 
             ScriptFunctionCall function(m_globalObject, m_frontendApiObject.get(), "contextMenuItemSelected"_s, WebCore::functionCallHandlerFromAnyThread);
             function.appendArgument(itemNumber);
-            function.call();
+            std::ignore = function.call();
         }
     }
     
@@ -144,7 +144,7 @@ private:
     {
         if (m_frontendHost) {
             ScriptFunctionCall function(m_globalObject, m_frontendApiObject.get(), "contextMenuCleared"_s, WebCore::functionCallHandlerFromAnyThread);
-            function.call();
+            std::ignore = function.call();
 
             m_frontendHost->m_menuProvider = nullptr;
         }

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -80,7 +80,7 @@ Inspector::Protocol::Page::ResourceType resourceTypeToProtocol(Inspector::Resour
     return Inspector::Protocol::Page::ResourceType::Other;
 }
 
-static bool WARN_UNUSED_RETURN decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
+WARN_UNUSED_RETURN static bool decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
 {
     if (buffer.data()) {
         PAL::TextEncoding encoding(textEncodingName);

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -513,7 +513,7 @@ void PageInspectorController::frontendInitialized()
     if (m_pauseAfterInitialization) {
         m_pauseAfterInitialization = false;
         if (auto* debuggerAgent = m_instrumentingAgents->enabledPageDebuggerAgent())
-            debuggerAgent->pause();
+            std::ignore = debuggerAgent->pause();
     }
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -109,8 +109,8 @@ void WorkerInspectorController::frontendInitialized()
     if (m_pauseAfterInitialization) {
         m_pauseAfterInitialization = false;
 
-        ensureDebuggerAgent().enable();
-        ensureDebuggerAgent().pause();
+        std::ignore = ensureDebuggerAgent().enable();
+        std::ignore = ensureDebuggerAgent().pause();
     }
 
     if (m_isAutomaticInspection && is<ServiceWorkerGlobalScope>(m_globalScope)) {

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -270,8 +270,8 @@ void InspectorAnimationAgent::didCreateFrontendAndBackend()
 
 void InspectorAnimationAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    stopTracking();
-    disable();
+    std::ignore = stopTracking();
+    std::ignore = disable();
 
     Ref agents = m_instrumentingAgents.get();
     ASSERT(agents->persistentAnimationAgent() == this);

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -56,7 +56,7 @@ void InspectorCPUProfilerAgent::didCreateFrontendAndBackend()
 
 void InspectorCPUProfilerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    stopTracking();
+    std::ignore = stopTracking();
 
     Ref { m_instrumentingAgents.get() }->setPersistentCPUProfilerAgent(nullptr);
 }

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -299,7 +299,7 @@ void InspectorCSSAgent::didCreateFrontendAndBackend()
 
 void InspectorCSSAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 void InspectorCSSAgent::reset()

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -111,7 +111,7 @@ void InspectorCanvasAgent::didCreateFrontendAndBackend()
 
 void InspectorCanvasAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 void InspectorCanvasAgent::discardAgent()

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -360,7 +360,7 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
 
     Inspector::Protocol::ErrorString ignored;
     setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
-    hideHighlight();
+    std::ignore = hideHighlight();
 
     Ref overlay = m_overlay.get();
     overlay->clearAllGridOverlays();
@@ -1367,7 +1367,7 @@ void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& er
 
         highlightMousedOverNode();
     } else
-        hideHighlight();
+        std::ignore = hideHighlight();
 
     protectedOverlay()->didSetSearchingForNode(m_searchingForNode);
 
@@ -1727,7 +1727,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Insp
     if (!config)
         return makeUnexpected(errorString);
 
-    protectedOverlay()->setGridOverlayForNode(*node, *config);
+    std::ignore = protectedOverlay()->setGridOverlayForNode(*node, *config);
 
     return { };
 }
@@ -1759,7 +1759,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Insp
     if (!config)
         return makeUnexpected(errorString);
 
-    protectedOverlay()->setFlexOverlayForNode(*node, *config);
+    std::ignore = protectedOverlay()->setFlexOverlayForNode(*node, *config);
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -74,7 +74,7 @@ void InspectorDOMStorageAgent::didCreateFrontendAndBackend()
 
 void InspectorDOMStorageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -526,7 +526,7 @@ void InspectorIndexedDBAgent::didCreateFrontendAndBackend()
 
 void InspectorIndexedDBAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorIndexedDBAgent::enable()

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -67,7 +67,7 @@ void InspectorLayerTreeAgent::didCreateFrontendAndBackend()
 
 void InspectorLayerTreeAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 void InspectorLayerTreeAgent::reset()

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -57,7 +57,7 @@ void InspectorMemoryAgent::didCreateFrontendAndBackend()
 
 void InspectorMemoryAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 
     Ref { m_instrumentingAgents.get() }->setPersistentMemoryAgent(nullptr);
 }

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -137,7 +137,7 @@ void InspectorNetworkAgent::didCreateFrontendAndBackend()
 
 void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 static Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
@@ -847,7 +847,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
     continuePendingRequests();
     continuePendingResponses();
 
-    setResourceCachingDisabled(false);
+    std::ignore = setResourceCachingDisabled(false);
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     setEmulatedConditions(std::nullopt);

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -122,7 +122,7 @@ void InspectorPageAgent::didCreateFrontendAndBackend()
 
 void InspectorPageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
@@ -146,12 +146,12 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 {
     Ref { m_instrumentingAgents.get() }->setEnabledPageAgent(nullptr);
 
-    setShowPaintRects(false);
+    std::ignore = setShowPaintRects(false);
 #if !PLATFORM(IOS_FAMILY)
-    setShowRulers(false);
+    std::ignore = setShowRulers(false);
 #endif
-    overrideUserAgent(nullString());
-    setEmulatedMedia(emptyString());
+    std::ignore = overrideUserAgent(nullString());
+    std::ignore = setEmulatedMedia(emptyString());
     overridePrefersColorScheme(std::nullopt);
 
     auto& inspectedPageSettings = m_inspectedPage->settings();

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -76,7 +76,7 @@ void InspectorTimelineAgent::didCreateFrontendAndBackend()
 
 void InspectorTimelineAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::enable()
@@ -157,7 +157,7 @@ void InspectorTimelineAgent::internalDisable()
 {
     Ref { m_instrumentingAgents.get() }->setEnabledTimelineAgent(nullptr);
 
-    stop();
+    std::ignore = stop();
 
     m_instruments.clear();
 }
@@ -370,7 +370,7 @@ void InspectorTimelineAgent::startProgrammaticCapture()
     if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent()) {
         m_programmaticCaptureRestoreBreakpointActiveValue = webDebuggerAgent->breakpointsActive();
         if (m_programmaticCaptureRestoreBreakpointActiveValue)
-            webDebuggerAgent->setBreakpointsActive(false);
+            std::ignore = webDebuggerAgent->setBreakpointsActive(false);
     } else
         m_programmaticCaptureRestoreBreakpointActiveValue = false;
 
@@ -391,7 +391,7 @@ void InspectorTimelineAgent::stopProgrammaticCapture()
     // Re-enable breakpoints if they were enabled.
     if (m_programmaticCaptureRestoreBreakpointActiveValue) {
         if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent())
-            webDebuggerAgent->setBreakpointsActive(true);
+            std::ignore = webDebuggerAgent->setBreakpointsActive(true);
     }
 }
 
@@ -432,9 +432,9 @@ void InspectorTimelineAgent::toggleScriptProfilerInstrument(InstrumentState stat
 {
     if (auto* scriptProfilerAgent = Ref { m_instrumentingAgents.get() }->persistentScriptProfilerAgent()) {
         if (state == InstrumentState::Start)
-            scriptProfilerAgent->startTracking(true);
+            std::ignore = scriptProfilerAgent->startTracking(true);
         else
-            scriptProfilerAgent->stopTracking();
+            std::ignore = scriptProfilerAgent->stopTracking();
     }
 }
 
@@ -443,9 +443,9 @@ void InspectorTimelineAgent::toggleHeapInstrument(InstrumentState state)
     if (auto* heapAgent = Ref { m_instrumentingAgents.get() }->persistentWebHeapAgent()) {
         if (state == InstrumentState::Start) {
             if (shouldStartHeapInstrument())
-                heapAgent->startTracking();
+                std::ignore = heapAgent->startTracking();
         } else
-            heapAgent->stopTracking();
+            std::ignore = heapAgent->stopTracking();
     }
 }
 
@@ -454,9 +454,9 @@ void InspectorTimelineAgent::toggleCPUInstrument(InstrumentState state)
 #if ENABLE(RESOURCE_USAGE)
     if (auto* cpuProfilerAgent = Ref { m_instrumentingAgents.get() }->persistentCPUProfilerAgent()) {
         if (state == InstrumentState::Start)
-            cpuProfilerAgent->startTracking();
+            std::ignore = cpuProfilerAgent->startTracking();
         else
-            cpuProfilerAgent->stopTracking();
+            std::ignore = cpuProfilerAgent->stopTracking();
     }
 #else
     UNUSED_PARAM(state);
@@ -468,9 +468,9 @@ void InspectorTimelineAgent::toggleMemoryInstrument(InstrumentState state)
 #if ENABLE(RESOURCE_USAGE)
     if (auto* memoryAgent = Ref { m_instrumentingAgents.get() }->persistentMemoryAgent()) {
         if (state == InstrumentState::Start)
-            memoryAgent->startTracking();
+            std::ignore = memoryAgent->startTracking();
         else
-            memoryAgent->stopTracking();
+            std::ignore = memoryAgent->stopTracking();
     }
 #else
     UNUSED_PARAM(state);
@@ -492,9 +492,9 @@ void InspectorTimelineAgent::toggleAnimationInstrument(InstrumentState state)
 {
     if (auto* animationAgent = Ref { m_instrumentingAgents.get() }->persistentAnimationAgent()) {
         if (state == InstrumentState::Start)
-            animationAgent->startTracking();
+            std::ignore = animationAgent->startTracking();
         else
-            animationAgent->stopTracking();
+            std::ignore = animationAgent->stopTracking();
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -58,7 +58,7 @@ void InspectorWorkerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     Ref { m_instrumentingAgents.get() }->setPersistentWorkerAgent(nullptr);
 
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::enable()

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -177,7 +177,7 @@ void PageDebuggerAgent::mainFrameStartedLoading()
     if (isPaused()) {
         setSuppressAllPauses(true);
 
-        resume();
+        std::ignore = resume();
     }
 }
 

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -279,7 +279,7 @@ void PageTimelineAgent::mainFrameStartedLoading()
 
     // Pre-emptively disable breakpoints. The frontend must re-enable them.
     if (auto* webDebuggerAgent = Ref { m_instrumentingAgents.get() }->enabledWebDebuggerAgent())
-        webDebuggerAgent->setBreakpointsActive(false);
+        std::ignore = webDebuggerAgent->setBreakpointsActive(false);
 
     // Inform the frontend we started an auto capture. The frontend must stop capture.
     autoCaptureStarted();

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -54,7 +54,7 @@ struct FetchOptions {
     FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, keepAlive, WTFMove(integrity).isolatedCopy(), clientIdentifier, resultingClientIdentifier }; }
 
     template<class Encoder> void encodePersistent(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decodePersistent(Decoder&, FetchOptions&);
+    template<class Decoder> WARN_UNUSED_RETURN static bool decodePersistent(Decoder&, FetchOptions&);
 
     Destination destination { Destination::EmptyString };
     Mode mode { Mode::NoCors };

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -262,7 +262,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     }
 
     CachedResourceRequest cachedResourceRequest { ResourceRequest { request }, options };
-    frame.protectedDocument()->protectedCachedResourceLoader()->requestPingResource(WTFMove(cachedResourceRequest));
+    std::ignore = frame.protectedDocument()->protectedCachedResourceLoader()->requestPingResource(WTFMove(cachedResourceRequest));
 }
 
 // // https://html.spec.whatwg.org/multipage/origin.html#sanitize-url-report

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -264,7 +264,7 @@ private:
     bool allPoliciesWithDispositionAllow(Disposition, ViolatedDirectiveCallback&&, Predicate&&, Args&&...) const;
 
     template<typename Predicate, typename... Args>
-    bool allPoliciesAllow(NOESCAPE const ViolatedDirectiveCallback&, Predicate&&, Args&&...) const WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool allPoliciesAllow(NOESCAPE const ViolatedDirectiveCallback&, Predicate&&, Args&&...) const;
     bool shouldPerformEarlyCSPCheck() const;
     
     using ResourcePredicate = const ContentSecurityPolicyDirective *(ContentSecurityPolicyDirectiveList::*)(const URL &, bool) const;

--- a/Source/WebCore/platform/KeyedCoding.h
+++ b/Source/WebCore/platform/KeyedCoding.h
@@ -41,15 +41,15 @@ public:
 
     virtual ~KeyedDecoder() = default;
 
-    virtual WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeInt32(const String& key, int32_t&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeInt64(const String& key, int64_t&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeFloat(const String& key, float&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeDouble(const String& key, double&) = 0;
-    virtual WARN_UNUSED_RETURN bool decodeString(const String& key, String&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeBytes(const String& key, std::span<const uint8_t>&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeBool(const String& key, bool&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeUInt32(const String& key, uint32_t&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeUInt64(const String& key, uint64_t&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeInt32(const String& key, int32_t&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeInt64(const String& key, int64_t&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeFloat(const String& key, float&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeDouble(const String& key, double&) = 0;
+    WARN_UNUSED_RETURN virtual bool decodeString(const String& key, String&) = 0;
 
     template<typename T> WARN_UNUSED_RETURN
     bool decodeBytes(const String& key, Vector<T>& vector)

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -64,7 +64,7 @@
 
 namespace WebCore {
 
-static WARN_UNUSED_RETURN AudioBufferList* tryCreateAudioBufferList(size_t numberOfBuffers)
+WARN_UNUSED_RETURN static AudioBufferList* tryCreateAudioBufferList(size_t numberOfBuffers)
 {
     if (!numberOfBuffers)
         return nullptr;

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -282,7 +282,7 @@ public:
 
     WEBCORE_EXPORT static void registerFactory(CDMProxyFactory&);
     WEBCORE_EXPORT static void unregisterFactory(CDMProxyFactory&);
-    WEBCORE_EXPORT static WARN_UNUSED_RETURN RefPtr<CDMProxy> createCDMProxyForKeySystem(const String&);
+    WARN_UNUSED_RETURN WEBCORE_EXPORT static RefPtr<CDMProxy> createCDMProxyForKeySystem(const String&);
 
 protected:
     virtual RefPtr<CDMProxy> createCDMProxy(const String&) = 0;

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -201,7 +201,7 @@ public:
 
     // Return false if x + width or y + height overflows.
     WEBCORE_EXPORT bool isValid() const;
-    WEBCORE_EXPORT IntRect WARN_UNUSED_RETURN toRectWithExtentsClippedToNumericLimits() const;
+    WARN_UNUSED_RETURN WEBCORE_EXPORT IntRect toRectWithExtentsClippedToNumericLimits() const;
 
     friend bool operator==(const IntRect&, const IntRect&) = default;
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -375,7 +375,7 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
     return erasedRanges;
 }
 
-static WARN_UNUSED_RETURN bool decodeTimeComparator(const PresentationOrderSampleMap::MapType::value_type& a, const PresentationOrderSampleMap::MapType::value_type& b)
+WARN_UNUSED_RETURN static bool decodeTimeComparator(const PresentationOrderSampleMap::MapType::value_type& a, const PresentationOrderSampleMap::MapType::value_type& b)
 {
     return Ref { a.second }->decodeTime() < Ref { b.second }->decodeTime();
 };

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -360,7 +360,7 @@ protected:
     bool updateErrors();
 
     // Called once by all the public entry points that eventually call OpenGL.
-    bool makeContextCurrent() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool makeContextCurrent();
 
     // Initializes the instance. Returns false if the instance should not be used.
     bool initialize();
@@ -404,7 +404,7 @@ protected:
     virtual void invalidateKnownTextureContent(GCGLuint);
     bool supportsExtensionImpl(ASCIILiteral) const;
     // Enables extensions only if all are supported, returns true if all the extensions are supported. No changes if false is returned.
-    bool enableExtensionsImpl(std::initializer_list<ASCIILiteral>) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool enableExtensionsImpl(std::initializer_list<ASCIILiteral>);
     bool isExtensionEnabledImpl(ASCIILiteral) const;
 
     // Only for non-WebGL 2.0 contexts.

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -336,10 +336,10 @@ public:
         friend bool operator==(const Decomposed4Type&, const Decomposed4Type&) = default;
     };
     
-    bool decompose2(Decomposed2Type&) const WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool decompose2(Decomposed2Type&) const;
     void recompose2(const Decomposed2Type&);
 
-    WEBCORE_EXPORT bool decompose4(Decomposed4Type&) const WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN WEBCORE_EXPORT bool decompose4(Decomposed4Type&) const;
     void recompose4(const Decomposed4Type&);
 
     WEBCORE_EXPORT void blend(const TransformationMatrix& from, double progress, CompositeOperation = CompositeOperation::Replace);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -70,7 +70,7 @@ public:
 
     WARN_UNUSED_RETURN GUniquePtr<GstStructure> mediaCaptureStats();
 
-    virtual WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const = 0;
+    WARN_UNUSED_RETURN virtual GRefPtr<GstPad> outgoingSourcePad() const = 0;
     virtual RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) = 0;
 
     void replaceTrack(const RefPtr<MediaStreamTrack>&);

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -72,7 +72,7 @@ public:
     static RenderWidget* find(const Widget&);
 
     enum class ChildWidgetState { Valid, Destroyed };
-    ChildWidgetState updateWidgetPosition() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN ChildWidgetState updateWidgetPosition();
     WEBCORE_EXPORT IntRect windowClipRect() const;
 
     virtual bool requiresAcceleratedCompositing() const;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -38,7 +38,7 @@ public:
     explicit RenderStyle(CreateDefaultStyleTag);
     RenderStyle(const RenderStyle&, CloneTag);
 
-    RenderStyle replace(RenderStyle&&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderStyle replace(RenderStyle&&);
 
     static RenderStyle& defaultStyleSingleton();
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -51,7 +51,7 @@ public:
     enum class IsInternalMove : bool { No, Yes };
     enum class WillBeDestroyed : bool { No, Yes };
     enum class CanCollapseAnonymousBlock : bool { No, Yes };
-    RenderPtr<RenderObject> detach(RenderElement&, RenderObject&, WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderElement&, RenderObject&, WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
 
     enum class TearDownType : uint8_t {
         Root,                          // destroy root renderer
@@ -82,8 +82,8 @@ private:
     void attachToRenderElement(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
     void attachToRenderElementInternal(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
 
-    RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detachFromRenderGrid(RenderGrid& parent, RenderObject& child, WillBeDestroyed) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed);
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detachFromRenderGrid(RenderGrid& parent, RenderObject& child, WillBeDestroyed);
 
     void move(RenderBoxModelObject& from, RenderBoxModelObject& to, RenderObject& child, RenderObject* beforeChild, NormalizeAfterInsertion);
     // Move all of the kids from |startChild| up to but excluding |endChild|. 0 can be passed as the |endChild| to denote

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
@@ -42,8 +42,8 @@ public:
     void attach(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attachIgnoringContinuation(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    RenderPtr<RenderObject> detach(RenderBlock& parent, RenderObject& oldChild, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detach(RenderBlockFlow& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderBlock& parent, RenderObject& oldChild, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderBlockFlow& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
 
     void dropAnonymousBoxChild(RenderBlock& parent, RenderBlock& child);
     void childBecameNonInline(RenderBlock& parent, RenderElement& child);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
@@ -42,8 +42,8 @@ public:
     void attach(RenderButton& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderMenuList& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detach(RenderMenuList& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderMenuList& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
 private:
     RenderBlock& findOrCreateParentForChild(RenderButton&);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
@@ -51,11 +51,11 @@ public:
     void attach(RenderSVGText& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    RenderPtr<RenderObject> detach(LegacyRenderSVGRoot& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detach(LegacyRenderSVGContainer& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detach(RenderSVGInline& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(LegacyRenderSVGRoot& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(LegacyRenderSVGContainer& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderSVGInline& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
-    RenderPtr<RenderObject> detach(RenderSVGText& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderSVGText& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
 private:
     RenderSVGViewportContainer& findOrCreateParentForChild(RenderSVGRoot&);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -160,49 +160,49 @@ public:
 
     std::optional<FailedCheck> check();
 
-    Result<void> visit(ShaderModule&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(ShaderModule&);
 
     // Declarations
-    Result<void> visit(AST::Declaration&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::Structure&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::Variable&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::Function&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::TypeAlias&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::ConstAssert&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::Declaration&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::Structure&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::Variable&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::Function&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::TypeAlias&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::ConstAssert&);
 
     // Attributes
-    Result<void> visit(AST::Attribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::AlignAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::BindingAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::GroupAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::IdAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::LocationAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::SizeAttribute&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::WorkgroupSizeAttribute&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::Attribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::AlignAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::BindingAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::GroupAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::IdAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::LocationAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::SizeAttribute&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::WorkgroupSizeAttribute&);
 
     // Statements
-    Result<void> visit(AST::Statement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::AssignmentStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::CallStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::CompoundAssignmentStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::CompoundStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::DecrementIncrementStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::IfStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::PhonyAssignmentStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::ReturnStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::ForStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::LoopStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::WhileStatement&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::SwitchStatement&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::Statement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::AssignmentStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::CallStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::CompoundAssignmentStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::CompoundStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::DecrementIncrementStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::IfStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::PhonyAssignmentStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::ReturnStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::ForStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::LoopStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::WhileStatement&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::SwitchStatement&);
 
     // Expressions
-    Result<void> visit(AST::Expression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::FieldAccessExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::IndexAccessExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::BinaryExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::IdentifierExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::CallExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::UnaryExpression&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::Expression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::FieldAccessExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::IndexAccessExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::BinaryExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::IdentifierExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::CallExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::UnaryExpression&);
 
     // Literal Expressions
     void visit(AST::BoolLiteral&);
@@ -214,59 +214,59 @@ public:
     void visit(AST::AbstractFloatLiteral&);
 
     // Types
-    Result<void> visit(AST::ArrayTypeExpression&) WARN_UNUSED_RETURN;
-    Result<void> visit(AST::ElaboratedTypeExpression&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::ArrayTypeExpression&);
+    WARN_UNUSED_RETURN Result<void> visit(AST::ElaboratedTypeExpression&);
 
-    Result<void> visit(AST::Continuing&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> visit(AST::Continuing&);
 
 private:
-    Result<void> declareBuiltins() WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> declareBuiltins();
 
-    Result<const Type*> vectorFieldAccess(const Types::Vector&, AST::FieldAccessExpression&) WARN_UNUSED_RETURN;
-    Result<void> visitAttributes(AST::Attribute::List&) WARN_UNUSED_RETURN;
-    Result<void> visitStatements(AST::Statement::List&) WARN_UNUSED_RETURN;
-    Result<void> bitcast(AST::CallExpression&, const Vector<const Type*>&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<const Type*> vectorFieldAccess(const Types::Vector&, AST::FieldAccessExpression&);
+    WARN_UNUSED_RETURN Result<void> visitAttributes(AST::Attribute::List&);
+    WARN_UNUSED_RETURN Result<void> visitStatements(AST::Statement::List&);
+    WARN_UNUSED_RETURN Result<void> bitcast(AST::CallExpression&, const Vector<const Type*>&);
 
-    Result<const Type*> check(AST::Expression&, Constraint, Evaluation) WARN_UNUSED_RETURN;
-    Result<const Type*> infer(AST::Expression&, Evaluation, DiscardResult = DiscardResult::No) WARN_UNUSED_RETURN;
-    Result<const Type*> resolve(AST::Expression&) WARN_UNUSED_RETURN;
-    Result<const Type*> lookupType(const AST::Identifier&) WARN_UNUSED_RETURN;
-    Result<void> validateF16Usage(const SourceSpan&, const Type*) WARN_UNUSED_RETURN;
-    Result<void> introduceType(const AST::Identifier&, const Type*) WARN_UNUSED_RETURN;
-    Result<void> introduceValue(const AST::Identifier&, const Type*, Evaluation = Evaluation::Runtime, std::optional<ConstantValue> = std::nullopt) WARN_UNUSED_RETURN;
-    Result<void> introduceFunction(const AST::Identifier&, const Type*) WARN_UNUSED_RETURN;
-    Result<void> convertValue(const SourceSpan&, const Type*, std::optional<ConstantValue>&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<const Type*> check(AST::Expression&, Constraint, Evaluation);
+    WARN_UNUSED_RETURN Result<const Type*> infer(AST::Expression&, Evaluation, DiscardResult = DiscardResult::No);
+    WARN_UNUSED_RETURN Result<const Type*> resolve(AST::Expression&);
+    WARN_UNUSED_RETURN Result<const Type*> lookupType(const AST::Identifier&);
+    WARN_UNUSED_RETURN Result<void> validateF16Usage(const SourceSpan&, const Type*);
+    WARN_UNUSED_RETURN Result<void> introduceType(const AST::Identifier&, const Type*);
+    WARN_UNUSED_RETURN Result<void> introduceValue(const AST::Identifier&, const Type*, Evaluation = Evaluation::Runtime, std::optional<ConstantValue> = std::nullopt);
+    WARN_UNUSED_RETURN Result<void> introduceFunction(const AST::Identifier&, const Type*);
+    WARN_UNUSED_RETURN Result<void> convertValue(const SourceSpan&, const Type*, std::optional<ConstantValue>&);
 
     void inferred(const Type*);
-    bool unify(const Type*, const Type*) WARN_UNUSED_RETURN;
-    bool convertValueImpl(const SourceSpan&, const Type*, ConstantValue&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool unify(const Type*, const Type*);
+    WARN_UNUSED_RETURN bool convertValueImpl(const SourceSpan&, const Type*, ConstantValue&);
 
-    Result<void> binaryExpression(const SourceSpan&, AST::Expression*, AST::BinaryOperation, AST::Expression&, AST::Expression&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> binaryExpression(const SourceSpan&, AST::Expression*, AST::BinaryOperation, AST::Expression&, AST::Expression&);
 
     template<typename TargetConstructor, typename Validator, typename... Arguments>
-    Result<void> allocateSimpleConstructor(ASCIILiteral, TargetConstructor, const Validator&, Arguments&&...) WARN_UNUSED_RETURN;
-    Result<void> allocateTextureStorageConstructor(ASCIILiteral, Types::TextureStorage::Kind) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> allocateSimpleConstructor(ASCIILiteral, TargetConstructor, const Validator&, Arguments&&...);
+    WARN_UNUSED_RETURN Result<void> allocateTextureStorageConstructor(ASCIILiteral, Types::TextureStorage::Kind);
 
     bool isModuleScope() const;
 
-    Result<AccessMode> accessMode(AST::Expression&) WARN_UNUSED_RETURN;
-    Result<TexelFormat> texelFormat(AST::Expression&) WARN_UNUSED_RETURN;
-    Result<AddressSpace> addressSpace(AST::Expression&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<AccessMode> accessMode(AST::Expression&);
+    WARN_UNUSED_RETURN Result<TexelFormat> texelFormat(AST::Expression&);
+    WARN_UNUSED_RETURN Result<AddressSpace> addressSpace(AST::Expression&);
 
     template<typename CallArguments>
-    Result<const Type*> chooseOverload(ASCIILiteral, const SourceSpan&, AST::Expression*, const String&, CallArguments&& valueArguments, const Vector<const Type*>& typeArguments) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<const Type*> chooseOverload(ASCIILiteral, const SourceSpan&, AST::Expression*, const String&, CallArguments&& valueArguments, const Vector<const Type*>& typeArguments);
 
     template<typename Node>
-    Result<void> setConstantValue(Node&, const Type*, const ConstantValue&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<void> setConstantValue(Node&, const Type*, const ConstantValue&);
 
-    Result<Behaviors> analyze(AST::Statement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::CompoundStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::ForStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::IfStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::LoopStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::SwitchStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyze(AST::WhileStatement&) WARN_UNUSED_RETURN;
-    Result<Behaviors> analyzeStatements(AST::Statement::List&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::Statement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::CompoundStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::ForStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::IfStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::LoopStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::SwitchStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::WhileStatement&);
+    WARN_UNUSED_RETURN Result<Behaviors> analyzeStatements(AST::Statement::List&);
 
     ShaderModule& m_shaderModule;
     const Type* m_inferredType { nullptr };
@@ -305,7 +305,7 @@ Result<void> TypeChecker::declareBuiltins()
 
     CHECK(introduceType(AST::Identifier::make("ptr"_s), m_types.typeConstructorType(
         "ptr"_s,
-        [this](AST::ElaboratedTypeExpression& type) WARN_UNUSED_RETURN -> Result<const Type*> {
+        [this](AST::ElaboratedTypeExpression& type) -> Result<const Type*> {
             auto argumentCount = type.arguments().size();
             if (argumentCount < 2) [[unlikely]]
                 TYPE_ERROR(type.span(), "'ptr' requires at least 2 template arguments"_s);
@@ -352,7 +352,7 @@ Result<void> TypeChecker::declareBuiltins()
 
     CHECK(introduceType(AST::Identifier::make("atomic"_s), m_types.typeConstructorType(
         "atomic"_s,
-        [this](AST::ElaboratedTypeExpression& type) WARN_UNUSED_RETURN -> Result<const Type*> {
+        [this](AST::ElaboratedTypeExpression& type) -> Result<const Type*> {
             if (type.arguments().size() != 1) [[unlikely]]
                 TYPE_ERROR(type.span(), "'atomic' requires 1 template argument"_s);
 
@@ -1116,7 +1116,7 @@ Result<void> TypeChecker::visit(AST::SwitchStatement& statement)
     if (!satisfies(valueType, Constraints::ConcreteInteger)) [[unlikely]]
         TYPE_ERROR(statement.value().span(), "switch selector must be of type i32 or u32"_s);
 
-    const auto& visitClause = [&](AST::SwitchClause& clause) WARN_UNUSED_RETURN -> Result<void> {
+    const auto& visitClause = [&](AST::SwitchClause& clause) -> Result<void> {
         for (auto& selector : clause.selectors) {
             UNWRAP(selectorType, infer(selector, Evaluation::Runtime));
             if (unify(valueType, selectorType)) {
@@ -1197,7 +1197,7 @@ Result<void> TypeChecker::visit(AST::Expression& expression)
 
 Result<void> TypeChecker::visit(AST::FieldAccessExpression& access)
 {
-    const auto& accessImpl = [&](const Type* baseType, bool* canBeReference = nullptr, bool* isVector = nullptr) WARN_UNUSED_RETURN -> Result<const Type*> {
+    const auto& accessImpl = [&](const Type* baseType, bool* canBeReference = nullptr, bool* isVector = nullptr) -> Result<const Type*> {
         if (std::holds_alternative<Types::Struct>(*baseType)) {
             auto& structType = std::get<Types::Struct>(*baseType);
             auto it = structType.fields.find(access.fieldName().id());
@@ -1238,7 +1238,7 @@ Result<void> TypeChecker::visit(AST::FieldAccessExpression& access)
         TYPE_ERROR(access.span(), "invalid member access expression. Expected vector or struct, got '"_s, *baseType, '\'');
     };
 
-    const auto& referenceImpl = [&](const auto& type) WARN_UNUSED_RETURN -> Result<void> {
+    const auto& referenceImpl = [&](const auto& type) -> Result<void> {
         bool canBeReference = true;
         bool isVector = false;
 
@@ -1266,7 +1266,7 @@ Result<void> TypeChecker::visit(AST::FieldAccessExpression& access)
 
 Result<void> TypeChecker::visit(AST::IndexAccessExpression& access)
 {
-    const auto& constantAccess = [&]<typename T>(std::optional<unsigned> typeSize) WARN_UNUSED_RETURN -> Result<void> {
+    const auto& constantAccess = [&]<typename T>(std::optional<unsigned> typeSize) -> Result<void> {
         auto constantBase = access.base().constantValue();
         auto constantIndex = access.index().constantValue();
 
@@ -1288,7 +1288,7 @@ Result<void> TypeChecker::visit(AST::IndexAccessExpression& access)
         return { };
     };
 
-    const auto& accessImpl = [&](const Type* base, bool* isVector = nullptr) WARN_UNUSED_RETURN -> Result<const Type*> {
+    const auto& accessImpl = [&](const Type* base, bool* isVector = nullptr) -> Result<const Type*> {
         const Type* result = nullptr;
         if (auto* array = std::get_if<Types::Array>(base)) {
             result = array->element;
@@ -1322,7 +1322,7 @@ Result<void> TypeChecker::visit(AST::IndexAccessExpression& access)
     if (!unify(m_types.i32Type(), index) && !unify(m_types.u32Type(), index) && !unify(m_types.abstractIntType(), index)) [[unlikely]]
         TYPE_ERROR(access.span(), "index must be of type 'i32' or 'u32', found: '"_s, *index, '\'');
 
-    const auto& referenceImpl = [&](const auto& type) WARN_UNUSED_RETURN -> Result<void> {
+    const auto& referenceImpl = [&](const auto& type) -> Result<void> {
         bool isVector = false;
         UNWRAP(result, accessImpl(type.element, &isVector));
         result = m_types.referenceType(type.addressSpace, result, type.accessMode, isVector);
@@ -1406,7 +1406,7 @@ Result<void> TypeChecker::visit(AST::CallExpression& call)
     bool isArrayType = is<AST::ArrayTypeExpression>(target);
 
     Vector<const Type*> typeArguments;
-    UNWRAP(targetName, [&]() WARN_UNUSED_RETURN -> Result<String> {
+    UNWRAP(targetName, [&]() -> Result<String> {
         if (isNamedType)
             return { downcast<AST::IdentifierExpression>(target).identifier() };
         if (isArrayType)
@@ -2662,7 +2662,7 @@ Result<void> TypeChecker::allocateSimpleConstructor(ASCIILiteral name, TargetCon
 {
     return introduceType(AST::Identifier::make(name), m_types.typeConstructorType(
         name,
-        [this, constructor, &validate, arguments...](AST::ElaboratedTypeExpression& type) WARN_UNUSED_RETURN -> Result<const Type*> {
+        [this, constructor, &validate, arguments...](AST::ElaboratedTypeExpression& type) -> Result<const Type*> {
             if (type.arguments().size() != 1) [[unlikely]]
                 TYPE_ERROR(type.span(), '\'', type.base(), "' requires 1 template argument"_s);
 
@@ -2680,7 +2680,7 @@ Result<void> TypeChecker::allocateTextureStorageConstructor(ASCIILiteral name, T
 {
     return introduceType(AST::Identifier::make(name), m_types.typeConstructorType(
         name,
-        [this, kind](AST::ElaboratedTypeExpression& type) WARN_UNUSED_RETURN -> Result<const Type*> {
+        [this, kind](AST::ElaboratedTypeExpression& type) -> Result<const Type*> {
             if (type.arguments().size() != 2) [[unlikely]]
                 TYPE_ERROR(type.span(), '\'', type.base(), "' requires 2 template argument"_s);
 

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1449,7 +1449,7 @@ uint64_t BindGroup::makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLay
     return (static_cast<uint64_t>(aspect) - 1) | (static_cast<uint64_t>(baseMipLevel) << 1) | (static_cast<uint64_t>(baseArrayLayer) << 32);
 }
 
-static bool WARN_UNUSED_RETURN setArgumentBuffer(id<MTLArgumentEncoder> encoder, id<MTLBuffer> buffer)
+WARN_UNUSED_RETURN static bool setArgumentBuffer(id<MTLArgumentEncoder> encoder, id<MTLBuffer> buffer)
 {
     if (!encoder || !buffer)
         return false;

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -98,7 +98,7 @@ public:
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
-    uint64_t WARN_UNUSED_RETURN retainCounterSampleBuffer(CommandEncoder&);
+    WARN_UNUSED_RETURN uint64_t retainCounterSampleBuffer(CommandEncoder&);
     void releaseCounterSampleBuffer(uint64_t);
     void retainTimestampsForOneUpdate(NSMutableSet<id<MTLCounterSampleBuffer>> *);
     void waitForAllCommitedWorkToComplete();

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -116,7 +116,7 @@ public:
         uint64_t offset;
     };
     static DrawIndexResult clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
-    bool WARN_UNUSED_RETURN splitRenderPass();
+    WARN_UNUSED_RETURN bool splitRenderPass();
     static std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(const RenderPipeline*, bool& needsValidationLayerWorkaround, uint64_t (^)(uint32_t));
 
 private:

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -147,7 +147,7 @@ private:
     void mergeStatistic(const ResourceLoadStatistics&);
     void merge(WebCore::SQLiteStatement*, const ResourceLoadStatistics&);
     void clearDatabaseContents();
-    bool insertObservedDomain(const ResourceLoadStatistics&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool insertObservedDomain(const ResourceLoadStatistics&);
     void insertDomainRelationships(const ResourceLoadStatistics&);
     void insertDomainRelationshipList(const String&, const HashSet<RegistrableDomain>&, unsigned);
     bool relationshipExists(WebCore::SQLiteStatementAutoResetScope&, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const;
@@ -203,7 +203,7 @@ private:
     void removeDataRecords(CompletionHandler<void()>&&);
     void pruneStatisticsIfNeeded() override;
     enum class AddedRecord : bool { No, Yes };
-    std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&);
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldRemoveAllButCookiesFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldEnforceSameSiteStrictFor(DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -255,7 +255,7 @@ private:
     void mergeStatistic(const ResourceLoadStatistics&);
     void merge(WebCore::SQLiteStatement*, const ResourceLoadStatistics&);
     void incrementRecordsDeletedCountForDomains(HashSet<RegistrableDomain>&&);
-    bool insertObservedDomain(const ResourceLoadStatistics&) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN bool insertObservedDomain(const ResourceLoadStatistics&);
     void insertDomainRelationships(const ResourceLoadStatistics&);
     void insertDomainRelationshipList(const String&, const HashSet<RegistrableDomain>&, unsigned);
     bool relationshipExists(WebCore::SQLiteStatementAutoResetScope&, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const;
@@ -310,7 +310,7 @@ private:
     void markAsPrevalentIfHasRedirectedToPrevalent();
     
     // reason is used for logging purpose.
-    std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&, ASCIILiteral reason) WARN_UNUSED_RETURN;
+    WARN_UNUSED_RETURN std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&, ASCIILiteral reason);
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldRemoveAllButCookiesFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldEnforceSameSiteStrictFor(DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -48,7 +48,7 @@ protected:
     ~DatabaseUtilities();
 
     WebCore::SQLiteStatementAutoResetScope scopedStatement(std::unique_ptr<WebCore::SQLiteStatement>&, ASCIILiteral query, ASCIILiteral logString) const;
-    ScopeExit<Function<void()>> WARN_UNUSED_RETURN beginTransactionIfNecessary();
+    WARN_UNUSED_RETURN ScopeExit<Function<void()>> beginTransactionIfNecessary();
     enum class CreatedNewFile : bool { No, Yes };
     CreatedNewFile openDatabaseAndCreateSchemaIfNecessary();
     void enableForeignKeys();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -47,7 +47,7 @@ struct DataKey {
         encoder << partition << type << identifier;
     }
 
-    template <class Decoder> static WARN_UNUSED_RETURN bool decodeForPersistence(Decoder& decoder, DataKey& dataKey)
+    template <class Decoder> WARN_UNUSED_RETURN static bool decodeForPersistence(Decoder& decoder, DataKey& dataKey)
     {
         return decoder.decode(dataKey.partition) && decoder.decode(dataKey.type) && decoder.decode(dataKey.identifier);
     }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -594,7 +594,7 @@ struct RecordMetaData {
     uint64_t headerOffset { 0 };
 };
 
-static WARN_UNUSED_RETURN bool decodeRecordMetaData(RecordMetaData& metaData, const Data& fileData)
+WARN_UNUSED_RETURN static bool decodeRecordMetaData(RecordMetaData& metaData, const Data& fileData)
 {
     bool success = false;
     fileData.apply([&metaData, &success](std::span<const uint8_t> span) {
@@ -658,7 +658,7 @@ static WARN_UNUSED_RETURN bool decodeRecordMetaData(RecordMetaData& metaData, co
     return success;
 }
 
-static WARN_UNUSED_RETURN bool decodeRecordHeader(const Data& fileData, RecordMetaData& metaData, Data& headerData, const Salt& salt)
+WARN_UNUSED_RETURN static bool decodeRecordHeader(const Data& fileData, RecordMetaData& metaData, Data& headerData, const Salt& salt)
 {
     if (!decodeRecordMetaData(metaData, fileData)) {
         LOG(NetworkCacheStorage, "(NetworkProcess) meta data decode failure");

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1720,7 +1720,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
 
     MESSAGE_CHECK_COMPLETION(isStorageAreaTypeEnabled(connection, storageArea->storageType()), connection, completionHandler());
 
-    storageArea->clear(connection.uniqueID(), implIdentifier, WTFMove(urlString));
+    std::ignore = storageArea->clear(connection.uniqueID(), implIdentifier, WTFMove(urlString));
     completionHandler();
 
     writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());

--- a/Source/WebKit/Platform/IPC/ConnectionHandle.h
+++ b/Source/WebKit/Platform/IPC/ConnectionHandle.h
@@ -55,19 +55,19 @@ public:
         : m_handle(WTFMove(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
-    int release() WARN_UNUSED_RETURN { return m_handle.release(); }
+    WARN_UNUSED_RETURN int release() { return m_handle.release(); }
 #elif OS(WINDOWS)
     ConnectionHandle(Win32Handle&& inHandle)
         : m_handle(WTFMove(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
-    HANDLE leak() WARN_UNUSED_RETURN { return m_handle.leak(); }
+    WARN_UNUSED_RETURN HANDLE leak() { return m_handle.leak(); }
 #elif OS(DARWIN)
     ConnectionHandle(MachSendRight&& sendRight)
         : m_handle(WTFMove(sendRight))
     { }
     explicit operator bool() const { return MACH_PORT_VALID(m_handle.sendRight()); }
-    mach_port_t leakSendRight() WARN_UNUSED_RETURN { return m_handle.leakSendRight(); }
+    WARN_UNUSED_RETURN mach_port_t leakSendRight() { return m_handle.leakSendRight(); }
 #endif
 
 private:

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -56,7 +56,7 @@ SandboxExtensionImpl::~SandboxExtensionImpl()
         secureMemsetSpan(m_token.mutableSpan(), 0);
 }
 
-bool WARN_UNUSED_RETURN SandboxExtensionImpl::consume()
+WARN_UNUSED_RETURN bool SandboxExtensionImpl::consume()
 {
     m_handle = sandbox_extension_consume(m_token.data());
 #if PLATFORM(IOS_FAMILY_SIMULATOR)

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -61,9 +61,9 @@ public:
     SandboxExtensionImpl(std::span<const uint8_t>);
     ~SandboxExtensionImpl();
 
-    bool WARN_UNUSED_RETURN consume();
+    WARN_UNUSED_RETURN bool consume();
     bool invalidate();
-    std::span<const uint8_t> WARN_UNUSED_RETURN getSerializedFormat();
+    WARN_UNUSED_RETURN std::span<const uint8_t> getSerializedFormat();
 
     SandboxExtensionImpl(SandboxExtensionImpl&& other)
         : m_token(std::exchange(other.m_token, CString()))

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -123,7 +123,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
 
 void WebExtensionContext::runtimeReload()
 {
-    reload();
+    std::ignore = reload();
 }
 
 void WebExtensionContext::runtimeSendMessage(const String& extensionID, const String& messageJSON, const WebExtensionMessageSenderParameters& senderParameters, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -362,7 +362,7 @@ void WebExtensionController::unloadAll()
 {
     auto contextsCopy = m_extensionContexts;
     for (Ref context : contextsCopy)
-        unload(context);
+        std::ignore = unload(context);
 }
 
 void WebExtensionController::dispatchDidLoad(WebExtensionContext& context)

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
@@ -65,7 +65,7 @@ void InspectorBrowserAgent::didCreateFrontendAndBackend()
 
 void InspectorBrowserAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
-    disable();
+    std::ignore = disable();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorBrowserAgent::enable()

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -977,7 +977,7 @@ static void decodeBackForwardTreeNode(HistoryEntryDataDecoder& decoder, FrameSta
 #endif
 }
 
-static WARN_UNUSED_RETURN bool decodeSessionHistoryEntryData(std::span<const uint8_t> buffer, FrameState& mainFrameState)
+WARN_UNUSED_RETURN static bool decodeSessionHistoryEntryData(std::span<const uint8_t> buffer, FrameState& mainFrameState)
 {
     HistoryEntryDataDecoder decoder { buffer };
 
@@ -992,12 +992,12 @@ static WARN_UNUSED_RETURN bool decodeSessionHistoryEntryData(std::span<const uin
     return decoder.finishDecoding();
 }
 
-static WARN_UNUSED_RETURN bool decodeSessionHistoryEntryData(CFDataRef historyEntryData, FrameState& mainFrameState)
+WARN_UNUSED_RETURN static bool decodeSessionHistoryEntryData(CFDataRef historyEntryData, FrameState& mainFrameState)
 {
     return decodeSessionHistoryEntryData(span(historyEntryData), mainFrameState);
 }
 
-static WARN_UNUSED_RETURN bool decodeSessionHistoryEntry(CFDictionaryRef entryDictionary, FrameState& backForwardListItemState)
+WARN_UNUSED_RETURN static bool decodeSessionHistoryEntry(CFDictionaryRef entryDictionary, FrameState& backForwardListItemState)
 {
     RetainPtr title = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(entryDictionary, sessionHistoryEntryTitleKey));
     if (!title)
@@ -1032,7 +1032,7 @@ static WARN_UNUSED_RETURN bool decodeSessionHistoryEntry(CFDictionaryRef entryDi
     return true;
 }
 
-static WARN_UNUSED_RETURN bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<Ref<FrameState>>& entries)
+WARN_UNUSED_RETURN static bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<Ref<FrameState>>& entries)
 {
     for (CFIndex i = 0, size = CFArrayGetCount(entriesArray); i < size; ++i) {
         RetainPtr entryDictionary = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(entriesArray, i));
@@ -1049,7 +1049,7 @@ static WARN_UNUSED_RETURN bool decodeSessionHistoryEntries(CFArrayRef entriesArr
     return true;
 }
 
-static WARN_UNUSED_RETURN bool decodeV0SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
+WARN_UNUSED_RETURN static bool decodeV0SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr currentIndexNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(sessionHistoryDictionary, sessionHistoryCurrentIndexKey));
     if (!currentIndexNumber)
@@ -1085,7 +1085,7 @@ static WARN_UNUSED_RETURN bool decodeV0SessionHistory(CFDictionaryRef sessionHis
     return true;
 }
 
-static WARN_UNUSED_RETURN bool decodeV1SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
+WARN_UNUSED_RETURN static bool decodeV1SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr currentIndexNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(sessionHistoryDictionary, sessionHistoryCurrentIndexKey));
     if (!currentIndexNumber) {
@@ -1116,7 +1116,7 @@ static WARN_UNUSED_RETURN bool decodeV1SessionHistory(CFDictionaryRef sessionHis
     return true;
 }
 
-static WARN_UNUSED_RETURN bool decodeSessionHistory(CFDictionaryRef backForwardListDictionary, BackForwardListState& backForwardListState)
+WARN_UNUSED_RETURN static bool decodeSessionHistory(CFDictionaryRef backForwardListDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr sessionHistoryVersionNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(backForwardListDictionary, sessionHistoryVersionKey));
     if (!sessionHistoryVersionNumber) {

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -63,7 +63,7 @@ public:
     String cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, WebCore::IncludeSecureCookies);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const String& cookieString, WebCore::ShouldRelaxThirdPartyCookieBlocking);
 
-    PendingCookieUpdateCounter::Token WARN_UNUSED_RETURN willSetCookieFromDOM();
+    WARN_UNUSED_RETURN PendingCookieUpdateCounter::Token willSetCookieFromDOM();
     void didSetCookieFromDOM(PendingCookieUpdateCounter::Token, const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const WebCore::Cookie&, WebCore::ShouldRelaxThirdPartyCookieBlocking);
 
     void allCookiesDeleted();

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -343,7 +343,7 @@ static ASCIILiteral statusText(unsigned statusCode)
 static Vector<uint8_t> toUTF8Vector(const String& string)
 {
     Vector<uint8_t> result;
-    string.tryGetUTF8([&](std::span<const char8_t> utf8) {
+    std::ignore = string.tryGetUTF8([&](std::span<const char8_t> utf8) {
         result.append(byteCast<uint8_t>(utf8));
         return true;
     });


### PR DESCRIPTION
#### 8b9bc965527bbea25f4088a426c343e4ba988cc5
<pre>
Modernize WTF WARN_UNUSED_RETURN to use C++17 [[nodiscard]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=303730">https://bugs.webkit.org/show_bug.cgi?id=303730</a>
<a href="https://rdar.apple.com/166033098">rdar://166033098</a>

Reviewed by Chris Dumez.

Replace GCC compiler-specific annotation with standard C++17 [[nodiscard]] attribute.

This moves WARN_UNUSED_RETURN to the left side of the expression, as [[nodiscard]]
requires stricter placement than the GCC annotation.

Tests: Source/JavaScriptCore/API/tests/testapi.cpp
       Tools/TestWebKitAPI/cocoa/HTTPServer.mm
* Source/JavaScriptCore/API/JSRetainPtr.h:
* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::promiseUnhandledRejectionFromUnhandledRejectionCallback):
(TestAPI::promiseEarlyHandledRejections):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h:
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::withIndexingType):
(): Deleted.
* Source/JavaScriptCore/heap/Weak.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp:
(Inspector::JSGlobalObjectConsoleClient::startConsoleProfile):
(Inspector::JSGlobalObjectConsoleClient::stopConsoleProfile):
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::frontendInitialized):
* Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp:
(Inspector::InspectorAgent::willDestroyFrontendAndBackend):
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::willDestroyFrontendAndBackend):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::didBecomeIdle):
(Inspector::InspectorDebuggerAgent::clearInspectorBreakpointState):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::willDestroyFrontendAndBackend):
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::willDestroyFrontendAndBackend):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::resize):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::decodeHexImpl):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::ensureLength):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::add):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElemDrop):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSize):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::getLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::teeLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::addGrowMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCurrentMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDataDrop):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicBinaryRMW):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicWait):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicNotify):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicFence):
(JSC::Wasm::BBQJITImpl::BBQJIT::truncTrapping):
(JSC::Wasm::BBQJITImpl::BBQJIT::truncSaturated):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewElem):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayInitElem):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayInitData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addAnyConvertExtern):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExternConvertAny):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32RemS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64RemS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32RemU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64RemU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Div):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Div):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Max):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Max):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Lt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Lt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Le):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Le):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Gt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Gt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ge):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ge):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Popcnt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ReinterpretF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ReinterpretI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32DemoteF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64PromoteF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Copysign):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Copysign):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Abs):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Abs):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Sqrt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Sqrt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Neg):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Neg):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncSF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncSF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncUF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncUF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncSF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncSF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncUF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncUF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefEq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefFunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBlock):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoop):
(JSC::Wasm::BBQJITImpl::BBQJIT::addIf):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElse):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElseToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTry):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTryTable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatch):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchAll):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchAllToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDelegate):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDelegateToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReturn):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranch):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSwitch):
(JSC::Wasm::BBQJITImpl::BBQJIT::endBlock):
(JSC::Wasm::BBQJITImpl::BBQJIT::addEndToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCrash):
(JSC::Wasm::BBQJITImpl::BBQJIT::addFusedIfCompare):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicLoadOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefI31):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefTest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend8S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend32S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ReinterpretF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ReinterpretI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefIsNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRethrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShuffle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtmul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStoreLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadExtend):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadPad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDI_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDBitwiseSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_VV):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelaxedFMA):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicLoadOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefI31):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefTest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend8S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend32S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ReinterpretF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ReinterpretI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefIsNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRethrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShuffle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtmul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStoreLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadExtend):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadPad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDI_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDBitwiseSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::fixupOutOfBoundsIndicesForSwizzle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_VV):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelaxedFMA):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::fail const):
(JSC::Wasm::ConstExprGenerator::getGlobal):
(JSC::Wasm::ConstExprGenerator::addRefI31):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addExternConvertAny):
(JSC::Wasm::ConstExprGenerator::addI32Add):
(JSC::Wasm::ConstExprGenerator::addI64Add):
(JSC::Wasm::ConstExprGenerator::addI32Sub):
(JSC::Wasm::ConstExprGenerator::addI64Sub):
(JSC::Wasm::ConstExprGenerator::addI32Mul):
(JSC::Wasm::ConstExprGenerator::addI64Mul):
(JSC::Wasm::ConstExprGenerator::addRefFunc):
(JSC::Wasm::ConstExprGenerator::endBlock):
(JSC::Wasm::ConstExprGenerator::endTopLevel):
(JSC::Wasm::ConstExprGenerator::addConstant):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::simd):
(JSC::Wasm::FunctionParser::validationFail const):
(JSC::Wasm::FunctionParser::validationFailHelper const):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::fail const):
(JSC::Wasm::IPIntGenerator::addFusedBranchCompare):
(JSC::Wasm::IPIntGenerator::addFusedIfCompare):
(JSC::Wasm::IPIntGenerator::addDrop):
(JSC::Wasm::IPIntGenerator::addSIMDLoad):
(JSC::Wasm::IPIntGenerator::addSIMDStore):
(JSC::Wasm::IPIntGenerator::addSIMDSplat):
(JSC::Wasm::IPIntGenerator::addSIMDShuffle):
(JSC::Wasm::IPIntGenerator::addSIMDShift):
(JSC::Wasm::IPIntGenerator::addSIMDExtmul):
(JSC::Wasm::IPIntGenerator::addSIMDLoadSplat):
(JSC::Wasm::IPIntGenerator::addSIMDLoadLane):
(JSC::Wasm::IPIntGenerator::addSIMDStoreLane):
(JSC::Wasm::IPIntGenerator::addSIMDLoadExtend):
(JSC::Wasm::IPIntGenerator::addSIMDLoadPad):
(JSC::Wasm::IPIntGenerator::addExtractLane):
(JSC::Wasm::IPIntGenerator::addReplaceLane):
(JSC::Wasm::IPIntGenerator::addSIMDI_V):
(JSC::Wasm::IPIntGenerator::addSIMDV_V):
(JSC::Wasm::IPIntGenerator::addSIMDBitwiseSelect):
(JSC::Wasm::IPIntGenerator::addSIMDRelOp):
(JSC::Wasm::IPIntGenerator::addSIMDV_VV):
(JSC::Wasm::IPIntGenerator::addSIMDRelaxedFMA):
(JSC::Wasm::IPIntGenerator::addRefIsNull):
(JSC::Wasm::IPIntGenerator::addRefFunc):
(JSC::Wasm::IPIntGenerator::addRefAsNonNull):
(JSC::Wasm::IPIntGenerator::addRefEq):
(JSC::Wasm::IPIntGenerator::addTableGet):
(JSC::Wasm::IPIntGenerator::addTableSet):
(JSC::Wasm::IPIntGenerator::addTableInit):
(JSC::Wasm::IPIntGenerator::addElemDrop):
(JSC::Wasm::IPIntGenerator::addTableSize):
(JSC::Wasm::IPIntGenerator::addTableGrow):
(JSC::Wasm::IPIntGenerator::addTableFill):
(JSC::Wasm::IPIntGenerator::addTableCopy):
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::IPIntGenerator::addLocal):
(JSC::Wasm::IPIntGenerator::getLocal):
(JSC::Wasm::IPIntGenerator::setLocal):
(JSC::Wasm::IPIntGenerator::teeLocal):
(JSC::Wasm::IPIntGenerator::getGlobal):
(JSC::Wasm::IPIntGenerator::setGlobal):
(JSC::Wasm::IPIntGenerator::load):
(JSC::Wasm::IPIntGenerator::store):
(JSC::Wasm::IPIntGenerator::addGrowMemory):
(JSC::Wasm::IPIntGenerator::addCurrentMemory):
(JSC::Wasm::IPIntGenerator::addMemoryFill):
(JSC::Wasm::IPIntGenerator::addMemoryCopy):
(JSC::Wasm::IPIntGenerator::addMemoryInit):
(JSC::Wasm::IPIntGenerator::addDataDrop):
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicWait):
(JSC::Wasm::IPIntGenerator::atomicNotify):
(JSC::Wasm::IPIntGenerator::atomicFence):
(JSC::Wasm::IPIntGenerator::addRefI31):
(JSC::Wasm::IPIntGenerator::addI31GetS):
(JSC::Wasm::IPIntGenerator::addI31GetU):
(JSC::Wasm::IPIntGenerator::addArrayNew):
(JSC::Wasm::IPIntGenerator::addArrayNewData):
(JSC::Wasm::IPIntGenerator::addArrayNewElem):
(JSC::Wasm::IPIntGenerator::addArrayNewFixed):
(JSC::Wasm::IPIntGenerator::addArrayNewDefault):
(JSC::Wasm::IPIntGenerator::addArrayGet):
(JSC::Wasm::IPIntGenerator::addArraySet):
(JSC::Wasm::IPIntGenerator::addArrayLen):
(JSC::Wasm::IPIntGenerator::addArrayFill):
(JSC::Wasm::IPIntGenerator::addArrayCopy):
(JSC::Wasm::IPIntGenerator::addArrayInitElem):
(JSC::Wasm::IPIntGenerator::addArrayInitData):
(JSC::Wasm::IPIntGenerator::addStructNew):
(JSC::Wasm::IPIntGenerator::addStructNewDefault):
(JSC::Wasm::IPIntGenerator::addStructGet):
(JSC::Wasm::IPIntGenerator::addStructSet):
(JSC::Wasm::IPIntGenerator::addRefTest):
(JSC::Wasm::IPIntGenerator::addRefCast):
(JSC::Wasm::IPIntGenerator::addAnyConvertExtern):
(JSC::Wasm::IPIntGenerator::addExternConvertAny):
(JSC::Wasm::IPIntGenerator::addI32Add):
(JSC::Wasm::IPIntGenerator::addI64Add):
(JSC::Wasm::IPIntGenerator::addI32Sub):
(JSC::Wasm::IPIntGenerator::addI64Sub):
(JSC::Wasm::IPIntGenerator::addI32Mul):
(JSC::Wasm::IPIntGenerator::addI64Mul):
(JSC::Wasm::IPIntGenerator::addI32DivS):
(JSC::Wasm::IPIntGenerator::addI32DivU):
(JSC::Wasm::IPIntGenerator::addI64DivS):
(JSC::Wasm::IPIntGenerator::addI64DivU):
(JSC::Wasm::IPIntGenerator::addI32RemS):
(JSC::Wasm::IPIntGenerator::addI32RemU):
(JSC::Wasm::IPIntGenerator::addI64RemS):
(JSC::Wasm::IPIntGenerator::addI64RemU):
(JSC::Wasm::IPIntGenerator::addI32And):
(JSC::Wasm::IPIntGenerator::addI64And):
(JSC::Wasm::IPIntGenerator::addI32Xor):
(JSC::Wasm::IPIntGenerator::addI64Xor):
(JSC::Wasm::IPIntGenerator::addI32Or):
(JSC::Wasm::IPIntGenerator::addI64Or):
(JSC::Wasm::IPIntGenerator::addI32Shl):
(JSC::Wasm::IPIntGenerator::addI32ShrU):
(JSC::Wasm::IPIntGenerator::addI32ShrS):
(JSC::Wasm::IPIntGenerator::addI64Shl):
(JSC::Wasm::IPIntGenerator::addI64ShrU):
(JSC::Wasm::IPIntGenerator::addI64ShrS):
(JSC::Wasm::IPIntGenerator::addI32Rotl):
(JSC::Wasm::IPIntGenerator::addI64Rotl):
(JSC::Wasm::IPIntGenerator::addI32Rotr):
(JSC::Wasm::IPIntGenerator::addI64Rotr):
(JSC::Wasm::IPIntGenerator::addI32Popcnt):
(JSC::Wasm::IPIntGenerator::addI64Popcnt):
(JSC::Wasm::IPIntGenerator::addI32Clz):
(JSC::Wasm::IPIntGenerator::addI64Clz):
(JSC::Wasm::IPIntGenerator::addI32Ctz):
(JSC::Wasm::IPIntGenerator::addI64Ctz):
(JSC::Wasm::IPIntGenerator::addF32Add):
(JSC::Wasm::IPIntGenerator::addF64Add):
(JSC::Wasm::IPIntGenerator::addF32Sub):
(JSC::Wasm::IPIntGenerator::addF64Sub):
(JSC::Wasm::IPIntGenerator::addF32Mul):
(JSC::Wasm::IPIntGenerator::addF64Mul):
(JSC::Wasm::IPIntGenerator::addF32Div):
(JSC::Wasm::IPIntGenerator::addF64Div):
(JSC::Wasm::IPIntGenerator::addF32Min):
(JSC::Wasm::IPIntGenerator::addF32Max):
(JSC::Wasm::IPIntGenerator::addF64Min):
(JSC::Wasm::IPIntGenerator::addF64Max):
(JSC::Wasm::IPIntGenerator::addF32Nearest):
(JSC::Wasm::IPIntGenerator::addF64Nearest):
(JSC::Wasm::IPIntGenerator::addF32Floor):
(JSC::Wasm::IPIntGenerator::addF64Floor):
(JSC::Wasm::IPIntGenerator::addF32Ceil):
(JSC::Wasm::IPIntGenerator::addF64Ceil):
(JSC::Wasm::IPIntGenerator::addF32Copysign):
(JSC::Wasm::IPIntGenerator::addF64Copysign):
(JSC::Wasm::IPIntGenerator::addF32Sqrt):
(JSC::Wasm::IPIntGenerator::addF64Sqrt):
(JSC::Wasm::IPIntGenerator::addF32Neg):
(JSC::Wasm::IPIntGenerator::addF64Neg):
(JSC::Wasm::IPIntGenerator::addF32Abs):
(JSC::Wasm::IPIntGenerator::addF64Abs):
(JSC::Wasm::IPIntGenerator::addI32Eq):
(JSC::Wasm::IPIntGenerator::addI32Ne):
(JSC::Wasm::IPIntGenerator::addI32LtS):
(JSC::Wasm::IPIntGenerator::addI32LtU):
(JSC::Wasm::IPIntGenerator::addI32LeS):
(JSC::Wasm::IPIntGenerator::addI32LeU):
(JSC::Wasm::IPIntGenerator::addI32GtS):
(JSC::Wasm::IPIntGenerator::addI32GtU):
(JSC::Wasm::IPIntGenerator::addI32GeU):
(JSC::Wasm::IPIntGenerator::addI32GeS):
(JSC::Wasm::IPIntGenerator::addI32Eqz):
(JSC::Wasm::IPIntGenerator::addI64Eq):
(JSC::Wasm::IPIntGenerator::addI64Ne):
(JSC::Wasm::IPIntGenerator::addI64GtS):
(JSC::Wasm::IPIntGenerator::addI64GtU):
(JSC::Wasm::IPIntGenerator::addI64GeS):
(JSC::Wasm::IPIntGenerator::addI64GeU):
(JSC::Wasm::IPIntGenerator::addI64LtS):
(JSC::Wasm::IPIntGenerator::addI64LtU):
(JSC::Wasm::IPIntGenerator::addI64LeS):
(JSC::Wasm::IPIntGenerator::addI64LeU):
(JSC::Wasm::IPIntGenerator::addI64Eqz):
(JSC::Wasm::IPIntGenerator::addF32Eq):
(JSC::Wasm::IPIntGenerator::addF32Ne):
(JSC::Wasm::IPIntGenerator::addF32Lt):
(JSC::Wasm::IPIntGenerator::addF32Le):
(JSC::Wasm::IPIntGenerator::addF32Gt):
(JSC::Wasm::IPIntGenerator::addF32Ge):
(JSC::Wasm::IPIntGenerator::addF64Eq):
(JSC::Wasm::IPIntGenerator::addF64Ne):
(JSC::Wasm::IPIntGenerator::addF64Lt):
(JSC::Wasm::IPIntGenerator::addF64Le):
(JSC::Wasm::IPIntGenerator::addF64Gt):
(JSC::Wasm::IPIntGenerator::addF64Ge):
(JSC::Wasm::IPIntGenerator::addI64ExtendSI32):
(JSC::Wasm::IPIntGenerator::addI64ExtendUI32):
(JSC::Wasm::IPIntGenerator::addI32Extend8S):
(JSC::Wasm::IPIntGenerator::addI32Extend16S):
(JSC::Wasm::IPIntGenerator::addI64Extend8S):
(JSC::Wasm::IPIntGenerator::addI64Extend16S):
(JSC::Wasm::IPIntGenerator::addI64Extend32S):
(JSC::Wasm::IPIntGenerator::addF64Trunc):
(JSC::Wasm::IPIntGenerator::addF32Trunc):
(JSC::Wasm::IPIntGenerator::addI32TruncSF64):
(JSC::Wasm::IPIntGenerator::addI32TruncSF32):
(JSC::Wasm::IPIntGenerator::addI32TruncUF64):
(JSC::Wasm::IPIntGenerator::addI32TruncUF32):
(JSC::Wasm::IPIntGenerator::addI64TruncSF64):
(JSC::Wasm::IPIntGenerator::addI64TruncSF32):
(JSC::Wasm::IPIntGenerator::addI64TruncUF64):
(JSC::Wasm::IPIntGenerator::addI64TruncUF32):
(JSC::Wasm::IPIntGenerator::truncSaturated):
(JSC::Wasm::IPIntGenerator::addI32WrapI64):
(JSC::Wasm::IPIntGenerator::addF32DemoteF64):
(JSC::Wasm::IPIntGenerator::addF64PromoteF32):
(JSC::Wasm::IPIntGenerator::addF32ReinterpretI32):
(JSC::Wasm::IPIntGenerator::addI32ReinterpretF32):
(JSC::Wasm::IPIntGenerator::addF64ReinterpretI64):
(JSC::Wasm::IPIntGenerator::addI64ReinterpretF64):
(JSC::Wasm::IPIntGenerator::addF32ConvertSI32):
(JSC::Wasm::IPIntGenerator::addF32ConvertUI32):
(JSC::Wasm::IPIntGenerator::addF32ConvertSI64):
(JSC::Wasm::IPIntGenerator::addF32ConvertUI64):
(JSC::Wasm::IPIntGenerator::addF64ConvertSI32):
(JSC::Wasm::IPIntGenerator::addF64ConvertUI32):
(JSC::Wasm::IPIntGenerator::addF64ConvertSI64):
(JSC::Wasm::IPIntGenerator::addF64ConvertUI64):
(JSC::Wasm::IPIntGenerator::addTopLevel):
(JSC::Wasm::IPIntGenerator::addSelect):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElse):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addTry):
(JSC::Wasm::IPIntGenerator::addTryTable):
(JSC::Wasm::IPIntGenerator::addCatch):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAll):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegate):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addThrow):
(JSC::Wasm::IPIntGenerator::addRethrow):
(JSC::Wasm::IPIntGenerator::addThrowRef):
(JSC::Wasm::IPIntGenerator::addReturn):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addBranchNull):
(JSC::Wasm::IPIntGenerator::addBranchCast):
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::endBlock):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
(JSC::Wasm::IPIntGenerator::addUnreachable):
(JSC::Wasm::IPIntGenerator::addCrash):
* Source/JavaScriptCore/wasm/WasmNameSectionParser.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::fail const):
(JSC::Wasm::OMGIRGenerator::addConstant):
(JSC::Wasm::OMGIRGenerator::addEndToUnreachable):
(JSC::Wasm::OMGIRGenerator::endTopLevel):
(JSC::Wasm::OMGIRGenerator::addFusedBranchCompare):
(JSC::Wasm::OMGIRGenerator::addFusedIfCompare):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addConstant):
(JSC::Wasm::OMGIRGenerator::addEndToUnreachable):
(JSC::Wasm::OMGIRGenerator::endTopLevel):
(JSC::Wasm::OMGIRGenerator::addFusedBranchCompare):
(JSC::Wasm::OMGIRGenerator::addFusedIfCompare):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::fail const):
* Source/JavaScriptCore/wasm/WasmPlan.h:
(JSC::Wasm::Plan::failed const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::fail):
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
* Source/WTF/wtf/AllocSpanMixin.h:
(WTF::AllocSpanMixin::leakSpan):
* Source/WTF/wtf/CheckedArithmetic.h:
* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/Function.h:
(WTF::Function&lt;Out):
* Source/WTF/wtf/LEBDecoder.h:
(WTF::LEBDecoder::decodeUInt):
(WTF::LEBDecoder::decodeInt):
(WTF::LEBDecoder::decodeUInt32):
(WTF::LEBDecoder::decodeUInt64):
(WTF::LEBDecoder::decodeInt32):
(WTF::LEBDecoder::decodeInt64):
* Source/WTF/wtf/MachSendRight.h:
* Source/WTF/wtf/MallocCommon.h:
* Source/WTF/wtf/MallocPtr.h:
(WTF::MallocPtr::leakPtr):
* Source/WTF/wtf/MappedFileData.h:
(WTF::FileSystemImpl::MappedFileData::leakHandle):
* Source/WTF/wtf/OSObjectPtr.h:
(WTF::OSObjectPtr::leakRef):
* Source/WTF/wtf/Ref.h:
(WTF::Ref::copyRef const):
(WTF::Ref::leakRef):
* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::copyRef const):
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/Scope.h:
* Source/WTF/wtf/glib/GRefPtr.h:
(WTF::GRefPtr::leakRef):
(WTF::GRefPtr::ref):
* Source/WTF/wtf/persistence/PersistentDecoder.h:
* Source/WTF/wtf/text/AtomString.h:
(WTF::makeStringByReplacingAll):
* Source/WTF/wtf/text/MakeString.h:
(WTF::makeStringByInserting):
* Source/WTF/wtf/text/StringView.h:
(WTF::makeStringByReplacingAll):
(WTF::makeStringByReplacing):
(WTF::makeStringBySimplifyingNewLines):
* Source/WTF/wtf/text/WTFString.h:
(WTF::makeStringByReplacingAll):
* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixFileDescriptor::release):
* Source/WTF/wtf/win/GDIObject.h:
* Source/WTF/wtf/win/Win32Handle.h:
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::decodeKey):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::toRtpCodecCapability):
* Source/WebCore/css/CSSStyleProperties.h:
(WebCore::PropertySetCSSStyleProperties::willMutate):
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::HTMLResourcePreloader::preload):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::decodeBuffer):
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::frontendInitialized):
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::frontendInitialized):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
(WebCore::InspectorCPUProfilerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorDOMAgent::setSearchingForNode):
(WebCore::InspectorDOMAgent::showGridOverlay):
(WebCore::InspectorDOMAgent::showFlexOverlay):
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::InspectorIndexedDBAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
(WebCore::InspectorMemoryAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorNetworkAgent::disable):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorPageAgent::disable):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorTimelineAgent::internalDisable):
(WebCore::InspectorTimelineAgent::startProgrammaticCapture):
(WebCore::InspectorTimelineAgent::stopProgrammaticCapture):
(WebCore::InspectorTimelineAgent::toggleScriptProfilerInstrument):
(WebCore::InspectorTimelineAgent::toggleHeapInstrument):
(WebCore::InspectorTimelineAgent::toggleCPUInstrument):
(WebCore::InspectorTimelineAgent::toggleMemoryInstrument):
(WebCore::InspectorTimelineAgent::toggleAnimationInstrument):
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
(WebCore::InspectorWorkerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::mainFrameStartedLoading):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::mainFrameStartedLoading):
* Source/WebCore/loader/FetchOptions.h:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/platform/KeyedCoding.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::tryCreateAudioBufferList):
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::decodeTimeComparator):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::declareBuiltins):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::allocateSimpleConstructor):
(WGSL::TypeChecker::allocateTextureStorageConstructor):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::setArgumentBuffer):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/DatabaseUtilities.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::DataKey::decodeForPersistence):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::decodeRecordMetaData):
(WebKit::NetworkCache::decodeRecordHeader):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::clear):
* Source/WebKit/Platform/IPC/ConnectionHandle.h:
(IPC::ConnectionHandle::release):
(IPC::ConnectionHandle::leak):
(IPC::ConnectionHandle::leakSendRight):
(): Deleted.
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::consume):
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeReload):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::unloadAll):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp:
(WebKit::InspectorBrowserAgent::willDestroyFrontendAndBackend):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::decodeSessionHistoryEntryData):
(WebKit::decodeSessionHistoryEntry):
(WebKit::decodeSessionHistoryEntries):
(WebKit::decodeV0SessionHistory):
(WebKit::decodeV1SessionHistory):
(WebKit::decodeSessionHistory):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::toUTF8Vector):

Canonical link: <a href="https://commits.webkit.org/304287@main">https://commits.webkit.org/304287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73a8d66f8cf391dcbee23989bc09f9e76a4f6daf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135053 "36 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86879 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3165 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3156 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28417 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5389 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7185 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35507 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166430 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70756 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43492 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->