### PR TITLE
SpeculationRules - Fix failing invalid tags tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Sec-Speculation-Tags [rule-based]: integer tag assert_false: expected false got true
-FAIL Sec-Speculation-Tags [rule-based]: object tag assert_false: expected false got true
-FAIL Sec-Speculation-Tags [rule-based]: null value tag assert_false: expected false got true
+PASS Sec-Speculation-Tags [rule-based]: integer tag
+PASS Sec-Speculation-Tags [rule-based]: object tag
+PASS Sec-Speculation-Tags [rule-based]: null value tag
 PASS Sec-Speculation-Tags [rule-based]: non-printable character tag
 PASS Sec-Speculation-Tags [rule-based]: string with non-printable character tag
 PASS Sec-Speculation-Tags [rule-based]: non-ascii string tag

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Sec-Speculation-Tags [ruleset-based]: integer tag assert_false: expected false got true
-FAIL Sec-Speculation-Tags [ruleset-based]: object tag assert_false: expected false got true
-FAIL Sec-Speculation-Tags [ruleset-based]: null value tag assert_false: expected false got true
+PASS Sec-Speculation-Tags [ruleset-based]: integer tag
+PASS Sec-Speculation-Tags [ruleset-based]: object tag
+PASS Sec-Speculation-Tags [ruleset-based]: null value tag
 PASS Sec-Speculation-Tags [ruleset-based]: non-printable character tag
 PASS Sec-Speculation-Tags [ruleset-based]: string with non-printable character tag
 PASS Sec-Speculation-Tags [ruleset-based]: non-ascii string tag

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -298,9 +298,11 @@ static std::optional<SpeculationRules::Rule> parseSingleRule(const JSON::Object&
 
     // 18. If input["tag"] exists:
     auto tagValue = input.getValue("tag"_s);
-    if (tagValue && tagValue->type() == JSON::Value::Type::String) {
-        String ruleTag = tagValue->asString();
+    if (tagValue) {
         // 18.1. If input["tag"] is not a speculation rule tag... return null.
+        if (tagValue->type() != JSON::Value::Type::String)
+            return std::nullopt;
+        String ruleTag = tagValue->asString();
         if (!ruleTag.containsOnlyASCII() || !ruleTag.containsOnly<isASCIIPrintable>())
             return std::nullopt;
         StringBuilder ruleTagBuilder;
@@ -358,15 +360,17 @@ bool SpeculationRules::parseSpeculationRules(Node& sourceNode, const StringView&
 
     String rulesetLevelTag;
     auto tagValue = jsonObject->getValue("tag"_s);
-    // 4. If parsed["tag"] exists:
-    if (tagValue && tagValue->type() == JSON::Value::Type::String) {
+    // 5. If parsed["tag"] exists:
+    if (tagValue) {
+        // 5.1. If parsed["tag"] is not a speculation rule tag, then throw a TypeError indicating that the speculation rule tag is invalid.
+        if (tagValue->type() != JSON::Value::Type::String)
+            return false;
         String candidateTag = tagValue->asString();
-        // 4.1. If parsed["tag"] is not a speculation rule tag, then throw a TypeError indicating that the speculation rule tag is invalid.
         if (!candidateTag.containsOnlyASCII() || !candidateTag.containsOnly<isASCIIPrintable>())
             return false;
         StringBuilder ruleTagBuilder;
         ruleTagBuilder.appendQuotedJSONString(candidateTag);
-        // 4.2. Set tag to parsed["tag"].
+        // 5.2. Set tag to parsed["tag"].
         rulesetLevelTag = ruleTagBuilder.toString();
     }
 


### PR DESCRIPTION
#### 0ffe75385f5fd5d57f4fec1419e0bfe948054ba7
<pre>
SpeculationRules - Fix failing invalid tags tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=303817">https://bugs.webkit.org/show_bug.cgi?id=303817</a>

Reviewed by Alex Christensen.

Some of the invalid tag tests are rightfully failing, due to unaligned behavior with the spec in case of non-string invalid tags.
This PR fixes that by aligning the implementation with the spec.

No new tests, but progression on existing ones.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&amp;type=prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&amp;type=prefetch-expected.txt: Progression.
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::parseSingleRule): Return false for non-string tags.
(WebCore::SpeculationRules::parseSpeculationRules): Return false for non-string tags.

Canonical link: <a href="https://commits.webkit.org/304262@main">https://commits.webkit.org/304262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c26a8e0db855c668932349e38b6f8878c901825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5332 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2941 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144953 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111368 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5164 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60757 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6906 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35229 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70487 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->