### PR TITLE
Cut down use of String::fromUTF8 and ASCIILiteral::fromLiteralUnsafe

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose-expected.txt
@@ -1,256 +1,53 @@
 
-FAIL 3041  HIRAGANA LETTER SMALL A may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3043  HIRAGANA LETTER SMALL I may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3045  HIRAGANA LETTER SMALL U may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3047  HIRAGANA LETTER SMALL E may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3049  HIRAGANA LETTER SMALL O may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3063  HIRAGANA LETTER SMALL TU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3083  HIRAGANA LETTER SMALL YA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3085  HIRAGANA LETTER SMALL YU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3087  HIRAGANA LETTER SMALL YO may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 308E  HIRAGANA LETTER SMALL WA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3095  HIRAGANA LETTER SMALL KA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3096  HIRAGANA LETTER SMALL KE may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A1  KATAKANA LETTER SMALL A may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A3  KATAKANA LETTER SMALL I may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A5  KATAKANA LETTER SMALL U may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A7  KATAKANA LETTER SMALL E may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A9  KATAKANA LETTER SMALL O may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30C3  KATAKANA LETTER SMALL TU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E3  KATAKANA LETTER SMALL YA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E5  KATAKANA LETTER SMALL YU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E7  KATAKANA LETTER SMALL YO may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30EE  KATAKANA LETTER SMALL WA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30F5  KATAKANA LETTER SMALL KA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30F6  KATAKANA LETTER SMALL KE may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F0  KATAKANA LETTER SMALL KU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F1  KATAKANA LETTER SMALL SI may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F2  KATAKANA LETTER SMALL SU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F3  KATAKANA LETTER SMALL TO may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F4  KATAKANA LETTER SMALL NU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F5  KATAKANA LETTER SMALL HA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F6  KATAKANA LETTER SMALL HI may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F7  KATAKANA LETTER SMALL HU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F8  KATAKANA LETTER SMALL HE may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F9  KATAKANA LETTER SMALL HO may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FA  KATAKANA LETTER SMALL MU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FB  KATAKANA LETTER SMALL RA may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FC  KATAKANA LETTER SMALL RI may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FD  KATAKANA LETTER SMALL RU may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FE  KATAKANA LETTER SMALL RE may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FF  KATAKANA LETTER SMALL RO may appear at line start if loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose assert_approx_equals: expected 54 +/- 1 but got 84
-3041
-文文文文文文ぁ字字
-文文文文文文
-ぁ字字
-3043
-文文文文文文ぃ字字
-文文文文文文
-ぃ字字
-3045
-文文文文文文ぅ字字
-文文文文文文
-ぅ字字
-3047
-文文文文文文ぇ字字
-文文文文文文
-ぇ字字
-3049
-文文文文文文ぉ字字
-文文文文文文
-ぉ字字
-3063
-文文文文文文っ字字
-文文文文文文
-っ字字
-3083
-文文文文文文ゃ字字
-文文文文文文
-ゃ字字
-3085
-文文文文文文ゅ字字
-文文文文文文
-ゅ字字
-3087
-文文文文文文ょ字字
-文文文文文文
-ょ字字
-308E
-文文文文文文ゎ字字
-文文文文文文
-ゎ字字
-3095
-文文文文文文ゕ字字
-文文文文文文
-ゕ字字
-3096
-文文文文文文ゖ字字
-文文文文文文
-ゖ字字
-30A1
-文文文文文文ァ字字
-文文文文文文
-ァ字字
-30A3
-文文文文文文ィ字字
-文文文文文文
-ィ字字
-30A5
-文文文文文文ゥ字字
-文文文文文文
-ゥ字字
-30A7
-文文文文文文ェ字字
-文文文文文文
-ェ字字
-30A9
-文文文文文文ォ字字
-文文文文文文
-ォ字字
-30C3
-文文文文文文ッ字字
-文文文文文文
-ッ字字
-30E3
-文文文文文文ャ字字
-文文文文文文
-ャ字字
-30E5
-文文文文文文ュ字字
-文文文文文文
-ュ字字
-30E7
-文文文文文文ョ字字
-文文文文文文
-ョ字字
-30EE
-文文文文文文ヮ字字
-文文文文文文
-ヮ字字
-30F5
-文文文文文文ヵ字字
-文文文文文文
-ヵ字字
-30F6
-文文文文文文ヶ字字
-文文文文文文
-ヶ字字
-30FC
-文文文文文文ー字字
-文文文文文文
-ー字字
-31F0
-文文文文文文ㇰ字字
-文文文文文文
-ㇰ字字
-31F1
-文文文文文文ㇱ字字
-文文文文文文
-ㇱ字字
-31F2
-文文文文文文ㇲ字字
-文文文文文文
-ㇲ字字
-31F3
-文文文文文文ㇳ字字
-文文文文文文
-ㇳ字字
-31F4
-文文文文文文ㇴ字字
-文文文文文文
-ㇴ字字
-31F5
-文文文文文文ㇵ字字
-文文文文文文
-ㇵ字字
-31F6
-文文文文文文ㇶ字字
-文文文文文文
-ㇶ字字
-31F7
-文文文文文文ㇷ字字
-文文文文文文
-ㇷ字字
-31F8
-文文文文文文ㇸ字字
-文文文文文文
-ㇸ字字
-31F9
-文文文文文文ㇹ字字
-文文文文文文
-ㇹ字字
-31FA
-文文文文文文ㇺ字字
-文文文文文文
-ㇺ字字
-31FB
-文文文文文文ㇻ字字
-文文文文文文
-ㇻ字字
-31FC
-文文文文文文ㇼ字字
-文文文文文文
-ㇼ字字
-31FD
-文文文文文文ㇽ字字
-文文文文文文
-ㇽ字字
-31FE
-文文文文文文ㇾ字字
-文文文文文文
-ㇾ字字
-31FF
-文文文文文文ㇿ字字
-文文文文文文
-ㇿ字字
-FF67
-文文文文文文ｧ字字
-文文文文文文
-ｧ字字
-FF68
-文文文文文文ｨ字字
-文文文文文文
-ｨ字字
-FF69
-文文文文文文ｩ字字
-文文文文文文
-ｩ字字
-FF6A
-文文文文文文ｪ字字
-文文文文文文
-ｪ字字
-FF6B
-文文文文文文ｫ字字
-文文文文文文
-ｫ字字
-FF6C
-文文文文文文ｬ字字
-文文文文文文
-ｬ字字
-FF6D
-文文文文文文ｭ字字
-文文文文文文
-ｭ字字
-FF6E
-文文文文文文ｮ字字
-文文文文文文
-ｮ字字
-FF6F
-文文文文文文ｯ字字
-文文文文文文
-ｯ字字
-FF70
-文文文文文文ｰ字字
-文文文文文文
-ｰ字字
+PASS 3041  HIRAGANA LETTER SMALL A may appear at line start if loose
+PASS 3043  HIRAGANA LETTER SMALL I may appear at line start if loose
+PASS 3045  HIRAGANA LETTER SMALL U may appear at line start if loose
+PASS 3047  HIRAGANA LETTER SMALL E may appear at line start if loose
+PASS 3049  HIRAGANA LETTER SMALL O may appear at line start if loose
+PASS 3063  HIRAGANA LETTER SMALL TU may appear at line start if loose
+PASS 3083  HIRAGANA LETTER SMALL YA may appear at line start if loose
+PASS 3085  HIRAGANA LETTER SMALL YU may appear at line start if loose
+PASS 3087  HIRAGANA LETTER SMALL YO may appear at line start if loose
+PASS 308E  HIRAGANA LETTER SMALL WA may appear at line start if loose
+PASS 3095  HIRAGANA LETTER SMALL KA may appear at line start if loose
+PASS 3096  HIRAGANA LETTER SMALL KE may appear at line start if loose
+PASS 30A1  KATAKANA LETTER SMALL A may appear at line start if loose
+PASS 30A3  KATAKANA LETTER SMALL I may appear at line start if loose
+PASS 30A5  KATAKANA LETTER SMALL U may appear at line start if loose
+PASS 30A7  KATAKANA LETTER SMALL E may appear at line start if loose
+PASS 30A9  KATAKANA LETTER SMALL O may appear at line start if loose
+PASS 30C3  KATAKANA LETTER SMALL TU may appear at line start if loose
+PASS 30E3  KATAKANA LETTER SMALL YA may appear at line start if loose
+PASS 30E5  KATAKANA LETTER SMALL YU may appear at line start if loose
+PASS 30E7  KATAKANA LETTER SMALL YO may appear at line start if loose
+PASS 30EE  KATAKANA LETTER SMALL WA may appear at line start if loose
+PASS 30F5  KATAKANA LETTER SMALL KA may appear at line start if loose
+PASS 30F6  KATAKANA LETTER SMALL KE may appear at line start if loose
+PASS 30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose
+PASS 31F0  KATAKANA LETTER SMALL KU may appear at line start if loose
+PASS 31F1  KATAKANA LETTER SMALL SI may appear at line start if loose
+PASS 31F2  KATAKANA LETTER SMALL SU may appear at line start if loose
+PASS 31F3  KATAKANA LETTER SMALL TO may appear at line start if loose
+PASS 31F4  KATAKANA LETTER SMALL NU may appear at line start if loose
+PASS 31F5  KATAKANA LETTER SMALL HA may appear at line start if loose
+PASS 31F6  KATAKANA LETTER SMALL HI may appear at line start if loose
+PASS 31F7  KATAKANA LETTER SMALL HU may appear at line start if loose
+PASS 31F8  KATAKANA LETTER SMALL HE may appear at line start if loose
+PASS 31F9  KATAKANA LETTER SMALL HO may appear at line start if loose
+PASS 31FA  KATAKANA LETTER SMALL MU may appear at line start if loose
+PASS 31FB  KATAKANA LETTER SMALL RA may appear at line start if loose
+PASS 31FC  KATAKANA LETTER SMALL RI may appear at line start if loose
+PASS 31FD  KATAKANA LETTER SMALL RU may appear at line start if loose
+PASS 31FE  KATAKANA LETTER SMALL RE may appear at line start if loose
+PASS 31FF  KATAKANA LETTER SMALL RO may appear at line start if loose
+PASS FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if loose
+PASS FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if loose
+PASS FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if loose
+PASS FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if loose
+PASS FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if loose
+PASS FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if loose
+PASS FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if loose
+PASS FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if loose
+PASS FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if loose
+PASS FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal-expected.txt
@@ -1,256 +1,53 @@
 
-FAIL 3041  HIRAGANA LETTER SMALL A may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3043  HIRAGANA LETTER SMALL I may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3045  HIRAGANA LETTER SMALL U may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3047  HIRAGANA LETTER SMALL E may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3049  HIRAGANA LETTER SMALL O may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3063  HIRAGANA LETTER SMALL TU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3083  HIRAGANA LETTER SMALL YA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3085  HIRAGANA LETTER SMALL YU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3087  HIRAGANA LETTER SMALL YO may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 308E  HIRAGANA LETTER SMALL WA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3095  HIRAGANA LETTER SMALL KA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 3096  HIRAGANA LETTER SMALL KE may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A1  KATAKANA LETTER SMALL A may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A3  KATAKANA LETTER SMALL I may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A5  KATAKANA LETTER SMALL U may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A7  KATAKANA LETTER SMALL E may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30A9  KATAKANA LETTER SMALL O may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30C3  KATAKANA LETTER SMALL TU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E3  KATAKANA LETTER SMALL YA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E5  KATAKANA LETTER SMALL YU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30E7  KATAKANA LETTER SMALL YO may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30EE  KATAKANA LETTER SMALL WA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30F5  KATAKANA LETTER SMALL KA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30F6  KATAKANA LETTER SMALL KE may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F0  KATAKANA LETTER SMALL KU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F1  KATAKANA LETTER SMALL SI may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F2  KATAKANA LETTER SMALL SU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F3  KATAKANA LETTER SMALL TO may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F4  KATAKANA LETTER SMALL NU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F5  KATAKANA LETTER SMALL HA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F6  KATAKANA LETTER SMALL HI may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F7  KATAKANA LETTER SMALL HU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F8  KATAKANA LETTER SMALL HE may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31F9  KATAKANA LETTER SMALL HO may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FA  KATAKANA LETTER SMALL MU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FB  KATAKANA LETTER SMALL RA may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FC  KATAKANA LETTER SMALL RI may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FD  KATAKANA LETTER SMALL RU may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FE  KATAKANA LETTER SMALL RE may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 31FF  KATAKANA LETTER SMALL RO may appear at line start if normal assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-FAIL FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal assert_approx_equals: expected 54 +/- 1 but got 84
-3041
-文文文文文文ぁ字字
-文文文文文文
-ぁ字字
-3043
-文文文文文文ぃ字字
-文文文文文文
-ぃ字字
-3045
-文文文文文文ぅ字字
-文文文文文文
-ぅ字字
-3047
-文文文文文文ぇ字字
-文文文文文文
-ぇ字字
-3049
-文文文文文文ぉ字字
-文文文文文文
-ぉ字字
-3063
-文文文文文文っ字字
-文文文文文文
-っ字字
-3083
-文文文文文文ゃ字字
-文文文文文文
-ゃ字字
-3085
-文文文文文文ゅ字字
-文文文文文文
-ゅ字字
-3087
-文文文文文文ょ字字
-文文文文文文
-ょ字字
-308E
-文文文文文文ゎ字字
-文文文文文文
-ゎ字字
-3095
-文文文文文文ゕ字字
-文文文文文文
-ゕ字字
-3096
-文文文文文文ゖ字字
-文文文文文文
-ゖ字字
-30A1
-文文文文文文ァ字字
-文文文文文文
-ァ字字
-30A3
-文文文文文文ィ字字
-文文文文文文
-ィ字字
-30A5
-文文文文文文ゥ字字
-文文文文文文
-ゥ字字
-30A7
-文文文文文文ェ字字
-文文文文文文
-ェ字字
-30A9
-文文文文文文ォ字字
-文文文文文文
-ォ字字
-30C3
-文文文文文文ッ字字
-文文文文文文
-ッ字字
-30E3
-文文文文文文ャ字字
-文文文文文文
-ャ字字
-30E5
-文文文文文文ュ字字
-文文文文文文
-ュ字字
-30E7
-文文文文文文ョ字字
-文文文文文文
-ョ字字
-30EE
-文文文文文文ヮ字字
-文文文文文文
-ヮ字字
-30F5
-文文文文文文ヵ字字
-文文文文文文
-ヵ字字
-30F6
-文文文文文文ヶ字字
-文文文文文文
-ヶ字字
-30FC
-文文文文文文ー字字
-文文文文文文
-ー字字
-31F0
-文文文文文文ㇰ字字
-文文文文文文
-ㇰ字字
-31F1
-文文文文文文ㇱ字字
-文文文文文文
-ㇱ字字
-31F2
-文文文文文文ㇲ字字
-文文文文文文
-ㇲ字字
-31F3
-文文文文文文ㇳ字字
-文文文文文文
-ㇳ字字
-31F4
-文文文文文文ㇴ字字
-文文文文文文
-ㇴ字字
-31F5
-文文文文文文ㇵ字字
-文文文文文文
-ㇵ字字
-31F6
-文文文文文文ㇶ字字
-文文文文文文
-ㇶ字字
-31F7
-文文文文文文ㇷ字字
-文文文文文文
-ㇷ字字
-31F8
-文文文文文文ㇸ字字
-文文文文文文
-ㇸ字字
-31F9
-文文文文文文ㇹ字字
-文文文文文文
-ㇹ字字
-31FA
-文文文文文文ㇺ字字
-文文文文文文
-ㇺ字字
-31FB
-文文文文文文ㇻ字字
-文文文文文文
-ㇻ字字
-31FC
-文文文文文文ㇼ字字
-文文文文文文
-ㇼ字字
-31FD
-文文文文文文ㇽ字字
-文文文文文文
-ㇽ字字
-31FE
-文文文文文文ㇾ字字
-文文文文文文
-ㇾ字字
-31FF
-文文文文文文ㇿ字字
-文文文文文文
-ㇿ字字
-FF67
-文文文文文文ｧ字字
-文文文文文文
-ｧ字字
-FF68
-文文文文文文ｨ字字
-文文文文文文
-ｨ字字
-FF69
-文文文文文文ｩ字字
-文文文文文文
-ｩ字字
-FF6A
-文文文文文文ｪ字字
-文文文文文文
-ｪ字字
-FF6B
-文文文文文文ｫ字字
-文文文文文文
-ｫ字字
-FF6C
-文文文文文文ｬ字字
-文文文文文文
-ｬ字字
-FF6D
-文文文文文文ｭ字字
-文文文文文文
-ｭ字字
-FF6E
-文文文文文文ｮ字字
-文文文文文文
-ｮ字字
-FF6F
-文文文文文文ｯ字字
-文文文文文文
-ｯ字字
-FF70
-文文文文文文ｰ字字
-文文文文文文
-ｰ字字
+PASS 3041  HIRAGANA LETTER SMALL A may appear at line start if normal
+PASS 3043  HIRAGANA LETTER SMALL I may appear at line start if normal
+PASS 3045  HIRAGANA LETTER SMALL U may appear at line start if normal
+PASS 3047  HIRAGANA LETTER SMALL E may appear at line start if normal
+PASS 3049  HIRAGANA LETTER SMALL O may appear at line start if normal
+PASS 3063  HIRAGANA LETTER SMALL TU may appear at line start if normal
+PASS 3083  HIRAGANA LETTER SMALL YA may appear at line start if normal
+PASS 3085  HIRAGANA LETTER SMALL YU may appear at line start if normal
+PASS 3087  HIRAGANA LETTER SMALL YO may appear at line start if normal
+PASS 308E  HIRAGANA LETTER SMALL WA may appear at line start if normal
+PASS 3095  HIRAGANA LETTER SMALL KA may appear at line start if normal
+PASS 3096  HIRAGANA LETTER SMALL KE may appear at line start if normal
+PASS 30A1  KATAKANA LETTER SMALL A may appear at line start if normal
+PASS 30A3  KATAKANA LETTER SMALL I may appear at line start if normal
+PASS 30A5  KATAKANA LETTER SMALL U may appear at line start if normal
+PASS 30A7  KATAKANA LETTER SMALL E may appear at line start if normal
+PASS 30A9  KATAKANA LETTER SMALL O may appear at line start if normal
+PASS 30C3  KATAKANA LETTER SMALL TU may appear at line start if normal
+PASS 30E3  KATAKANA LETTER SMALL YA may appear at line start if normal
+PASS 30E5  KATAKANA LETTER SMALL YU may appear at line start if normal
+PASS 30E7  KATAKANA LETTER SMALL YO may appear at line start if normal
+PASS 30EE  KATAKANA LETTER SMALL WA may appear at line start if normal
+PASS 30F5  KATAKANA LETTER SMALL KA may appear at line start if normal
+PASS 30F6  KATAKANA LETTER SMALL KE may appear at line start if normal
+PASS 30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal
+PASS 31F0  KATAKANA LETTER SMALL KU may appear at line start if normal
+PASS 31F1  KATAKANA LETTER SMALL SI may appear at line start if normal
+PASS 31F2  KATAKANA LETTER SMALL SU may appear at line start if normal
+PASS 31F3  KATAKANA LETTER SMALL TO may appear at line start if normal
+PASS 31F4  KATAKANA LETTER SMALL NU may appear at line start if normal
+PASS 31F5  KATAKANA LETTER SMALL HA may appear at line start if normal
+PASS 31F6  KATAKANA LETTER SMALL HI may appear at line start if normal
+PASS 31F7  KATAKANA LETTER SMALL HU may appear at line start if normal
+PASS 31F8  KATAKANA LETTER SMALL HE may appear at line start if normal
+PASS 31F9  KATAKANA LETTER SMALL HO may appear at line start if normal
+PASS 31FA  KATAKANA LETTER SMALL MU may appear at line start if normal
+PASS 31FB  KATAKANA LETTER SMALL RA may appear at line start if normal
+PASS 31FC  KATAKANA LETTER SMALL RI may appear at line start if normal
+PASS 31FD  KATAKANA LETTER SMALL RU may appear at line start if normal
+PASS 31FE  KATAKANA LETTER SMALL RE may appear at line start if normal
+PASS 31FF  KATAKANA LETTER SMALL RO may appear at line start if normal
+PASS FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if normal
+PASS FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if normal
+PASS FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if normal
+PASS FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if normal
+PASS FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if normal
+PASS FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if normal
+PASS FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if normal
+PASS FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if normal
+PASS FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if normal
+PASS FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-iteration-loose-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-iteration-loose-expected.txt
@@ -1,31 +1,8 @@
 
-FAIL 3005  IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 309D  HIRAGANA ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 309E  HIRAGANA VOICED ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30FD  KATAKANA ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-FAIL 30FE  KATAKANA VOICED ITERATION MARK may appear at line start if lang unknown and loose assert_approx_equals: expected 69 +/- 1 but got 99
-3005
-文文文文文文々字字
-文文文文文文
-々字字
-303B
-文文文文文文〻字字
-文文文文文文
-〻字字
-309D
-文文文文文文ゝ字字
-文文文文文文
-ゝ字字
-309E
-文文文文文文ゞ字字
-文文文文文文
-ゞ字字
-30FD
-文文文文文文ヽ字字
-文文文文文文
-ヽ字字
-30FE
-文文文文文文ヾ字字
-文文文文文文
-ヾ字字
+PASS 3005  IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose
+PASS 303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose
+PASS 309D  HIRAGANA ITERATION MARK may appear at line start if lang unknown and loose
+PASS 309E  HIRAGANA VOICED ITERATION MARK may appear at line start if lang unknown and loose
+PASS 30FD  KATAKANA ITERATION MARK may appear at line start if lang unknown and loose
+PASS 30FE  KATAKANA VOICED ITERATION MARK may appear at line start if lang unknown and loose
+

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -149,13 +149,13 @@ void InlineAccess::dumpCacheSizesAndCrash()
 }
 
 
-ALWAYS_INLINE static bool linkCodeInline(const char* name, CCallHelpers& jit, StructureStubInfo& stubInfo)
+ALWAYS_INLINE static bool linkCodeInline(ASCIILiteral name, CCallHelpers& jit, StructureStubInfo& stubInfo)
 {
     if (jit.m_assembler.buffer().codeSize() <= stubInfo.inlineCodeSize()) {
         bool needsBranchCompaction = true;
         LinkBuffer linkBuffer(jit, stubInfo.startLocation, stubInfo.inlineCodeSize(), LinkBuffer::Profile::InlineCache, JITCompilationMustSucceed, needsBranchCompaction);
         ASSERT(linkBuffer.isValid());
-        FINALIZE_CODE(linkBuffer, NoPtrTag, ASCIILiteral::fromLiteralUnsafe(name), "InlineAccessType: '%s'", name);
+        FINALIZE_CODE(linkBuffer, NoPtrTag, name, "InlineAccessType: '%s'", name.characters());
         return true;
     }
 

--- a/Source/JavaScriptCore/jit/SpecializedThunkJIT.h
+++ b/Source/JavaScriptCore/jit/SpecializedThunkJIT.h
@@ -170,13 +170,13 @@ namespace JSC {
             ret();
         }
         
-        MacroAssemblerCodeRef<JITThunkPtrTag> finalize(CodePtr<JITThunkPtrTag> fallback, const char* thunkKind)
+        MacroAssemblerCodeRef<JITThunkPtrTag> finalize(CodePtr<JITThunkPtrTag> fallback, ASCIILiteral thunkKind)
         {
             m_failures.linkThunk(CodeLocationLabel<JITThunkPtrTag>(fallback), this);
             LinkBuffer patchBuffer(*this, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
             for (unsigned i = 0; i < m_calls.size(); i++)
                 patchBuffer.link(m_calls[i].first, m_calls[i].second);
-            return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, ASCIILiteral::fromLiteralUnsafe(thunkKind), "Specialized thunk for %s", thunkKind);
+            return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, thunkKind, "Specialized thunk for %s", thunkKind.characters());
         }
 
         // Assumes that the target function uses fpRegister0 as the first argument

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -76,7 +76,7 @@ namespace LLInt {
 // and others LLIntEntrypoints.
 
 template<PtrTag tag>
-static MacroAssemblerCodeRef<tag> generateThunkWithJumpTo(LLIntCode target, const char *thunkKind)
+static MacroAssemblerCodeRef<tag> generateThunkWithJumpTo(LLIntCode target, ASCIILiteral thunkKind)
 {
     JSInterfaceJIT jit;
 
@@ -91,17 +91,17 @@ static MacroAssemblerCodeRef<tag> generateThunkWithJumpTo(LLIntCode target, cons
     jit.farJump(scratch, OperationPtrTag);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::LLIntThunk);
-    return FINALIZE_THUNK(patchBuffer, tag, ASCIILiteral::fromLiteralUnsafe(thunkKind), "LLInt %s thunk", thunkKind);
+    return FINALIZE_THUNK(patchBuffer, tag, thunkKind, "LLInt %s thunk", thunkKind.characters());
 }
 
 template<PtrTag tag>
-static MacroAssemblerCodeRef<tag> generateThunkWithJumpTo(OpcodeID opcodeID, const char *thunkKind)
+static MacroAssemblerCodeRef<tag> generateThunkWithJumpTo(OpcodeID opcodeID, ASCIILiteral thunkKind)
 {
     return generateThunkWithJumpTo<tag>(LLInt::getCodeFunctionPtr<OperationPtrTag>(opcodeID), thunkKind);
 }
 
 template<PtrTag tag>
-static MacroAssemblerCodeRef<tag> generateThunkWithJumpToPrologue(OpcodeID opcodeID, const char *thunkKind)
+static MacroAssemblerCodeRef<tag> generateThunkWithJumpToPrologue(OpcodeID opcodeID, ASCIILiteral thunkKind)
 {
     JSInterfaceJIT jit;
 
@@ -118,21 +118,21 @@ static MacroAssemblerCodeRef<tag> generateThunkWithJumpToPrologue(OpcodeID opcod
     jit.farJump(scratch, OperationPtrTag);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::LLIntThunk);
-    return FINALIZE_THUNK(patchBuffer, tag, ASCIILiteral::fromLiteralUnsafe(thunkKind), "LLInt %s jump to prologue thunk", thunkKind);
+    return FINALIZE_THUNK(patchBuffer, tag, thunkKind, "LLInt %s jump to prologue thunk", thunkKind.characters());
 }
 
 template<PtrTag tag>
-static MacroAssemblerCodeRef<tag> generateThunkWithJumpToLLIntReturnPoint(LLIntCode target, const char *thunkKind)
+static MacroAssemblerCodeRef<tag> generateThunkWithJumpToLLIntReturnPoint(LLIntCode target, ASCIILiteral thunkKind)
 {
     JSInterfaceJIT jit;
     assertIsTaggedWith<OperationPtrTag>(target);
     jit.farJump(CCallHelpers::TrustedImmPtr(target), OperationPtrTag);
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::LLIntThunk);
-    return FINALIZE_THUNK(patchBuffer, tag, ASCIILiteral::fromLiteralUnsafe(thunkKind), "LLInt %s return point thunk", thunkKind);
+    return FINALIZE_THUNK(patchBuffer, tag, thunkKind, "LLInt %s return point thunk", thunkKind.characters());
 }
 
 template<PtrTag tag>
-static MacroAssemblerCodeRef<tag> generateThunkWithJumpToLLIntReturnPoint(OpcodeID opcodeID, const char *thunkKind)
+static MacroAssemblerCodeRef<tag> generateThunkWithJumpToLLIntReturnPoint(OpcodeID opcodeID, ASCIILiteral thunkKind)
 {
     return generateThunkWithJumpToLLIntReturnPoint<tag>(LLInt::getCodeFunctionPtr<OperationPtrTag>(opcodeID), thunkKind);
 }
@@ -292,7 +292,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> callToThrowThunk()
     static LazyNeverDestroyed<MacroAssemblerCodeRef<ExceptionHandlerPtrTag>> codeRef;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
-        codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(llint_throw_during_call_trampoline, "LLInt::callToThrow thunk"));
+        codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(llint_throw_during_call_trampoline, "LLInt::callToThrow thunk"_s));
     });
     return codeRef;
 }
@@ -302,7 +302,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> handleUncaughtExceptionThunk()
     static LazyNeverDestroyed<MacroAssemblerCodeRef<ExceptionHandlerPtrTag>> codeRef;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
-        codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(llint_handle_uncaught_exception, "handle_uncaught_exception"));
+        codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(llint_handle_uncaught_exception, "handle_uncaught_exception"_s));
     });
     return codeRef;
 }
@@ -314,7 +314,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> handleCatchThunk(OpcodeSize size)
         static LazyNeverDestroyed<MacroAssemblerCodeRef<ExceptionHandlerPtrTag>> codeRef;
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
-            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getCodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch"));
+            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getCodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch"_s));
         });
         return codeRef;
     }
@@ -322,7 +322,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> handleCatchThunk(OpcodeSize size)
         static LazyNeverDestroyed<MacroAssemblerCodeRef<ExceptionHandlerPtrTag>> codeRef;
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
-            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getWide16CodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch16"));
+            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getWide16CodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch16"_s));
         });
         return codeRef;
     }
@@ -330,7 +330,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> handleCatchThunk(OpcodeSize size)
         static LazyNeverDestroyed<MacroAssemblerCodeRef<ExceptionHandlerPtrTag>> codeRef;
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
-            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getWide32CodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch32"));
+            codeRef.construct(generateThunkWithJumpTo<ExceptionHandlerPtrTag>(LLInt::getWide32CodeFunctionPtr<OperationPtrTag>(op_catch), "op_catch32"_s));
         });
         return codeRef;
     }
@@ -376,7 +376,7 @@ MacroAssemblerCodeRef<JSEntryPtrTag> fuzzerReturnEarlyFromLoopHintThunk()
     static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
-        codeRef.construct(generateThunkWithJumpTo<JSEntryPtrTag>(fuzzer_return_early_from_loop_hint, "fuzzer_return_early_from_loop_hint"));
+        codeRef.construct(generateThunkWithJumpTo<JSEntryPtrTag>(fuzzer_return_early_from_loop_hint, "fuzzer_return_early_from_loop_hint"_s));
     });
     return codeRef;
 }
@@ -818,7 +818,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunk()
         static std::once_flag onceKey; \
         std::call_once(onceKey, [&] { \
             if (Options::useJIT()) \
-                codeRef.construct(generateThunkWithJumpTo<JITThunkPtrTag>(target, #target)); \
+                codeRef.construct(generateThunkWithJumpTo<JITThunkPtrTag>(target, #target ""_s)); \
             else \
                 codeRef.construct(getCodeRef<JITThunkPtrTag>(target)); \
         }); \

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
@@ -39,7 +39,7 @@ Ref<JSON::Value> Bytecode::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex);
-    result->setString(dumper.keys().m_opcode, String::fromUTF8(opcodeNames[m_opcodeID]));
+    result->setString(dumper.keys().m_opcode, opcodeNames[m_opcodeID]);
     result->setString(dumper.keys().m_description, String::fromUTF8(m_description.span()));
     return result;
 }

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
@@ -66,7 +66,7 @@ Ref<JSON::Value> Bytecodes::toJSON(Dumper& dumper) const
             sourceCode = makeString(StringView(sourceCode).left(size - 1), horizontalEllipsis);
     }
     result->setString(dumper.keys().m_sourceCode, WTF::move(sourceCode));
-    result->setString(dumper.keys().m_hash, String::fromUTF8(toCString(m_hash).span()));
+    result->setString(dumper.keys().m_hash, toString(m_hash));
     result->setDouble(dumper.keys().m_instructionCount, m_instructionCount);
     addSequenceProperties(dumper, result.get());
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
@@ -101,9 +101,9 @@ void Compilation::setJettisonReason(JettisonReason jettisonReason, const FireDet
     
     m_jettisonReason = jettisonReason;
     if (detail)
-        m_additionalJettisonReason = toCString(*detail);
+        m_additionalJettisonReason = toString(*detail);
     else
-        m_additionalJettisonReason = CString();
+        m_additionalJettisonReason = { };
 }
 
 void Compilation::dump(PrintStream& out) const
@@ -115,7 +115,7 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
-    result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toCString(m_kind).span()));
+    result->setString(dumper.keys().m_compilationKind, toString(m_kind));
 
     auto profiledBytecodes = JSON::Array::create();
     for (const auto& bytecode : m_profiledBytecodes)
@@ -149,9 +149,9 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
     result->setDouble(dumper.keys().m_numInlinedGetByIds, m_numInlinedGetByIds);
     result->setDouble(dumper.keys().m_numInlinedPutByIds, m_numInlinedPutByIds);
     result->setDouble(dumper.keys().m_numInlinedCalls, m_numInlinedCalls);
-    result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toCString(m_jettisonReason).span()));
+    result->setString(dumper.keys().m_jettisonReason, toString(m_jettisonReason));
     if (!m_additionalJettisonReason.isNull())
-        result->setString(dumper.keys().m_additionalJettisonReason, String::fromUTF8(m_additionalJettisonReason.span()));
+        result->setString(dumper.keys().m_additionalJettisonReason, m_additionalJettisonReason);
 
     result->setString(dumper.keys().m_uid, makeString(m_uid));
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.h
@@ -94,7 +94,7 @@ private:
     unsigned m_numInlinedPutByIds;
     unsigned m_numInlinedCalls;
     JettisonReason m_jettisonReason;
-    CString m_additionalJettisonReason;
+    String m_additionalJettisonReason;
     UID m_uid;
 };
 

--- a/Source/JavaScriptCore/runtime/BundlePath.h
+++ b/Source/JavaScriptCore/runtime/BundlePath.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <string>
 #include <wtf/text/CString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/BundlePath.mm
+++ b/Source/JavaScriptCore/runtime/BundlePath.mm
@@ -27,14 +27,12 @@
 #import "BundlePath.h"
 
 #import <Foundation/Foundation.h>
-#import <string>
 
 @interface JSJavaScriptCoreFinder : NSObject
 @end
 
 @implementation JSJavaScriptCoreFinder
 @end
-
 
 namespace JSC {
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -71,7 +71,7 @@ static String fromStdFileSystemPath(const std::filesystem::path& path)
     // FIXME: This uses u8string so how can it be correct inside HAVE(MISSING_U8STRING)?
     return String::fromUTF8(unsafeSpan(path.u8string().c_str()));
 #else
-    return String::fromUTF8(span(path.u8string()));
+    return span(path.u8string());
 #endif
 }
 

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -155,7 +155,7 @@ std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView su
     if (!fileHandle)
         return { nullString(), FileHandle() };
 
-    return { String::fromUTF8(temporaryFilePath.span().data()), WTF::move(fileHandle) };
+    return { byteCast<char8_t>(temporaryFilePath.span()), WTF::move(fileHandle) };
 }
 
 NSString *createTemporaryDirectory(NSString *directoryPrefix)

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -145,7 +145,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void LibraryPathDiagnosticsLogger::logExecutablePath(void)
 {
-    logString(std::initializer_list<String> { "Path"_s }, FileSystem::realPath(String::fromUTF8(_CFProcessPath())));
+    logString(std::initializer_list<String> { "Path"_s }, FileSystem::realPath(FileSystem::stringFromFileSystemRepresentation(_CFProcessPath())));
 }
 
 void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
@@ -154,7 +154,7 @@ void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
     _dyld_get_shared_cache_uuid(uuid);
 
     auto sharedCacheInfo = JSON::Object::create();
-    sharedCacheInfo->setString("Path"_s, FileSystem::realPath(String::fromUTF8(dyld_shared_cache_file_path())));
+    sharedCacheInfo->setString("Path"_s, FileSystem::realPath(FileSystem::stringFromFileSystemRepresentation(dyld_shared_cache_file_path())));
     sharedCacheInfo->setString("UUID"_s, uuidToString(uuid));
 
     logObject(std::initializer_list<String> { "SharedCache"_s }, WTF::move(sharedCacheInfo));
@@ -200,7 +200,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     auto libraryObject = JSON::Object::create();
 
-    libraryObject->setString("Path"_s, FileSystem::realPath(String::fromUTF8(info.dli_fname)));
+    libraryObject->setString("Path"_s, FileSystem::realPath(FileSystem::stringFromFileSystemRepresentation(info.dli_fname)));
     libraryObject->setString("UUID"_s, uuidToString(uuid));
 
 #if HAVE(SHARED_REGION_SPI)

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -177,6 +177,11 @@ constexpr std::span<const char8_t> operator""_span(const char8_t* characters, si
     return unsafeMakeSpan(characters, n);
 }
 
+constexpr std::span<const char16_t> operator""_span(const char16_t* characters, size_t n)
+{
+    return unsafeMakeSpan(characters, n);
+}
+
 } // inline StringLiterals
 
 // ASCIILiteral is null terminated

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -125,12 +125,6 @@ AtomString AtomString::number(double number)
     return AtomString { byteCast<Latin1Character>(span) };
 }
 
-AtomString AtomString::fromUTF8Internal(std::span<const char> characters)
-{
-    ASSERT(!characters.empty());
-    return AtomStringImpl::add(byteCast<char8_t>(characters));
-}
-
 #ifndef NDEBUG
 
 void AtomString::show() const

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -43,9 +43,12 @@ public:
     AtomString(StringImpl* baseString, unsigned start, unsigned length);
 
     // FIXME: AtomString doesn’t always have AtomStringImpl, so one of those two names needs to change.
-    AtomString(UniquedStringImpl* uid);
+    AtomString(UniquedStringImpl*);
 
     AtomString(ASCIILiteral);
+
+    // Construct a string with UTF-8 data, null string if it contains invalid UTF-8 sequences.
+    AtomString(std::span<const char8_t>);
 
     static AtomString lookUp(std::span<const char16_t> characters) { return AtomStringImpl::lookUp(characters); }
 
@@ -68,7 +71,7 @@ public:
     std::span<const char16_t> span16() const LIFETIME_BOUND { return m_string.span16(); }
     unsigned length() const { return m_string.length(); }
 
-    char16_t operator[](unsigned int i) const { return m_string[i]; }
+    char16_t operator[](unsigned i) const { return m_string[i]; }
 
     WTF_EXPORT_PRIVATE static AtomString number(int);
     WTF_EXPORT_PRIVATE static AtomString number(unsigned);
@@ -124,21 +127,13 @@ public:
         : AtomString(characters, characters ? wcslen(characters) : 0) { }
 #endif
 
-    // AtomString::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
-    static AtomString fromUTF8(std::span<const char>);
-    static AtomString fromUTF8(const char*);
-
 #ifndef NDEBUG
     void show() const;
 #endif
 
 private:
-    explicit AtomString(const char*);
-
     enum class CaseConvertType { Upper, Lower };
     template<CaseConvertType> AtomString convertASCIICase() const;
-
-    WTF_EXPORT_PRIVATE static AtomString fromUTF8Internal(std::span<const char>);
 
     String m_string;
 };
@@ -171,6 +166,11 @@ inline AtomString::AtomString(std::span<const Latin1Character> string)
 }
 
 inline AtomString::AtomString(std::span<const char16_t> string)
+    : m_string(AtomStringImpl::add(string))
+{
+}
+
+inline AtomString::AtomString(std::span<const char8_t> string)
     : m_string(AtomStringImpl::add(string))
 {
 }
@@ -256,24 +256,6 @@ inline const AtomString& emptyAtom() { SUPPRESS_MEMORY_UNSAFE_CAST return *reint
 inline AtomString::AtomString(ASCIILiteral literal)
     : m_string(literal.length() ? AtomStringImpl::add(literal) : Ref { *emptyAtom().impl() })
 {
-}
-
-inline AtomString AtomString::fromUTF8(std::span<const char> characters)
-{
-    if (!characters.data())
-        return nullAtom();
-    if (characters.empty())
-        return emptyAtom();
-    return fromUTF8Internal(characters);
-}
-
-inline AtomString AtomString::fromUTF8(const char* characters)
-{
-    if (!characters)
-        return nullAtom();
-    if (!*characters)
-        return emptyAtom();
-    return fromUTF8Internal(unsafeSpan(characters));
 }
 
 inline AtomString String::toExistingAtomString() const

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -476,9 +476,16 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char8_t> characters)
 {
+    if (!characters.data())
+        return nullptr;
+
+    if (characters.empty())
+        return uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
+
     HashedUTF8Characters buffer { characters, computeUTF16LengthWithHash(characters) };
     if (!buffer.length.hash)
         return nullptr;
+
     return addToStringTable<HashedUTF8Characters, HashedUTF8CharactersTranslator>(buffer);
 }
 

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -49,7 +49,7 @@ public:
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral);
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
-    static RefPtr<AtomStringImpl> add(std::span<const char8_t>);
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const char8_t>);
 
 #if USE(CF)
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(CFStringRef);

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -319,14 +319,14 @@ private:
 };
 
 template<typename UnderlyingElementType> struct PaddingSpecification {
-    Latin1Character character;
+    char16_t character;
     unsigned length;
     UnderlyingElementType underlyingElement;
 };
 
-template<typename UnderlyingElementType> PaddingSpecification<UnderlyingElementType> pad(char character, unsigned length, UnderlyingElementType element)
+template<typename UnderlyingElementType> PaddingSpecification<UnderlyingElementType> pad(char16_t character, unsigned length, UnderlyingElementType element)
 {
-    return { byteCast<Latin1Character>(character), length, element };
+    return { character, length, element };
 }
 
 template<typename UnderlyingElementType> class StringTypeAdapter<PaddingSpecification<UnderlyingElementType>> {
@@ -338,7 +338,7 @@ public:
     }
 
     unsigned length() const { return std::max(m_padding.length, m_underlyingAdapter.length()); }
-    bool is8Bit() const { return m_underlyingAdapter.is8Bit(); }
+    bool is8Bit() const { return m_underlyingAdapter.is8Bit() && isLatin1(m_padding.character); }
     template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
         unsigned underlyingLength = m_underlyingAdapter.length();

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -40,24 +40,28 @@
 namespace WTF {
 
 // Construct a string with UTF-16 data.
+// FIXME: We could implement the rule where a null span turns into a null String in StringImpl::create instead of here.
 String::String(std::span<const char16_t> characters)
     : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullptr)
 {
 }
 
 // Construct a string with latin1 data.
+// FIXME: We could implement the rule where a null span turns into a null String in StringImpl::create instead of here.
 String::String(std::span<const Latin1Character> characters)
     : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullptr)
 {
 }
 
 // Construct a string with UTF-8 data.
+// FIXME: We could implement the rule where a null span turns into a null String in StringImpl::create instead of here.
 String::String(std::span<const char8_t> characters)
-    : m_impl(StringImpl::create(characters))
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(characters) } : nullptr)
 {
 }
 
 // Construct a string with Latin-1 data.
+// FIXME: We could implement the rule where a null span turns into a null String in StringImpl::create instead of here.
 String::String(std::span<const char> characters)
     : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<Latin1Character>(characters)) } : nullptr)
 {

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -29,6 +29,30 @@
 
 namespace WTF {
 
+template<typename T, size_t size>
+auto dynamicEquivalent(std::span<T, size> span)
+{
+    return std::span<T> { span };
+}
+
+template<typename T>
+auto dynamicSpan(T& argument)
+{
+    return dynamicEquivalent(std::span { argument });
+}
+
+template<typename T, size_t size>
+auto immutableDynamicEquivalent(std::span<T, size> span)
+{
+    return std::span<const T> { span };
+}
+
+template<typename T>
+auto immutableDynamicSpan(T& argument)
+{
+    return immutableDynamicEquivalent(std::span { argument });
+}
+
 class TextBreakIteratorICU {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(TextBreakIteratorICU);
 public:
@@ -152,12 +176,10 @@ private:
         if (behavior == LineMode::Behavior::Default)
             return locale;
 
-        // The uloc functions model locales as char*, so we have to downconvert our AtomString.
-        auto utf8Locale = locale.string().utf8();
-        if (!utf8Locale.length())
-            return locale;
-        Vector<char> scratchBuffer(utf8Locale.length() + 11, 0);
-        memcpySpan(scratchBuffer.mutableSpan(), utf8Locale.span());
+        // The uloc functions take const char* for locales, and locale strings are all ASCII.
+        std::array<Latin1Character, ULOC_FULLNAME_CAPACITY> buffer;
+        StringView { locale }.getCharacters(dynamicSpan(buffer));
+        zeroSpan(dynamicSpan(buffer).subspan(locale.length()));
 
         const char* keywordValue = nullptr;
         switch (behavior) {
@@ -177,18 +199,9 @@ private:
         }
 
         UErrorCode status = U_ZERO_ERROR;
-        int32_t lengthNeeded = uloc_setKeywordValue("lb", keywordValue, scratchBuffer.mutableSpan().data(), scratchBuffer.size(), &status);
+        int32_t lengthNeeded = uloc_setKeywordValue("lb", keywordValue, byteCast<char>(buffer.data()), buffer.size(), &status);
         if (U_SUCCESS(status))
-            return AtomString::fromUTF8(scratchBuffer.subspan(0, lengthNeeded));
-        if (needsToGrowToProduceBuffer(status)) {
-            scratchBuffer.grow(lengthNeeded + 1);
-            zeroSpan(scratchBuffer.mutableSpan().subspan(utf8Locale.length()));
-            status = U_ZERO_ERROR;
-            int32_t lengthNeeded2 = uloc_setKeywordValue("lb", keywordValue, scratchBuffer.mutableSpan().data(), scratchBuffer.size(), &status);
-            if (!U_SUCCESS(status) || lengthNeeded != lengthNeeded2)
-                return locale;
-            return AtomString::fromUTF8(scratchBuffer.subspan(0, lengthNeeded));
-        }
+            return immutableDynamicSpan(buffer).subspan(0, lengthNeeded);
         return locale;
     }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4273,14 +4273,9 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
             }
             // Fall through to other name computation methods.
         } else {
-            String inputValue = input->value();
-            if (input->isPasswordField()) {
-                StringBuilder passwordValue;
-                passwordValue.reserveCapacity(inputValue.length());
-                for (size_t i = 0; i < inputValue.length(); i++)
-                    passwordValue.append(String::fromUTF8("•"));
-                return passwordValue.toString();
-            }
+            auto inputValue = input->value();
+            if (input->isPasswordField())
+                return makeString(pad(bullet, inputValue.get().length(), ""_s));
             return inputValue;
         }
     }

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -32,6 +32,7 @@
 #include "ResourceRequest.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <JavaScriptCore/JavaScript.h>
+#include <JavaScriptCore/OpaqueJSString.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
@@ -418,12 +419,14 @@ auto RedirectAction::RegexSubstitutionAction::deserialize(std::span<const uint8_
 
 static JSRetainPtr<JSStringRef> makeJSString(ASCIILiteral literal)
 {
-    return adopt(JSStringCreateWithUTF8CString(literal));
+    // This is a safer cpp false positive (rdar://148521896).
+    SUPPRESS_UNCOUNTED_ARG return adopt(JSStringCreateWithUTF8CString(literal));
 }
 
 static JSRetainPtr<JSStringRef> makeJSString(const String& string)
 {
-    return adopt(JSStringCreateWithUTF8CString(string.utf8().data()));
+    // This is a safer cpp false positive (rdar://148521896).
+    SUPPRESS_UNCOUNTED_ARG return adopt(JSStringCreateWithUTF8CString(string.utf8().data()));
 }
 
 void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
@@ -439,25 +442,25 @@ void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
         return JSValueToObject(context, value, nullptr);
     };
     auto getProperty = [&] (JSValueRef value, ASCIILiteral name) {
-        return JSObjectGetProperty(context, toObject(value), makeJSString(name).get(), nullptr);
+        // This is a safer cpp false positive (rdar://148521896).
+        SUPPRESS_UNCOUNTED_ARG return JSObjectGetProperty(context, toObject(value), makeJSString(name).get(), nullptr);
     };
     auto getArrayValue = [&] (JSValueRef value, size_t index) {
         return JSObjectGetPropertyAtIndex(context, toObject(value), index, nullptr);
     };
     auto valueToWTFString = [&] (JSValueRef value) {
-        auto string = adopt(JSValueToStringCopy(context, value, nullptr));
-        size_t bufferSize = JSStringGetMaximumUTF8CStringSize(string.get());
-        Vector<char> buffer(bufferSize);
-        JSStringGetUTF8CString(string.get(), buffer.mutableSpan().data(), buffer.size());
-        return String::fromUTF8(buffer.span().data());
+        // This is a safer cpp false positive (rdar://148521896).
+        SUPPRESS_UNCOUNTED_ARG return adopt(JSValueToStringCopy(context, value, nullptr))->string();
     };
 
     // Effectively execute this JavaScript:
     // const regexp = new RegExp(regexFilter);
     // const result = url.match(regexp);
-    JSValueRef regexFilterValue = JSValueMakeString(context, makeJSString(regexFilter).get());
+    // This is a safer cpp false positive (rdar://148521896).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef regexFilterValue = JSValueMakeString(context, makeJSString(regexFilter).get());
     JSObjectRef regexp = JSObjectMakeRegExp(context, 1, &regexFilterValue, nullptr);
-    JSValueRef urlValue = JSValueMakeString(context, makeJSString(url.string()).get());
+    // This is a safer cpp false positive (rdar://148521896).
+    SUPPRESS_UNCOUNTED_ARG JSValueRef urlValue = JSValueMakeString(context, makeJSString(url.string()).get());
     JSObjectRef matchFunction = JSValueToObject(context, getProperty(urlValue, "match"_s), nullptr);
     JSValueRef result = JSObjectCallAsFunction(context, matchFunction, toObject(urlValue), 1, &regexp, nullptr);
     if (!JSValueIsArray(context, result))

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -161,7 +161,7 @@ const HashMap<String, int>& WebGLProgram::uniformLocations() LIFETIME_BOUND
     if (!m_state.uniformLocations) {
         auto& locations = m_state.uniformLocations.emplace();
         for (auto& activeUniform : activeUniforms()) {
-            auto name = String::fromUTF8(activeUniform.name.data());
+            auto name = String::fromUTF8(activeUniform.name.span());
             locations.add(name, activeUniform.locations[0]);
             if (name.endsWith("[0]"_s)) {
                 auto baseName = name.left(name.length() - 3);
@@ -183,7 +183,7 @@ const HashMap<String, unsigned>& WebGLProgram::uniformIndices() LIFETIME_BOUND
         auto activeUniforms = this->activeUniforms();
         for (unsigned i = 0; i < activeUniforms.size(); ++i) {
             auto& activeUniform = activeUniforms[i];
-            auto name = String::fromUTF8(activeUniform.name.data());
+            auto name = String::fromUTF8(activeUniform.name.span());
             indices.add(name, i);
             if (name.endsWith("[0]"_s)) {
                 auto baseName = name.left(name.length() - 3);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5562,9 +5562,9 @@ void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGL
 
     if (type == GraphicsContextGL::DEBUG_TYPE_ERROR) {
         level = MessageLevel::Error;
-        formattedMessage = makeString("WebGL: "_s, errorCodeToString(glEnumToErrorCode(id)), ": "_s, String::fromUTF8(message.span()));
+        formattedMessage = makeString("WebGL: "_s, errorCodeToString(glEnumToErrorCode(id)), ": "_s, byteCast<char8_t>(message.span()));
     } else
-        formattedMessage = makeString("WebGL debug message: type:"_s, debugMessageTypeToString(type), ", id:"_s, id, " severity: "_s, debugMessageSeverityToString(severity), ": "_s, String::fromUTF8(message.span()));
+        formattedMessage = makeString("WebGL debug message: type:"_s, debugMessageTypeToString(type), ", id:"_s, id, " severity: "_s, debugMessageSeverityToString(severity), ": "_s, byteCast<char8_t>(message.span()));
 
     auto consoleMessage = makeUnique<Inspector::ConsoleMessage>(MessageSource::Rendering, MessageType::Log, level, WTF::move(formattedMessage));
     scriptExecutionContext->addConsoleMessage(WTF::move(consoleMessage));

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -158,7 +158,7 @@ static bool platformTypeConformsToWebArchivePBoardType(NSString *platformType, U
     return false;
 }
 
-static const char *safeTypeForDOMToReadAndWriteForPlatformType(NSString *platformType, PlatformPasteboard::IncludeImageTypes includeImageTypes)
+static ASCIILiteral safeTypeForDOMToReadAndWriteForPlatformType(NSString *platformType, PlatformPasteboard::IncludeImageTypes includeImageTypes)
 {
     RetainPtr utType = [UTType typeWithIdentifier:platformType];
     if ([utType conformsToType:UTTypePlainText])
@@ -191,12 +191,10 @@ static Vector<String> webSafeTypes(NSArray<NSString *> *platformTypes, PlatformP
             continue;
         }
 
-        if (auto* coercedType = safeTypeForDOMToReadAndWriteForPlatformType(type, includeImageTypes)) {
-            auto domTypeAsString = String::fromUTF8(coercedType);
-            if (domTypeAsString == "text/uri-list"_s && ([platformTypes containsObject:UTTypeFileURL.identifier] || shouldAvoidExposingURLType()))
+        if (auto coercedType = safeTypeForDOMToReadAndWriteForPlatformType(type, includeImageTypes)) {
+            if (coercedType == "text/uri-list"_s && ([platformTypes containsObject:UTTypeFileURL.identifier] || shouldAvoidExposingURLType()))
                 continue;
-
-            domPasteboardTypes.add(WTF::move(domTypeAsString));
+            domPasteboardTypes.add(coercedType);
         }
     }
     return copyToVector(domPasteboardTypes);

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -701,6 +701,11 @@ static inline bool isValidHeaderNameCharacter(CharacterType character)
     }
 }
 
+static bool isValid(std::span<const char8_t> codeUnits)
+{
+    return WTF::Unicode::checkUTF8(codeUnits).characters.size() == codeUnits.size();
+}
+
 size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, StringView& nameStr, String& valueStr, bool strict)
 {
     auto p = data;
@@ -777,8 +782,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
         failureReason = makeString("CR doesn't follow LF after header value at "_s, trimInputSample(p));
         return 0;
     }
-    valueStr = String::fromUTF8(value.span());
-    if (valueStr.isNull()) {
+    if (!isValid(byteCast<char8_t>(value.span()))) {
         failureReason = "Invalid UTF-8 sequence in header value"_s;
         return 0;
     }

--- a/Source/WebCore/style/computed/StyleComputedStyle+DifferenceLogging.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle+DifferenceLogging.h
@@ -37,13 +37,13 @@
 namespace WebCore {
 
 #define LOG_IF_DIFFERENT(name) \
-    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), name, other.name); } while (0)
+    do { logIfDifferent(ts, #name ""_s, name, other.name); } while (0)
 
 #define LOG_IF_DIFFERENT_WITH_CAST(type, name) \
-    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), static_cast<type>(name), static_cast<type>(other.name)); } while (0)
+    do { logIfDifferent(ts, #name ""_s, static_cast<type>(name), static_cast<type>(other.name)); } while (0)
 
 #define LOG_IF_DIFFERENT_WITH_FROM_RAW(type, name) \
-    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), type::fromRaw(name), type::fromRaw(other.name)); } while (0)
+    do { logIfDifferent(ts, #name ""_s, type::fromRaw(name), type::fromRaw(other.name)); } while (0)
 
 template<class T>
 struct is_pointer_wrapper : std::false_type { };

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -741,12 +741,12 @@ static inline String toString(const xmlChar* string)
 
 static inline AtomString toAtomString(std::span<const xmlChar> string)
 {
-    return AtomString::fromUTF8(byteCast<char>(string));
+    return byteCast<char8_t>(string);
 }
 
 static inline AtomString toAtomString(const xmlChar* string)
 {
-    return AtomString::fromUTF8(byteCast<char>(string));
+    return byteCast<char8_t>(unsafeSpan(byteCast<char>(string)));
 }
 
 struct _xmlSAX2Namespace {

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -153,7 +153,7 @@ String stringByResolvingSymlinksInPath(StringView path)
 {
     char resolvedPath[PATH_MAX] = { 0 };
     realpath(path.utf8().data(), resolvedPath);
-    return String::fromUTF8(resolvedPath);
+    return FileSystem::stringFromFileSystemRepresentation(resolvedPath);
 }
 
 String resolveAndCreateReadWriteDirectoryForSandboxExtension(StringView path)

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -117,7 +117,7 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashDueWebKitFrameworkVersionMi
 static void checkFrameworkVersion(xpc_object_t message)
 {
     auto uiProcessWebKitBundleVersion = xpcDictionaryGetString(message, "WebKitBundleVersion"_s);
-    auto webkitBundleVersion = ASCIILiteral::fromLiteralUnsafe(WEBKIT_BUNDLE_VERSION);
+    auto webkitBundleVersion = WEBKIT_BUNDLE_VERSION ""_s;
     if (!uiProcessWebKitBundleVersion.isNull() && uiProcessWebKitBundleVersion != webkitBundleVersion) {
         auto errorMessage = makeString("WebKit framework version mismatch: "_s, uiProcessWebKitBundleVersion, " != "_s, webkitBundleVersion);
         logAndSetCrashLogMessage(errorMessage.utf8().data());

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -450,8 +450,8 @@ gboolean webkit_user_content_manager_register_script_message_handler(WebKitUserC
     g_return_val_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager), FALSE);
     g_return_val_if_fail(name, FALSE);
 
-    Ref<WebScriptMessageHandler> handler =
-        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), AtomString::fromUTF8(name), API::ContentWorld::pageContentWorldSingleton());
+    Ref handler =
+        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), byteCast<char8_t>(unsafeSpan(name)), API::ContentWorld::pageContentWorldSingleton());
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 
@@ -467,8 +467,8 @@ gboolean webkit_user_content_manager_register_script_message_handler(WebKitUserC
     g_return_val_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager), FALSE);
     g_return_val_if_fail(name, FALSE);
 
-    Ref<WebScriptMessageHandler> handler =
-        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), AtomString::fromUTF8(name), worldName ? webkitContentWorld(worldName) : API::ContentWorld::pageContentWorldSingleton());
+    Ref handler =
+        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), byteCast<char8_t>(unsafeSpan(name)), worldName ? webkitContentWorld(worldName) : API::ContentWorld::pageContentWorldSingleton());
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 
@@ -512,7 +512,7 @@ gboolean webkit_user_content_manager_register_script_message_handler_with_reply(
     g_return_val_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager), FALSE);
     g_return_val_if_fail(name, FALSE);
 
-    auto handler = WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, true), AtomString::fromUTF8(name), worldName ? webkitContentWorld(worldName) : API::ContentWorld::pageContentWorldSingleton());
+    auto handler = WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, true), byteCast<char8_t>(unsafeSpan(name)), worldName ? webkitContentWorld(worldName) : API::ContentWorld::pageContentWorldSingleton());
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 
@@ -523,8 +523,8 @@ gboolean webkit_user_content_manager_register_script_message_handler_in_world(We
     g_return_val_if_fail(name, FALSE);
     g_return_val_if_fail(worldName, FALSE);
 
-    Ref<WebScriptMessageHandler> handler =
-        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), AtomString::fromUTF8(name), webkitContentWorld(worldName));
+    Ref handler =
+        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), byteCast<char8_t>(unsafeSpan(name)), webkitContentWorld(worldName));
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 
@@ -534,7 +534,7 @@ void webkit_user_content_manager_unregister_script_message_handler_in_world(WebK
     g_return_if_fail(name);
     g_return_if_fail(worldName);
 
-    manager->priv->userContentController->removeUserMessageHandlerForName(String::fromUTF8(name), webkitContentWorld(worldName));
+    manager->priv->userContentController->removeUserMessageHandlerForName(byteCast<char8_t>(unsafeSpan(name)), webkitContentWorld(worldName));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -325,16 +325,16 @@ static inline void decodeFrameState(GVariant* frameStateVariant, FrameState& fra
     frameState.originalURLString = String::fromUTF8(originalURLString);
     // frameState.referrer must not be an empty string since we never want to
     // send an empty Referer header. Bug #159606.
-    if (auto referrerString = String::fromUTF8(referrer); !referrerString.isEmpty())
+    if (AtomString referrerString = byteCast<char8_t>(unsafeSpan(referrer)); !referrerString.isEmpty())
         frameState.referrer = WTF::move(referrerString);
-    if (auto targetString = AtomString::fromUTF8(target); !targetString.isEmpty())
+    if (AtomString targetString = byteCast<char8_t>(unsafeSpan(target)); !targetString.isEmpty())
         frameState.target = WTF::move(targetString);
     if (gsize documentStateLength = g_variant_iter_n_children(documentStateIter.get())) {
         Vector<AtomString> documentState;
         documentState.reserveInitialCapacity(documentStateLength);
         const char* documentStateString;
         while (g_variant_iter_next(documentStateIter.get(), "&s", &documentStateString))
-            documentState.append(AtomString::fromUTF8(documentStateString));
+            documentState.append(AtomString { byteCast<char8_t>(unsafeSpan(documentStateString)) });
         frameState.setDocumentState(documentState);
     }
     if (stateObjectDataIter) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3125,13 +3125,7 @@ static NSString *computeStringHashForContentBlockerRules(NSString *rules)
 {
     SHA1 sha1;
     sha1.addUTF8Bytes(rules);
-
-    SHA1::Digest digest;
-    sha1.computeHash(digest);
-
-    auto hashAsCString = SHA1::hexDigest(digest);
-    auto hashAsString = String::fromUTF8(hashAsCString.span()).createNSString();
-    return [hashAsString stringByAppendingString:[NSString stringWithFormat:@"-%zu", currentDeclarativeNetRequestRuleTranslatorVersion]];
+    return [NSString stringWithFormat:@"%s-%zu", sha1.computeHexDigest().data(), currentDeclarativeNetRequestRuleTranslatorVersion];
 }
 
 void WebExtensionContext::compileDeclarativeNetRequestRules(NSDictionary *rulesData, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -43,6 +43,7 @@
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
+#include <wtf/SortedArrayMap.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -2183,41 +2184,41 @@ static bool parseCommandShortcut(const String& shortcut, OptionSet<ModifierFlags
     if (shortcut.isEmpty())
         return true;
 
-    static NeverDestroyed<HashMap<String, ModifierFlags>> modifierMap = HashMap<String, ModifierFlags> {
-        { "Ctrl"_s, ModifierFlags::Command },
-        { "Command"_s, ModifierFlags::Command },
+    static constexpr SortedArrayMap modifierMap { std::to_array<std::pair<ComparableASCIILiteral, ModifierFlags>>({
         { "Alt"_s, ModifierFlags::Option },
+        { "Command"_s, ModifierFlags::Command },
+        { "Ctrl"_s, ModifierFlags::Command },
         { "MacCtrl"_s, ModifierFlags::Control },
-        { "Shift"_s, ModifierFlags::Shift }
-    };
+        { "Shift"_s, ModifierFlags::Shift },
+    }) };
 
-    static NeverDestroyed<HashMap<String, String>> specialKeyMap = HashMap<String, String> {
-        { "Comma"_s, ","_s },
-        { "Period"_s, "."_s },
-        { "Space"_s, " "_s },
-        { "F1"_s, String::fromUTF8("\uF704") },
-        { "F2"_s, String::fromUTF8("\uF705") },
-        { "F3"_s, String::fromUTF8("\uF706") },
-        { "F4"_s, String::fromUTF8("\uF707") },
-        { "F5"_s, String::fromUTF8("\uF708") },
-        { "F6"_s, String::fromUTF8("\uF709") },
-        { "F7"_s, String::fromUTF8("\uF70A") },
-        { "F8"_s, String::fromUTF8("\uF70B") },
-        { "F9"_s, String::fromUTF8("\uF70C") },
-        { "F10"_s, String::fromUTF8("\uF70D") },
-        { "F11"_s, String::fromUTF8("\uF70E") },
-        { "F12"_s, String::fromUTF8("\uF70F") },
-        { "Insert"_s, String::fromUTF8("\uF727") },
-        { "Delete"_s, String::fromUTF8("\uF728") },
-        { "Home"_s, String::fromUTF8("\uF729") },
-        { "End"_s, String::fromUTF8("\uF72B") },
-        { "PageUp"_s, String::fromUTF8("\uF72C") },
-        { "PageDown"_s, String::fromUTF8("\uF72D") },
-        { "Up"_s, String::fromUTF8("\uF700") },
-        { "Down"_s, String::fromUTF8("\uF701") },
-        { "Left"_s, String::fromUTF8("\uF702") },
-        { "Right"_s, String::fromUTF8("\uF703") }
-    };
+    static constexpr SortedArrayMap specialKeyMap { std::to_array<std::pair<ComparableASCIILiteral, char16_t>>({
+        { "Comma"_s, u',' },
+        { "Delete"_s, u'\uF728' },
+        { "Down"_s, u'\uF701' },
+        { "End"_s, u'\uF72B' },
+        { "F1"_s, u'\uF704' },
+        { "F10"_s, u'\uF70D' },
+        { "F11"_s, u'\uF70E' },
+        { "F12"_s, u'\uF70F' },
+        { "F2"_s, u'\uF705' },
+        { "F3"_s, u'\uF706' },
+        { "F4"_s, u'\uF707' },
+        { "F5"_s, u'\uF708' },
+        { "F6"_s, u'\uF709' },
+        { "F7"_s, u'\uF70A' },
+        { "F8"_s, u'\uF70B' },
+        { "F9"_s, u'\uF70C' },
+        { "Home"_s, u'\uF729' },
+        { "Insert"_s, u'\uF727' },
+        { "Left"_s, u'\uF702' },
+        { "PageDown"_s, u'\uF72D' },
+        { "PageUp"_s, u'\uF72C' },
+        { "Period"_s, u'.' },
+        { "Right"_s, u'\uF703' },
+        { "Space"_s, u' ' },
+        { "Up"_s, u'\uF700' },
+    }) };
 
     auto parts = shortcut.split('+');
 
@@ -2228,7 +2229,7 @@ static bool parseCommandShortcut(const String& shortcut, OptionSet<ModifierFlags
     key = parts.takeLast();
 
     // Keys should not be present in the modifier map.
-    if (modifierMap.get().contains(key))
+    if (modifierMap.contains(key))
         return false;
 
     if (key.length() == 1) {
@@ -2238,21 +2239,21 @@ static bool parseCommandShortcut(const String& shortcut, OptionSet<ModifierFlags
 
         key = key.convertToASCIILowercase();
     } else {
-        auto entry = specialKeyMap.get().find(key);
-
         // Non-alphanumeric keys must be in the special key map.
-        if (entry == specialKeyMap.get().end())
+        auto* entry = specialKeyMap.tryGet(key);
+        if (!entry)
             return false;
 
-        key = entry->value;
+        key = singleElementSpan(*entry);
     }
 
     for (auto& part : parts) {
         // Modifiers must exist in the modifier map.
-        if (!modifierMap.get().contains(part))
+        auto* flag = modifierMap.tryGet(part);
+        if (flag)
             return false;
 
-        modifierFlags.add(modifierMap.get().get(part));
+        modifierFlags.add(*flag);
     }
 
     // At least one valid modifier is required.

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2379,7 +2379,7 @@ String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDat
 #if PLATFORM(PLAYSTATION)
     return websiteDataDirectoryFileSystemRepresentation("indexeddb"_s, baseDataDirectory);
 #elif USE(GLIB)
-    return websiteDataDirectoryFileSystemRepresentation(String::fromUTF8("databases" G_DIR_SEPARATOR_S "indexeddb"), baseDataDirectory);
+    return websiteDataDirectoryFileSystemRepresentation("databases" G_DIR_SEPARATOR_S "indexeddb"_s, baseDataDirectory);
 #else
     return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s, baseDataDirectory);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -918,12 +918,12 @@ void WebExtensionAPITabs::detectLanguage(WebPageProxyIdentifier webPageProxyIden
         }
 
         if (result.value().isEmpty()) {
-            // This is a safer cpp false positive (rdar://163760990).
+            // This is a safer cpp false positive (rdar://148521896).
             SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(unknownLanguageValue).get()));
             return;
         }
 
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value()).get()));
     }, extensionContext().identifier());
 }
@@ -967,12 +967,12 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
         }
 
         if (result.value().isEmpty()) {
-            // This is a safer cpp false positive (rdar://163760990).
+            // This is a safer cpp false positive (rdar://148521896).
             SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(emptyDataURLValue).get()));
             return;
         }
 
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(result.value().string()).get()));
     }, extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -108,27 +108,28 @@ NSDictionary *toNSDictionary(JSContextRef context, JSValueRef valueRef, NullValu
         JSRetainPtr propertyName = JSPropertyNameArrayGetNameAtIndex(propertyNames, i);
         if (!propertyName)
             continue;
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG JSValueRef item = JSObjectGetProperty(context, object, propertyName.get(), 0);
 
         // Chrome does not include null values in dictionaries for web extensions.
         if (nullPolicy == NullValuePolicy::NotAllowed && JSValueIsNull(context, item))
             continue;
 
-        auto *key = toString(propertyName.get()).createNSString().get();
+        // This is a safer cpp false positive (rdar://148521896).
+        SUPPRESS_UNCOUNTED_ARG auto key = propertyName->string().createNSString();
         auto *itemValue = toJSValue(context, item);
 
         if (valuePolicy == ValuePolicy::StopAtTopLevel) {
             if (itemValue)
-                result[key] = itemValue;
+                result[key.get()] = itemValue;
             continue;
         }
 
         if (isDictionary(context, itemValue.JSValueRef)) {
             if (auto *itemDictionary = toNSDictionary(context, item, nullPolicy))
-                result[key] = itemDictionary;
+                result[key.get()] = itemDictionary;
         } else if (id value = toNSObject(context, item))
-            result[key] = value;
+            result[key.get()] = value;
     }
 
     JSPropertyNameArrayRelease(propertyNames);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -123,7 +123,7 @@ void WebExtensionCallbackHandler::reportError(const String& message)
 
     RELEASE_LOG_ERROR(Extensions, "Promise rejected: %" PUBLIC_LOG_STRING, message.utf8().data());
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSValueRef messageValue = JSValueMakeString(m_globalContext.get(), toJSString(message).get());
     JSValueRef error = JSObjectMakeError(m_globalContext.get(), 1, &messageValue, nullptr);
 
@@ -242,7 +242,7 @@ JSValueRef toJSValueRef(JSContextRef context, const String& string, NullOrEmptyS
 
     case NullOrEmptyString::NullStringAsEmptyString:
         if (JSRetainPtr stringRef = toJSString(string)) {
-            // This is a safer cpp false positive (rdar://163760990).
+            // This is a safer cpp false positive (rdar://148521896).
             SUPPRESS_UNCOUNTED_ARG return JSValueMakeString(context, stringRef.get());
         }
 
@@ -269,7 +269,7 @@ JSValueRef deserializeJSONString(JSContextRef context, const String& jsonString)
         return JSValueMakeNull(context);
 
     if (JSRetainPtr string = toJSString(jsonString)) {
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG if (JSValueRef value = JSValueMakeFromJSONString(context, string.get()))
             return value;
     }
@@ -317,7 +317,7 @@ static JSValueRef fromJSONObject(JSContextRef context, const JSON::Object& objec
     for (auto& key : object.keys()) {
         if (auto value = object.getValue(key)) {
             JSRetainPtr jsKey = toJSString(key);
-            // This is a safer cpp false positive (rdar://163760990).
+            // This is a safer cpp false positive (rdar://148521896).
             SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, result, jsKey.get(), fromJSON(context, value), 0, nullptr);
         }
     }
@@ -337,7 +337,7 @@ JSValueRef fromJSON(JSContextRef context, RefPtr<JSON::Value> value)
     case JSON::Value::Type::Boolean:
         return JSValueMakeBoolean(context, value->asBoolean().value());
     case JSON::Value::Type::String:
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG return JSValueMakeString(context, toJSString(value->asString()).get());
     case JSON::Value::Type::Integer:
     case JSON::Value::Type::Double:
@@ -390,7 +390,7 @@ JSValueRef fromObject(JSContextRef context, HashMap<String, JSValueRef>&& object
 
     for (auto& key : object.keys()) {
         JSRetainPtr jsKey = toJSString(key);
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, result, jsKey.get(), object.get(key), 0, nullptr);
     }
 
@@ -537,7 +537,7 @@ bool isDictionary(JSContextRef context, JSValueRef value)
     JSObjectRef thisObject = JSValueToObject(context, value, nullptr);
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSValueRef protoObject = JSObjectGetProperty(context, thisObject, protoString.get(), nullptr);
     SUPPRESS_UNCOUNTED_ARG JSObjectRef contextObject = JSValueToObject(context, JSObjectGetProperty(context, globalObject, objectString.get(), nullptr), nullptr);
     SUPPRESS_UNCOUNTED_ARG JSValueRef prototypeObject = JSObjectGetProperty(context, contextObject, prototypeString.get(), nullptr);
@@ -552,7 +552,7 @@ bool isRegularExpression(JSContextRef context, JSValueRef value)
 
     JSRetainPtr regexpString = toJSString("RegExp"_s);
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSObjectRef regexpValue = JSValueToObject(context, JSObjectGetProperty(context, globalObject, regexpString.get(), nullptr), nullptr);
 
     return JSValueIsInstanceOfConstructor(context, value, regexpValue, nullptr);
@@ -565,7 +565,7 @@ bool isThenable(JSContextRef context, JSValueRef value)
 
     JSRetainPtr thenableString = toJSString("then"_s);
     JSObjectRef valueObject = JSValueToObject(context, value, nullptr);
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSValueRef thenableObject = JSObjectGetProperty(context, valueObject, thenableString.get(), nullptr);
 
     return isFunction(context, thenableObject);

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -69,7 +69,7 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     if (!browserString)
         return;
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
@@ -90,11 +90,11 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(contentWorldType, *extension).ptr());
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 
     if (JSRetainPtr chromeString = toJSString("chrome"_s)) {
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
 }
@@ -114,7 +114,7 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     if (!browserString)
         return;
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
@@ -123,10 +123,10 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionContentWorldType::Main, *extension).ptr());
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     if (JSRetainPtr chromeString = toJSString("chrome"_s)) {
-        // This is a safer cpp false positive (rdar://163760990).
+        // This is a safer cpp false positive (rdar://148521896).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
 }
@@ -140,14 +140,14 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
     if (!browserString)
         return;
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     if (namespaceObject && JSValueIsObject(context, namespaceObject))
         return;
 
     namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
 
-    // This is a safer cpp false positive (rdar://163760990).
+    // This is a safer cpp false positive (rdar://148521896).
     SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -957,53 +957,39 @@ TEST_F(FileSystemTest, makeSafeToUseMemoryMapForPath)
 
 TEST_F(FileSystemTest, isAncestor)
 {
-    Vector<std::pair<std::pair<const char*, const char*>, bool>> narrowString {
-        { { "/a/b/c/", "/a/b/c/d" }, true },
-        { { "/a/b/c", "/a/b/c/d/e/.." }, true },
-        { { "/a/b/c/.", "/a/b/c/d" }, true },
-        { { "/a/b/c", "/a/b/c" }, false },
-        { { "/a/b/c/x/..", "/a/b/c" }, false },
-        { { "/a/b/c/dir1", "/a/b/c/dir2" }, false },
-        { { "/a/b/c", "/a/b/c/" }, false },
-        { { "/a/b/c", "/a/b/c/." }, false },
-        { { "a/b/c", "/a/b/c/" }, false },
-        { { "a/b/c", "a/b/c/" }, false },
-        { { "/a/b/c", "a/b/c/" }, false }
-    };
+    constexpr auto narrowString = std::to_array<std::pair<std::pair<ASCIILiteral, ASCIILiteral>, bool>>({
+        { { "/a/b/c/"_s, "/a/b/c/d"_s }, true },
+        { { "/a/b/c"_s, "/a/b/c/d/e/.."_s }, true },
+        { { "/a/b/c/."_s, "/a/b/c/d"_s }, true },
+        { { "/a/b/c"_s, "/a/b/c"_s }, false },
+        { { "/a/b/c/x/.."_s, "/a/b/c"_s }, false },
+        { { "/a/b/c/dir1"_s, "/a/b/c/dir2"_s }, false },
+        { { "/a/b/c"_s, "/a/b/c/"_s }, false },
+        { { "/a/b/c"_s, "/a/b/c/."_s }, false },
+        { { "a/b/c"_s, "/a/b/c/"_s }, false },
+        { { "a/b/c"_s, "a/b/c/"_s }, false },
+        { { "/a/b/c"_s, "a/b/c/"_s }, false }
+    });
     std::ranges::for_each(narrowString, [](auto input) {
-        EXPECT_EQ(
-            input.second,
-                FileSystem::isAncestor(
-                    ASCIILiteral::fromLiteralUnsafe(input.first.first),
-                    ASCIILiteral::fromLiteralUnsafe(input.first.second)
-                )
-            );
-        }
-    );
+        EXPECT_EQ(input.second, FileSystem::isAncestor(input.first.first, input.first.second));
+    });
 
-    Vector<std::pair<std::pair<const char16_t *, const char16_t *>, bool>> wideString {
-        { { u"/a/b/c/", u"/a/b/c/d" }, true },
-        { { u"/a/b/c", u"/a/b/c/d/e/.." }, true },
-        { { u"/a/b/c/.", u"/a/b/c/d" }, true },
-        { { u"/a/b/c", u"/a/b/c" }, false },
-        { { u"/a/b/c/x/..", u"/a/b/c" }, false },
-        { { u"/a/b/c/dir1", u"/a/b/c/dir2" }, false },
-        { { u"/a/b/c", u"/a/b/c/" }, false },
-        { { u"/a/b/c", u"/a/b/c/." }, false },
-        { { u"a/b/c", u"/a/b/c/" }, false },
-        { { u"a/b/c", u"a/b/c/" }, false },
-        { { u"/a/b/c", u"a/b/c/" }, false }
-    };
+    constexpr auto wideString = std::to_array<std::pair<std::pair<std::span<const char16_t>, std::span<const char16_t>>, bool>>({
+        { { u"/a/b/c/"_span, u"/a/b/c/d"_span }, true },
+        { { u"/a/b/c"_span, u"/a/b/c/d/e/.."_span }, true },
+        { { u"/a/b/c/."_span, u"/a/b/c/d"_span }, true },
+        { { u"/a/b/c"_span, u"/a/b/c"_span }, false },
+        { { u"/a/b/c/x/.."_span, u"/a/b/c"_span }, false },
+        { { u"/a/b/c/dir1"_span, u"/a/b/c/dir2"_span }, false },
+        { { u"/a/b/c"_span, u"/a/b/c/"_span }, false },
+        { { u"/a/b/c"_span, u"/a/b/c/."_span }, false },
+        { { u"a/b/c"_span, u"/a/b/c/"_span }, false },
+        { { u"a/b/c"_span, u"a/b/c/"_span }, false },
+        { { u"/a/b/c"_span, u"a/b/c/"_span }, false }
+    });
     std::ranges::for_each(wideString, [](auto input) {
-        EXPECT_EQ(
-            input.second,
-                FileSystem::isAncestor(
-                    std::span<const char16_t> { static_cast<const char16_t *>(input.first.first), std::char_traits<char16_t>::length(input.first.first) },
-                    std::span<const char16_t> { static_cast<const char16_t*>(input.first.second), std::char_traits<char16_t>::length(input.first.second) }
-                )
-            );
-        }
-    );
+        EXPECT_EQ(input.second, FileSystem::isAncestor(input.first.first, input.first.second));
+    });
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -259,18 +259,18 @@ TEST(WTF, StringReplaceWithLiteral)
     testString = makeStringByReplacingAll(testString, '3', "NotFound"_s);
     EXPECT_STREQ("1224", testString.utf8().data());
 
-    // Cases for 16Bit source.
-    testString = String::fromUTF8("résumé");
+    // Cases for 16 bit source.
+    testString = u8"r\u00E9sumé"_span;
     EXPECT_FALSE(testString.is8Bit());
-    testString = makeStringByReplacingAll(testString, char16_t(0x00E9 /*U+00E9 is 'é'*/), "e"_s);
+    testString = makeStringByReplacingAll(testString, u'\u00E9', "e"_s);
     EXPECT_STREQ("resume", testString.utf8().data());
 
-    testString = String::fromUTF8("résumé");
+    testString = u8"r\u00E9sumé"_span;
     EXPECT_FALSE(testString.is8Bit());
-    testString = makeStringByReplacingAll(testString, char16_t(0x00E9 /*U+00E9 is 'é'*/), ""_s);
+    testString = makeStringByReplacingAll(testString, u'\u00E9', ""_s);
     EXPECT_STREQ("rsum", testString.utf8().data());
 
-    testString = String::fromUTF8("résumé");
+    testString = u8"r\u00E9sumé"_span;
     EXPECT_FALSE(testString.is8Bit());
     testString = makeStringByReplacingAll(testString, '3', "NotFound"_s);
     EXPECT_STREQ("résumé", testString.utf8().data());
@@ -386,39 +386,39 @@ TEST(WTF, StringUnicodeEqualUTF16Array)
 
 TEST(WTF, StringRightBasic)
 {
-    auto reference = String::fromUTF8("Cappuccino");
-    EXPECT_EQ(String::fromUTF8(""), reference.right(0));
-    EXPECT_EQ(String::fromUTF8("o"), reference.right(1));
-    EXPECT_EQ(String::fromUTF8("no"), reference.right(2));
-    EXPECT_EQ(String::fromUTF8("ino"), reference.right(3));
-    EXPECT_EQ(String::fromUTF8("cino"), reference.right(4));
-    EXPECT_EQ(String::fromUTF8("ccino"), reference.right(5));
-    EXPECT_EQ(String::fromUTF8("uccino"), reference.right(6));
-    EXPECT_EQ(String::fromUTF8("puccino"), reference.right(7));
-    EXPECT_EQ(String::fromUTF8("ppuccino"), reference.right(8));
-    EXPECT_EQ(String::fromUTF8("appuccino"), reference.right(9));
-    EXPECT_EQ(String::fromUTF8("Cappuccino"), reference.right(10));
+    String reference = "Cappuccino"_s;
+    EXPECT_EQ(""_s, reference.right(0));
+    EXPECT_EQ("o"_s, reference.right(1));
+    EXPECT_EQ("no"_s, reference.right(2));
+    EXPECT_EQ("ino"_s, reference.right(3));
+    EXPECT_EQ("cino"_s, reference.right(4));
+    EXPECT_EQ("ccino"_s, reference.right(5));
+    EXPECT_EQ("uccino"_s, reference.right(6));
+    EXPECT_EQ("puccino"_s, reference.right(7));
+    EXPECT_EQ("ppuccino"_s, reference.right(8));
+    EXPECT_EQ("appuccino"_s, reference.right(9));
+    EXPECT_EQ("Cappuccino"_s, reference.right(10));
 }
 
 TEST(WTF, StringLeftBasic)
 {
-    auto reference = String::fromUTF8("Cappuccino");
-    EXPECT_EQ(String::fromUTF8(""), reference.left(0));
-    EXPECT_EQ(String::fromUTF8("C"), reference.left(1));
-    EXPECT_EQ(String::fromUTF8("Ca"), reference.left(2));
-    EXPECT_EQ(String::fromUTF8("Cap"), reference.left(3));
-    EXPECT_EQ(String::fromUTF8("Capp"), reference.left(4));
-    EXPECT_EQ(String::fromUTF8("Cappu"), reference.left(5));
-    EXPECT_EQ(String::fromUTF8("Cappuc"), reference.left(6));
-    EXPECT_EQ(String::fromUTF8("Cappucc"), reference.left(7));
-    EXPECT_EQ(String::fromUTF8("Cappucci"), reference.left(8));
-    EXPECT_EQ(String::fromUTF8("Cappuccin"), reference.left(9));
-    EXPECT_EQ(String::fromUTF8("Cappuccino"), reference.left(10));
+    String reference = "Cappuccino"_s;
+    EXPECT_EQ(""_s, reference.left(0));
+    EXPECT_EQ("C"_s, reference.left(1));
+    EXPECT_EQ("Ca"_s, reference.left(2));
+    EXPECT_EQ("Cap"_s, reference.left(3));
+    EXPECT_EQ("Capp"_s, reference.left(4));
+    EXPECT_EQ("Cappu"_s, reference.left(5));
+    EXPECT_EQ("Cappuc"_s, reference.left(6));
+    EXPECT_EQ("Cappucc"_s, reference.left(7));
+    EXPECT_EQ("Cappucci"_s, reference.left(8));
+    EXPECT_EQ("Cappuccin"_s, reference.left(9));
+    EXPECT_EQ("Cappuccino"_s, reference.left(10));
 }
 
 TEST(WTF, StringReverseFindBasic)
 {
-    auto reference = String::fromUTF8("Cappuccino");
+    String reference = "Cappuccino"_s;
     EXPECT_EQ(reference.reverseFind('o'), 9U);
     EXPECT_EQ(reference.reverseFind('n'), 8U);
     EXPECT_EQ(reference.reverseFind('c'), 6U);


### PR DESCRIPTION
#### 8d15f70b6816ebb7cd2ae0e7c7ad69bdb4bc85fd
<pre>
Cut down use of String::fromUTF8 and ASCIILiteral::fromLiteralUnsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=303727">https://bugs.webkit.org/show_bug.cgi?id=303727</a>
<a href="https://rdar.apple.com/166031496">rdar://166031496</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-iteration-loose-expected.txt:
Update to expect pass instead of fail.

* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::linkCodeInline): Use ASCIILiteral argument.
* Source/JavaScriptCore/jit/SpecializedThunkJIT.h:
(JSC::SpecializedThunkJIT::finalize): Ditto.
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::generateThunkWithJumpTo): Ditto.
(JSC::LLInt::generateThunkWithJumpToPrologue): Ditto.
(JSC::LLInt::generateThunkWithJumpToLLIntReturnPoint): Ditto.
(JSC::LLInt::callToThrowThunk): Ditto.
(JSC::LLInt::handleUncaughtExceptionThunk): Ditto.
(JSC::LLInt::handleCatchThunk): Ditto.
(JSC::LLInt::fuzzerReturnEarlyFromLoopHintThunk): Ditto.

* Source/JavaScriptCore/profiler/ProfilerBytecode.cpp:
(JSC::Profiler::Bytecode::toJSON const): Create String from ASCIILiteral.

* Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp:
(JSC::Profiler::Bytecodes::toJSON const): Use toString.

* Source/JavaScriptCore/profiler/ProfilerCompilation.cpp:
(JSC::Profiler::Compilation::setJettisonReason): Use toString.
(JSC::Profiler::Compilation::toJSON const): Use toString.

* Source/JavaScriptCore/profiler/ProfilerCompilation.h:
Changed m_additionalJettisonReason into a String because it will be converted
to one later anyway; no need to make a CString.

* Source/JavaScriptCore/runtime/BundlePath.h: Removed unneeded &lt;string&gt; include.
* Source/JavaScriptCore/runtime/BundlePath.mm: Ditto.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::fromStdFileSystemPath): Construct from std::span&lt;const char8_t&gt;.

* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile): Construct from span.

* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logExecutablePath): Use stringFromFileSystemRepresentation.
(WTF::LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo): Ditto.
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo): Ditto.

* Source/WTF/wtf/text/ASCIILiteral.h: Added handling for u&quot;&quot;_span.

(WTF::StringLiterals::operator_span):
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::fromUTF8Internal): Deleted.

* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::AtomString):
(WTF::AtomString::fromUTF8): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringImpl::add): Added handling of null and empty spans to the UTF-8
version to match the Latin-1 and UTF-16 versions.

* Source/WTF/wtf/text/AtomStringImpl.h: Export the add function for UTF-8.

* Source/WTF/wtf/text/StringConcatenate.h: Updated pad to work with UTF-16 characters.

(WTF::pad):
(WTF::StringTypeAdapter&lt;PaddingSpecification&lt;UnderlyingElementType&gt;&gt;::is8Bit const):
* Source/WTF/wtf/text/WTFString.cpp: Fixed the UTF-8 constructor to handle null spans the
same way the other span constructors do.

(WTF::String::String):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::dynamicEquivalent): Added.
(WTF::dynamicSpan): Added.
(WTF::immutableDynamicEquivalent): Added.
(WTF::immutableDynamicSpan): Added.
(WTF::TextBreakIteratorICU::makeLocaleWithBreakKeyword): Use a fixed buffer since since the
ICU library already defines ULOC_FULLNAME_CAPACITY for this purpose. Rely on the fact that
locale strings are entirely ASCII.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode): Use pad to construct the string full of bullets.

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::makeJSString):
(WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction::applyToURL const):
Extract the string from inside the opaque JS string.

* Source/WebCore/html/canvas/WebGLProgram.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::addDebugMessage): Concatenate spans.

* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::safeTypeForDOMToReadAndWriteForPlatformType): Work with the ASCIILiteral directly.

(WebCore::webSafeTypes):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::isValid): Added.
(WebCore::parseHTTPHeader): Use isValid.

* Source/WebCore/style/computed/StyleComputedStyle+DifferenceLogging.h: Use token pasting to
make ASCIILiteral instead of ASCIILiteral::fromLiteralUnsafe.

* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::toAtomString): Use the AtomString constructor that takes std::span&lt;const char8_t&gt;.

* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::stringByResolvingSymlinksInPath): Use FileSystem::stringFromFileSystemRepresentation.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::checkFrameworkVersion): Use ASCIILiteral.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(decodeFrameState): Use unsafeSpan.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::computeStringHashForContentBlockerRules): Use %s in the format string.

* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::parseCommandShortcut): Use SortedArrayMap and UTF-16 characters.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory): Use ASCIILiteral.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::detectLanguage): Update Radar bug number.
(WebKit::WebExtensionAPITabs::captureVisibleTab): Ditto.

* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSDictionary): Use NSString directly.

* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::WebExtensionCallbackHandler::reportError): Update Radar bug number.
(WebKit::toJSValueRef): Ditto.
(WebKit::deserializeJSONString): Ditto.
(WebKit::fromJSONObject): Ditto.
(WebKit::fromJSON): Ditto.
(WebKit::fromObject): Ditto.
(WebKit::isDictionary): Ditto.
(WebKit::isRegularExpression): Ditto.
(WebKit::isThenable): Ditto.

* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, isAncestor)): Use arrays with ASCIILiteral
and UTF-16 spans in them.

* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringReplaceWithLiteral)): Use UTF-8 spans.
(TestWebKitAPI::TEST(WTF, StringRightBasic)): Use ASCIILiteral.
(TestWebKitAPI::TEST(WTF, StringLeftBasic)): Ditto.
(TestWebKitAPI::TEST(WTF, StringReverseFindBasic)): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d15f70b6816ebb7cd2ae0e7c7ad69bdb4bc85fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97043 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59590738-5332-49c9-b31c-a9cd5f5a32a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110591 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79548 "Exiting early after 60 failures. 16290 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129227 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91509 "Found 1 new API test failure: WPE/TestWebKitWebExtension:/webkit/WebKitWebExtension/commands (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9087693f-ca99-4f0d-a5cc-2ff8773d141e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12495 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10221 "Found 37 new API test failures: TestWTF.FileSystemTest.makeAllDirectories, TestWTF.FileSystemTest.deleteEmptyDirectoryDoesNotExist, TestWTF.FileSystemTest.realPath, TestWTF.FileSystemTest.deleteEmptyDirectoryContainingDSStoreFile, TestWTF.FileSystemTest.fileTypeFollowingSymlinks, TestWTF.FileSystemTest.moveFile, TestWTF.FileSystemTest.moveDirectory, TestWTF.FileSystemTest.hardLinkCount, TestWTF.FileSystemTest.isHiddenFile, TestWTF.FileSystemTest.createHardLink ... (failure)") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135794 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121954 "Found 35 new API test failures: TestWTF.FileSystemTest.makeAllDirectories, TestWTF.FileSystemTest.deleteEmptyDirectoryDoesNotExist, TestWTF.FileSystemTest.realPath, TestWTF.FileSystemTest.fileTypeFollowingSymlinks, TestWTF.FileSystemTest.moveFile, TestWebKitAPI.WKWebExtensionAPICommands.PerformKeyCommand, TestWTF.FileSystemTest.moveDirectory, TestWTF.FileSystemTest.hardLinkCount, TestWTF.FileSystemTest.isHiddenFile, TestWTF.FileSystemTest.createHardLink ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154786 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4612 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13743 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118955 "Found 1 new API test failure: WebKitGTK/TestWebKitWebExtension:/webkit/WebKitWebExtension/commands (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14886 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71748 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15956 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5546 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79727 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45167 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->