### PR TITLE
SpeculationRules: ensure prefetches properly use the HTTP cache

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: Navigation should have used the prefetch expected "navigational-prefetch" but got ""
+FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: Navigation should have used the prefetch expected "navigational-prefetch" but got "cache"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: Navigation should have retrieved the response from the HTTP Cache. expected "cache" but got "navigational-prefetch"
+PASS Test that prefetches use/store responses to/from the HTTP cache.
 

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -60,7 +60,8 @@ public:
     void prefetch(const URL&, const Vector<String>& tags, std::optional<ReferrerPolicy>, bool lowPriority = false);
     void removePrefetch(const URL&);
     bool wasPrefetched(const URL&) const;
-    Box<NetworkLoadMetrics> takePrefetchedNetworkLoadMetrics(const URL&);
+    Box<NetworkLoadMetrics> takePrefetchedResourceMetrics(const URL&);
+    void clearPrefetchedResourcesExcept(const URL&);
 
     // CachedRawResourceClient
     void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2344,6 +2344,12 @@ void FrameLoader::commitProvisionalLoad()
     RefPtr pdl = m_provisionalDocumentLoader;
     Ref frame = m_frame.get();
 
+    // Clear prefetch resources for URLs other than the one being navigated to.
+    // This ensures that prefetches are only used for the immediate next navigation,
+    // not for subsequent navigations to the same URL.
+    if (pdl)
+        m_documentPrefetcher->clearPrefetchedResourcesExcept(pdl->url());
+
     std::unique_ptr<CachedPage> cachedPage;
     if (m_loadingFromCachedPage && history().provisionalItem())
         cachedPage = BackForwardCache::singleton().take(*history().protectedProvisionalItem(), frame->protectedPage().get());

--- a/Source/WebCore/loader/ResourceTiming.cpp
+++ b/Source/WebCore/loader/ResourceTiming.cpp
@@ -70,6 +70,15 @@ void ResourceTiming::updateExposure(const SecurityOrigin& origin)
     m_isSameOriginRequest = m_isSameOriginRequest && origin.canRequest(m_url, OriginAccessPatternsForWebProcess::singleton());
 }
 
+String ResourceTiming::deliveryType() const
+{
+    if (m_networkLoadMetrics.fromPrefetch)
+        return "navigational-prefetch"_s;
+    if (m_networkLoadMetrics.fromCache)
+        return "cache"_s;
+    return emptyString();
+}
+
 Vector<Ref<PerformanceServerTiming>> ResourceTiming::populateServerTiming() const
 {
     // To increase privacy, this additional check was proposed at https://github.com/w3c/resource-timing/issues/342 .

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -48,7 +48,7 @@ public:
 
     const URL& url() const { return m_url; }
     const String& initiatorType() const { return m_initiatorType; }
-    String deliveryType() const { return m_networkLoadMetrics.fromPrefetch ? "navigational-prefetch"_s : emptyString(); }
+    String deliveryType() const;
     const ResourceLoadTiming& resourceLoadTiming() const { return m_resourceLoadTiming; }
     const NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
     NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 NetworkLoadMetrics::NetworkLoadMetrics() = default;
 
-NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
+NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
     : redirectStart(WTFMove(redirectStart))
     , fetchStart(WTFMove(fetchStart))
     , domainLookupStart(WTFMove(domainLookupStart))
@@ -55,6 +55,7 @@ NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicT
     , failsTAOCheck(failsTAOCheck)
     , hasCrossOriginRedirect(hasCrossOriginRedirect)
     , fromPrefetch(fromPrefetch)
+    , fromCache(fromCache)
     , privacyStance(privacyStance)
     , responseBodyBytesReceived(responseBodyBytesReceived)
     , responseBodyDecodedSize(responseBodyDecodedSize)
@@ -75,6 +76,8 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
     MonotonicTime originalResponseStart = responseStart;
     MonotonicTime originalResponseEnd = responseEnd;
     MonotonicTime originalWorkerStart = workerStart;
+    bool originalFromPrefetch = fromPrefetch;
+    bool originalFromCache = fromCache;
 
     *this = other;
 
@@ -100,6 +103,10 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
         responseEnd = originalResponseEnd;
     if (!workerStart)
         workerStart = originalWorkerStart;
+    if (!fromPrefetch)
+        fromPrefetch = originalFromPrefetch;
+    if (!fromCache)
+        fromCache = originalFromCache;
 
     if (!responseEnd)
         responseEnd = MonotonicTime::now();
@@ -157,6 +164,7 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
     copy.failsTAOCheck = failsTAOCheck;
     copy.hasCrossOriginRedirect = hasCrossOriginRedirect;
     copy.fromPrefetch = fromPrefetch;
+    copy.fromCache = fromCache;
 
     copy.privacyStance = privacyStance;
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -65,7 +65,7 @@ class NetworkLoadMetrics {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkLoadMetrics);
 public:
     WEBCORE_EXPORT NetworkLoadMetrics();
-    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
+    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
 
     WEBCORE_EXPORT static const NetworkLoadMetrics& emptyMetrics();
 
@@ -110,6 +110,7 @@ public:
     bool failsTAOCheck : 1 { false };
     bool hasCrossOriginRedirect : 1 { false };
     bool fromPrefetch : 1 { false };
+    bool fromCache : 1 { false };
 
     PrivacyStance privacyStance { PrivacyStance::Unknown };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7400,6 +7400,7 @@ class WebCore::NetworkLoadMetrics {
     [BitField] bool failsTAOCheck;
     [BitField] bool hasCrossOriginRedirect;
     [BitField] bool fromPrefetch;
+    [BitField] bool fromCache;
 
     WebCore::PrivacyStance privacyStance;
 


### PR DESCRIPTION
#### eb08df79713cd4903328e7c76a52bc994d8d3be0
<pre>
SpeculationRules: ensure prefetches properly use the HTTP cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=303752">https://bugs.webkit.org/show_bug.cgi?id=303752</a>

Reviewed by Alex Christensen.

Currently the prefetch-uses-cache tests are expecting to fail.
This PR fixes that by:
* Adding a &quot;cache&quot; value to `deliveryType()`.
* Removing the non-current URLs from the prefetch cache when navigating.

This gets the test to pass, as it was relying on both these characteristics.

No new tests, but progressions on existing tests.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt: Expectation change.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt: Progression.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished): Function rename.
(WebCore::DocumentLoader::commitData): Set the cache state.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::takePrefetchedResourceMetrics): Remove resource from MemoryCache when navigated to.
(WebCore::DocumentPrefetcher::clearPrefetchedResourcesExcept): Remove non-current resources from MemoryCache.
(WebCore::DocumentPrefetcher::takePrefetchedNetworkLoadMetrics): Deleted.
* Source/WebCore/loader/DocumentPrefetcher.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad): Call clearPrefetchResourcesExcept.
* Source/WebCore/loader/ResourceTiming.cpp:
(WebCore::ResourceTiming::deliveryType const): Return a &quot;cache&quot; value if needed.
* Source/WebCore/loader/ResourceTiming.h:
(WebCore::ResourceTiming::deliveryType const):
* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::NetworkLoadMetrics): Handle fromCache.
(WebCore::NetworkLoadMetrics::updateFromFinalMetrics): Handle fromCache.
(WebCore::NetworkLoadMetrics::isolatedCopy const): Handle fromCache.
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Handle fromCache.

Canonical link: <a href="https://commits.webkit.org/304259@main">https://commits.webkit.org/304259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb41c20fed200911ef1db0d95b277b41254c0cb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6898 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120627 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2827 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2708 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6717 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/5960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5045 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60595 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6767 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70351 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->