### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE with AudioBufferList

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1511,11 +1511,11 @@ template<typename Object, typename Allocator = FastMalloc> void destroyWithTrail
     Allocator::free(object);
 }
 
-template<typename T, typename U>
-ALWAYS_INLINE void lazyInitialize(const std::unique_ptr<T>& ptr, const std::unique_ptr<U>&& obj)
+template<typename T, typename TDeleter, typename U, typename UDeleter>
+ALWAYS_INLINE void lazyInitialize(const std::unique_ptr<T, TDeleter>& ptr, const std::unique_ptr<U, UDeleter>&& obj)
 {
     RELEASE_ASSERT(!ptr);
-    const_cast<std::unique_ptr<T>&>(ptr) = std::move(const_cast<std::unique_ptr<U>&&>(obj));
+    const_cast<std::unique_ptr<T, TDeleter>&>(ptr) = std::move(const_cast<std::unique_ptr<U, UDeleter>&&>(obj)); // NOLINT.
 }
 
 ALWAYS_INLINE std::optional<double> stringToDouble(std::span<const char> buffer, size_t& parsedLength)

--- a/Source/WTF/wtf/SystemFree.h
+++ b/Source/WTF/wtf/SystemFree.h
@@ -31,10 +31,9 @@ namespace WTF {
 
 template<typename T>
 struct SystemFree {
-    static_assert(std::is_trivially_destructible_v<T> || std::is_void_v<T>);
-
     void operator()(T* pointer) const
     {
+        static_assert(std::is_trivially_destructible_v<T> || std::is_void_v<T>);
         free(const_cast<std::remove_cv_t<T>*>(pointer));
     }
 };

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -63,12 +63,9 @@ struct SystemMallocBase {
 
     static T* zeroedMalloc(size_t size)
     {
-        T* result = static_cast<T*>(::malloc(size));
+        T* result = static_cast<T*>(::calloc(1, size));
         if (!result)
             CRASH();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        memset(result, 0, size);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return result;
     }
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -31,10 +31,10 @@
 #include "AudioBus.h"
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
 #include "WebAudioBufferList.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/StdLibExtras.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		44B1A8682A7C5BAD00DC80A6 /* Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8622A7C334D00DC80A6 /* Device.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44B1A8692A7C606000DC80A6 /* UserInterfaceIdiom.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8662A7C339300DC80A6 /* UserInterfaceIdiom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44E1A8B021FA54EB00C3048E /* LookupSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */; };
+		46EF05202EE6A96E00238BB9 /* CoreAudioExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46EF051F2EE6A96E00238BB9 /* CoreAudioExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46FF911929196C73006005B5 /* SleepDisablerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46FF911829196C73006005B5 /* SleepDisablerIOS.mm */; };
 		5157ADFD2B23B9F300C0E095 /* ContactsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5157ADFE2B23B9F300C0E095 /* ContactsSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5157ADFC2B23B9F300C0E095 /* ContactsSoftLink.mm */; };
@@ -634,6 +635,7 @@
 		44E1A8AD21FA54DA00C3048E /* LookupSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LookupSoftLink.h; sourceTree = "<group>"; };
 		44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LookupSoftLink.mm; sourceTree = "<group>"; };
 		44EEA0FE2747438900594A83 /* NSServicesRolloverButtonCellSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSServicesRolloverButtonCellSPI.h; sourceTree = "<group>"; };
+		46EF051F2EE6A96E00238BB9 /* CoreAudioExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreAudioExtras.h; sourceTree = "<group>"; };
 		46FF911829196C73006005B5 /* SleepDisablerIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SleepDisablerIOS.mm; sourceTree = "<group>"; };
 		4996C0F22717642B002C125D /* TCCSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TCCSPI.h; sourceTree = "<group>"; };
 		5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactsSoftLink.h; sourceTree = "<group>"; };
@@ -1015,6 +1017,7 @@
 			children = (
 				416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */,
 				416E995223DAE6BE00E871CB /* AudioToolboxSoftLink.h */,
+				46EF051F2EE6A96E00238BB9 /* CoreAudioExtras.h */,
 				0CF99CA61F738436007EE793 /* CoreMediaSoftLink.cpp */,
 				0CF99CA71F738437007EE793 /* CoreMediaSoftLink.h */,
 				1C77C8C725D7972000635E0C /* CoreTextSoftLink.cpp */,
@@ -1434,6 +1437,7 @@
 				DD20DE6527BC90F90093D175 /* config.h in Headers */,
 				5157ADFD2B23B9F300C0E095 /* ContactsSoftLink.h in Headers */,
 				5157AE072B23CD8100C0E095 /* ContactsSPI.h in Headers */,
+				46EF05202EE6A96E00238BB9 /* CoreAudioExtras.h in Headers */,
 				DD20DDCE27BC90D70093D175 /* CoreAudioSPI.h in Headers */,
 				4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */,
 				7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h
@@ -35,6 +35,10 @@ DECLARE_SYSTEM_HEADER
 #include <CoreAudio/AudioHardwarePriv.h>
 #else
 
+enum {
+    kAudioHardwarePropertyProcessIsRunning = 'prun'
+};
+
 #if PLATFORM(MAC)
 #include <CoreAudio/AudioHardware.h>
 

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -35,9 +35,9 @@
 #include "MultiChannelResampler.h"
 #include "PushPullFIFO.h"
 #include "SharedAudioDestination.h"
-#include "SpanCoreAudio.h"
 #include "SpatialAudioExperienceHelper.h"
 #include <algorithm>
+#include <pal/cf/CoreAudioExtras.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -42,7 +42,6 @@
 #include "Logging.h"
 #include "MediaSampleAVFObjC.h"
 #include "SharedBuffer.h"
-#include "SpanCoreAudio.h"
 #include "VideoTrackPrivate.h"
 #include "WebMAudioUtilitiesCocoa.h"
 #include <AudioToolbox/AudioConverter.h>
@@ -50,6 +49,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <SourceBufferParserWebM.h>
 #include <limits>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Function.h>
 #include <wtf/NativePromise.h>
@@ -58,6 +58,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
+
 #include <pal/cf/AudioToolboxSoftLink.h>
 #include <pal/cf/CoreMediaSoftLink.h>
 
@@ -357,8 +358,8 @@ std::optional<size_t> AudioFileReader::decodeWebMData(AudioBufferList& bufferLis
             // So we set it to what there is left to decode instead.
             UInt32 numFrames = std::min<uint32_t>(std::numeric_limits<int32_t>::max() / sizeof(float), numberOfFrames - totalDecodedFrames);
 
-            auto decodedBuffers = WebCore::span(*decodedBufferList);
-            auto bufferListBuffers = WebCore::span(bufferList);
+            auto decodedBuffers = PAL::span(*decodedBufferList);
+            auto bufferListBuffers = PAL::span(bufferList);
             for (UInt32 i = 0; i < inFormat.mChannelsPerFrame; ++i) {
                 decodedBuffers[i].mNumberChannels = 1;
                 decodedBuffers[i].mDataByteSize = numFrames * sizeof(float);
@@ -551,7 +552,7 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
     AudioFloatArray rightChannel;
 
     RELEASE_ASSERT(bufferList->mNumberBuffers == numberOfChannels);
-    auto buffers = WebCore::span(*bufferList);
+    auto buffers = PAL::span(*bufferList);
     if (mixToMono && numberOfChannels == 2) {
         leftChannel.resize(numberOfFrames);
         rightChannel.resize(numberOfFrames);

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
@@ -30,7 +30,6 @@
 #include "CAAudioStreamDescription.h"
 #include "CMUtilities.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
 #include "WebAudioBufferList.h"
 #include <AudioToolbox/AudioCodec.h>
 #include <AudioToolbox/AudioConverter.h>
@@ -39,6 +38,7 @@
 #include <Foundation/NSValue.h>
 #include <algorithm>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Scope.h>
 #include <wtf/ZippedRange.h>

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
@@ -28,10 +28,10 @@
 
 #include "Logging.h"
 #include "NotImplemented.h"
-#include "SpanCoreAudio.h"
 #include "VectorMath.h"
 #include <Accelerate/Accelerate.h>
 #include <AudioToolbox/AudioConverter.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/ZippedRange.h>

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -30,10 +30,10 @@
 
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
 #include "VectorMath.h"
 #include <Accelerate/Accelerate.h>
 #include <CoreAudio/CoreAudioTypes.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -27,7 +27,7 @@
 
 #include <CoreAudio/CoreAudioTypes.h>
 #include <WebCore/PlatformAudioData.h>
-#include <WebCore/SpanCoreAudio.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -83,12 +83,11 @@ private:
     void initializeList(std::span<uint8_t>, size_t);
     RetainPtr<CMBlockBufferRef> setSampleCountWithBlockBuffer(size_t);
 
-    size_t m_listBufferSize { 0 };
     uint32_t m_bytesPerFrame { 0 };
     uint32_t m_channelCount { 0 };
     size_t m_sampleCount { 0 };
-    const std::unique_ptr<AudioBufferList> m_canonicalList;
-    const std::unique_ptr<AudioBufferList> m_list;
+    const std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_canonicalList;
+    const std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_list;
     RetainPtr<CMBlockBufferRef> m_blockBuffer;
     Vector<uint8_t> m_flatBuffer;
 };

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -29,12 +29,9 @@
 #if PLATFORM(MAC)
 
 #include <algorithm>
+#include <pal/spi/cf/CoreAudioSPI.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/darwin/DispatchExtras.h>
-
-enum {
-    kAudioHardwarePropertyProcessIsRunning = 'prun'
-};
 
 namespace WebCore {
     

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -31,8 +31,8 @@
 #import "FloatConversion.h"
 #import "Logging.h"
 #import "NotImplemented.h"
-#import "SpanCoreAudio.h"
 #import <CoreAudio/AudioHardware.h>
+#import <pal/cf/CoreAudioExtras.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/MainThread.h>
 #import <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -30,6 +30,7 @@
 #include <WebCore/AudioSourceProvider.h>
 #include <wtf/MediaTime.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/SystemFree.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueRef.h>
@@ -95,7 +96,7 @@ private:
     RetainPtr<AVMutableAudioMix> m_avAudioMix;
     RetainPtr<MTAudioProcessingTapRef> m_tap;
     RetainPtr<AudioConverterRef> m_converter;
-    std::unique_ptr<AudioBufferList> m_list;
+    std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_list;
     std::unique_ptr<AudioStreamBasicDescription> m_tapDescription;
     std::unique_ptr<AudioStreamBasicDescription> m_outputDescription;
     std::unique_ptr<CARingBuffer> m_ringBuffer;

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -35,8 +35,8 @@
 #include "CoreAudioCaptureDevice.h"
 #include "CoreAudioCaptureDeviceManager.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
 #include <Accelerate/Accelerate.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <pal/spi/cocoa/AudioToolboxSPI.h>
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp
@@ -33,12 +33,12 @@
 #include "CoreAudioCaptureInternalUnit.h"
 #include "CoreAudioCaptureSource.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
 #include <AudioToolbox/AudioConverter.h>
 #include <AudioUnit/AudioUnit.h>
 #include <CoreMedia/CMSync.h>
 #include <mach/mach_time.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <pal/cf/CoreAudioExtras.h>
 #include <pal/spi/cf/CoreAudioSPI.h>
 #include <sys/time.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.mm
@@ -38,13 +38,13 @@
 #import "MockRealtimeMediaSourceCenter.h"
 #import "NotImplemented.h"
 #import "RealtimeMediaSourceSettings.h"
-#import "SpanCoreAudio.h"
 #import "WebAudioBufferList.h"
 #import "WebAudioSourceProviderCocoa.h"
 #import <AVFoundation/AVAudioBuffer.h>
 #import <AudioToolbox/AudioConverter.h>
 #import <CoreAudio/CoreAudioTypes.h>
 #import <numbers>
+#import <pal/cf/CoreAudioExtras.h>
 #import <wtf/IndexedRange.h>
 #import <wtf/RunLoop.h>
 #import <wtf/StdLibExtras.h>

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
@@ -32,7 +32,7 @@
 #include "LibWebRTCAudioFormat.h"
 #include "LibWebRTCProvider.h"
 #include "Logging.h"
-#include "SpanCoreAudio.h"
+#include <pal/cf/CoreAudioExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -42,9 +42,9 @@
 #if PLATFORM(COCOA)
 #include <WebCore/AudioUtilitiesCocoa.h>
 #include <WebCore/CARingBuffer.h>
-#include <WebCore/SpanCoreAudio.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <mach/mach_time.h>
+#include <pal/cf/CoreAudioExtras.h>
 #endif
 
 namespace WebKit {
@@ -239,7 +239,7 @@ void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
 
         // Associate the destination data array with the output bus then fill the FIFO.
         for (UInt32 i = 0; i < numberOfBuffers; ++i) {
-            auto memory = WebCore::mutableSpan<float>(buffers[i]);
+            auto memory = PAL::mutableSpan<float>(buffers[i]);
             if (numberOfFrames < memory.size())
                 memory = memory.first(numberOfFrames);
             m_outputBus->setChannelMemory(i, memory);


### PR DESCRIPTION
#### cb84985b00a603e34f8688f31305b646df43122f
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE with AudioBufferList
<a href="https://bugs.webkit.org/show_bug.cgi?id=303743">https://bugs.webkit.org/show_bug.cgi?id=303743</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::lazyInitialize):
* Source/WTF/wtf/SystemFree.h:
(WTF::SystemFree::operator() const):
* Source/WTF/wtf/SystemMalloc.h:
(WTF::SystemMallocBase::zeroedMalloc):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cf/CoreAudioExtras.h: Renamed from Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h.
(PAL::allocationSize):
(PAL::createAudioBufferList):
* Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::decodeWebMData const):
(WebCore::AudioFileReader::createBus):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::WebAudioBufferList):
(WebCore::WebAudioBufferList::reset):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::prepare):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.cpp:
* Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.mm:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::renderAudio):

Canonical link: <a href="https://commits.webkit.org/304157@main">https://commits.webkit.org/304157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67a50f1242dbcb3d880d4f49545c3e8b6df11afc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86654 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83778 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20866ab2-2cba-4f39-bf1d-3b8652db206c) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/134079 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2932 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2839 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126768 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144945 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133237 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6850 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39483 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5160 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6898 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35219 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70479 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43422 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->