### PR TITLE
Web Inspector: Replace deprecated String.prototype.substr with substring and at for single parameters

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/MIMETypeUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/MIMETypeUtilities.js
@@ -35,7 +35,7 @@ WI.fileExtensionForFilename = function(filename)
     if (index === filename.length - 1)
         return null;
 
-    return filename.substr(index + 1);
+    return filename.substring(index + 1);
 };
 
 WI.fileExtensionForURL = function(url)

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -857,7 +857,7 @@ Object.defineProperty(String.prototype, "truncateStart",
 
         if (this.length <= maxLength)
             return this;
-        return ellipsis + this.substr(this.length - maxLength + 1);
+        return ellipsis + this.substring(this.length - maxLength + 1);
     }
 });
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
@@ -310,7 +310,7 @@ WI.HARBuilder = class HARBuilder
         if (!index)
             return undefined;
 
-        let portString = remoteAddress.substr(index + 1);
+        let portString = remoteAddress.substring(index + 1);
         let port = parseInt(portString);
         if (isNaN(port))
             return undefined;

--- a/Source/WebInspectorUI/UserInterface/Models/Cookie.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Cookie.js
@@ -163,7 +163,7 @@ WI.Cookie = class Cookie
         let sameSite = WI.Cookie.SameSiteType.None;
 
         // Parse Attributes
-        let remaining = header.substr(nameValueMatch[0].length);
+        let remaining = header.substring(nameValueMatch[0].length);
         let attributes = remaining.split(/; ?/);
         for (let attribute of attributes) {
             if (!attribute)

--- a/Source/WebInspectorUI/UserInterface/Models/Gradient.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Gradient.js
@@ -130,7 +130,7 @@ WI.Gradient = class Gradient
                     continue;
 
                 var stop = {color};
-                if (component.length && component[0].substr(-1) === "%")
+                if (component.length && component[0].at(-1) === "%")
                     stop.offset = parseFloat(component.shift()) / 100;
                 return stop;
             }

--- a/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
+++ b/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
@@ -317,7 +317,7 @@ TestHarness = class TestHarness extends WI.Object
             return "(unknown)";
 
         let lastPathSeparator = Math.max(url.lastIndexOf("/"), url.lastIndexOf("\\"));
-        let location = lastPathSeparator > 0 ? url.substr(lastPathSeparator + 1) : url;
+        let location = lastPathSeparator > 0 ? url.substring(lastPathSeparator + 1) : url;
         if (!location.length)
             location = "(unknown)";
 
@@ -336,7 +336,7 @@ TestHarness = class TestHarness extends WI.Object
         let frameName = nameAndURLSeparator > 0 ? frame.substr(0, nameAndURLSeparator) : "(anonymous)";
 
         let lastPathSeparator = Math.max(frame.lastIndexOf("/"), frame.lastIndexOf("\\"));
-        let frameLocation = lastPathSeparator > 0 ? frame.substr(lastPathSeparator + 1) : frame;
+        let frameLocation = lastPathSeparator > 0 ? frame.substring(lastPathSeparator + 1) : frame;
         if (!frameLocation.length)
             frameLocation = "unknown";
 


### PR DESCRIPTION
#### e2e6e3b758f6e8966f8a3d05b5b6234eea60dea5
<pre>
Web Inspector: Replace deprecated String.prototype.substr with substring and at for single parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=303832">https://bugs.webkit.org/show_bug.cgi?id=303832</a>
<a href="https://rdar.apple.com/problem/166140736">rdar://problem/166140736</a>

Reviewed by Devin Rousso.

String.prototype.substr is deprecated (Annex B) and should be replaced
with modern alternatives.

Using at in places with negative values, and using substring in places we can prove will never be below 0.

Only handling the single parameter case, because the two parameter function calls have different syntax:
String.prototype.substr ( start, length )
String.prototype.slice ( start, end )

* Source/WebInspectorUI/UserInterface/Base/MIMETypeUtilities.js:
(WI.fileExtensionForFilename):
* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(get return):
* Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js:
(WI.HARBuilder.port):
* Source/WebInspectorUI/UserInterface/Models/Cookie.js:
(WI.Cookie.parseSetCookieResponseHeader):
* Source/WebInspectorUI/UserInterface/Models/Gradient.js:
(WI.Gradient.stopsWithComponents):
* Source/WebInspectorUI/UserInterface/Test/TestHarness.js:
(TestHarness.sanitizeURL):
(TestHarness.sanitizeStackFrame):

Canonical link: <a href="https://commits.webkit.org/304181@main">https://commits.webkit.org/304181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22df26b71fb56aeef2773b4109e6fb98729a5063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86714 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1138bb0-3433-4fab-9581-2c82f805c823) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/97eb2317-879b-4f24-9668-cbea7f9581ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d10a1463-a7b5-4d5d-851c-9959f6376167) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2996 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2916 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145021 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39563 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5222 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60858 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6970 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35294 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6870 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->