### PR TITLE
Adopt LIFETIME_BOUND in more places

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -72,16 +72,16 @@ public:
         return m_buffer->isShared();
     }
 
-    void* baseAddress() const
+    void* baseAddress() const LIFETIME_BOUND
     {
         if (isDetached())
             return nullptr;
         return m_baseAddress.getMayBeNull();
     }
 
-    void* data() const { return baseAddress(); }
-    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
-    std::span<uint8_t> mutableSpan() const { return { static_cast<uint8_t*>(data()), byteLength() }; }
+    void* data() const LIFETIME_BOUND { return baseAddress(); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return { static_cast<const uint8_t*>(data()), byteLength() }; }
+    std::span<uint8_t> mutableSpan() const LIFETIME_BOUND { return { static_cast<uint8_t*>(data()), byteLength() }; }
     Vector<uint8_t> toVector() const { return span(); }
 
     size_t byteOffsetRaw() const { return m_byteOffset; }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -783,8 +783,8 @@ public:
         return m_is8Bit ? create(span8()) : create(span16());
     }
 
-    std::span<const Latin1Character> span8() const { return { this->template buffer<Latin1Character>(), m_length }; }
-    std::span<const char16_t> span16() const { return { this->template buffer<char16_t>(), m_length }; }
+    std::span<const Latin1Character> span8() const LIFETIME_BOUND { return { this->template buffer<Latin1Character>(), m_length }; }
+    std::span<const char16_t> span16() const LIFETIME_BOUND { return { this->template buffer<char16_t>(), m_length }; }
 
 private:
     bool m_is8Bit : 1;

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -279,10 +279,10 @@ public:
     }
 
     bool hasVector() const { return !!m_vector; }
-    void* vector() const { return m_vector.getMayBeNull(); }
-    void* vectorWithoutPACValidation() const { return m_vector.getUnsafe(); }
+    void* vector() const LIFETIME_BOUND { return m_vector.getMayBeNull(); }
+    void* vectorWithoutPACValidation() const LIFETIME_BOUND { return m_vector.getUnsafe(); }
 
-    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(vector()), byteLength() }; }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return { static_cast<const uint8_t*>(vector()), byteLength() }; }
     
     size_t byteOffset() const
     {

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -137,13 +137,13 @@ public:
 
     void dump(PrintStream& out) const;
 
-    std::span<WordType> storage() { return bits; }
-    std::span<const WordType> storage() const { return bits; }
+    std::span<WordType> storage() LIFETIME_BOUND { return bits; }
+    std::span<const WordType> storage() const LIFETIME_BOUND { return bits; }
 
     constexpr size_t storageLengthInBytes() { return sizeof(bits); }
 
-    std::span<uint8_t> storageBytes() { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(bits.data()), storageLengthInBytes()); }
-    std::span<const uint8_t> storageBytes() const { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(bits.data()), storageLengthInBytes()); }
+    std::span<uint8_t> storageBytes() LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(bits.data()), storageLengthInBytes()); }
+    std::span<const uint8_t> storageBytes() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(bits.data()), storageLengthInBytes()); }
 
 private:
     void cleanseLastWord();

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -506,14 +506,14 @@ private:
     bool equalsSlowCaseSimple(const BitVector& other) const;
     WTF_EXPORT_PRIVATE uintptr_t hashSlowCase() const;
     
-    std::span<uintptr_t> words()
+    std::span<uintptr_t> words() LIFETIME_BOUND
     {
         if (isInline())
             return singleElementSpan(m_bitsOrPointer);
         return outOfLineBits()->wordsSpan();
     }
 
-    std::span<const uintptr_t> words() const
+    std::span<const uintptr_t> words() const LIFETIME_BOUND
     {
         if (isInline())
             return singleElementSpan(m_bitsOrPointer);

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -69,8 +69,8 @@ public:
     const Win32Handle& fileMapping() const { return m_fileMapping; }
     explicit operator bool() const { return !!m_fileData.data(); }
     size_t size() const { return m_fileData.size(); }
-    std::span<const uint8_t> span() const { return m_fileData; }
-    std::span<uint8_t> mutableSpan() { return m_fileData; }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData; }
+    std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData; }
 #endif
 
 private:

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
@@ -48,7 +48,7 @@ public:
     bool removeKey(const IDBKeyData&);
     bool contains(const IDBKeyData&);
 
-    const IDBKeyData* getLowest() const;
+    const IDBKeyData* getLowest() const LIFETIME_BOUND;
 
     uint64_t getCount() const;
 
@@ -77,13 +77,13 @@ public:
         IDBKeyDataSet::reverse_iterator m_reverseIterator;
     };
 
-    Iterator begin();
-    Iterator reverseBegin(CursorDuplicity);
+    Iterator begin() LIFETIME_BOUND;
+    Iterator reverseBegin(CursorDuplicity) LIFETIME_BOUND;
 
     // Finds the key, or the next higher record after the key.
-    Iterator find(const IDBKeyData&);
+    Iterator find(const IDBKeyData&) LIFETIME_BOUND;
     // Finds the key, or the next lowest record before the key.
-    Iterator reverseFind(const IDBKeyData&, CursorDuplicity);
+    Iterator reverseFind(const IDBKeyData&, CursorDuplicity) LIFETIME_BOUND;
 
     bool unique() const { return m_unique; }
     Vector<IDBKeyData> keys() const;

--- a/Source/WebCore/Modules/mediasource/SampleMap.h
+++ b/Source/WebCore/Modules/mediasource/SampleMap.h
@@ -56,15 +56,15 @@ public:
 
     size_t size() const { return m_samples.size(); }
 
-    WEBCORE_EXPORT iterator findSampleWithPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT iterator findSampleContainingPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT iterator findSampleContainingOrAfterPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT iterator findSampleStartingOnOrAfterPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT iterator findSampleStartingAfterPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT reverse_iterator reverseFindSampleContainingPresentationTime(const MediaTime&);
-    WEBCORE_EXPORT reverse_iterator reverseFindSampleBeforePresentationTime(const MediaTime&);
-    WEBCORE_EXPORT iterator_range findSamplesBetweenPresentationTimes(const MediaTime&, const MediaTime&);
-    WEBCORE_EXPORT iterator_range findSamplesBetweenPresentationTimesFromEnd(const MediaTime&, const MediaTime&);
+    WEBCORE_EXPORT iterator findSampleWithPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSampleContainingPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSampleContainingOrAfterPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSampleStartingOnOrAfterPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSampleStartingAfterPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator reverseFindSampleContainingPresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator reverseFindSampleBeforePresentationTime(const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator_range findSamplesBetweenPresentationTimes(const MediaTime&, const MediaTime&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator_range findSamplesBetweenPresentationTimesFromEnd(const MediaTime&, const MediaTime&) LIFETIME_BOUND;
 
 private:
     MapType m_samples;
@@ -83,24 +83,24 @@ public:
     typedef std::pair<reverse_iterator, reverse_iterator> reverse_iterator_range;
     typedef MapType::value_type value_type;
 
-    iterator begin() { return m_samples.begin(); }
-    const_iterator begin() const { return m_samples.begin(); }
-    iterator end() { return m_samples.end(); }
-    const_iterator end() const { return m_samples.end(); }
-    reverse_iterator rbegin() { return m_samples.rbegin(); }
-    const_reverse_iterator rbegin() const { return m_samples.rbegin(); }
-    reverse_iterator rend() { return m_samples.rend(); }
-    const_reverse_iterator rend() const { return m_samples.rend(); }
-    size_t size() const { return m_samples.size(); }
+    iterator begin() LIFETIME_BOUND { return m_samples.begin(); }
+    const_iterator begin() const LIFETIME_BOUND { return m_samples.begin(); }
+    iterator end() LIFETIME_BOUND { return m_samples.end(); }
+    const_iterator end() const LIFETIME_BOUND { return m_samples.end(); }
+    reverse_iterator rbegin() LIFETIME_BOUND { return m_samples.rbegin(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return m_samples.rbegin(); }
+    reverse_iterator rend() LIFETIME_BOUND { return m_samples.rend(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return m_samples.rend(); }
+    size_t size() const LIFETIME_BOUND { return m_samples.size(); }
 
-    WEBCORE_EXPORT iterator findSampleWithDecodeKey(const KeyType&);
-    WEBCORE_EXPORT iterator findSampleAfterDecodeKey(const KeyType&);
-    WEBCORE_EXPORT reverse_iterator reverseFindSampleWithDecodeKey(const KeyType&);
-    WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime());
-    WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToDecodeIterator(reverse_iterator);
-    WEBCORE_EXPORT iterator findSyncSampleAfterPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime());
-    WEBCORE_EXPORT iterator findSyncSampleAfterDecodeIterator(iterator);
-    WEBCORE_EXPORT reverse_iterator_range findDependentSamples(const MediaSample&);
+    WEBCORE_EXPORT iterator findSampleWithDecodeKey(const KeyType&) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSampleAfterDecodeKey(const KeyType&) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator reverseFindSampleWithDecodeKey(const KeyType&) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime()) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToDecodeIterator(reverse_iterator) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSyncSampleAfterPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime()) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSyncSampleAfterDecodeIterator(iterator) LIFETIME_BOUND;
+    WEBCORE_EXPORT reverse_iterator_range findDependentSamples(const MediaSample&) LIFETIME_BOUND;
     WEBCORE_EXPORT Vector<value_type> findSamplesBetweenDecodeKeys(const KeyType&, const KeyType&);
 
 private:
@@ -122,10 +122,10 @@ public:
     template<typename I>
     void addRange(I begin, I end);
 
-    DecodeOrderSampleMap& decodeOrder() { return m_decodeOrder; }
-    const DecodeOrderSampleMap& decodeOrder() const { return m_decodeOrder; }
-    PresentationOrderSampleMap& presentationOrder() { return m_decodeOrder.m_presentationOrder; }
-    const PresentationOrderSampleMap& presentationOrder() const { return m_decodeOrder.m_presentationOrder; }
+    DecodeOrderSampleMap& decodeOrder() LIFETIME_BOUND { return m_decodeOrder; }
+    const DecodeOrderSampleMap& decodeOrder() const LIFETIME_BOUND { return m_decodeOrder; }
+    PresentationOrderSampleMap& presentationOrder() LIFETIME_BOUND { return m_decodeOrder.m_presentationOrder; }
+    const PresentationOrderSampleMap& presentationOrder() const LIFETIME_BOUND { return m_decodeOrder.m_presentationOrder; }
 
 private:
     DecodeOrderSampleMap m_decodeOrder;

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -73,7 +73,7 @@ public:
 
     // Native channel data access.
     RefPtr<Float32Array> channelData(unsigned channelIndex);
-    std::span<float> rawChannelData(unsigned channelIndex);
+    std::span<float> rawChannelData(unsigned channelIndex) LIFETIME_BOUND;
     void zero();
 
     // Because an AudioBuffer has a JavaScript wrapper, which will be garbage collected, it may take a while for this object to be deleted.

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1991,7 +1991,7 @@ private:
                     return true;
                 }
                 write(dataLength);
-                write(data->data().span());
+                write(data->data().protectedArrayBufferView()->span());
                 write(data->colorSpace());
                 return true;
             }

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -52,8 +52,8 @@ public:
     static CSSSelectorList makeJoining(const Vector<const CSSSelectorList*>&);
 
     bool isEmpty() const { return !m_selectorArray; }
-    const CSSSelector* first() const { return m_selectorArray.get(); }
-    const CSSSelector* selectorAt(size_t index) const
+    const CSSSelector* first() const LIFETIME_BOUND { return m_selectorArray.get(); }
+    const CSSSelector* selectorAt(size_t index) const LIFETIME_BOUND
     {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return &m_selectorArray[index];

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -268,21 +268,21 @@ struct Children {
     Children& operator=(Children&&);
     Children& operator=(Vector<Child>&&);
 
-    iterator begin();
-    iterator end();
-    reverse_iterator rbegin();
-    reverse_iterator rend();
+    iterator begin() LIFETIME_BOUND;
+    iterator end() LIFETIME_BOUND;
+    reverse_iterator rbegin() LIFETIME_BOUND;
+    reverse_iterator rend() LIFETIME_BOUND;
 
-    const_iterator begin() const;
-    const_iterator end() const;
-    const_reverse_iterator rbegin() const;
-    const_reverse_iterator rend() const;
+    const_iterator begin() const LIFETIME_BOUND;
+    const_iterator end() const LIFETIME_BOUND;
+    const_reverse_iterator rbegin() const LIFETIME_BOUND;
+    const_reverse_iterator rend() const LIFETIME_BOUND;
 
     bool isEmpty() const;
     size_t size() const;
 
-    Child& operator[](size_t i);
-    const Child& operator[](size_t i) const;
+    Child& operator[](size_t i) LIFETIME_BOUND;
+    const Child& operator[](size_t i) const LIFETIME_BOUND;
 
     bool operator==(const Children&) const = default;
 };

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -58,26 +58,26 @@ public:
 
     bool atEnd() const { return m_tokens.empty(); }
 
-    const CSSParserToken* begin() const { return std::to_address(m_tokens.begin()); }
-    const CSSParserToken* end() const { return std::to_address(m_tokens.end()); }
+    const CSSParserToken* begin() const LIFETIME_BOUND { return std::to_address(m_tokens.begin()); }
+    const CSSParserToken* end() const LIFETIME_BOUND { return std::to_address(m_tokens.end()); }
 
     size_t size() const { return m_tokens.size(); }
 
-    const CSSParserToken& peek(size_t offset = 0) const
+    const CSSParserToken& peek(size_t offset = 0) const LIFETIME_BOUND
     {
         if (offset < m_tokens.size())
             return m_tokens[offset];
         return eofToken();
     }
 
-    const CSSParserToken& consume()
+    const CSSParserToken& consume() LIFETIME_BOUND
     {
         if (m_tokens.empty())
             return eofToken();
         return WTF::consume(m_tokens);
     }
 
-    const CSSParserToken& consumeIncludingWhitespace()
+    const CSSParserToken& consumeIncludingWhitespace() LIFETIME_BOUND
     {
         auto& result = consume();
         consumeWhitespace();
@@ -98,13 +98,13 @@ public:
     }
 
     void trimTrailingWhitespace();
-    const CSSParserToken& consumeLast();
+    const CSSParserToken& consumeLast() LIFETIME_BOUND;
 
     CSSParserTokenRange consumeAll() { return { std::exchange(m_tokens, std::span<const CSSParserToken> { }) }; }
 
     String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
-    std::span<const CSSParserToken> span() const { return m_tokens; }
+    std::span<const CSSParserToken> span() const LIFETIME_BOUND { return m_tokens; }
 
     static CSSParserToken& eofToken();
 

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -299,8 +299,8 @@ struct SpaceSeparatedEnumSet {
 
     constexpr StorageType toRaw() const { return value.toRaw(); }
 
-    constexpr const_iterator begin() const { return value.begin(); }
-    constexpr const_iterator end() const { return value.end(); }
+    constexpr const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    constexpr const_iterator end() const LIFETIME_BOUND { return value.end(); }
 
     constexpr bool isEmpty() const { return value.isEmpty(); }
     constexpr size_t size() const { return value.size(); }
@@ -384,8 +384,8 @@ struct CommaSeparatedEnumSet {
 
     constexpr StorageType toRaw() const { return value.toRaw(); }
 
-    constexpr const_iterator begin() const { return value.begin(); }
-    constexpr const_iterator end() const { return value.end(); }
+    constexpr const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    constexpr const_iterator end() const LIFETIME_BOUND { return value.end(); }
 
     constexpr bool isEmpty() const { return value.isEmpty(); }
     constexpr size_t size() const { return value.size(); }
@@ -460,8 +460,8 @@ struct SpaceSeparatedListHashSet {
         return result;
     }
 
-    constexpr const_iterator begin() const { return value.begin(); }
-    constexpr const_iterator end() const { return value.end(); }
+    constexpr const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    constexpr const_iterator end() const LIFETIME_BOUND { return value.end(); }
 
     constexpr bool isEmpty() const { return value.isEmpty(); }
     constexpr size_t size() const { return value.size(); }
@@ -503,8 +503,8 @@ struct CommaSeparatedListHashSet {
         return result;
     }
 
-    constexpr const_iterator begin() const { return value.begin(); }
-    constexpr const_iterator end() const { return value.end(); }
+    constexpr const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    constexpr const_iterator end() const LIFETIME_BOUND { return value.end(); }
 
     constexpr bool isEmpty() const { return value.isEmpty(); }
     constexpr size_t size() const { return value.size(); }
@@ -543,14 +543,14 @@ template<typename T, size_t inlineCapacity = 0> struct SpaceSeparatedVector {
         return WTF::map<inlineCapacity>(std::forward<SizedRange>(range), std::forward<Mapper>(mapper));
     }
 
-    const_iterator begin() const { return value.begin(); }
-    const_iterator end() const { return value.end(); }
-    const_reverse_iterator rbegin() const { return value.rbegin(); }
-    const_reverse_iterator rend() const { return value.rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value.end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value.rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value.rend(); }
 
     bool isEmpty() const { return value.isEmpty(); }
     size_t size() const { return value.size(); }
-    const T& operator[](size_t i) const { return value[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value[i]; }
 
     bool contains(const auto& x) const { return value.contains(x); }
     bool containsIf(NOESCAPE const Invocable<bool(const value_type&)> auto& f) const { return value.containsIf(f); }
@@ -590,14 +590,14 @@ template<typename T, size_t inlineCapacity = 0> struct CommaSeparatedVector {
         return WTF::map<inlineCapacity>(std::forward<SizedRange>(range), std::forward<Mapper>(mapper));
     }
 
-    const_iterator begin() const { return value.begin(); }
-    const_iterator end() const { return value.end(); }
-    const_reverse_iterator rbegin() const { return value.rbegin(); }
-    const_reverse_iterator rend() const { return value.rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value.end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value.rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value.rend(); }
 
     bool isEmpty() const { return value.isEmpty(); }
     size_t size() const { return value.size(); }
-    const T& operator[](size_t i) const { return value[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value[i]; }
 
     bool contains(const auto& x) const { return value.contains(x); }
     bool containsIf(NOESCAPE const Invocable<bool(const value_type&)> auto& f) const { return value.containsIf(f); }
@@ -648,14 +648,14 @@ template<typename T> struct SpaceSeparatedFixedVector {
         return Container::createWithSizeFromGenerator(size, std::forward<Generator>(generator));
     }
 
-    const_iterator begin() const { return value.begin(); }
-    const_iterator end() const { return value.end(); }
-    const_reverse_iterator rbegin() const { return value.rbegin(); }
-    const_reverse_iterator rend() const { return value.rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value.end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value.rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value.rend(); }
 
     bool isEmpty() const { return value.isEmpty(); }
     size_t size() const { return value.size(); }
-    const T& operator[](size_t i) const { return value[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value[i]; }
 
     const T& first() const LIFETIME_BOUND { return value.first(); }
     const T& last() const LIFETIME_BOUND { return value.last(); }
@@ -709,14 +709,14 @@ template<typename T> struct CommaSeparatedFixedVector {
         return Container::createWithSizeFromGenerator(size, std::forward<Generator>(generator));
     }
 
-    const_iterator begin() const { return value.begin(); }
-    const_iterator end() const { return value.end(); }
-    const_reverse_iterator rbegin() const { return value.rbegin(); }
-    const_reverse_iterator rend() const { return value.rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value.end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value.rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value.rend(); }
 
     bool isEmpty() const { return value.isEmpty(); }
     size_t size() const { return value.size(); }
-    const T& operator[](size_t i) const { return value[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value[i]; }
 
     const T& first() const LIFETIME_BOUND { return value.first(); }
     const T& last() const LIFETIME_BOUND { return value.last(); }
@@ -769,14 +769,14 @@ template<typename T> struct SpaceSeparatedRefCountedFixedVector {
         return Container::createWithSizeFromGenerator(size, std::forward<Generator>(generator));
     }
 
-    const_iterator begin() const { return value->begin(); }
-    const_iterator end() const { return value->end(); }
-    const_reverse_iterator rbegin() const { return value->rbegin(); }
-    const_reverse_iterator rend() const { return value->rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value->begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value->end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value->rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value->rend(); }
 
     bool isEmpty() const { return value->isEmpty(); }
     size_t size() const { return value->size(); }
-    const T& operator[](size_t i) const { return value.get()[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value.get()[i]; }
 
     const T& first() const LIFETIME_BOUND { return value->first(); }
     const T& last() const LIFETIME_BOUND { return value->last(); }
@@ -827,14 +827,14 @@ template<typename T> struct CommaSeparatedRefCountedFixedVector {
         return Container::createWithSizeFromGenerator(size, std::forward<Generator>(generator));
     }
 
-    const_iterator begin() const { return value->begin(); }
-    const_iterator end() const { return value->end(); }
-    const_reverse_iterator rbegin() const { return value->rbegin(); }
-    const_reverse_iterator rend() const { return value->rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return value->begin(); }
+    const_iterator end() const LIFETIME_BOUND { return value->end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return value->rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return value->rend(); }
 
     bool isEmpty() const { return value->isEmpty(); }
     size_t size() const { return value->size(); }
-    const T& operator[](size_t i) const { return value.get()[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return value.get()[i]; }
 
     const T& first() const LIFETIME_BOUND { return value->first(); }
     const T& last() const LIFETIME_BOUND { return value->last(); }
@@ -1020,11 +1020,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     {
     }
 
-    const_iterator begin() const { return { .it = value.begin(), .atEndForDefault = !isDefault(), .owner = this }; }
-    const_iterator end() const { return { .it = value.end(), .atEndForDefault = true, .owner = this }; }
+    const_iterator begin() const LIFETIME_BOUND { return { .it = value.begin(), .atEndForDefault = !isDefault(), .owner = this }; }
+    const_iterator end() const LIFETIME_BOUND { return { .it = value.end(), .atEndForDefault = true, .owner = this }; }
 
     size_t size() const { return isDefault() ? 1 : value.size(); }
-    const value_type& operator[](size_t i) const { return isDefault() ? defaulter() : value[i]; }
+    const value_type& operator[](size_t i) const LIFETIME_BOUND { return isDefault() ? defaulter() : value[i]; }
 
     bool contains(const auto& x) const { return isDefault() ? (x == defaulter()) : value.contains(x); }
     bool containsIf(NOESCAPE const Invocable<bool(const value_type&)> auto& f) const { return isDefault() ? f(defaulter()) : value.containsIf(f); }

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -71,7 +71,7 @@ public:
         m_refCount = tempRefCount;
     }
 
-    const AtomString& keyString() const { return m_keyString; }
+    const AtomString& keyString() const LIFETIME_BOUND { return m_keyString; }
 
     static constexpr ptrdiff_t tokensMemoryOffset() { return sizeof(SpaceSplitStringData); }
 
@@ -105,7 +105,7 @@ public:
     enum class ShouldFoldCase : bool { No, Yes };
     SpaceSplitString(const AtomString&, ShouldFoldCase);
 
-    const AtomString& keyString() const
+    const AtomString& keyString() const LIFETIME_BOUND
     {
         if (m_data)
             return m_data->keyString();
@@ -121,16 +121,16 @@ public:
 
     unsigned size() const { return m_data ? m_data->size() : 0; }
     bool isEmpty() const { return !m_data; }
-    const AtomString& operator[](unsigned i) const
+    const AtomString& operator[](unsigned i) const LIFETIME_BOUND
     {
         ASSERT_WITH_SECURITY_IMPLICATION(m_data);
         return (*m_data)[i];
     }
 
-    auto begin() const { return m_data ? m_data->begin() : nullptr; }
-    auto end() const { return m_data ? m_data->end() : nullptr; }
-    auto begin() { return m_data ? m_data->begin() : nullptr; }
-    auto end() { return m_data ? m_data->end() : nullptr; }
+    auto begin() const LIFETIME_BOUND { return m_data ? m_data->begin() : nullptr; }
+    auto end() const LIFETIME_BOUND { return m_data ? m_data->end() : nullptr; }
+    auto begin() LIFETIME_BOUND { return m_data ? m_data->begin() : nullptr; }
+    auto end() LIFETIME_BOUND { return m_data ? m_data->end() : nullptr; }
 
     static bool spaceSplitStringContainsValue(StringView spaceSplitString, StringView value, ShouldFoldCase);
 

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -54,7 +54,6 @@ public:
     Ref<JSC::ArrayBufferView> protectedArrayBufferView() const { return m_arrayBufferView; }
     auto byteLength() const { return protectedArrayBufferView()->byteLength(); }
     auto isDetached() const { return protectedArrayBufferView()->isDetached(); }
-    auto span() const { return protectedArrayBufferView()->span(); }
 
     Ref<JSC::Uint8ClampedArray> asUint8ClampedArray() const;
     Ref<JSC::Float16Array> asFloat16Array() const;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2533,10 +2533,11 @@ RefPtr<ByteArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossi
     auto cachedBuffer = ByteArrayPixelBuffer::tryCreate(cachedFormat, size);
     if (!cachedBuffer)
         return nullptr;
+    RefPtr dataAsUint8ClampedArray = imageData.data().asUint8ClampedArray();
     ConstPixelBufferConversionView source {
         .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace },
         .bytesPerRow = bytesPerRow,
-        .rows = imageData.data().asUint8ClampedArray()->span(),
+        .rows = dataAsUint8ClampedArray->span(),
     };
     PixelBufferConversionView destination {
         .format = cachedFormat,

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -148,8 +148,8 @@ struct NestedTimersMap {
             nestedTimers.remove(timeoutId);
     }
 
-    const_iterator begin() const { return nestedTimers.begin(); }
-    const_iterator end() const { return nestedTimers.end(); }
+    const_iterator begin() const LIFETIME_BOUND { return nestedTimers.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return nestedTimers.end(); }
 
 private:
     static NestedTimersMap& instance()

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -81,21 +81,21 @@ public:
         m_span = m_span.first(newLength);
     }
 
-    std::span<const float> span() const { return m_span; }
-    std::span<float> mutableSpan()
+    std::span<const float> span() const LIFETIME_BOUND { return m_span; }
+    std::span<float> mutableSpan() LIFETIME_BOUND
     {
         clearSilentFlag();
         return m_span;
     }
 
     // Direct access to PCM sample data. Non-const accessor clears silent flag.
-    float* mutableData()
+    float* mutableData() LIFETIME_BOUND
     {
         clearSilentFlag();
         return m_span.data();
     }
 
-    const float* data() const { return m_span.data(); }
+    const float* data() const LIFETIME_BOUND { return m_span.data(); }
 
     // Zeroes out all sample values in buffer.
     void zero()

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -60,7 +60,7 @@ public:
     RefPtr<AudioBus> createBus(float sampleRate, bool mixToMono); // Returns nullptr on error
 
     size_t dataSize() const { return m_data.size(); }
-    std::span<const uint8_t> span() const { return m_data; }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_data; }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -113,11 +113,4 @@ RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize
     return ByteArrayPixelBuffer::tryCreate(m_format, size);
 }
 
-std::span<const uint8_t> ByteArrayPixelBuffer::span() const
-{
-    Ref data = m_data;
-    ASSERT(data->byteLength() == (m_size.area() * 4));
-    return data->span();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -41,7 +41,6 @@ public:
     JSC::Uint8ClampedArray& data() const LIFETIME_BOUND { return m_data.get(); }
     Ref<JSC::Uint8ClampedArray> protectedData() const { return m_data; }
     Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
-    WEBCORE_EXPORT std::span<const uint8_t> span() const LIFETIME_BOUND;
 
     Type type() const override { return Type::ByteArray; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
@@ -115,13 +115,6 @@ RefPtr<PixelBuffer> Float16ArrayPixelBuffer::createScratchPixelBuffer(const IntS
     return Float16ArrayPixelBuffer::tryCreate(m_format, size);
 }
 
-std::span<const uint8_t> Float16ArrayPixelBuffer::span() const
-{
-    Ref data = m_data;
-    ASSERT(data->byteLength() == (m_size.area() * 4 * sizeof(Float16)));
-    return data->span();
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
@@ -42,7 +42,6 @@ public:
 
     JSC::Float16Array& data() const LIFETIME_BOUND { return m_data.get(); }
     Ref<JSC::Float16Array>&& takeData() { return WTFMove(m_data); }
-    WEBCORE_EXPORT std::span<const uint8_t> span() const LIFETIME_BOUND;
 
     Type type() const override { return Type::Float16Array; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -86,7 +86,7 @@ public:
     {
     }
 
-    BidiRange(Vector<T>& data, bool isLTR)
+    BidiRange(Vector<T>& data LIFETIME_BOUND, bool isLTR)
         : m_data(data.data())
         , m_length(data.size())
         , m_isLTR(isLTR)
@@ -119,8 +119,8 @@ public:
         unsigned m_logicalIndex;
     };
 
-    Iterator begin() const { return { *this, 0 }; }
-    Iterator end() const { return { *this, m_length }; }
+    Iterator begin() const LIFETIME_BOUND { return { *this, 0 }; }
+    Iterator end() const LIFETIME_BOUND { return { *this, m_length }; }
 
     Iterator fromIndex(unsigned index) const { return { *this, m_isLTR ? index : m_length - index - 1 }; }
 

--- a/Source/WebCore/platform/sql/SQLiteStatement.h
+++ b/Source/WebCore/platform/sql/SQLiteStatement.h
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT Vector<uint8_t> columnBlob(int col);
 
     // The returned Span stays valid until the next step() / reset() or destruction of the statement.
-    std::span<const uint8_t> columnBlobAsSpan(int col);
+    std::span<const uint8_t> columnBlobAsSpan(int col) LIFETIME_BOUND;
 
     SQLiteDatabase& database() { return m_database.get(); }
     

--- a/Source/WebCore/style/StyleBuilderChecking.h
+++ b/Source/WebCore/style/StyleBuilderChecking.h
@@ -66,9 +66,9 @@ template<typename ListType, typename ValueType> struct TypedRequiredList {
     }
 
     unsigned size() const { return list->size(); }
-    const ValueType& item(unsigned index) const { return downcast<ValueType>(*list->item(index)); }
-    TypedRequiredListIterator<ValueType> begin() const { return list->begin(); }
-    TypedRequiredListIterator<ValueType> end() const { return list->end(); }
+    const ValueType& item(unsigned index) const LIFETIME_BOUND { return downcast<ValueType>(*list->item(index)); }
+    TypedRequiredListIterator<ValueType> begin() const LIFETIME_BOUND { return list->begin(); }
+    TypedRequiredListIterator<ValueType> end() const LIFETIME_BOUND { return list->end(); }
 
     Ref<const ListType> list;
 };

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -202,21 +202,21 @@ struct Children {
     Children& operator=(Children&&);
     Children& operator=(Vector<Child>&&);
 
-    iterator begin();
-    iterator end();
-    reverse_iterator rbegin();
-    reverse_iterator rend();
+    iterator begin() LIFETIME_BOUND;
+    iterator end() LIFETIME_BOUND;
+    reverse_iterator rbegin() LIFETIME_BOUND;
+    reverse_iterator rend() LIFETIME_BOUND;
 
-    const_iterator begin() const;
-    const_iterator end() const;
-    const_reverse_iterator rbegin() const;
-    const_reverse_iterator rend() const;
+    const_iterator begin() const LIFETIME_BOUND;
+    const_iterator end() const LIFETIME_BOUND;
+    const_reverse_iterator rbegin() const LIFETIME_BOUND;
+    const_reverse_iterator rend() const LIFETIME_BOUND;
 
     bool isEmpty() const;
     size_t size() const;
 
-    Child& operator[](size_t i);
-    const Child& operator[](size_t i) const;
+    Child& operator[](size_t i) LIFETIME_BOUND;
+    const Child& operator[](size_t i) const LIFETIME_BOUND;
 
     bool operator==(const Children&) const = default;
 };

--- a/Source/WebCore/style/values/transforms/StyleTransformList.h
+++ b/Source/WebCore/style/values/transforms/StyleTransformList.h
@@ -56,14 +56,14 @@ struct TransformList {
     {
     }
 
-    const_iterator begin() const { return m_value.begin(); }
-    const_iterator end() const { return m_value.end(); }
-    const_reverse_iterator rbegin() const { return m_value.rbegin(); }
-    const_reverse_iterator rend() const { return m_value.rend(); }
+    const_iterator begin() const LIFETIME_BOUND { return m_value.begin(); }
+    const_iterator end() const LIFETIME_BOUND { return m_value.end(); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return m_value.rbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return m_value.rend(); }
 
     bool isEmpty() const { return m_value.isEmpty(); }
     size_t size() const { return m_value.size(); }
-    const TransformFunction& operator[](size_t i) const { return m_value[i]; }
+    const TransformFunction& operator[](size_t i) const LIFETIME_BOUND { return m_value[i]; }
 
     bool operator==(const TransformList&) const = default;
 

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -181,8 +181,8 @@ public:
         return makeUnique<SVGPathByteStream>(*this);
     }
 
-    DataIterator begin() const { return m_data->bytes().begin(); }
-    DataIterator end() const { return m_data->bytes().end(); }
+    DataIterator begin() const LIFETIME_BOUND { return m_data->bytes().begin(); }
+    DataIterator end() const LIFETIME_BOUND { return m_data->bytes().end(); }
 
     void append(uint8_t byte) { m_data.access().append(byte); }
     void append(std::span<const uint8_t> bytes) { m_data.access().append(bytes); }
@@ -205,7 +205,7 @@ public:
         m_data->updatePath(path);
     }
 
-    const Data::Bytes& bytes() const { return m_data->bytes(); }
+    const Data::Bytes& bytes() const LIFETIME_BOUND { return m_data->bytes(); }
 
     DataRef<Data> data() const { return m_data; }
     void setData(DataRef<Data>&& data) { m_data = WTFMove(data); }

--- a/Source/WebCore/xml/XPathNodeSet.h
+++ b/Source/WebCore/xml/XPathNodeSet.h
@@ -40,7 +40,7 @@ namespace WebCore {
             
             size_t size() const { return m_nodes.size(); }
             bool isEmpty() const { return m_nodes.isEmpty(); }
-            Node* operator[](unsigned i) const { return m_nodes.at(i).get(); }
+            Node* operator[](unsigned i) const LIFETIME_BOUND { return m_nodes.at(i).get(); }
             void reserveCapacity(size_t newCapacity) { m_nodes.reserveCapacity(newCapacity); }
             void clear() { m_nodes.clear(); }
 
@@ -64,8 +64,8 @@ namespace WebCore {
             void markSubtreesDisjoint(bool disjoint) { m_subtreesAreDisjoint = disjoint; }
             bool subtreesAreDisjoint() const { return m_subtreesAreDisjoint || m_nodes.size() < 2; }
 
-            const RefPtr<Node>* begin() const { return m_nodes.begin(); }
-            const RefPtr<Node>* end() const { return m_nodes.end(); }
+            const RefPtr<Node>* begin() const LIFETIME_BOUND { return m_nodes.begin(); }
+            const RefPtr<Node>* end() const LIFETIME_BOUND { return m_nodes.end(); }
 
         private:
             void traversalSort() const;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.h
@@ -43,11 +43,11 @@ public:
     bool isEmpty() const { return m_loaders.isEmpty(); }
     bool contains(WebCore::ResourceLoaderIdentifier identifier) const { return m_loaders.contains(identifier); }
     MapType::iterator begin() LIFETIME_BOUND { return m_loaders.begin(); }
-    MapType::ValuesIteratorRange values() { return m_loaders.values(); }
+    MapType::ValuesIteratorRange values() LIFETIME_BOUND { return m_loaders.values(); }
     void clear();
 
-    MapType::AddResult add(WebCore::ResourceLoaderIdentifier, Ref<NetworkResourceLoader>&&);
-    NetworkResourceLoader* get(WebCore::ResourceLoaderIdentifier) const;
+    MapType::AddResult add(WebCore::ResourceLoaderIdentifier, Ref<NetworkResourceLoader>&&) LIFETIME_BOUND;
+    NetworkResourceLoader* get(WebCore::ResourceLoaderIdentifier) const LIFETIME_BOUND;
     bool remove(WebCore::ResourceLoaderIdentifier);
     RefPtr<NetworkResourceLoader> take(WebCore::ResourceLoaderIdentifier);
 


### PR DESCRIPTION
#### b48c891f87648eda0bf643c72c1228db2a2f4915
<pre>
Adopt LIFETIME_BOUND in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=303731">https://bugs.webkit.org/show_bug.cgi?id=303731</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::baseAddress const): Deleted.
(JSC::ArrayBufferView::data const): Deleted.
(JSC::ArrayBufferView::span const): Deleted.
(JSC::ArrayBufferView::mutableSpan const): Deleted.
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::span8 const): Deleted.
(JSC::CachedUniquedStringImplBase::span16 const): Deleted.
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::vector const): Deleted.
(JSC::JSArrayBufferView::vectorWithoutPACValidation const): Deleted.
(JSC::JSArrayBufferView::span const): Deleted.
* Source/WTF/wtf/BitSet.h:
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/MappedFileData.h:
(WTF::FileSystemImpl::MappedFileData::span const): Deleted.
(WTF::FileSystemImpl::MappedFileData::mutableSpan): Deleted.
* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h:
* Source/WebCore/Modules/mediasource/SampleMap.h:
(WebCore::DecodeOrderSampleMap::begin): Deleted.
(WebCore::DecodeOrderSampleMap::begin const): Deleted.
(WebCore::DecodeOrderSampleMap::end): Deleted.
(WebCore::DecodeOrderSampleMap::end const): Deleted.
(WebCore::DecodeOrderSampleMap::rbegin): Deleted.
(WebCore::DecodeOrderSampleMap::rbegin const): Deleted.
(WebCore::DecodeOrderSampleMap::rend): Deleted.
(WebCore::DecodeOrderSampleMap::rend const): Deleted.
(WebCore::DecodeOrderSampleMap::size const): Deleted.
(WebCore::SampleMap::decodeOrder): Deleted.
(WebCore::SampleMap::decodeOrder const): Deleted.
(WebCore::SampleMap::presentationOrder): Deleted.
(WebCore::SampleMap::presentationOrder const): Deleted.
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::first const): Deleted.
(WebCore::CSSSelectorList::selectorAt const): Deleted.
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::begin const): Deleted.
(WebCore::CSSParserTokenRange::end const): Deleted.
(WebCore::CSSParserTokenRange::peek const): Deleted.
(WebCore::CSSParserTokenRange::consume): Deleted.
(WebCore::CSSParserTokenRange::consumeIncludingWhitespace): Deleted.
(WebCore::CSSParserTokenRange::span const): Deleted.
* Source/WebCore/css/values/CSSValueAggregates.h:
(WebCore::SpaceSeparatedEnumSet::begin const): Deleted.
(WebCore::SpaceSeparatedEnumSet::end const): Deleted.
(WebCore::CommaSeparatedEnumSet::begin const): Deleted.
(WebCore::CommaSeparatedEnumSet::end const): Deleted.
(WebCore::SpaceSeparatedListHashSet::begin const): Deleted.
(WebCore::SpaceSeparatedListHashSet::end const): Deleted.
(WebCore::CommaSeparatedListHashSet::begin const): Deleted.
(WebCore::CommaSeparatedListHashSet::end const): Deleted.
(WebCore::SpaceSeparatedVector::begin const): Deleted.
(WebCore::SpaceSeparatedVector::end const): Deleted.
(WebCore::SpaceSeparatedVector::rbegin const): Deleted.
(WebCore::SpaceSeparatedVector::rend const): Deleted.
(WebCore::SpaceSeparatedVector::operator[] const): Deleted.
(WebCore::CommaSeparatedVector::begin const): Deleted.
(WebCore::CommaSeparatedVector::end const): Deleted.
(WebCore::CommaSeparatedVector::rbegin const): Deleted.
(WebCore::CommaSeparatedVector::rend const): Deleted.
(WebCore::CommaSeparatedVector::operator[] const): Deleted.
(WebCore::SpaceSeparatedFixedVector::begin const): Deleted.
(WebCore::SpaceSeparatedFixedVector::end const): Deleted.
(WebCore::SpaceSeparatedFixedVector::rbegin const): Deleted.
(WebCore::SpaceSeparatedFixedVector::rend const): Deleted.
(WebCore::SpaceSeparatedFixedVector::operator[] const): Deleted.
(WebCore::CommaSeparatedFixedVector::begin const): Deleted.
(WebCore::CommaSeparatedFixedVector::end const): Deleted.
(WebCore::CommaSeparatedFixedVector::rbegin const): Deleted.
(WebCore::CommaSeparatedFixedVector::rend const): Deleted.
(WebCore::CommaSeparatedFixedVector::operator[] const): Deleted.
(WebCore::SpaceSeparatedRefCountedFixedVector::begin const): Deleted.
(WebCore::SpaceSeparatedRefCountedFixedVector::end const): Deleted.
(WebCore::SpaceSeparatedRefCountedFixedVector::rbegin const): Deleted.
(WebCore::SpaceSeparatedRefCountedFixedVector::rend const): Deleted.
(WebCore::SpaceSeparatedRefCountedFixedVector::operator[] const): Deleted.
(WebCore::CommaSeparatedRefCountedFixedVector::begin const): Deleted.
(WebCore::CommaSeparatedRefCountedFixedVector::end const): Deleted.
(WebCore::CommaSeparatedRefCountedFixedVector::rbegin const): Deleted.
(WebCore::CommaSeparatedRefCountedFixedVector::rend const): Deleted.
(WebCore::CommaSeparatedRefCountedFixedVector::operator[] const): Deleted.
(WebCore::ListOrDefault::begin const): Deleted.
(WebCore::ListOrDefault::end const): Deleted.
(WebCore::ListOrDefault::operator[] const): Deleted.
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::keyString const): Deleted.
(WebCore::SpaceSplitString::keyString const): Deleted.
(WebCore::SpaceSplitString::operator[] const): Deleted.
(WebCore::SpaceSplitString::begin const): Deleted.
(WebCore::SpaceSplitString::end const): Deleted.
(WebCore::SpaceSplitString::begin): Deleted.
(WebCore::SpaceSplitString::end): Deleted.
* Source/WebCore/html/ImageDataArray.h:
(WebCore::ImageDataArray::isDetached const):
(WebCore::ImageDataArray::span const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::NestedTimersMap::begin const): Deleted.
(WebCore::NestedTimersMap::end const): Deleted.
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
(WebCore::AudioFileReader::span const): Deleted.
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::span const):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::takeData):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp:
(WebCore::Float16ArrayPixelBuffer::span const):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h:
(WebCore::Float16ArrayPixelBuffer::takeData):
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::BidiRange::BidiRange):
(WebCore::BidiRange::begin const): Deleted.
(WebCore::BidiRange::end const): Deleted.
* Source/WebCore/platform/sql/SQLiteStatement.h:
* Source/WebCore/style/StyleBuilderChecking.h:
(WebCore::Style::TypedRequiredList::item const): Deleted.
(WebCore::Style::TypedRequiredList::begin const): Deleted.
(WebCore::Style::TypedRequiredList::end const): Deleted.
* Source/WebCore/style/calc/StyleCalculationTree.h:
* Source/WebCore/style/values/transforms/StyleTransformList.h:
(WebCore::Style::TransformList::begin const): Deleted.
(WebCore::Style::TransformList::end const): Deleted.
(WebCore::Style::TransformList::rbegin const): Deleted.
(WebCore::Style::TransformList::rend const): Deleted.
(WebCore::Style::TransformList::operator[] const): Deleted.
* Source/WebCore/svg/SVGPathByteStream.h:
* Source/WebCore/xml/XPathNodeSet.h:
(WebCore::XPath::NodeSet::operator[] const): Deleted.
(WebCore::XPath::NodeSet::begin const): Deleted.
(WebCore::XPath::NodeSet::end const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoadMap.h:
(WebKit::NetworkResourceLoadMap::values): Deleted.

Canonical link: <a href="https://commits.webkit.org/304133@main">https://commits.webkit.org/304133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19c485506d0c2ce5186b3208ddc2d1bd113238fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86525 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b4ca88d-19d5-4925-bc22-a4f2ed6b763e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102854 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70136 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9015293-d8f4-48ff-9cce-129958094348) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83652 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4c877944-6766-47d3-8003-0b7b0246d6e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2814 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2695 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126614 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114432 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144786 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133074 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111254 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5030 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60572 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35079 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165990 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70333 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->