### PR TITLE
WTF: Haiku filesystem and language support

### DIFF
--- a/Source/WTF/wtf/Language.h
+++ b/Source/WTF/wtf/Language.h
@@ -68,6 +68,10 @@ WTF_EXPORT_PRIVATE void listenForLanguageChangeNotifications();
 RetainPtr<CFArrayRef> minimizedLanguagesFromLanguages(CFArrayRef);
 #endif
 
+#if PLATFORM(HAIKU)
+WTF_EXPORT_PRIVATE void listenForLanguageChangeNotifications();
+#endif
+
 } // namespace WTF
 
 using WTF::ShouldMinimizeLanguages;

--- a/Source/WTF/wtf/PlatformHaiku.cmake
+++ b/Source/WTF/wtf/PlatformHaiku.cmake
@@ -3,6 +3,8 @@ list(APPEND WTF_SOURCES
     generic/WorkQueueGeneric.cpp
 
     haiku/CurrentProcessMemoryStatus.cpp
+    haiku/FileSystemHaiku.cpp
+    haiku/LanguageHaiku.cpp
     haiku/MemoryFootprintHaiku.cpp
 
     posix/CPUTimePOSIX.cpp

--- a/Source/WTF/wtf/haiku/FileSystemHaiku.cpp
+++ b/Source/WTF/wtf/haiku/FileSystemHaiku.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Haiku, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/FileSystem.h>
+
+#include <FindDirectory.h>
+#include <Path.h>
+
+namespace WTF {
+
+namespace FileSystemImpl {
+
+
+String localUserSpecificStorageDirectory()
+{
+    BPath path;
+    find_directory(B_USER_SETTINGS_DIRECTORY, &path);
+    return String::fromUTF8(path.Path());
+}
+
+} // namespace FileSystemImpl
+} // namespace WTF

--- a/Source/WTF/wtf/haiku/LanguageHaiku.cpp
+++ b/Source/WTF/wtf/haiku/LanguageHaiku.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2010 Stephan Aßmus <superstippi@gmx.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "Language.h"
+
+#include <Application.h>
+#include <LocaleRoster.h>
+#include <Message.h>
+#include <MessageFilter.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace WTF {
+
+static filter_result languagePreferencesDidChange(BMessage*, BHandler**, BMessageFilter*)
+{
+    languageDidChange();
+    return B_DISPATCH_MESSAGE;
+}
+
+void listenForLanguageChangeNotifications()
+{
+    static std::once_flag addedListener;
+    std::call_once(addedListener, [&] {
+        if (be_app->Lock()) {
+            BMessageFilter* localeListener = new BMessageFilter(B_LOCALE_CHANGED, languagePreferencesDidChange);
+            be_app->AddCommonFilter(localeListener);
+            be_app->Unlock();
+        }
+    });
+}
+
+Vector<String> platformUserPreferredLanguages(WTF::ShouldMinimizeLanguages)
+{
+    BMessage languages;
+    int32 count = 0;
+
+    BLocaleRoster::Default()->Refresh();
+    if (BLocaleRoster::Default()->GetPreferredLanguages(&languages) != B_OK
+        || languages.GetInfo("language", nullptr, &count) != B_OK
+        || !count)
+        return { "en"_s };
+
+    Vector<String> preferredLanguages(count, [&](size_t i) {
+        BString language;
+        languages.FindString("language", i, &language);
+        language.ReplaceAll('_', '-');
+        return String::fromUTF8(language.String());
+    });
+
+    return preferredLanguages;
+}
+
+}


### PR DESCRIPTION
#### 03df07d307c1b20968adbd66b681ada56da2c10a
<pre>
WTF: Haiku filesystem and language support
<a href="https://bugs.webkit.org/show_bug.cgi?id=305764">https://bugs.webkit.org/show_bug.cgi?id=305764</a>

Reviewed by Adrian Perez de Castro.

Upstream changes to filesystem and language access for Haiku: finding
the tmp directory, user configuration directory, and user preferred
languages using native APIs where no POSIX standard way is applicable.

No new tests: no changes to behavior of exisitng platforms.

* Source/WTF/wtf/PlatformHaiku.cmake: Add new files to the build.
* Source/WTF/wtf/haiku/FileSystemHaiku.cpp: Added.
Use native APIs to determine user settings directory.
* Source/WTF/wtf/haiku/LanguageHaiku.cpp: Added.
Use native APIs to detect user language settings.
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::fileCreationTime): enable shared code for Haiku
(WTF::FileSystemImpl::temporaryFileDirectory): use find_directory

Canonical link: <a href="https://commits.webkit.org/306080@main">https://commits.webkit.org/306080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a92255b9c2d02cc20adbc7af0f631bfd59fd014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148595 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9936 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7483 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8740 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132280 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151251 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12376 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11267 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122093 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1547 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171580 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76115 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->