### PR TITLE
Crash at  WebCore::LocalFrameView::scrollToAnchorFragment

### DIFF
--- a/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt
@@ -1,0 +1,1 @@
+PASS, if no crash

--- a/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html
+++ b/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>NavigateEvent scroll behavior with pending stylesheets should not crash</title>
+</head>
+<body>
+<div style="height: 3000px;"></div>
+<div id="target">Target Element</div>
+<div style="height: 3000px;"></div>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+navigation.addEventListener('navigate', e => {
+  e.intercept({
+    handler: () => Promise.resolve()
+  });
+});
+
+const link = document.createElement('link');
+link.rel = 'stylesheet';
+link.href = '../incremental/resources/delayed-css.py?delay=2000';
+document.head.appendChild(link);
+
+navigation.navigate("#target");
+
+setTimeout(function() {
+    link.remove();
+    document.body.innerHTML = "PASS, if no crash";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 50);
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -128,13 +128,27 @@ void NavigateEvent::processScrollBehavior(Document& document)
 
     if (m_navigationType == NavigationNavigationType::Traverse || m_navigationType == NavigationNavigationType::Reload) {
         if (m_navigationType == NavigationNavigationType::Reload && document.url().hasFragmentIdentifier()) {
+            if (!document.haveStylesheetsLoaded()) {
+                document.setGotoAnchorNeededAfterStylesheetsLoad(true);
+                return;
+            }
             if (document.frame()->view()->scrollToFragment(document.url()))
                 return;
         }
         document.frame()->loader().history().restoreScrollPositionAndViewState();
-    } else if (!document.frame()->view()->scrollToFragment(document.url())) {
-        if (!document.url().hasFragmentIdentifier())
-            document.frame()->view()->scrollTo({ 0, 0 });
+    } else {
+        if (!document.haveStylesheetsLoaded()) {
+            if (document.url().hasFragmentIdentifier())
+                document.setGotoAnchorNeededAfterStylesheetsLoad(true);
+            else
+                document.frame()->view()->scrollTo({ 0, 0 });
+            return;
+        }
+
+        if (!document.frame()->view()->scrollToFragment(document.url())) {
+            if (!document.url().hasFragmentIdentifier())
+                document.frame()->view()->scrollTo({ 0, 0 });
+        }
     }
 }
 


### PR DESCRIPTION
#### 099f13d31071116b3b5cc8c901768c99a5569421
<pre>
Crash at  WebCore::LocalFrameView::scrollToAnchorFragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=303781">https://bugs.webkit.org/show_bug.cgi?id=303781</a>
<a href="https://rdar.apple.com/164271286">rdar://164271286</a>

Reviewed by NOBODY (OOPS!).

Check if stylesheets are loaded before calling scrollToFragment() in
processScrollBehavior(), deferring the scroll if needed to avoid hitting
a RELEASE_ASSERT.

Test: http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html

* LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html: Added.
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099f13d31071116b3b5cc8c901768c99a5569421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142174 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83715 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2877 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2765 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144866 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39408 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111599 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5099 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35152 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70413 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->