### PR TITLE
[WTF] Share ProcessMemoryStatus declaration among Linux and Haiku

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -247,6 +247,7 @@ set(WTF_PUBLIC_HEADERS
     PrintStream.h
     PriorityQueue.h
     ProcessID.h
+    ProcessMemoryStatus.h
     ProcessPrivilege.h
     PtrTag.h
     RAMSize.h

--- a/Source/WTF/wtf/ProcessMemoryStatus.h
+++ b/Source/WTF/wtf/ProcessMemoryStatus.h
@@ -25,12 +25,26 @@
 
 #pragma once
 
-#include <wtf/ProcessMemoryStatus.h>
+#if OS(LINUX) || OS(HAIKU)
+
+#include <wtf/ForbidHeapAllocation.h>
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE void currentProcessMemoryStatus(ProcessMemoryStatus&);
+struct ProcessMemoryStatus {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    size_t size { 0 };
+    size_t resident { 0 };
+    size_t shared { 0 };
+    size_t text { 0 };
+    size_t lib { 0 };
+    size_t data { 0 };
+    size_t dt { 0 };
+};
 
 } // namespace WTF
 
-using WTF::currentProcessMemoryStatus;
+using WTF::ProcessMemoryStatus;
+
+#endif // OS(LINUX) || OS(HAIKU)

--- a/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.h
+++ b/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Igalia S.L.
+ * Copyright (C) 2016, 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,12 @@
 
 #pragma once
 
-namespace WTF {
+#include <wtf/ProcessMemoryStatus.h>
 
-struct ProcessMemoryStatus {
-    size_t size { 0 };
-    size_t resident { 0 };
-    size_t shared { 0 };
-    size_t text { 0 };
-    size_t lib { 0 };
-    size_t data { 0 };
-    size_t dt { 0 };
-};
+namespace WTF {
 
 void currentProcessMemoryStatus(ProcessMemoryStatus&);
 
 } // namespace WTF
 
-using WTF::ProcessMemoryStatus;
 using WTF::currentProcessMemoryStatus;


### PR DESCRIPTION
#### 801e62168653b673f11ca88480676819cd52b4ea
<pre>
[WTF] Share ProcessMemoryStatus declaration among Linux and Haiku
<a href="https://bugs.webkit.org/show_bug.cgi?id=303774">https://bugs.webkit.org/show_bug.cgi?id=303774</a>

Reviewed by Michael Catanzaro.

Add a new &lt;wtf/ProcessMemoryStatus.h&gt; with the definition of the
ProcessMemoryStatus struct, and then reuse that from both the Linux-
and Haiku-specific implementations. While at it, annotate the struct
with WTF_FORBID_HEAP_ALLOCATION because its usage is always stack
allocated, and ideally should stay that way.

Canonical link: <a href="https://commits.webkit.org/305590@main">https://commits.webkit.org/305590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3eb7f08e9fede76fa41599cbb833e9254a93825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5263 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2878 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2766 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126698 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144867 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133158 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5104 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60667 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6833 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35153 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166069 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70414 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43407 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->