### PR TITLE
AX: 304101@main introduced the possibility of ref'ing AXIsolatedObjects in a non-thread-safe way

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -18,7 +18,6 @@ Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
 [ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
-[ Mac ] accessibility/isolatedtree/AXIsolatedObject.h
 animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 contentextensions/ContentExtensionsBackend.cpp

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -168,8 +168,8 @@ FloatRect AXIsolatedObject::convertRectToPlatformSpace(const FloatRect& rect, Ac
     if (space == AccessibilityConversionSpace::Screen)
         return convertFrameToSpace(rect, space);
 
-    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, this, protectedThis = Ref { *this }] () -> FloatRect {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, context = mainThreadContext()] () -> FloatRect {
+        if (RefPtr axObject = context.axObjectOnMainThread())
             return axObject->convertRectToPlatformSpace(rect, space);
         return { };
     });
@@ -355,8 +355,8 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([this, protectedThis = Ref { *this }] () {
-        RefPtr axObject = associatedAXObject();
+    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([context = mainThreadContext()] () {
+        RefPtr axObject = context.axObjectOnMainThread();
         return axObject ? axObject->textMarkerRange() : AXTextMarkerRange();
     });
 }
@@ -384,8 +384,8 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRangeForNSRange(const NSRange& ran
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([&range, this, protectedThis = Ref { *this }] () -> AXTextMarkerRange {
-        RefPtr axObject = associatedAXObject();
+    return Accessibility::retrieveValueFromMainThread<AXTextMarkerRange>([&range, context = mainThreadContext()] () -> AXTextMarkerRange {
+        RefPtr axObject = context.axObjectOnMainThread();
         return axObject ? axObject->textMarkerRangeForNSRange(range) : AXTextMarkerRange();
     });
 }
@@ -447,8 +447,8 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText);
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
     if (!isConfined || !attributedText) {
-        return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, this, protectedThis = Ref { *this }] () mutable -> RetainPtr<NSAttributedString> {
-            if (RefPtr axObject = associatedAXObject())
+        return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, context = mainThreadContext()] () mutable -> RetainPtr<NSAttributedString> {
+            if (RefPtr axObject = context.axObjectOnMainThread())
                 return axObject->attributedStringForTextMarkerRange(WTFMove(markerRange), spellCheck);
             return { };
         });
@@ -516,8 +516,8 @@ IntPoint AXIsolatedObject::clickPoint()
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<IntPoint>([this, protectedThis = Ref { *this }] () -> IntPoint {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<IntPoint>([context = mainThreadContext()] () -> IntPoint {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->clickPoint();
         return { };
     });
@@ -527,8 +527,8 @@ bool AXIsolatedObject::pressedIsPresent() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<bool>([this, protectedThis = Ref { *this }] () -> bool {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([context = mainThreadContext()] () -> bool {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->pressedIsPresent();
         return false;
     });
@@ -538,8 +538,8 @@ Vector<String> AXIsolatedObject::determineDropEffects() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<Vector<String>>([this, protectedThis = Ref { * this }] () -> Vector<String> {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<String>>([context = mainThreadContext()] () -> Vector<String> {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->determineDropEffects();
         return { };
     });
@@ -549,8 +549,8 @@ int AXIsolatedObject::layoutCount() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<int>([this, protectedThis = Ref { *this }] () -> int {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<int>([context = mainThreadContext()] () -> int {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->layoutCount();
         return { };
     });
@@ -560,8 +560,8 @@ Vector<String> AXIsolatedObject::classList() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<Vector<String>>([this] () -> Vector<String> {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<String>>([context = mainThreadContext()] () -> Vector<String> {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->classList();
         return { };
     });
@@ -571,8 +571,8 @@ String AXIsolatedObject::computedRoleString() const
 {
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
-    return Accessibility::retrieveValueFromMainThread<String>([this, protectedThis = Ref { *this }] () -> String {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<String>([context = mainThreadContext()] () -> String {
+        if (RefPtr object = context.axObjectOnMainThread())
             return object->computedRoleString().isolatedCopy();
         return { };
     });


### PR DESCRIPTION
#### 2ae8856c87fd5e7c55cb3308abb4d4b1b42e7fc8
<pre>
AX: 304101@main introduced the possibility of ref&apos;ing AXIsolatedObjects in a non-thread-safe way
<a href="https://bugs.webkit.org/show_bug.cgi?id=303847">https://bugs.webkit.org/show_bug.cgi?id=303847</a>
<a href="https://rdar.apple.com/166150627">rdar://166150627</a>

Reviewed by Joshua Hoffman.

304101@main added refs to AXIsolatedObjects in functions that are not necessarily guaranteed to be on the accessibility
thread, introducing the possibilty of thread-safety violations.

Fix this by introducing a new class: AXIsolatedObject::MainThreadContext. This class contains the (thread-safe) context
necessary to hydrate an AccessibilityObject on the main-thread. Then we use this class whenever calling out to the
main-thread to perform an action (e.g. retrieveValueFromMainThread, peformFunctionOnMainThreadAndWait).

* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::performDismissAction):
(WebCore::AXIsolatedObject::setValue):
(WebCore::AXIsolatedObject::selectedText const):
(WebCore::AXIsolatedObject::accessibilityHitTest const):
(WebCore::AXIsolatedObject::getOrRetrievePropertyValue):
(WebCore::AXIsolatedObject::findTextRanges const):
(WebCore::AXIsolatedObject::performTextOperation):
(WebCore::AXIsolatedObject::elementRect const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::convertFrameToSpace const):
(WebCore::AXIsolatedObject::replaceTextInRange):
(WebCore::AXIsolatedObject::insertionPointLineNumber const):
(WebCore::AXIsolatedObject::identifierAttribute const):
(WebCore::AXIsolatedObject::doAXRangeForLine const):
(WebCore::AXIsolatedObject::doAXStringForRange const):
(WebCore::AXIsolatedObject::characterRangeForPoint const):
(WebCore::AXIsolatedObject::doAXRangeForIndex const):
(WebCore::AXIsolatedObject::doAXStyleRangeForIndex const):
(WebCore::AXIsolatedObject::doAXBoundsForRange const):
(WebCore::AXIsolatedObject::doAXBoundsForRangeUsingCharacterOffset const):
(WebCore::AXIsolatedObject::doAXLineForIndex):
(WebCore::AXIsolatedObject::modelElementChildren):
(WebCore::AXIsolatedObject::isOnScreen const):
(WebCore::AXIsolatedObject::misspellingRanges const):
(WebCore::AXIsolatedObject::hasSameFont):
(WebCore::AXIsolatedObject::hasSameFontColor):
(WebCore::AXIsolatedObject::hasSameStyle):
(WebCore::AXIsolatedObject::linkRelValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::convertRectToPlatformSpace const):
(WebCore::AXIsolatedObject::textMarkerRange const):
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
(WebCore::AXIsolatedObject::clickPoint):
(WebCore::AXIsolatedObject::pressedIsPresent const):
(WebCore::AXIsolatedObject::determineDropEffects const):
(WebCore::AXIsolatedObject::layoutCount const):
(WebCore::AXIsolatedObject::classList const):
(WebCore::AXIsolatedObject::computedRoleString const):

Canonical link: <a href="https://commits.webkit.org/304201@main">https://commits.webkit.org/304201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e7df5dec6e899d45f4dc461687097e46938332c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86741 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e75ccdf-c80d-49d0-8115-5b6689947cab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103045 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/05e49e49-094b-4453-b5f4-e777e2984144) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83884 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f278a8c8-7643-4c06-b834-86c007643690) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5407 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3024 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2959 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145063 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39596 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5247 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60890 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35324 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6791 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70585 "Found 1 new failure in accessibility/isolatedtree/AXIsolatedObject.h and found 2 fixed files: accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm, accessibility/isolatedtree/AXIsolatedObject.h") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->