### PR TITLE
Nested identical filters are not rendered.

### DIFF
--- a/LayoutTests/css3/filters/nested-identical-filters-expected.html
+++ b/LayoutTests/css3/filters/nested-identical-filters-expected.html
@@ -1,0 +1,17 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+  div {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    background: green;
+  }
+</style>
+</head>
+<body>
+  <div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/nested-identical-filters.html
+++ b/LayoutTests/css3/filters/nested-identical-filters.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+  div {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    filter: invert(100%);
+  }
+  #inner {
+    background: green;
+  }
+</style>
+</head>
+<body>
+  <div id=outer>
+    <div id=inner>
+    </div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -44,8 +44,12 @@ void GraphicsContextState::repurpose(Purpose purpose)
 
 #if USE(CG)
     // CGContextBeginTransparencyLayer() sets the CG global alpha to 1. Keep the clone's alpha in sync.
-    if (purpose == Purpose::TransparencyLayer)
+    if (purpose == Purpose::TransparencyLayer) {
         m_alpha = 1;
+        m_style = std::nullopt;
+        m_dropShadow = std::nullopt;
+        m_compositeMode = { CompositeOperator::SourceOver, BlendMode::Normal };
+    }
 #endif
 
     m_purpose = purpose;


### PR DESCRIPTION
#### c887d10d61230f23a647b1d8fed8a7faa1b022d5
<pre>
Nested identical filters are not rendered.
<a href="https://bugs.webkit.org/show_bug.cgi?id=302900">https://bugs.webkit.org/show_bug.cgi?id=302900</a>
<a href="https://rdar.apple.com/165163823">rdar://165163823</a>

Reviewed by Simon Fraser.

Pushing a transparency layer causes any current filter style (or shadow, or
composite operation) to be applied to the layer when popped, and don&apos;t apply to
the content in the layer.

Make sure we clear those states from the GraphicsContext tracking, to match the
behaviour of what CG is doing.

If they&apos;re not cleared, then a nested filter (or second filter primitive of the
same filter property) that is identical is incorrectly considered a no-op, and
doesn&apos;t get forwarded to the platform code.

Test: css3/filters/nested-identical-filters.html

* LayoutTests/css3/filters/nested-identical-filters-expected.html: Added.
* LayoutTests/css3/filters/nested-identical-filters.html: Added.
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::repurpose):

Canonical link: <a href="https://commits.webkit.org/304143@main">https://commits.webkit.org/304143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d592cd38904d292a44b1fe1f3e3cb69d751498b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86599 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70200 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83723 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2882 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2772 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144873 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5102 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6839 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35187 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6645 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->