### PR TITLE
[Navigation API] processScrollBehavior should wait for stylesheet loading before scrolling to fragment.

### DIFF
--- a/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt
@@ -1,0 +1,1 @@
+PASS, if no crash

--- a/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html
+++ b/LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>NavigateEvent scroll behavior with pending stylesheets should not crash</title>
+</head>
+<body>
+<div style="height: 3000px;"></div>
+<div id="target">Target Element</div>
+<div style="height: 3000px;"></div>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+navigation.addEventListener('navigate', e => {
+  e.intercept({
+    handler: () => Promise.resolve()
+  });
+});
+
+const link = document.createElement('link');
+link.rel = 'stylesheet';
+link.href = '../incremental/resources/delayed-css.py?delay=2000';
+document.head.appendChild(link);
+
+navigation.navigate("#target");
+
+setTimeout(function() {
+    link.remove();
+    document.body.innerHTML = "PASS, if no crash";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 50);
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 53a56f18efe58689adda39c52b9c49cd3c884bd9
<pre>
[Navigation API] processScrollBehavior should wait for stylesheet loading before scrolling to fragment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303783">https://bugs.webkit.org/show_bug.cgi?id=303783</a>
<a href="https://rdar.apple.com/164271286">rdar://164271286</a>

Reviewed by Chris Dumez.

The scrollToAnchorFragment() that is called from scrollToFragment() contains a
RELEASE_ASSERT(document.haveStylesheetsLoaded()), requiring stylesheets to be fully
loaded before the function can be safely called. This constraint necessitates
conditional execution where  scrollToFragment() is only invoked when stylesheets
are loaded, with alternative handling used when they are not.

However, the current processScrollBehavior() implementation unconditionally calls
scrollToFragment() and relies on its boolean return value to determine whether
fallback scroll behavior should be applied. This pattern prevents moving to the
required conditional call approach, as the decision logic is embedded within
scrollToFragment() rather than being determined beforehand.

To enable this transition, the current implementation must be refactored to
eliminate dependency on scrollToFragment() return values. Instead, all
decision logic needs to be moved to explicit pre-checks that determine the
appropriate scroll behavior before any fragment scrolling is attempted.

Refactor the implementation to:
- Pre-validate anchor existence using Document::findAnchor() before calling
  scrollToFragment().
- Check stylesheet loading status and use setGotoAnchorNeededAfterStylesheetsLoad()
  when needed.
- Remove dependency on scrollToFragment() return value by handling all fallback
  cases through explicit conditionals.
- Maintain identical logic flow for all navigation types.

No behavior change.

* LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/navigate-event-scroll-deferred-with-pending-stylesheet.html: Added.
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):

Co-authored-by: Nipun Shukla &lt;nipun_shukla@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/304273@main">https://commits.webkit.org/304273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/020a9023405b2126be9688f3c571a301b1d2770d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86867 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b92cbe02-2ad6-4c14-858a-c60347dc653c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103182 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/179b3d67-9295-4595-a07b-d86def6b0425) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84035 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87e48031-b129-4871-babd-f412768fc467) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3155 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3137 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145239 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7120 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28409 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5377 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7168 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->