### PR TITLE
[Site Isolation] window.open with blob URLs should work with site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt
@@ -1,0 +1,10 @@
+Verifies that an iframe can open a blob pop-up
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe's blob pop-up successfully opened
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/iframe-blob-url.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-blob-url.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+    description("Verifies that an iframe can open a blob pop-up");
+
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    addEventListener("message", (event) => {
+        if (event.data === "finish test" && window.testRunner)
+            testPassed("iframe's blob pop-up successfully opened");
+            testRunner.notifyDone();
+    });
+
+</script>
+
+<iframe src="http://localhost:8000/site-isolation/resources/window-open-blob-url.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html
@@ -1,0 +1,14 @@
+<script>
+    const htmlContent = `
+        <!DOCTYPE html>
+        <html>
+        <h1>Blob URL Loaded</h1>
+        </html>
+        `;
+    
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const blobUrl = URL.createObjectURL(blob);
+    const blobPopUp = window.open(blobUrl);
+
+    window.parent.postMessage("finish test", "*");
+</script>


### PR DESCRIPTION
#### f31c4670e79112678cef306c261e34e062c48c72
<pre>
[Site Isolation] window.open with blob URLs should work with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=303766">https://bugs.webkit.org/show_bug.cgi?id=303766</a>
<a href="https://rdar.apple.com/165842879">rdar://165842879</a>

Reviewed by NOBODY (OOPS!).

Add test in WebKitTestRunner

* LayoutTests/http/tests/site-isolation/iframe-blob-url-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-blob-url.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-open-blob-url.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31c4670e79112678cef306c261e34e062c48c72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142179 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b74350bd-2bb1-47de-b6ea-b64f25587612) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6965 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8dec4d83-777c-4c56-a6b1-852120a04f9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137601 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5410 "Found 1 new test failure: http/tests/site-isolation/iframe-blob-url.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5bfb386-a628-4760-8da0-f02d557cf642) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5266 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2881 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2770 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144871 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39416 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6860 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5691 "Found 1 new test failure: http/tests/site-isolation/iframe-blob-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111608 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5101 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116968 "Exiting early after 10 failures. 133 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60671 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6837 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35160 "1 flakes") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6879 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/6752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->