### PR TITLE
SpeculationRules - Support Clear-Site-Data

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -843,8 +843,6 @@ imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/docume
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url-cross-origin.html [ Skip ]
 
-# This is passing, but timing out as `Clear-Site-Data: *` is making the test framework fail to get its own messages.
-imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html [ Skip ]
 # This is timing out because we do not support singleton prefetch matching, and the different initiators have different FrameLoaders.
 imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html [ Skip ]
 # These tests output noisy console logs.

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL clear-site-data prefetchCache headers should prevent it from being fetched assert_equals: expected (undefined) undefined but got (string) "prefetch"
+PASS clear-site-data cache headers should prevent it from being fetched
+PASS clear-site-data prefetchCache in same window should clear its prefetch cache
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html
@@ -25,7 +25,6 @@
     });
     window.open("/../../clear-site-data/support/clear-site-data-prefetchCache.py");
     await gotMessage;
-
     await agent.navigate(nextUrl);
     // Because Clear-Site-Data response header is sent, prefetches are expected
     // to be evicted.
@@ -33,7 +32,7 @@
     assert_not_prefetched(await agent.getRequestHeaders());
   }, "clear-site-data prefetchCache headers should prevent it from being fetched");
 
-    // Test that Clear-Site-Data header value "cache" clears prefetch cache
+  // Test that Clear-Site-Data header value "cache" clears prefetch cache
   promise_test(async t => {
     let agent = await spawnWindow(t, { protocol: 'https' });
     let nextUrl = agent.getExecutorURL({protocol: 'https', page: 2 });
@@ -49,13 +48,24 @@
       });
     });
     let cache_helper = "cache_helper=" + self.crypto.randomUUID() + "&";
-    window.open("/../../clear-site-data/support/clear-site-data-cache.py?" + cache_helper + "response=single_html&cache&clear_first=all");
+    window.open("/../../clear-site-data/support/clear-site-data-cache.py?" + cache_helper + "response=single_html&cache&clear_first=cache");
     await gotMessage;
-
     await agent.navigate(nextUrl);
     // Because Clear-Site-Data response header is sent, prefetches are expected
     // to be evicted.
     // The navigation to nextURL is not expected to use the prefetch cache.
     assert_not_prefetched(await agent.getRequestHeaders());
   }, "clear-site-data cache headers should prevent it from being fetched");
+
+  promise_test(async t => {
+    let agent = await spawnWindow(t, { protocol: 'https' });
+    let nextUrl = agent.getExecutorURL({protocol: 'https', page: 2 });
+    await agent.forceSinglePrefetch(nextUrl);
+
+    await agent.execute_script(async () => {
+      await fetch("/../../clear-site-data/support/clear-site-data-prefetchCache.py");
+    });
+    await agent.navigate(nextUrl);
+    assert_not_prefetched(await agent.getRequestHeaders());
+  }, "clear-site-data prefetchCache in same window should clear its prefetch cache");
 </script>

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -219,4 +219,18 @@ void DocumentPrefetcher::clearPrefetchedResourcesExcept(const URL& url)
     });
 }
 
+// https://wicg.github.io/nav-speculation/prefetch.html#clear-prefetch-cache
+void DocumentPrefetcher::clearPrefetchedResourcesForOrigin(const SecurityOrigin& origin)
+{
+    m_prefetchedData.removeIf([&origin](auto& entry) {
+        Ref urlOrigin = SecurityOrigin::create(entry.key);
+        if (origin.isSameOriginAs(urlOrigin)) {
+            if (entry.value.resource)
+                MemoryCache::singleton().remove(*entry.value.resource);
+            return true;
+        }
+        return false;
+    });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -40,6 +40,7 @@ class CachedRawResource;
 class DocumentLoader;
 class FrameLoader;
 class ResourceRequest;
+class SecurityOrigin;
 
 enum class ReferrerPolicy : uint8_t;
 
@@ -62,6 +63,7 @@ public:
     bool wasPrefetched(const URL&) const;
     Box<NetworkLoadMetrics> takePrefetchedResourceMetrics(const URL&);
     void clearPrefetchedResourcesExcept(const URL&);
+    void clearPrefetchedResourcesForOrigin(const SecurityOrigin&);
 
     // CachedRawResourceClient
     void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -605,8 +605,10 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
             result.add(ClearSiteDataValue::ExecutionContexts);
         else if (trimmedValue == "\"storage\""_s)
             result.add(ClearSiteDataValue::Storage);
+        else if (trimmedValue == "\"prefetchCache\""_s)
+            result.add(ClearSiteDataValue::PrefetchCache);
         else if (trimmedValue == "\"*\""_s)
-            result.add({ ClearSiteDataValue::Cache, ClearSiteDataValue::Cookies, ClearSiteDataValue::ExecutionContexts, ClearSiteDataValue::Storage });
+            result.add({ ClearSiteDataValue::Cache, ClearSiteDataValue::Cookies, ClearSiteDataValue::ExecutionContexts, ClearSiteDataValue::Storage, ClearSiteDataValue::PrefetchCache });
     }
     return result;
 }

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -75,6 +75,7 @@ enum class ClearSiteDataValue : uint8_t {
     Cookies = 1 << 1,
     ExecutionContexts = 1 << 2,
     Storage = 1 << 3,
+    PrefetchCache = 1 << 4,
 };
 
 enum class RangeAllowWhitespace : bool { No, Yes };


### PR DESCRIPTION
#### d69efcab765ad5504bffb197e272af1fa5ebf7bc
<pre>
SpeculationRules - Support Clear-Site-Data
<a href="https://bugs.webkit.org/show_bug.cgi?id=303826">https://bugs.webkit.org/show_bug.cgi?id=303826</a>

Reviewed by Alex Christensen.

This adds support for `Clear-Site-Data: prefetchCache`.

No new tests, but existing tests progress.

* LayoutTests/TestExpectations: Removed skipped test.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived): Clear prefetchCache after parsing Clear-Site-Data headers.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::clearPrefetchedResourcesForOrigin): Implement the clearing of prefetched resources.
* Source/WebCore/loader/DocumentPrefetcher.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didReceiveResponse): Clear prefetchCache after parsing Clear-Site-Data headers.
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseClearSiteDataHeader): Add prefetchCache handling.
* Source/WebCore/platform/network/HTTPParsers.h:

Canonical link: <a href="https://commits.webkit.org/304470@main">https://commits.webkit.org/304470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa51a66afba5bf15a253f03013bee935a1a12c8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103657 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84529 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3618 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3962 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146101 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112392 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5865 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61664 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7747 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35996 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71299 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->