### PR TITLE
[GStreamer][WebRTC] Increase spec compliance for ICE candidate stats

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2623,9 +2623,11 @@ webrtc/video-replace-track.html [ Pass Failure Timeout Crash ]
 # GStreamerRtpSenderBackend::setMediaStreamIds() unimplemented.
 webkit.org/b/235885 webrtc/video.html [ Skip ]
 
-# webrtcbin emits no ICE candidate stats for a PeerConnection managing only one data-channel.
+# Expected to pass when updating SDK to GStreamer 1.28.
 webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html [ Skip ]
 
 # Pending investigation.
 webkit.org/b/235885 fast/mediastream/mediastreamtrack-video-clone.html [ Failure ]
@@ -2709,7 +2711,6 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-transactionId.html [ Fai
 
 imported/w3c/web-platform-tests/webrtc/protocol/ [ Pass ]
 imported/w3c/web-platform-tests/webrtc/protocol/bundle.https.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/crypto-suite.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/dtls-fingerprint-validation.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/dtls-setup.https.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -25,8 +25,6 @@
 #include "ExceptionOr.h"
 #include "GStreamerRegistryScanner.h"
 #include "OpenSSLCryptoUniquePtr.h"
-#include "RTCIceCandidate.h"
-#include "RTCIceProtocol.h"
 #include <cstdint>
 #include <limits>
 #include <openssl/bn.h>
@@ -45,47 +43,6 @@ GST_DEBUG_CATEGORY_STATIC(webkit_webrtc_utils_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_utils_debug
 
 namespace WebCore {
-
-static inline RTCIceComponent toRTCIceComponent(int component)
-{
-    return component == 1 ? RTCIceComponent::Rtp : RTCIceComponent::Rtcp;
-}
-
-static inline std::optional<RTCIceProtocol> toRTCIceProtocol(const String& protocol)
-{
-    if (protocol.isEmpty())
-        return { };
-    if (protocol == "udp"_s)
-        return RTCIceProtocol::Udp;
-    ASSERT(protocol == "tcp"_s);
-    return RTCIceProtocol::Tcp;
-}
-
-static inline std::optional<RTCIceTcpCandidateType> toRTCIceTcpCandidateType(const String& type)
-{
-    if (type.isEmpty())
-        return { };
-    if (type == "active"_s)
-        return RTCIceTcpCandidateType::Active;
-    if (type == "passive"_s)
-        return RTCIceTcpCandidateType::Passive;
-    ASSERT(type == "so"_s);
-    return RTCIceTcpCandidateType::So;
-}
-
-static inline std::optional<RTCIceCandidateType> toRTCIceCandidateType(const String& type)
-{
-    if (type.isEmpty())
-        return { };
-    if (type == "host"_s)
-        return RTCIceCandidateType::Host;
-    if (type == "srflx"_s)
-        return RTCIceCandidateType::Srflx;
-    if (type == "prflx"_s)
-        return RTCIceCandidateType::Prflx;
-    ASSERT(type == "relay"_s);
-    return RTCIceCandidateType::Relay;
-}
 
 RefPtr<RTCError> toRTCError(GError* rtcError)
 {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -30,7 +30,10 @@
 #include "RTCCertificate.h"
 #include "RTCDtlsTransport.h"
 #include "RTCError.h"
+#include "RTCIceCandidate.h"
+#include "RTCIceComponent.h"
 #include "RTCIceConnectionState.h"
+#include "RTCIceProtocol.h"
 #include "RTCIceTransportPolicy.h"
 #include "RTCIceTransportState.h"
 #include "RTCRtpSendParameters.h"
@@ -48,6 +51,47 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+
+inline RTCIceComponent toRTCIceComponent(int component)
+{
+    return component == 1 ? RTCIceComponent::Rtp : RTCIceComponent::Rtcp;
+}
+
+inline std::optional<RTCIceProtocol> toRTCIceProtocol(StringView protocol)
+{
+    if (protocol.isEmpty())
+        return { };
+    if (protocol == "udp"_s)
+        return RTCIceProtocol::Udp;
+    ASSERT(protocol == "tcp"_s);
+    return RTCIceProtocol::Tcp;
+}
+
+inline std::optional<RTCIceTcpCandidateType> toRTCIceTcpCandidateType(StringView type)
+{
+    if (type.isEmpty())
+        return { };
+    if (type == "active"_s)
+        return RTCIceTcpCandidateType::Active;
+    if (type == "passive"_s)
+        return RTCIceTcpCandidateType::Passive;
+    ASSERT(type == "so"_s);
+    return RTCIceTcpCandidateType::So;
+}
+
+inline std::optional<RTCIceCandidateType> toRTCIceCandidateType(StringView type)
+{
+    if (type.isEmpty())
+        return { };
+    if (type == "host"_s)
+        return RTCIceCandidateType::Host;
+    if (type == "srflx"_s)
+        return RTCIceCandidateType::Srflx;
+    if (type == "prflx"_s)
+        return RTCIceCandidateType::Prflx;
+    ASSERT(type == "relay"_s);
+    return RTCIceCandidateType::Relay;
+}
 
 inline RTCRtpTransceiverDirection toRTCRtpTransceiverDirection(GstWebRTCRTPTransceiverDirection direction)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -54,6 +54,11 @@ WTF_DEFINE_GPTR_DELETER(GstFFTF32, gst_fft_f32_free)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_description_free)
 WTF_DEFINE_GPTR_DELETER(GstSDPMessage, gst_sdp_message_free)
 WTF_DEFINE_GPTR_DELETER(GstSDPMedia, gst_sdp_media_free)
+
+#if GST_CHECK_VERSION(1, 27, 0)
+WTF_DEFINE_GPTR_DELETER(GstWebRTCICECandidate, gst_webrtc_ice_candidate_free)
+WTF_DEFINE_GPTR_DELETER(GstWebRTCICECandidatePair, gst_webrtc_ice_candidate_pair_free)
+#endif // GST_CHECK_VERSION(1, 27, 0)
 #endif
 }
 


### PR DESCRIPTION
#### 53ac924b3cfcbf0dc4237e4cba2ceead732d334c
<pre>
[GStreamer][WebRTC] Increase spec compliance for ICE candidate stats
<a href="https://bugs.webkit.org/show_bug.cgi?id=290451">https://bugs.webkit.org/show_bug.cgi?id=290451</a>

Reviewed by Xabier Rodriguez-Calvar.

Implement the new ICETransport-&gt;get_selected_candidate_pair vfunc in the Rice backend and fill
ICE candidate stats from GStreamer ICE candidate stats. This will allow us to unflag several layout
tests once the SDK is updated to GStreamer 1.28.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp:
(populateCandidateStats):
(fillCredentials):
(riceCandidateToGst):
(webkitGstWebRTCIceTransportGetSelectedCandidatePair):
(webkit_gst_webrtc_ice_transport_class_init):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::candidateFromGstWebRTC):
(WebCore::GStreamerIceTransportBackend::selectedCandidatePairChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
(WebCore::iceCandidateType): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCIceComponent): Deleted.
(WebCore::toRTCIceProtocol): Deleted.
(WebCore::toRTCIceTcpCandidateType): Deleted.
(WebCore::toRTCIceCandidateType): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
(WebCore::toRTCIceComponent):
(WebCore::toRTCIceProtocol):
(WebCore::toRTCIceTcpCandidateType):
(WebCore::toRTCIceCandidateType):
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/304217@main">https://commits.webkit.org/304217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b5d5bf251c86b6220284c55323b8257434ab0bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7206 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5647 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5469 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3047 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7036 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5307 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117235 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7085 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70657 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->