### PR TITLE
Fix out-of-bounds read in HTMLMetaCharsetParser.cpp

### DIFF
--- a/LayoutTests/fast/encoding/meta-charset-whitespace-only-expected.txt
+++ b/LayoutTests/fast/encoding/meta-charset-whitespace-only-expected.txt
@@ -1,0 +1,3 @@
+Meta charset parser should not crash on "charset" followed by whitespace only.
+
+PASS

--- a/LayoutTests/fast/encoding/meta-charset-whitespace-only.html
+++ b/LayoutTests/fast/encoding/meta-charset-whitespace-only.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content="charset   ">
+</head>
+<body>
+<p>Meta charset parser should not crash on "charset" followed by whitespace only.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+document.write("PASS");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/encoding/meta-charset-whitespace-variations-expected.txt
+++ b/LayoutTests/fast/encoding/meta-charset-whitespace-variations-expected.txt
@@ -1,0 +1,3 @@
+Meta charset parser should handle various whitespace edge cases after "charset".
+
+PASS

--- a/LayoutTests/fast/encoding/meta-charset-whitespace-variations.html
+++ b/LayoutTests/fast/encoding/meta-charset-whitespace-variations.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content="charset	"><!-- tabs -->
+<meta content="charset
+
+
+"><!-- multiple spaces and newlines -->
+<meta content="charset "><!-- single space -->
+</head>
+<body>
+<p>Meta charset parser should handle various whitespace edge cases after "charset".</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+document.write("PASS");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -58,6 +58,10 @@ static StringView extractCharset(StringView value)
         while (pos < length && value[pos] <= ' ')
             ++pos;
 
+        // Ensure we're in bounds before checking for '='.
+        if (pos >= length)
+            break;
+
         if (value[pos] != '=')
             continue;
 


### PR DESCRIPTION
#### e85dcb7a35a724d209e896b6a6fb4be9bd97fe3e
<pre>
Fix out-of-bounds read in HTMLMetaCharsetParser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=303520">https://bugs.webkit.org/show_bug.cgi?id=303520</a>
<a href="https://rdar.apple.com/163574708">rdar://163574708</a>

Reviewed by David Kilzer.

A potential out-of-bounds read vulnerability in HTMLMetaCharsetParser.cpp caused a crash
when processing malformed meta tags containing &quot;charset&quot; followed by whitespace
(e.g., &lt;meta content=&quot;charset   &quot;&gt;). The extractCharset() function skipped whitespace
after finding &quot;charset&quot; but failed to verify the position was still within bounds before
accessing the next character to check for &apos;=&apos;, triggering a hardening check failure due
to an out of range index.

The fix adds a simple bounds check (if (pos &gt;= length) break;) after the whitespace-skipping
loop to prevent the attempted out-of-bounds access.

Tests: fast/encoding/meta-charset-whitespace-only.html
       fast/encoding/meta-charset-whitespace-variations.html

* LayoutTests/fast/encoding/meta-charset-whitespace-only-expected.txt: Added.
* LayoutTests/fast/encoding/meta-charset-whitespace-only.html: Added.
* LayoutTests/fast/encoding/meta-charset-whitespace-variations-expected.txt: Added.
* LayoutTests/fast/encoding/meta-charset-whitespace-variations.html: Added.
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::extractCharset):

Originally-landed-as: 301765.353@safari-7623-branch (0bdd687a5d22). <a href="https://rdar.apple.com/163574708">rdar://163574708</a>
Canonical link: <a href="https://commits.webkit.org/304132@main">https://commits.webkit.org/304132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe0800fb05d53f62c7f645d68db54ec5d33855f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86567 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6348a8ce-54c0-4df0-a238-5f7a2cf99632) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102890 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70174 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab36c1b6-4034-4280-afdb-653857c98c48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83691 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6108a82-156e-4cfb-ad3f-400b52b04480) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2852 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2735 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144835 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39382 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5069 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60636 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6799 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35127 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6609 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->