### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in DynamicsCompressor.cpp

### DIFF
--- a/Source/WebCore/platform/audio/DynamicsCompressor.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.cpp
@@ -108,7 +108,6 @@ void DynamicsCompressor::process(const AudioBus& sourceBus, AudioBus& destinatio
 
     switch (numberOfChannels) {
     case 2: // stereo
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         m_sourceChannels[0] = sourceBus.channel(0)->span();
 
         if (numberOfSourceChannels > 1)
@@ -116,7 +115,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         else
             // Simply duplicate mono channel input data to right channel for stereo processing.
             m_sourceChannels[1] = m_sourceChannels[0];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         break;
     default:
@@ -126,10 +124,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return;
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (unsigned i = 0; i < numberOfChannels; ++i)
         m_destinationChannels[i] = destinationBus.channel(i)->mutableSpan();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     float dbThreshold = parameterValue(ParamThreshold);
     float dbKnee = parameterValue(ParamKnee);
@@ -181,8 +177,8 @@ void DynamicsCompressor::reset()
 
 void DynamicsCompressor::setNumberOfChannels(unsigned numberOfChannels)
 {
-    m_sourceChannels = makeUniqueArray<std::span<const float>>(numberOfChannels);
-    m_destinationChannels = makeUniqueArray<std::span<float>>(numberOfChannels);
+    m_sourceChannels = FixedVector<std::span<const float>>(numberOfChannels);
+    m_destinationChannels = FixedVector<std::span<float>>(numberOfChannels);
 
     m_compressor.setNumberOfChannels(numberOfChannels);
     m_numberOfChannels = numberOfChannels;

--- a/Source/WebCore/platform/audio/DynamicsCompressor.h
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.h
@@ -32,8 +32,8 @@
 #include "DynamicsCompressorKernel.h"
 #include "ZeroPole.h"
 #include <memory>
+#include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueArray.h>
 
 namespace WebCore {
 
@@ -92,13 +92,13 @@ protected:
     std::array<float, ParamLast> m_parameters;
     void initializeParameters();
 
-    std::span<std::span<const float>> sourceChannels() const { return unsafeMakeSpan(m_sourceChannels.get(), m_numberOfChannels); }
-    std::span<std::span<float>> destinationChannels() const { return unsafeMakeSpan(m_destinationChannels.get(), m_numberOfChannels); }
+    std::span<const std::span<const float>> sourceChannels() const { return m_sourceChannels.span(); }
+    std::span<std::span<float>> destinationChannels() { return m_destinationChannels.mutableSpan(); }
 
     float m_sampleRate;
 
-    UniqueArray<std::span<const float>> m_sourceChannels;
-    UniqueArray<std::span<float>> m_destinationChannels;
+    FixedVector<std::span<const float>> m_sourceChannels;
+    FixedVector<std::span<float>> m_destinationChannels;
 
     // The core compressor.
     DynamicsCompressorKernel m_compressor;

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
@@ -189,7 +189,7 @@ float DynamicsCompressorKernel::updateStaticCurveParameters(float dbThreshold, f
     return m_K;
 }
 
-void DynamicsCompressorKernel::process(std::span<std::span<const float>> sourceChannels,
+void DynamicsCompressorKernel::process(std::span<const std::span<const float>> sourceChannels,
                                        std::span<std::span<float>> destinationChannels,
                                        unsigned framesToProcess,
                                        float dbThreshold,

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.h
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.h
@@ -44,7 +44,7 @@ public:
     void setNumberOfChannels(unsigned);
 
     // Performs stereo-linked compression.
-    void process(std::span<std::span<const float>> sourceChannels,
+    void process(std::span<const std::span<const float>> sourceChannels,
                  std::span<std::span<float>> destinationChannels,
                  unsigned framesToProcess,
                  float dbThreshold,


### PR DESCRIPTION
#### df9b1fc2f4973c30fe00df08d255f64b65cb3fc0
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in DynamicsCompressor.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=303802">https://bugs.webkit.org/show_bug.cgi?id=303802</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/audio/DynamicsCompressor.cpp:
(WebCore::DynamicsCompressor::process):
(WebCore::DynamicsCompressor::setNumberOfChannels):
* Source/WebCore/platform/audio/DynamicsCompressor.h:
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(WebCore::DynamicsCompressorKernel::process):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.h:

Canonical link: <a href="https://commits.webkit.org/304185@main">https://commits.webkit.org/304185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f9a9ffa247d90962330e905ca9a73c0584e6b1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86632 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3808491f-6a55-4bc2-b800-ed2c14d344da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102948 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70223 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b2e21a75-a6ee-49b5-80e3-cb9ca402ced6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51001a91-609d-4009-8444-6b62c396c791) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5301 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2911 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144916 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111342 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5131 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60707 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6874 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35189 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->