### PR TITLE
[JSC] GreedyRegAlloc: implement intra-block live range splitting

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -39,14 +39,25 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numFastTmps)                          \
     macro(numUnspillableTmps)                   \
     macro(numSpillTmps)                         \
-    macro(numSplitTmps)                         \
     macro(numTmpsOut)                           \
+    macro(numSpilledTmps)                       \
     macro(numSpillStackSlots)                   \
     macro(numLoadSpill)                         \
     macro(numStoreSpill)                        \
+    macro(numInPlaceSpill)                      \
     macro(numMoveSpillSpillInsts)               \
     macro(numRematerializeConst)                \
     macro(maxLiveRangeSize)                     \
+    macro(didSpill)                             \
+    macro(numSplitAroundClobbers)               \
+    macro(numSplitAroundClobberSpilled)         \
+    macro(numSplitIntraBlockNoCluster)          \
+    macro(numSplitIntraBlock)                   \
+    macro(numSplitIntraBlockClusterTmps)        \
+    macro(numSplitIntraBlockClusterTmpsSpilled) \
+    macro(numSplitIntraBlockLoad)               \
+    macro(numSplitIntraBlockStore)              \
+    macro(numInsts)        \
 
 class AirAllocateRegistersStats {
     WTF_MAKE_NONCOPYABLE(AirAllocateRegistersStats);

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -120,9 +120,9 @@ public:
     bool isConstDef(unsigned absoluteIndex) const
     {
         if constexpr (bank == GP)
-            return m_gpConstDefs.quickGet(absoluteIndex);
+            return m_gpConstDefs.get(absoluteIndex);
         else
-            return m_fpConstDefs.quickGet(absoluteIndex);
+            return m_fpConstDefs.get(absoluteIndex);
     }
 
     template<Bank bank>


### PR DESCRIPTION
#### 823ded11d0caf68359fe9ac511e7c06d8c637e4f
<pre>
[JSC] GreedyRegAlloc: implement intra-block live range splitting
<a href="https://bugs.webkit.org/show_bug.cgi?id=303868">https://bugs.webkit.org/show_bug.cgi?id=303868</a>
<a href="https://rdar.apple.com/166163403">rdar://166163403</a>

Reviewed by Marcus Plutowski.

To give the register allocator more options when under register pressure,
implement live range splitting within a basic block. Within a block,
if a Tmp cannot be allocated to a register, then the allocator
attempts to create new Tmps to carry the values within use-def clusters
inside each basic block that the Tmp is accessed. This way, we have
a pattern in a basic block such as:

use Tmp
use Tmp
def Tmp
use Tmp

(in this example, the first cluster has 2 uses of Tmp and the second
cluster has a def and use of Tmp.)

and Tmp spills, currently the allocator will (in the worst case, ignoring
other existing optimizations) rewrite this to:

Mov (spill), r0
use r0
Move (spill), r1
use r1
def r2
Move r2, (spill)
Move (spill), r3
use r3

With intra-block live range splitting, the allocator now has the option
to write this as:

Move (spill), r0
use r0
use r0
def r1
Move r1, (spill) # emitted only if Tmp is live out of the block
use r1

Note that this has some overlap with the fixObviousSpills pass, which
can do a similar transformation when rN==rM, etc. But doing this
at register allocation time can find additional opportunities when
the spill tmps did not happen to get the same register.

Also note that fixObviousSpills can do some additional transformations
such as rewriting constant materializations as Adds and replacing
spill uses with registers across block boundaries. So both are useful.

In the future, this form of live range splitting can be enhanced to
split across loops rather than just intra-block, so spilled
tmps can potentially live in a register for the duration of the loop.

Canonical link: <a href="https://commits.webkit.org/304261@main">https://commits.webkit.org/304261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d074d9efef8d99e43642ee639ccd3d7bba59955

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135041 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142549 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/8073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137987 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/8073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/8073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3145 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/127061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/8073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145247 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133538 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/7126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/111924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20832 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/7174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166419 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->