### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in PixelBufferConversion.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -323,14 +323,10 @@ static Float16 readFloat16(const std::span<const uint8_t>& span8, size_t offset)
 {
     union {
         Float16 float16 { };
-        uint8_t bytes[sizeof(Float16)];
+        std::array<uint8_t, sizeof(Float16)> bytes;
     } float16OrBytesUnion;
-    for (size_t i = 0; i < sizeof(Float16); ++i) {
-        auto u8 = span8[offset + i];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        float16OrBytesUnion.bytes[i] = u8;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    }
+    for (size_t i = 0; i < sizeof(Float16); ++i)
+        float16OrBytesUnion.bytes[i] = span8[offset + i];
     return float16OrBytesUnion.float16;
 }
 
@@ -338,14 +334,10 @@ static void writeFloat16(Float16 f16, const std::span<uint8_t>& spanFloat16, siz
 {
     union {
         Float16 float16 { };
-        uint8_t bytes[sizeof(Float16)];
+        std::array<uint8_t, sizeof(Float16)> bytes;
     } float16OrBytesUnion(f16);
-    for (size_t i = 0; i < sizeof(Float16); ++i) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        auto u8 = float16OrBytesUnion.bytes[i];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        spanFloat16[offset + i] = u8;
-    }
+    for (size_t i = 0; i < sizeof(Float16); ++i)
+        spanFloat16[offset + i] = float16OrBytesUnion.bytes[i];
 }
 
 static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
@@ -385,14 +377,10 @@ static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConvers
             static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
             union {
                 Pixel16 pixel16 { };
-                uint8_t bytes[sizeof(Pixel16)];
+                std::array<uint8_t, sizeof(Pixel16)> bytes;
             } pixel16OrBytesUnion;
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte) {
-                auto value = source.rows[sourceRowStartOffset + offset + byte];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                pixel16OrBytesUnion.bytes[byte] = value;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-            }
+            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
+                pixel16OrBytesUnion.bytes[byte] = source.rows[sourceRowStartOffset + offset + byte];
             if (source.format.alphaFormat != destination.format.alphaFormat) {
                 if (source.format.alphaFormat == AlphaPremultiplication::Unpremultiplied && destination.format.alphaFormat == AlphaPremultiplication::Premultiplied) {
                     auto fa = float(pixel16OrBytesUnion.pixel16.a);
@@ -408,12 +396,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 } else
                     RELEASE_ASSERT_NOT_REACHED();
             }
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                auto value = pixel16OrBytesUnion.bytes[byte];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-                destination.rows[destinationRowStartOffset + offset + byte] = value;
-            }
+            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
+                destination.rows[destinationRowStartOffset + offset + byte] = pixel16OrBytesUnion.bytes[byte];
             offset += sizeof(Pixel16);
         }
         sourceRowStartOffset += source.bytesPerRow;


### PR DESCRIPTION
#### 65cd83d43afff48f119a76e55c192f52c441f04d
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in PixelBufferConversion.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=303797">https://bugs.webkit.org/show_bug.cgi?id=303797</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::readFloat16):
(WebCore::writeFloat16):
(WebCore::convertImagePixelsFromFloat16ToFloat16):

Canonical link: <a href="https://commits.webkit.org/304182@main">https://commits.webkit.org/304182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d28f0cc7bf8df466ada6b51cb2768495ce953067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86628 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102943 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70220 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/522124e9-517d-4086-9395-43b9607a0a56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83748 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5292 "Found 1 new test failure: imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2908 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2804 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144908 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111339 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28346 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5129 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116998 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60703 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6870 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35188 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->