### PR TITLE
[Cookie Store API] get() and getAll() should share the same code path

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -69,6 +69,9 @@ public:
 private:
     explicit CookieStore(ScriptExecutionContext*);
 
+    enum class GetType : bool { Get, GetAll };
+    void getShared(GetType, CookieStoreGetOptions&&, Ref<DeferredPromise>&&);
+
     // CookieChangeListener
     void cookiesAdded(const String& host, const Vector<Cookie>&) final;
     void cookiesDeleted(const String& host, const Vector<Cookie>&) final;


### PR DESCRIPTION
#### 25c05d906dcd30e93d960bfd4ef6e108762e3f64
<pre>
[Cookie Store API] get() and getAll() should share the same code path
<a href="https://bugs.webkit.org/show_bug.cgi?id=303860">https://bugs.webkit.org/show_bug.cgi?id=303860</a>
<a href="https://rdar.apple.com/166158960">rdar://166158960</a>

Reviewed by Chris Dumez.

Both functions have all the same checks and steps with only two differences:

1. If the passed in CookieStoreGetOptions is empty, get() throws a TypeError,
   getAll() does not throw any error.

2. get() returns a single cookie, getAll() returns a set of cookies.

So, to reduce code duplication, we create a new getShared() function that both
get() and getAll() will call. In order to differentiate between get() and getAll()
so we can implement the two differences noted above, we introduce a new enum
GetType.

This is tested by existing Cookie Store tests.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::getShared):
(WebCore::CookieStore::MainThreadBridge::getAll): Deleted.
* Source/WebCore/Modules/cookie-store/CookieStore.h:

Canonical link: <a href="https://commits.webkit.org/304476@main">https://commits.webkit.org/304476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/878c44eb0e487c9ecf29f0cfb5e787c47a0a182d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86715 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc6d13a3-a430-44a8-8a22-37e64f21d870) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103021 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70315 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22199012-e343-4e77-ab3b-fceb74c616e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83848 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c28ebd3-8328-45ae-ab7b-1a313eea56cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5384 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2994 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145022 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6926 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111405 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111732 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5223 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60859 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20912 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6971 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35296 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70553 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6998 "Failed to checkout and rebase branch from PR 55117") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->