### PR TITLE
WTF Memory management functions for Haiku

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -43,6 +43,10 @@
 #endif // HAVE(RESOURCE_H)
 #endif
 
+#if OS(HAIKU)
+#include <OS.h>
+#endif
+
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 #include <wtf/Atomics.h>
 #include <wtf/HashMap.h>
@@ -811,6 +815,12 @@ FastMallocStatistics fastMallocStatistics()
     PROCESS_MEMORY_COUNTERS resourceUsage;
     GetProcessMemoryInfo(GetCurrentProcess(), &resourceUsage, sizeof(resourceUsage));
     statistics.committedVMBytes = resourceUsage.PeakWorkingSetSize;
+#elif OS(HAIKU)
+    ssize_t cookie = nullptr;
+    statistics.committedVMBytes = 0;
+    area_info info;
+    while (get_next_area_info(B_CURRENT_TEAM, &cookie, &info) == B_OK)
+        statistics.committedVMBytes += info.ram_size;
 #elif HAVE(RESOURCE_H)
     struct rusage resourceUsage;
     getrusage(RUSAGE_SELF, &resourceUsage);

--- a/Source/WTF/wtf/PlatformHaiku.cmake
+++ b/Source/WTF/wtf/PlatformHaiku.cmake
@@ -2,6 +2,9 @@ list(APPEND WTF_SOURCES
     generic/MainThreadGeneric.cpp
     generic/WorkQueueGeneric.cpp
 
+    haiku/CurrentProcessMemoryStatus.cpp
+    haiku/MemoryFootprintHaiku.cpp
+
     posix/CPUTimePOSIX.cpp
     posix/FileHandlePOSIX.cpp
     posix/FileSystemPOSIX.cpp

--- a/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp
+++ b/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 Haiku, inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CurrentProcessMemoryStatus.h"
+
+#include <OS.h>
+
+
+namespace WTF {
+
+void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
+{
+    memoryStatus.size = 0;
+    memoryStatus.resident = 0;
+    memoryStatus.shared = 0;
+    memoryStatus.text = 0;
+    memoryStatus.data = 0;
+
+    area_info area;
+    ssize_t cookie = 0;
+
+    while (get_next_area_info(0, &cookie, &area) == B_OK) {
+        memoryStatus.size += area.size;
+        memoryStatus.resident += area.ram_size;
+
+        if (area.copy_count > 0)
+            memoryStatus.shared += area.size;
+
+        if (area.protection & B_EXECUTE_AREA)
+            memoryStatus.text += area.size;
+        else
+            memoryStatus.data += area.size;
+    }
+
+    memoryStatus.lib = memoryStatus.size;
+    memoryStatus.dt = memoryStatus.size;
+}
+
+} // namespace WTF
+

--- a/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.h
+++ b/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WTF {
+
+struct ProcessMemoryStatus {
+    size_t size { 0 };
+    size_t resident { 0 };
+    size_t shared { 0 };
+    size_t text { 0 };
+    size_t lib { 0 };
+    size_t data { 0 };
+    size_t dt { 0 };
+};
+
+void currentProcessMemoryStatus(ProcessMemoryStatus&);
+
+} // namespace WTF
+
+using WTF::ProcessMemoryStatus;
+using WTF::currentProcessMemoryStatus;

--- a/Source/WTF/wtf/haiku/MemoryFootprintHaiku.cpp
+++ b/Source/WTF/wtf/haiku/MemoryFootprintHaiku.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Haiku, inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/MemoryFootprint.h>
+
+#include <image.h>
+
+
+namespace WTF {
+
+size_t memoryFootprint()
+{
+    image_info info;
+    int32* cookie = nullptr;
+
+    size_t heapSize = 0;
+
+    while (get_next_image_info(B_CURRENT_TEAM, cookie, &info) == B_OK)
+        heapSize += info.data_size;
+
+    return heapSize;
+}
+
+}

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -37,6 +37,8 @@
 
 #if OS(LINUX)
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
+#elif OS(HAIKU)
+#include <wtf/haiku/CurrentProcessMemoryStatus.h>
 #elif OS(FREEBSD)
 #include <sys/sysctl.h>
 #include <sys/types.h>
@@ -111,7 +113,7 @@ void MemoryPressureHandler::holdOff(Seconds seconds)
 
 static size_t processMemoryUsage()
 {
-#if OS(LINUX)
+#if OS(LINUX) || OS(HAIKU)
     ProcessMemoryStatus memoryStatus;
     currentProcessMemoryStatus(memoryStatus);
     return (memoryStatus.resident - memoryStatus.shared);


### PR DESCRIPTION
#### 99dbf190711012921585003f644a6f8993d8b71c
<pre>
WTF Memory management functions for Haiku

Reviewed by Adrian Perez de Castro.

Add needed support to get memory size and usage on Haiku.
Existing code is not suitable because of use of getrusage (not all
returned fields are in POSIX), /proc filesystem, or other nonstandard
code.

No new tests: no impact on other ports.
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastMallocStatistics): Implement getting RAM usage for Haiku.
* Source/WTF/wtf/PlatformHaiku.cmake: Add new files to the build.
* Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp: Added.
(WTF::currentProcessMemoryStatus): Get memory usage for Haiku.
* Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.h: Added.
* Source/WTF/wtf/haiku/MemoryFootprintHaiku.cpp: Added.
(WTF::memoryFootprint): Get memory usage for Haiku.
* Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp:
(WTF::processMemoryUsage): Wire access to memory usage in a way similar to Linux.

Canonical link: <a href="https://commits.webkit.org/304097@main">https://commits.webkit.org/304097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3979369a7a5de443fc76d2d083c572ad6bcac125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86531 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102859 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2818 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2701 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126622 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144794 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133082 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111258 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111542 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5036 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116892 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60581 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6758 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35085 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/165996 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70341 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43391 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->