### PR TITLE
Revert the reduced timeout from 303928@main

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1065,6 +1065,7 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
 
     def __init__(self, *args, **kwargs):
         kwargs['logEnviron'] = False
+        kwargs['timeout'] = 3 * 60 * 60
         super().__init__(*args, **kwargs)
 
     def _is_valid_additional_argument(self, argument):

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1260,7 +1260,7 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', base_command + ' > logs.txt 2>&1 ; ret=$? ; grep "Ran " logs.txt ; exit $ret'],
                         logfiles={'json': self.jsonFileName},
                         env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
-                        timeout=1200,
+                        timeout=10800,
                         )
             .exit(0),
         )
@@ -1277,7 +1277,7 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', base_command + ' > logs.txt 2>&1 ; ret=$? ; grep "Ran " logs.txt ; exit $ret'],
                         logfiles={'json': self.jsonFileName},
                         env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
-                        timeout=1200,
+                        timeout=10800,
                         )
             .log('stdio', stderr=stderr_output)
             .exit(1),


### PR DESCRIPTION
#### 89b7933d8260d2c991793881c4a4b2183b2bd246
<pre>
Revert the reduced timeout from 303928@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=303762">https://bugs.webkit.org/show_bug.cgi?id=303762</a>
<a href="https://rdar.apple.com/166070220">rdar://166070220</a>

Reviewed by Jonathan Bedard.

303928@main reduced the timeout for api tests from 3 hours to 20 minutes. It
was based on the assumption that these tests use filter-test-logs script which
itself outputs every 5 minutes. However, the assumption is incorrect and the
step doesn&apos;t use filter-test-logs yet.

We should revert the timeout for now. We can reduce it again once bug 303568 is fixed.

* Tools/CISupport/build-webkit-org/steps.py:
(RunAPITests.__init__):
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/304100@main">https://commits.webkit.org/304100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5aa394305fa764d96b896d14d3a9ea45baab68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134600 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7058 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142125 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c2914fc-506d-4b8b-96be-5e4d2fe1fcaa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136470 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/7658 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/6914 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/142125 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc6a80a8-ee46-4a4b-b7e3-a86f794045af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137547 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/7658 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142125 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1a309b7-5ee5-4bde-b9cb-e4ed3888a81d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/7658 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/2721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/7658 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/144818 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6733 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/144818 "Build was cancelled. Recent messages:Printed configuration") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/134028 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6807 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/6914 "Build was cancelled. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/144818 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/5061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60619 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6783 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/45838 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->