### PR TITLE
Resync `html/semantics/disabled-elements` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt
@@ -1,0 +1,11 @@
+hello world child  hello world child
+
+PASS Testing dblclick events when clicking child of disabled button.
+PASS Testing dblclick events when clicking child of disabled my-control.
+PASS Testing dblclick events when clicking disabled button.
+PASS Testing dblclick events when clicking disabled my-control.
+PASS Testing auxclick events when clicking child of disabled button.
+PASS Testing auxclick events when clicking child of disabled my-control.
+PASS Testing auxclick events when clicking disabled button.
+PASS Testing auxclick events when clicking disabled my-control.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html
@@ -9,6 +9,8 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 
+<!-- This test should be merged with disabled-event-dispatch.tentative.html after interop2023 is over. -->
+
 <div id=targetparent>
   <button disabled>
     hello world
@@ -25,7 +27,7 @@ customElements.define('my-control', class extends HTMLElement {
   static get formAssociated() { return true; }
 });
 
-['mousedown', 'mouseup', 'pointerdown', 'pointerup', 'click'].forEach(eventName => {
+['dblclick', 'auxclick'].forEach(eventName => {
   [true, false].forEach(clickChildElement => {
     for (const target of targetparent.children) {
       promise_test(async () => {
@@ -39,14 +41,29 @@ customElements.define('my-control', class extends HTMLElement {
         let targetchild = target.firstElementChild;
         targetchild.addEventListener(eventName, () => childReceivedEvent = true);
 
-        await test_driver.click(clickChildElement ? targetchild : target);
+        const elementToClick = clickChildElement ? targetchild : target;
+        if (eventName === 'dblclick') {
+          await (new test_driver.Actions()
+            .pointerMove(1, 1, {origin: elementToClick})
+            .pointerDown()
+            .pointerUp()
+            .pointerDown()
+            .pointerUp())
+            .send();
+        } else if (eventName === 'auxclick') {
+          const actions = new test_driver.Actions();
+          await actions
+            .pointerMove(1, 1, {origin: elementToClick})
+            .pointerDown({button: actions.ButtonType.MIDDLE})
+            .pointerUp({button: actions.ButtonType.MIDDLE})
+            .send();
+        }
 
-        const parentShouldReceiveEvents = eventName.startsWith('pointer');
-        assert_equals(parentReceivedEvent, parentShouldReceiveEvents,
+
+        const shouldReceiveEvents = eventName.startsWith('pointer') || eventName === 'auxclick';
+        assert_equals(parentReceivedEvent, shouldReceiveEvents,
                       `parent element received ${eventName} events`);
-
-        const targetShouldReceiveEvents = eventName.startsWith('pointer');
-        assert_equals(targetReceivedEvent, targetShouldReceiveEvents,
+        assert_equals(targetReceivedEvent, shouldReceiveEvents,
                       `target element received ${eventName} events`);
         assert_equals(childReceivedEvent, clickChildElement,
                       `child element received ${eventName} events`);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
@@ -20,8 +20,4 @@ PASS Testing click events when clicking child of disabled button.
 PASS Testing click events when clicking child of disabled my-control.
 PASS Testing click events when clicking disabled button.
 PASS Testing click events when clicking disabled my-control.
-PASS Testing dblclick events when clicking child of disabled button.
-PASS Testing dblclick events when clicking child of disabled my-control.
-PASS Testing dblclick events when clicking disabled button.
-PASS Testing dblclick events when clicking disabled my-control.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf8">
 <meta name="timeout" content="long">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Event propagation on disabled form elements</title>
 <link rel="author" href="mailto:krosylight@mozilla.com">
 <link rel="help" href="https://github.com/whatwg/html/issues/2368">
@@ -152,7 +153,11 @@
       await new Promise(resolve => t.step_timeout(resolve, 0));
 
       const expected = isDisabledFormControl(element) ? expectedEvents : nonDisabledExpectedEvents;
-      assert_array_equals(observedEvents.map(e => e.type), expected, "Observed events");
+
+      t.step_wait_func_done(() => observedEvents.length > 0,
+        () => assert_array_equals(observedEvents.map(e => e.type), expected, "Observed events"),
+        undefined, 1000, 10);
+      ;
 
       for (const observed of observedEvents) {
         assert_equals(observed.target, target, `${observed.type}.target`)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-checkbox-click.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabledElement.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt
@@ -1,0 +1,11 @@
+hello world child  hello world child
+
+FAIL Testing dblclick events when clicking child of disabled button. assert_equals: child element received dblclick events expected true but got false
+FAIL Testing dblclick events when clicking child of disabled my-control. assert_equals: child element received dblclick events expected true but got false
+PASS Testing dblclick events when clicking disabled button.
+PASS Testing dblclick events when clicking disabled my-control.
+FAIL Testing auxclick events when clicking child of disabled button. assert_equals: parent element received auxclick events expected true but got false
+FAIL Testing auxclick events when clicking child of disabled my-control. assert_equals: parent element received auxclick events expected true but got false
+FAIL Testing auxclick events when clicking disabled button. assert_equals: parent element received auxclick events expected true but got false
+FAIL Testing auxclick events when clicking disabled my-control. assert_equals: parent element received auxclick events expected true but got false
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3704,6 +3704,9 @@
     "imported/w3c/web-platform-tests/html/select/options-length-too-large.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 7ede82b95f34ac80650c755e64e3955448895d96
<pre>
Resync `html/semantics/disabled-elements` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=303733">https://bugs.webkit.org/show_bug.cgi?id=303733</a>
<a href="https://rdar.apple.com/166039347">rdar://166039347</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/bb493cfb216722d620698e9858496cd4c8090d0e">https://github.com/web-platform-tests/wpt/commit/bb493cfb216722d620698e9858496cd4c8090d0e</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log:
* LayoutTests/tests-options.json:

&gt; Platform Specific Expectation:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/304144@main">https://commits.webkit.org/304144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e353eb7e0a622b9dc5d816c475afccd3c66b424

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142244 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41e88a4e-b692-43a6-a7b6-09f467962a62) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ed0c027a-c6d1-4484-b9bb-d65a870f198e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83773 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b74b0c32-8449-4f3a-ab2f-bf894ef53f63) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2927 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2833 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144939 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39477 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5151 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6893 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35213 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6694 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->