### PR TITLE
[FeatureFlags] Gate GetBoundingClientRectZoomed enablement only for E and later

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -238,7 +238,7 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     if (linkedBefore(dyld_2024_SU_F_os_versions, DYLD_IOS_VERSION_18_5, DYLD_MACOSX_VERSION_15_5))
         disableBehavior(SDKAlignedBehavior::NavigationActionSourceFrameNonNull);
 
-    if (linkedBefore(dyld_2025_SU_B_os_versions, DYLD_IOS_VERSION_26_1, DYLD_MACOSX_VERSION_26_1))
+    if (linkedBefore(dyld_2025_SU_E_os_versions, DYLD_IOS_VERSION_26_4, DYLD_MACOSX_VERSION_26_4))
         disableBehavior(SDKAlignedBehavior::GetBoundingClientRectZoomed);
 
     disableAdditionalSDKAlignedBehaviors(behaviors);


### PR DESCRIPTION
#### fe39daf81270687f72082b5bc13bddb12550d900
<pre>
[FeatureFlags] Gate GetBoundingClientRectZoomed enablement only for E and later
<a href="https://bugs.webkit.org/show_bug.cgi?id=303842">https://bugs.webkit.org/show_bug.cgi?id=303842</a>
<a href="https://rdar.apple.com/163964638">rdar://163964638</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe39daf81270687f72082b5bc13bddb12550d900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134783 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7225 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86698 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/04f083f2-681e-4afc-a803-55fc91fe4a36) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7835 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7075 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/48a65997-9119-4891-ba64-f4c0805ca231) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137730 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/7835 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83825 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/62846c13-0ed2-435f-8da3-d07afde188f2) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/7835 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2890 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126821 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/7835 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144996 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133290 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6900 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6969 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7075 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111711 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60829 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6947 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/46032 "Hash fe39daf8 for PR 55112 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166193 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6746 "Hash fe39daf8 for PR 55112 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70529 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43437 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6981 "Hash fe39daf8 for PR 55112 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6854 "Hash fe39daf8 for PR 55112 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->