### PR TITLE
Web Inspector: Sources Navigation Sidebar is sometimes empty on page reload

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
@@ -998,9 +998,12 @@ WI.TreeOutline = class TreeOutline extends WI.Object
             treeElement._listItemNode.remove();
 
         for (let treeElement of treeElementsToAttach) {
-            treeElement.parent._childrenListNode.appendChild(treeElement._listItemNode);
-            if (treeElement._childrenListNode)
-                treeElement.parent._childrenListNode.appendChild(treeElement._childrenListNode);
+            // FIXME: <webkit.org/b/303914> Refactor logic for appending TreeElement nodes so the private member isn't accessed directly.
+            if (treeElement.parent._childrenListNode) {
+                treeElement.parent._childrenListNode.appendChild(treeElement._listItemNode);
+                if (treeElement._childrenListNode)
+                    treeElement.parent._childrenListNode.appendChild(treeElement._childrenListNode);
+            }
         }
 
         let attachedCount = treeElementsToAttach.size;


### PR DESCRIPTION
#### 97a29a8fcc7f5db9385bd05361fa0ac1cd6700e0
<pre>
Web Inspector: Sources Navigation Sidebar is sometimes empty on page reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=303833">https://bugs.webkit.org/show_bug.cgi?id=303833</a>
<a href="https://rdar.apple.com/166141968">rdar://166141968</a>

Reviewed by Devin Rousso.

It&apos;s not guaranteed that a `WI.TreeElement.prototype._childrenListNode` will exist
when trying to append elements to it. It gets created when calling `WI.TreeOutline.prototype.expand()`,
but there are a few early return conditions where the element is marked as expanded,
while the necessary DOM subtree is not created because there aren&apos;t yet children to attach to it.

In the flurry of activity that happens on page reload, there are a few codepaths that attempt
to populate the resources tree outline as well as attempting to reveal the previously selected element.
See `WI.FrameTreeElement.prototype._mainResourceDidChange`.

Only when `WI.TreeElement.hasChildren` is set to true (which isn&apos;t the same as `WI.TreeElement.prototype.children.length`)
do the conditions get satisfied to create the DOM element _childrenListNode that other elements get appended to
in `WI.TreeOutline.prototype._updateVirtualizedElements()`.

There&apos;s a lot of layering violation going on across tree outline and tree elements
where private methods and objects get called across boundaries. And there is a lot
of state spread across multiple booleans that&apos;s difficult to reason about.
This warrants a refactoring, but for now, this patch unblocks other investigations
hampered by the unhandled exception.

* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype._updateVirtualizedElements):

Canonical link: <a href="https://commits.webkit.org/304221@main">https://commits.webkit.org/304221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd554cb1d7a5c1a148c8e0edc791cb7d64b9ea0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142464 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7219 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5662 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/120960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83970 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3092 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3062 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145164 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39692 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111857 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5316 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35415 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->