### PR TITLE
[Site Isolation] Add WEBCORE_EXPORT to methods generated by generate-process-sync-data.py

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -160,7 +160,7 @@ def generate_process_sync_client_header(prefix, synched_datas):
     for data in synched_datas:
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
-        result.append('    void broadcast%sToOtherProcesses(const %s&);' % (data.name, data.fully_qualified_type))
+        result.append('    WEBCORE_EXPORT void broadcast%sToOtherProcesses(const %s&);' % (data.name, data.fully_qualified_type))
         if data.conditional is not None:
             result.append('#endif')
 

--- a/Source/WebCore/Scripts/tests/TestSyncClient.h
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.h
@@ -46,13 +46,13 @@ public:
     virtual void broadcastAllTestSyncDataToOtherProcesses(TestSyncData&) { }
 
 #if ENABLE(DOM_AUDIO_SESSION)
-    void broadcastAudioSessionTypeToOtherProcesses(const WebCore::DOMAudioSessionType&);
+    WEBCORE_EXPORT void broadcastAudioSessionTypeToOtherProcesses(const WebCore::DOMAudioSessionType&);
 #endif
-    void broadcastMainFrameURLChangeToOtherProcesses(const URL&);
-    void broadcastIsAutofocusProcessedToOtherProcesses(const bool&);
-    void broadcastUserDidInteractWithPageToOtherProcesses(const bool&);
-    void broadcastAnotherOneToOtherProcesses(const StringifyThis&);
-    void broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>&);
+    WEBCORE_EXPORT void broadcastMainFrameURLChangeToOtherProcesses(const URL&);
+    WEBCORE_EXPORT void broadcastIsAutofocusProcessedToOtherProcesses(const bool&);
+    WEBCORE_EXPORT void broadcastUserDidInteractWithPageToOtherProcesses(const bool&);
+    WEBCORE_EXPORT void broadcastAnotherOneToOtherProcesses(const StringifyThis&);
+    WEBCORE_EXPORT void broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>&);
 
 protected:
     virtual void broadcastTestSyncDataToOtherProcesses(const TestSyncSerializationData&) { }


### PR DESCRIPTION
#### dba7660e65ddf609459f1433feed68537d78c503
<pre>
[Site Isolation] Add WEBCORE_EXPORT to methods generated by generate-process-sync-data.py
<a href="https://rdar.apple.com/166089625">rdar://166089625</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303775">https://bugs.webkit.org/show_bug.cgi?id=303775</a>

Reviewed by Brady Eidson.

This allows WebKit code to call these methods without having to route
through another WebCore code.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(generate_process_sync_client_header):
* Source/WebCore/Scripts/tests/TestSyncClient.h:

Canonical link: <a href="https://commits.webkit.org/304175@main">https://commits.webkit.org/304175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9af0a7c3d2b4f7e640933cc792fef0526f0a700c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86590 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3b04bbef-d7a9-4e0e-849b-6686f0597b31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102909 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70196 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d246ae05-346c-490e-b28b-ece34c38c68f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa511555-30dd-46e2-a15f-6c44b6546f63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2875 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2763 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114482 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38825 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 35 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144864 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6779 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5097 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35150 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->