### PR TITLE
A fragment navigation always causes :focus-visible to match.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029-expected.txt
@@ -1,0 +1,10 @@
+This test checks that focusing an element by a fragment navigation using a pointing device does not cause :focus-visible matching.
+If the user-agent does not claim to support the :focus-visible pseudo-class then SKIP this test.
+Click the link below that says "Click me"
+If the element that says "I will be focused by the fragment navigation" has a red outline, then the test result is FAILURE. If the element has a green background, then the test result is SUCCESS.
+
+Click me
+I will be focused by the fragment navigation
+
+PASS :focus-visible should not match after a fragment navigation using a pointing device
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>CSS Test (Selectors): :focus-visible does not match after a fragment navigation using a pointing device</title>
+  <link rel="author" title="Harry Moore" href="harry-moore@live.co.uk" />
+  <link rel="help" href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo" />
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <style>
+    @supports not selector(:focus-visible) {
+      :focus {
+        outline: red solid 5px;
+        background-color: red;
+      }
+    }
+
+    :focus-visible {
+      outline: red solid 5px;
+    }
+
+    :focus:not(:focus-visible) {
+        outline: 0;
+        background-color: lime;
+    }
+  </style>
+</head>
+<body>
+  This test checks that focusing an element by a fragment navigation using a pointing device does not cause <code>:focus-visible</code> matching.
+  <ol id="instructions">
+    <li>If the user-agent does not claim to support the <code>:focus-visible</code> pseudo-class then SKIP this test.</li>
+    <li>Click the link below that says "Click me"</li>
+    <li>If the element that says "I will be focused by the fragment navigation" has a red outline, then the test result is FAILURE. If the element has a green background, then the test result is SUCCESS.</li>
+  </ol>
+  <br />
+
+  <!-- The tabindex on the anchor is needed for Safari on Apple platforms. Without it the anchor will not get focus on click. -->
+  <a id="link" href="#el" tabindex="0">Click me</a>
+  <div id="el" tabindex="-1">I will be focused by the fragment navigation</div>
+
+  <script>
+    async_test(function(t) {
+      el.addEventListener("focus", t.step_func(function() {
+          assert_equals(getComputedStyle(el).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${el.tagName}#${el.id} should be lime`);
+          assert_not_equals(getComputedStyle(el).outlineColor, "rgb(255, 0, 0)", `outlineColor for ${el.tagName}#${el.id} should NOT be red`);
+          t.done();
+      }));
+      test_driver.click(link);
+    }, ":focus-visible should not match after a fragment navigation using a pointing device");
+  </script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3250,8 +3250,14 @@ bool LocalFrameView::scrollToAnchorFragment(StringView fragmentIdentifier)
 
     if (anchorElement) {
         // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
-        if (anchorElement->isFocusable())
-            document->setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, { }, { }, FocusVisibility::Visible });
+        if (anchorElement->isFocusable()) {
+            FocusVisibility focusVisibility;
+            if (document->wasLastFocusByClick())
+                focusVisibility = FocusVisibility::Invisible;
+            else
+                focusVisibility = FocusVisibility::Visible;
+            document->setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, { }, { }, focusVisibility });
+        }
         else {
             document->setFocusedElement(nullptr);
             document->setFocusNavigationStartingNode(anchorElement.get());


### PR DESCRIPTION
#### 58b4938d23f4f0ac5b049599e71ce5fd8b95db89
<pre>
A fragment navigation always causes :focus-visible to match.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303824">https://bugs.webkit.org/show_bug.cgi?id=303824</a>

Reviewed by NOBODY (OOPS!).

Respect the latest focus trigger state on the document
when setting the focused element for a fragment navigation.

Test: imported/w3c/web-platform-tests/css/selectors/focus-visible-0029.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-029.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToAnchorFragment): Respect the latest focus trigger state on the document when setting the focused element.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d41e28988c4b240d187645cfd1873979ffce347

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131553 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92555 "2 flakes 11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180895 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140002 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139845 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43207 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28201 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107027 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35130 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41716 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->