### PR TITLE
The client app should be able to exit the immersive element

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
@@ -3,6 +3,7 @@ PASS Immersive API exists on model and document
 PASS Model immersive request fails without user activation
 PASS Model enters immersive mode with user activation
 PASS Document.exitImmersive() exits immersive model
+PASS WKWebview._exitImmersive() exits immersive model
 PASS Immersivechange events fire when entering immersive
 PASS Only one model can be immersive at a time
 PASS Exiting immersive model after an immersive update exits immersive mode

--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -59,6 +59,20 @@ promise_test(async t => {
 promise_test(async t => {
     const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
     
+    await test_driver.bless("immersive");
+    await model.requestImmersive();
+    assert_equals(document.immersiveElement, model, 'Model is immersive after request');
+
+    if (window.testRunner)
+        testRunner.exitImmersive();
+
+    await t.step_wait(() => document.immersiveElement === null, "Waiting for immersive element to be null");
+    assert_equals(document.immersiveElement, null, 'No immersive element after exit');
+}, 'WKWebview._exitImmersive() exits immersive model');
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "../resources/cube.usdz");
+    
     let modelChangeEvents = [];
     let documentChangeEvents = [];
     const modelHandler = () => { modelChangeEvents.push(document.immersiveElement); };

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -190,6 +190,21 @@ void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>
     });
 }
 
+void DocumentImmersive::exitImmersive()
+{
+    if (!immersiveElement())
+        return;
+
+    exitImmersive([weakThis = WeakPtr { *this }](auto result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        if (result.hasException())
+            RELEASE_LOG_ERROR(Immersive, "%p - DocumentImmersive: %s", protectedThis.get(), result.releaseException().message().utf8().data());
+    });
+}
+
 void DocumentImmersive::exitRemovedImmersiveElement(HTMLModelElement* element, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(element->immersive());

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -60,6 +60,7 @@ public:
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
+    WEBCORE_EXPORT void exitImmersive();
     void exitRemovedImmersiveElement(HTMLModelElement*, CompletionHandler<void()>&&);
 
     enum class EventType : bool { Change, Error };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2111,22 +2111,6 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 }
 #endif
 
-- (id<_WKImmersiveEnvironmentDelegate>)_immersiveEnvironmentDelegate
-{
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    return _immersiveEnvironmentDelegate.getAutoreleased();
-#else
-    return nil;
-#endif
-}
-
-- (void)_setImmersiveEnvironmentDelegate:(id<_WKImmersiveEnvironmentDelegate>)delegate
-{
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    _immersiveEnvironmentDelegate = delegate;
-#endif
-}
-
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
 - (void)_allowImmersiveElementFromURL:(const URL&)url completion:(CompletionHandler<void(bool)>&&)completion
 {
@@ -4607,6 +4591,29 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     _page->restoreAppHighlightsAndScrollToIndex(buffers, 0);
 #else
     UNUSED_PARAM(highlight);
+#endif
+}
+
+- (id<_WKImmersiveEnvironmentDelegate>)_immersiveEnvironmentDelegate
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    return _immersiveEnvironmentDelegate.getAutoreleased();
+#else
+    return nil;
+#endif
+}
+
+- (void)_setImmersiveEnvironmentDelegate:(id<_WKImmersiveEnvironmentDelegate>)delegate
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    _immersiveEnvironmentDelegate = delegate;
+#endif
+}
+
+- (void)_exitImmersive
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    _page->exitImmersive();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -505,6 +505,7 @@ for this property.
 @property (nonatomic, readonly) _WKSpatialBackdropSource *_spatialBackdropSource WK_API_AVAILABLE(visionos(26.0));
 
 @property (nonatomic, weak, setter=_setImmersiveEnvironmentDelegate:) id <_WKImmersiveEnvironmentDelegate> _immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)_exitImmersive WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 
 - (void)_grantAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
 - (void)_revokeAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13594,6 +13594,11 @@ void WebPageProxy::dismissImmersiveElement(CompletionHandler<void()>&& completio
     else
         completion();
 }
+
+void WebPageProxy::exitImmersive()
+{
+    send(Messages::WebPage::ExitImmersive());
+}
 #endif
 
 void WebPageProxy::copyLinkWithHighlight()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2883,6 +2883,10 @@ public:
     RefPtr<WebDeviceOrientationUpdateProviderProxy> webDeviceOrientationUpdateProviderProxy();
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void exitImmersive();
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -204,6 +204,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/DocumentFragment.h>
 #include <WebCore/DocumentFullscreen.h>
+#include <WebCore/DocumentImmersive.h>
 #include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/DocumentMarkerController.h>
@@ -7911,6 +7912,12 @@ void WebPage::presentImmersiveElement(const Element&, const LayerHostingContextI
 void WebPage::dismissImmersiveElement(const Element&, CompletionHandler<void()>&& completion)
 {
     sendWithAsyncReply(Messages::WebPageProxy::DismissImmersiveElement(), WTFMove(completion));
+}
+
+void WebPage::exitImmersive() const
+{
+    if (RefPtr localTopDocument = this->localTopDocument(); RefPtr protectedImmersive = localTopDocument->immersiveIfExists())
+        protectedImmersive->exitImmersive();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1693,6 +1693,7 @@ public:
     void allowImmersiveElement(const WebCore::Element&, CompletionHandler<void(bool)>&&);
     void presentImmersiveElement(const WebCore::Element&, const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&);
     void dismissImmersiveElement(const WebCore::Element&, CompletionHandler<void()>&&);
+    void exitImmersive() const;
 #endif
 
     void flushPendingEditorStateUpdate();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -930,4 +930,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ShowCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
     HideCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
 #endif
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    ExitImmersive()
+#endif
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -369,4 +369,7 @@ interface TestRunner {
     readonly attribute boolean canModifyResourceMonitorList;
 
     undefined setHasMouseDeviceForTesting(boolean hasMouseDevice);
+
+    // Immersive models
+    undefined exitImmersive();
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1572,6 +1572,11 @@ void TestRunner::setHasMouseDeviceForTesting(bool hasMouseDevice)
     postSynchronousPageMessage("SetHasMouseDeviceForTesting", hasMouseDevice);
 }
 
+void TestRunner::exitImmersive()
+{
+    postSynchronousPageMessage("ExitImmersive");
+}
+
 ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -480,6 +480,7 @@ public:
     }
 
     void setHasMouseDeviceForTesting(bool);
+    void exitImmersive();
 
 private:
     TestRunner();

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -472,6 +472,10 @@ public:
 
     void setHasMouseDeviceForTesting(bool);
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void exitImmersive();
+#endif
+
     void uiScriptDidComplete(const String& result, unsigned scriptCallbackID);
 
 private:

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1307,6 +1307,13 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    if (WKStringIsEqualToUTF8CString(messageName, "ExitImmersive")) {
+        TestController::singleton().exitImmersive();
+        return nullptr;
+    }
+#endif
+
     if (WKStringIsEqualToUTF8CString(messageName, "ShouldForceRepaint"))
         return adoptWK(WKBooleanCreate(m_forceRepaint));
 

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -646,4 +646,12 @@ void TestController::setHasMouseDeviceForTesting(bool hasMouseDevice)
 }
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+void TestController::exitImmersive()
+{
+    TestRunnerWKWebView *webView = mainWebView()->platformView();
+    [webView _exitImmersive];
+}
+#endif
+
 } // namespace WTR


### PR DESCRIPTION
#### f5da6586859790d1caf0f1b253578dafadb5968f
<pre>
The client app should be able to exit the immersive element
<a href="https://bugs.webkit.org/show_bug.cgi?id=303819">https://bugs.webkit.org/show_bug.cgi?id=303819</a>
<a href="https://rdar.apple.com/166127172">rdar://166127172</a>

Reviewed by Etienne Segonzac.

Add a method on WKWebView to trigger an exit on the current immersive element.

* LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
Test that the method works as expected.

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::exitImmersive):
* Source/WebCore/dom/DocumentImmersive.h:
Add an exitImmersive() method without callback that logs eventual errors.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _immersiveEnvironmentDelegate]):
(-[WKWebView _setImmersiveEnvironmentDelegate:]):
(-[WKWebView _exitImmersive]):
Move the private methods inside the private implementation of WKWebView.
Add the _exitImmersive private method.
This will be moved to an API with <a href="https://rdar.apple.com/problem/164244457">rdar://problem/164244457</a>.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::exitImmersive):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::exitImmersive const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Plumb the signal down to the immersive document.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::exitImmersive):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::exitImmersive):
Plumb a signal into the test runner to test the _exitImmersive method.

Canonical link: <a href="https://commits.webkit.org/304294@main">https://commits.webkit.org/304294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/097d568cac9bd9eb7d144656b7361bad18e3e5ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142678 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5640 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3242 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3270 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39893 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111673 "Found 1 new test failure: imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5475 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117444 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7300 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70852 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->