### PR TITLE
Removing an immersive model from the DOM should exit immersive session

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt
@@ -6,7 +6,7 @@ PASS Document.exitImmersive() exits immersive model
 PASS Immersivechange events fire when entering immersive
 PASS Only one model can be immersive at a time
 PASS Exiting immersive model after an immersive update exits immersive mode
-FAIL Removing immersive model from DOM exits immersive mode assert_equals: No immersive element after removal expected null but got Element node <model><source src="../resources/cube.usdz"></model>
+PASS Removing immersive model from DOM exits immersive mode
 PASS Immersiveerror event fires when request fails
 PASS CSS :immersive pseudo-class matches correctly
 PASS Model is complete once presented as immersive

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -293,9 +293,10 @@ void PlaceholderModelPlayer::ensureImmersivePresentation(CompletionHandler<void(
     ASSERT_NOT_REACHED("PlaceholderModelPlayer cannot provide a layer context identifier");
     completion(std::nullopt);
 }
+
 void PlaceholderModelPlayer::exitImmersivePresentation(CompletionHandler<void()>&& completion)
 {
-    ASSERT_NOT_REACHED("PlaceholderModelPlayer cannot exit an immersive presentation");
+    m_transformState->invalidateTransform();
     completion();
 }
 

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -60,7 +60,7 @@ public:
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
-    void exitRemovedImmersiveElement(HTMLModelElement*);
+    void exitRemovedImmersiveElement(HTMLModelElement*, CompletionHandler<void()>&&);
 
     enum class EventType : bool { Change, Error };
     void dispatchPendingEvents();


### PR DESCRIPTION
#### 074a62d9796aa0232b99b092836899abea266ad8
<pre>
Removing an immersive model from the DOM should exit immersive session
<a href="https://bugs.webkit.org/show_bug.cgi?id=303837">https://bugs.webkit.org/show_bug.cgi?id=303837</a>
<a href="https://rdar.apple.com/166145547">rdar://166145547</a>

Reviewed by Mike Wyrzykowski.

Exit immersive on page reload, navigation, and whenever the
model element looses its model player.

* LayoutTests/model-element/immersive/model-element-immersive-basic-expected.txt:
Update expected test results.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::deleteModelPlayer):
(WebCore::HTMLModelElement::removedFromAncestor):
Exit the immersive session whenever the model element
looses its model player.
Wait for the immersion exit completion before deleting the model player
to avoid black frames in the client app during dismissal.

* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::exitImmersivePresentation):
During a page navigation event, the model player may be replaced by a placeholder,
this allows to deallocate unused resources. We can still support an immersive
exit event on a placeholder model player simply by invalidating the transform
so that it gets re-calculated whenever the placeholder is replaced by a live
model player again.

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):
(WebCore::DocumentImmersive::exitImmersive):
(WebCore::DocumentImmersive::exitRemovedImmersiveElement):
* Source/WebCore/dom/DocumentImmersive.h:

Canonical link: <a href="https://commits.webkit.org/304285@main">https://commits.webkit.org/304285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10d29678058a44e925e24575acc01163e0996c50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103127 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70385 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83978 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3099 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111865 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28416 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5328 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117255 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60983 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7107 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35427 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70679 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->