### PR TITLE
Replace vmPageSize function with direct kernel page size

### DIFF
--- a/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
@@ -34,19 +34,9 @@
 
 namespace WTF {
 
-size_t vmPageSize()
-{
-#if PLATFORM(IOS_FAMILY)
-    return vm_kernel_page_size;
-#else
-    static size_t cached = sysconf(_SC_PAGESIZE);
-    return cached;
-#endif
-}
-
 void logFootprintComparison(const std::array<TagInfo, 256>& before, const std::array<TagInfo, 256>& after)
 {
-    const size_t pageSize = vmPageSize();
+    const size_t pageSize = vm_kernel_page_size;
 
     WTFLogAlways("Per-tag breakdown of memory reclaimed by pressure handler:");
     WTFLogAlways("  ## %16s %10s %10s %10s", "VM Tag", "Before", "After", "Diff");
@@ -121,7 +111,7 @@ std::array<TagInfo, 256> pagesPerVMTag()
 
         tags[info.user_tag].regionCount++;
 
-        tags[info.user_tag].reserved += size / vmPageSize();
+        tags[info.user_tag].reserved += size / vm_kernel_page_size;
 
         if (purgeableState == VM_PURGABLE_VOLATILE) {
             tags[info.user_tag].reclaimable += info.pages_resident;
@@ -129,7 +119,7 @@ std::array<TagInfo, 256> pagesPerVMTag()
         }
 
         if (purgeableState == VM_PURGABLE_EMPTY) {
-            tags[info.user_tag].reclaimable += size / vmPageSize();
+            tags[info.user_tag].reclaimable += size / vm_kernel_page_size;
             continue;
         }
 


### PR DESCRIPTION
<pre>Replace vmPageSize function with direct kernel page size
vmPageSize works on all Darwin platforms.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d895e338c945e970468b43d3b3d5696885d38be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134827 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7266 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86725 "Built successfully") 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7877 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Running analyze-compile-webkit-results") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7117 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137774 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/7877 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Running analyze-compile-webkit-results") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83861 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/7877 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Running analyze-compile-webkit-results") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2934 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126865 "Hash 9d895e33 for PR 55123 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/7877 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Running analyze-compile-webkit-results") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145039 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133334 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6942 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111413 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7003 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7117 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111746 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60872 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6986 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/46079 "Hash 9d895e33 for PR 55123 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166236 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6775 "Hash 9d895e33 for PR 55123 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70567 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43446 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7011 "Hash 9d895e33 for PR 55123 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6885 "Hash 9d895e33 for PR 55123 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->