### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in OpenTypeMathData.cpp

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -306,6 +306,9 @@ public:
 
     Ref<FragmentedSharedBuffer> asFragmentedSharedBuffer() const { return const_cast<SharedBuffer&>(*this); }
 
+    template<typename T>
+    bool isSpanWithinBounds(std::span<T> otherSpan) const;
+
 private:
     friend class SharedBufferBuilder;
 
@@ -447,6 +450,17 @@ private:
 };
 
 RefPtr<SharedBuffer> utf8Buffer(const String&);
+
+template<typename T>
+inline bool SharedBuffer::isSpanWithinBounds(std::span<T> otherSpan) const
+{
+    auto thisSpan = this->span();
+    auto otherByteSpan = asByteSpan(otherSpan);
+    if (std::to_address(otherByteSpan.end()) < std::to_address(thisSpan.begin()))
+        return false;
+    size_t offset = std::to_address(otherByteSpan.end()) - std::to_address(thisSpan.begin());
+    return offset <= size(); // "<=" because end is included as valid.
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -96,7 +96,7 @@ protected:
         if (position < bufferSpan.data())
             return false;
         size_t offset = static_cast<const uint8_t*>(position) - bufferSpan.data();
-        return offset <= buffer.size(); // "<=" because end is included as valid
+        return offset <= buffer.size(); // "<=" because end is included as valid.
     }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN


### PR DESCRIPTION
#### 29c842c7d5f1b0eececa06951c01e0aa60032216
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in OpenTypeMathData.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=303806">https://bugs.webkit.org/show_bug.cgi?id=303806</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBuffer::isSpanWithinBounds const):
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
(WebCore::OpenType::MathItalicsCorrectionInfo::italicsCorrections const):
(WebCore::OpenType::MathItalicsCorrectionInfo::getItalicCorrection const):
(WebCore::OpenType::GlyphAssembly::parts const):
(WebCore::OpenType::GlyphAssembly::getAssemblyParts const):
(WebCore::OpenType::MathGlyphConstruction::variantRecords const):
(WebCore::OpenType::MathGlyphConstruction::getSizeVariants const):
(WebCore::OpenType::MathVariants::mathGlyphConstructionsOffsets const):
(WebCore::OpenType::MathVariants::mathGlyphConstruction const):
* Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h:
(WebCore::OpenType::TableBase::isValidEnd):

Canonical link: <a href="https://commits.webkit.org/304210@main">https://commits.webkit.org/304210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5af4b5118cfc27e7bcf35b01c387f34c0b93537

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142403 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6480ebb4-1441-4c0b-acd8-c06effead8ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103087 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ec82d6f3-daf5-411d-b2d0-81a4abc2cfc5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83936 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a39c610-1018-494b-ae63-f40c3e6d2194) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5436 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3047 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2997 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145103 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39635 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5270 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60918 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7040 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35360 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->