### PR TITLE
Return `inherit` for Canvas Direction as `inherit` for Offscreen Canvas

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.default-expected.txt
@@ -1,5 +1,5 @@
 2d.text.direction.default
 Actual output:
 
-FAIL Canvas test: 2d.text.direction.default assert_equals: ctx.direction === 'inherit' (got ltr[string], expected inherit[string]) expected "inherit" but got "ltr"
+PASS Canvas test: 2d.text.direction.default
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.valid-expected.txt
@@ -1,5 +1,5 @@
 2d.text.direction.valid
 Actual output:
 
-FAIL Canvas test: 2d.text.direction.valid assert_equals: ctx.direction === 'inherit' (got ltr[string], expected inherit[string]) expected "inherit" but got "ltr"
+PASS Canvas test: 2d.text.direction.valid
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -251,9 +251,16 @@ inline TextDirection CanvasRenderingContext2D::toTextDirection(Direction directi
 
 CanvasDirection CanvasRenderingContext2D::direction() const
 {
-    if (state().direction == Direction::Inherit)
-        canvas().protectedDocument()->updateStyleIfNeeded();
-    return toTextDirection(state().direction) == TextDirection::RTL ? CanvasDirection::Rtl : CanvasDirection::Ltr;
+    switch (state().direction) {
+    case Direction::Inherit:
+        return CanvasDirection::Inherit;
+    case Direction::Rtl:
+        return CanvasDirection::Rtl;
+    case Direction::Ltr:
+        return CanvasDirection::Ltr;
+    }
+    ASSERT_NOT_REACHED();
+    return CanvasDirection::Inherit;
 }
 
 void CanvasRenderingContext2D::fillText(const String& text, double x, double y, std::optional<double> maxWidth)

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -145,16 +145,16 @@ RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
 
 CanvasDirection OffscreenCanvasRenderingContext2D::direction() const
 {
-    // FIXME: What should we do about inherit here?
     switch (state().direction) {
     case Direction::Inherit:
+        return Direction::Inherit;
     case Direction::Ltr:
         return Direction::Ltr;
     case Direction::Rtl:
         return Direction::Rtl;
     }
     ASSERT_NOT_REACHED();
-    return Direction::Ltr;
+    return Direction::Inherit;
 }
 
 auto OffscreenCanvasRenderingContext2D::fontProxy() -> const FontProxy* {


### PR DESCRIPTION
#### b648b24cced4c2b8c5fb1d9d7989cbe33ff640d4
<pre>
Return `inherit` for Canvas Direction as `inherit` for Offscreen Canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=303809">https://bugs.webkit.org/show_bug.cgi?id=303809</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

This patch is fixing failures for the canvas tests on WPT.
<a href="https://wpt.fyi/results/html/canvas/offscreen/text">https://wpt.fyi/results/html/canvas/offscreen/text</a>
<a href="https://wpt.fyi/results/html/canvas/element/text">https://wpt.fyi/results/html/canvas/element/text</a>

Note that the offscreen tests from WPT are not included in WebKit repo.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.direction.valid-expected.txt:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::direction const):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::direction const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b648b24cced4c2b8c5fb1d9d7989cbe33ff640d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86652 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43ed1ff0-627d-4f28-ac04-bde8dd00b33c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7024 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102965 "Found 1 new test failure: fast/canvas/canvas-direction.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70312 "Found 1 new test failure: fast/canvas/canvas-direction.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3a9cedbb-0f08-439f-b6ca-35eca51143bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137675 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5474 "Found 1 new test failure: fast/canvas/canvas-direction.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83775 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c4363e15-2cfa-451a-96d5-66f68fa5f654) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5320 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2931 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2837 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114549 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38899 "Found 1 new test failure: fast/canvas/canvas-direction.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144943 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6848 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39480 "Found 2 new test failures: fast/canvas/canvas-direction.html inspector/canvas/recording-html-2d.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111358 "Found 2 new test failures: fast/canvas/canvas-direction.html inspector/canvas/recording-html-2d.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6919 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5742 "Found 2 new test failures: fast/canvas/canvas-direction.html inspector/canvas/recording-html-2d.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111658 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5152 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6896 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35216 "Found 2 new test failures: fast/canvas/canvas-direction.html inspector/canvas/recording-html-2d.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->