### PR TITLE
[GStreamer][WebRTC] Add support for capture and certificate statistics

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -68,6 +68,8 @@ public:
 
     WARN_UNUSED_RETURN GUniquePtr<GstStructure> stats();
 
+    WARN_UNUSED_RETURN GUniquePtr<GstStructure> mediaCaptureStats();
+
     virtual WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const = 0;
     virtual RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) = 0;
 


### PR DESCRIPTION
#### 0ec90f07ca83d8fbb86a7382327c57609f70f81c
<pre>
[GStreamer][WebRTC] Add support for capture and certificate statistics
<a href="https://bugs.webkit.org/show_bug.cgi?id=303754">https://bugs.webkit.org/show_bug.cgi?id=303754</a>

Reviewed by Xabier Rodriguez-Calvar.

The audio and video capture stats are calculated by the mediastreamsrc when it is configured to
observe a capture MediaStreamTrack. Then the getStats() plumbing in the end-point gets them from the
outgoing media source which performs a custom query on its source element.

This patch also adds the plumbing for certificate stats which require some changes in GStreamer, not
merged yet.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::preprocessStats):
(WebCore::GStreamerMediaEndpoint::processStatsItem):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::CertificateStats::CertificateStats):
(WebCore::RTCStatsReport::MediaSourceStats::MediaSourceStats):
(WebCore::RTCStatsReport::AudioSourceStats::AudioSourceStats):
(WebCore::RTCStatsReport::VideoSourceStats::VideoSourceStats):
(WebCore::fillReportCallback):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stats):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::mediaCaptureStats):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/304213@main">https://commits.webkit.org/304213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7146be2b912b9831cff2f1b92a40e5c379baad3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70157 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120640 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83672 "Found 21 new API test failures: TestWebCore:GStreamerTest.gstStructureGetters, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/hsts, WPE/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, WPE/TestCookieManager:/webkit/WebKitCookieManager/sync-with-webview, TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, TestWebCore:GStreamerTest.hevcProfileParsing, TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2832 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6723 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111271 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5057 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60610 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6773 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70357 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->