### PR TITLE
REGRESSION (Safari 26): AudioData.copyTo() crashes the tab with valid conversion

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that copying last channel from interleaved to planar does not crash
+

--- a/LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash.html
+++ b/LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+test(() => {
+  const data = new AudioData({
+    numberOfChannels: 3,
+    data: new Float32Array([1, 1, 1]),
+    format: 'f32',
+    numberOfFrames: 1,
+    sampleRate: 48000,
+    timestamp: 0,
+  });
+
+  const dataBytes = new Float32Array(1);
+  data.copyTo(dataBytes, {planeIndex: 2, format: 'f32-planar'});
+
+  data.close();
+}, 'Test that copying last channel from interleaved to planar does not crash');
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -287,7 +287,7 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 
     auto copyElements = []<typename T>(std::span<T> destination, auto sourcePlane, size_t sampleOffset, size_t sampleIndexIncrement, size_t samples) {
         RELEASE_ASSERT(destination.size() >= samples);
-        RELEASE_ASSERT(sourcePlane.size() >= sampleIndexIncrement * samples + sampleOffset - 1);
+        RELEASE_ASSERT(sourcePlane.size() > sampleOffset + (samples - 1) * sampleIndexIncrement);
         size_t sourceSampleIndex = sampleOffset;
         for (size_t sample = 0; sample < samples; sample++) {
             destination[sample] = convertAudioSample<T>(sourcePlane[sourceSampleIndex]);


### PR DESCRIPTION
#### 3fe28c6ca9963aa0f9ca9f1e42e55234a38c766f
<pre>
REGRESSION (Safari 26): AudioData.copyTo() crashes the tab with valid conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=302521">https://bugs.webkit.org/show_bug.cgi?id=302521</a>
<a href="https://rdar.apple.com/164730320">rdar://164730320</a>

Reviewed by Jean-Yves Avenard.

The RELEASE_ASSERT in PlatformRawAudioDataCocoa::copyTo() required
(increment - 2) more elements than necessary. This caused crashes
when copying planeIndex 2 from 3-channel AudioData.

Test: http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash.html

* LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/audioData-copyTo-last-channel-does-not-crash.html: Added.
* Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
(WebCore::PlatformRawAudioData::copyTo):

Canonical link: <a href="https://commits.webkit.org/304728@main">https://commits.webkit.org/304728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/723a04be1f6afa9f55706e7b2a6f9d23ca0cb01b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7167 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45967 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70243 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5317 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2926 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111355 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28681 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5150 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6892 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35212 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70472 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->