### PR TITLE
REGRESSION (302241@main): Media controls dimming element is too big after zooming.

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-zoomed-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-zoomed-expected.txt
@@ -1,0 +1,11 @@
+PASS videoBoundingBox.width is 600
+PASS videoBoundingBox.height is 600
+PASS mediaControlsContainerBoundingBox.width is 600
+PASS mediaControlsContainerBoundingBox.height is 600
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-zoomed.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-zoomed.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<video style="width: 300px; height: 300px;" controls=""></video>
+</body>
+<script>
+if (!window.internals)
+  failTest("requires window.internals");
+
+window.internals.setPageZoomFactor(2);
+let video = document.querySelector("video");
+let videoBoundingBox = window.internals.boundingBox(video);
+
+let shadowRoot = window.internals.shadowRoot(video);
+let mediaControlsContainer = shadowRoot.querySelector(".media-controls-container");
+let mediaControlsContainerBoundingBox = window.internals.boundingBox(mediaControlsContainer);
+
+shouldBeEqualToNumber("videoBoundingBox.width", 600);
+shouldBeEqualToNumber("videoBoundingBox.height", 600);
+
+shouldBeEqualToNumber("mediaControlsContainerBoundingBox.width", 600);
+shouldBeEqualToNumber("mediaControlsContainerBoundingBox.height", 600);
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</html>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -984,8 +984,11 @@ void RenderReplaced::layoutShadowContent(const LayoutSize& oldSize)
         // and this method might be called many times per second during video playback, use a LayoutStateMaintainer:
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
         renderBox.setLocation(LayoutPoint(borderLeft(), borderTop()) + LayoutSize(paddingLeft(), paddingTop()));
-        renderBox.mutableStyle().setHeight(Style::PreferredSize::Fixed { newSize.height() });
-        renderBox.mutableStyle().setWidth(Style::PreferredSize::Fixed { newSize.width() });
+
+        auto usedZoom = renderBox.style().usedZoomForLength();
+        renderBox.mutableStyle().setHeight(Style::PreferredSize::Fixed { newSize.height() / usedZoom.value });
+        renderBox.mutableStyle().setWidth(Style::PreferredSize::Fixed { newSize.width() / usedZoom.value });
+
         renderBox.setNeedsLayout(MarkOnlyThis);
         renderBox.layout();
     }


### PR DESCRIPTION
#### 1807913583ffa26dc3f24488c3258a0b81ddf8d3
<pre>
REGRESSION (302241@main): Media controls dimming element is too big after zooming.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303935">https://bugs.webkit.org/show_bug.cgi?id=303935</a>
<a href="https://rdar.apple.com/166092545">rdar://166092545</a>

Reviewed by Vitor Roriz.

A video element, such as the one in the attached testcase, will create a
shadow DOM to hold the contents associated with its media controls. We
enter layout for the associated video inside of RenderVideo::layout and
eventually end up inside of RenderImage::layout to layout this shadow
DOM via the call to layoutShadowContent.

As part of this process, we will take the used value of the renderer and
mutate the RenderStyle of its children by setting the width and height
sizes to these values. However, since these are used values they have
already been affected by zoom so just directly setting them on the
RenderStyle will result in double zooming whenever those values get used
during layout. This is what ends up causing the media controls container
to grow larger than the video it is attached to. To fix this we will
need to divide out the zoom from these sizes so they get properly resolved.

Canonical link: <a href="https://commits.webkit.org/304299@main">https://commits.webkit.org/304299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3873d4b24757482ffff51a4a0fe5ba63db803641

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86889 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70454 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84062 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3175 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3168 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145270 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7147 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111582 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5394 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61085 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7197 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35502 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->