### PR TITLE
[threaded-animations] disable "Threaded Time-based Animations" when testing legacy behavior

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html
+++ b/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/webanimations/accelerated-animations-and-composite.html
+++ b/LayoutTests/webanimations/accelerated-animations-and-composite.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
 <script src="../resources/js-test.js"></script>
 <script>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
 <script src="../resources/js-test.js"></script>
 <script>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
 <script src="../resources/js-test.js"></script>
 <script>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <style>
 
 #target {

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-8.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-8.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
 <script src="../resources/js-test.js"></script>
 <script>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
 <script src="../resources/js-test.js"></script>
 <script>

--- a/LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html
+++ b/LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <script src="resources/rendering-frames.js"></script>


### PR DESCRIPTION
#### e4d0d6a5b25dc5ea974c0c008a7be7b6e1164e34
<pre>
[threaded-animations] disable &quot;Threaded Time-based Animations&quot; when testing legacy behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=303734">https://bugs.webkit.org/show_bug.cgi?id=303734</a>

Reviewed by Anne van Kesteren.

A few of the tests under `webanimations` are homegrown and testing specific details of our
Web Animations implementation, including a fair few limitations for our Core Animation
implementation of accelerated animations. These tests need to opt out of &quot;Threaded Time-based
Animations&quot; since they do not make sense in configurations where that feature is enabled.

Once that feature flag is removed, we can safely remove these tests altogether.

* LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html:
* LayoutTests/webanimations/accelerated-animations-and-composite.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-8.html:
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities.html:
* LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html:

Canonical link: <a href="https://commits.webkit.org/304085@main">https://commits.webkit.org/304085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d97b7dccbe27bcf2589f7bbb0a85111bedfd32c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86511 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c97a2ad-be57-433d-bcf2-7b24284db67b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c3174a7-b9b0-4d1a-84ca-7191b9c088a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83637 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69d37f06-ff68-4187-85f5-ecca21a2b7dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2800 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39319 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111519 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5017 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35064 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->