### PR TITLE
Add static assertions to simd_floatNxM wrapper types

### DIFF
--- a/Source/WebCore/Modules/Model/InternalAPI/DDFloat3.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDFloat3.h
@@ -57,6 +57,8 @@ struct DDFloat3 {
     {
     }
 };
-
+#if PLATFORM(COCOA)
+static_assert(sizeof(DDFloat3) == sizeof(simd_float3), "Wrapper type assumes it is the same size and alignment as the underlying vector type");
+#endif
 }
 

--- a/Source/WebCore/Modules/Model/InternalAPI/DDFloat4x4.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDFloat4x4.h
@@ -78,6 +78,9 @@ struct DDFloat4x4 {
     {
     }
 };
+#if PLATFORM(COCOA)
+static_assert(sizeof(DDFloat4x4) == sizeof(simd_float4x4), "Wrapper type assumes it is the same size and alignment as the underlying matrix type");
+#endif
 
 #if PLATFORM(COCOA)
 struct DDFloat3x3 {
@@ -105,6 +108,7 @@ struct DDFloat3x3 {
     {
     }
 };
+static_assert(sizeof(DDFloat3x3) == sizeof(simd_float3x3), "Wrapper type assumes it is the same size and alignment as the underlying matrix type");
 #endif
 
 }


### PR DESCRIPTION
#### f86811226c12e7480af66480f22e8e36c8f340cb
<pre>
Add static assertions to simd_floatNxM wrapper types
<a href="https://bugs.webkit.org/show_bug.cgi?id=303763">https://bugs.webkit.org/show_bug.cgi?id=303763</a>
<a href="https://rdar.apple.com/166071797">rdar://166071797</a>

Reviewed by NOBODY (OOPS!).

These types made some assumptions about struct member alignment and
overall struct alignment.

Currently they assume 16 byte alignment. If the code was compiled with
64 byte struct alignment, DDFloat3x3 would be incorrect if reinterpreted
as an array of simd_float3x3 instances assuming those were compiled with
16 byte alignment.

* Source/WebCore/Modules/Model/InternalAPI/DDFloat3.h:
* Source/WebCore/Modules/Model/InternalAPI/DDFloat4x4.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f86811226c12e7480af66480f22e8e36c8f340cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86568 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102891 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70175 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/384239fc-f9de-4e77-81f8-f3a3c4dca3bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83692 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/133966 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2853 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2736 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111576 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5071 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6800 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->