### PR TITLE
[iOS] Introduce MockMediaDeviceRouteController

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8162,3 +8162,5 @@ imported/w3c/web-platform-tests/css/CSS2/stacking-context/opacity-affects-block-
 imported/w3c/web-platform-tests/css/CSS2/stacking-context/zindex-affects-block-in-inline.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/webrtc/RTCDataChannel-worker-GC.html [ Failure Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-track-settings.tentative.html [ Failure Pass ]
+
+media/wireless-playback-media-player/ [ Skip ]

--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-connecting-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-connecting-expected.txt
@@ -1,0 +1,12 @@
+
+Test that a 'connecting' event is dispatched when a MediaDeviceRoute activates.
+
+EXPECTED (video.remote.state == 'disconnected') OK
+RUN(video.src = findMediaFile('video', '../content/test'))
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EVENT(connecting)
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-connecting.html
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-connecting.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.getElementsByTagName('video')[0];
+                testExpected('video.remote.state', 'disconnected');
+
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                const connectingPromise = waitFor(video.remote, 'connecting');
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await connectingPromise;
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a 'connecting' event is dispatched when a MediaDeviceRoute activates.</p> 
+    </body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2492,6 +2492,8 @@ set(WebCoreTestSupport_IDL_FILES
     testing/MockCDMFactory.idl
     testing/MockCaptionDisplaySettingsClientCallback.idl
     testing/MockContentFilterSettings.idl
+    testing/MockMediaDeviceRoute.idl
+    testing/MockMediaDeviceRouteController.idl
     testing/MockPageOverlay.idl
     testing/MockWebAuthenticationConfiguration.idl
     testing/ServiceWorkerInternals.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1461,9 +1461,9 @@ $(PROJECT_DIR)/dom/DeviceOrientationOrMotionPermissionState.idl
 $(PROJECT_DIR)/dom/Document+CSSOMView.idl
 $(PROJECT_DIR)/dom/Document+CaretPositionFromPoint.idl
 $(PROJECT_DIR)/dom/Document+Fullscreen.idl
-$(PROJECT_DIR)/dom/Document+Immersive.idl
 $(PROJECT_DIR)/dom/Document+HTML.idl
 $(PROJECT_DIR)/dom/Document+HTMLObsolete.idl
+$(PROJECT_DIR)/dom/Document+Immersive.idl
 $(PROJECT_DIR)/dom/Document+PageVisibility.idl
 $(PROJECT_DIR)/dom/Document+PointerLock.idl
 $(PROJECT_DIR)/dom/Document+Selection.idl
@@ -2149,6 +2149,8 @@ $(PROJECT_DIR)/testing/MockApplePaySetupFeature.idl
 $(PROJECT_DIR)/testing/MockCDMFactory.idl
 $(PROJECT_DIR)/testing/MockCaptionDisplaySettingsClientCallback.idl
 $(PROJECT_DIR)/testing/MockContentFilterSettings.idl
+$(PROJECT_DIR)/testing/MockMediaDeviceRoute.idl
+$(PROJECT_DIR)/testing/MockMediaDeviceRouteController.idl
 $(PROJECT_DIR)/testing/MockPageOverlay.idl
 $(PROJECT_DIR)/testing/MockPaymentAddress.idl
 $(PROJECT_DIR)/testing/MockPaymentContactFields.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2004,6 +2004,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCaptionDisplaySettingsClientC
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCaptionDisplaySettingsClientCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockContentFilterSettings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockContentFilterSettings.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRoute.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRoute.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteController.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteController.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPageOverlay.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPageOverlay.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPaymentAddress.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1788,6 +1788,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/testing/MockCDMFactory.idl \
     $(WebCore)/testing/MockCaptionDisplaySettingsClientCallback.idl \
     $(WebCore)/testing/MockContentFilterSettings.idl \
+	$(WebCore)/testing/MockMediaDeviceRoute.idl \
+	$(WebCore)/testing/MockMediaDeviceRouteController.idl \
     $(WebCore)/testing/MockPageOverlay.idl \
     $(WebCore)/testing/MockPaymentAddress.idl \
     $(WebCore)/testing/MockPaymentContactFields.idl \

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		A10826FA1F576292004772AC /* WebPanel.mm in Sources */ = {isa = PBXBuildFile; fileRef = A10826F81F576292004772AC /* WebPanel.mm */; };
 		A1175B4F1F6B337300C4B9F0 /* PopupMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1175B4D1F6B337300C4B9F0 /* PopupMenu.mm */; };
 		A1175B581F6B470500C4B9F0 /* DefaultSearchProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */; };
+		A13AB0832EE7AFDA003C1ED5 /* AVRoutingSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = A13AB0822EE7AFDA003C1ED5 /* AVRoutingSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A15E661B2EDA937A007FB56F /* AVRoutingSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = A15E66192EDA937A007FB56F /* AVRoutingSoftLink.mm */; };
 		A15E66242EDA972C007FB56F /* AVRoutingSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = A15E66182EDA937A007FB56F /* AVRoutingSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1F63CA021A4DBF7006FB43B /* PassKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */; };
@@ -698,6 +699,7 @@
 		A1175B551F6B470500C4B9F0 /* DefaultSearchProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DefaultSearchProvider.h; sourceTree = "<group>"; };
 		A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultSearchProvider.cpp; sourceTree = "<group>"; };
 		A1175B591F6B4A8400C4B9F0 /* NSScrollViewSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSScrollViewSPI.h; sourceTree = "<group>"; };
+		A13AB0822EE7AFDA003C1ED5 /* AVRoutingSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVRoutingSPI.h; sourceTree = "<group>"; };
 		A15E66182EDA937A007FB56F /* AVRoutingSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVRoutingSoftLink.h; sourceTree = "<group>"; };
 		A15E66192EDA937A007FB56F /* AVRoutingSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AVRoutingSoftLink.mm; sourceTree = "<group>"; };
 		A169B040248EF03900EE8B7B /* PassKitInstallmentsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassKitInstallmentsSPI.h; sourceTree = "<group>"; };
@@ -938,6 +940,7 @@
 		0C5AF90D1F43A4A4002EAC02 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				A13AB0822EE7AFDA003C1ED5 /* AVRoutingSPI.h */,
 				42EB2CA22D0388A400ECB173 /* AXRuntimeSPI.h */,
 				3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */,
 				F4F0A54B2B634D88001A54E5 /* BrowserEngineKitSPI.h */,
@@ -1421,6 +1424,7 @@
 				DD20DDDB27BC90D70093D175 /* AVFoundationSPI.h in Headers */,
 				DD20DDDC27BC90D70093D175 /* AVKitSPI.h in Headers */,
 				A15E66242EDA972C007FB56F /* AVRoutingSoftLink.h in Headers */,
+				A13AB0832EE7AFDA003C1ED5 /* AVRoutingSPI.h in Headers */,
 				DD20DDDD27BC90D70093D175 /* AVStreamDataParserSPI.h in Headers */,
 				42EB2CA32D0388A400ECB173 /* AXRuntimeSPI.h in Headers */,
 				DD20DDDE27BC90D70093D175 /* AXSpeechManagerSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/ios/AVRoutingSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/AVRoutingSPI.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#include <WebKitAdditions/AVRoutingSPIAdditions.h>
+
+#endif

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -33,7 +33,7 @@
 
 #define FOR_EACH_READONLY_KEY_PATH(Macro) \
     Macro(minValue, MinValue, float) \
-    Macro(maxValue, MinValue, float) \
+    Macro(maxValue, MaxValue, float) \
     Macro(segments, Segments, Vector<MediaTimelineSegment>) \
     Macro(currentSegment, CurrentSegment, std::optional<MediaTimelineSegment>) \
     Macro(state, State, MediaPlaybackSourceState) \

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -52,7 +52,7 @@ class MediaDeviceRouteController {
     friend class NeverDestroyed<MediaDeviceRouteController>;
 
 public:
-    static MediaDeviceRouteController& singleton();
+    WEBCORE_EXPORT static MediaDeviceRouteController& singleton();
 
     RefPtr<MediaDeviceRouteControllerClient> client() const { return m_client.get(); }
     void setClient(MediaDeviceRouteControllerClient* client) { m_client = client; }
@@ -60,19 +60,20 @@ public:
     RefPtr<MediaDeviceRoute> mostRecentActiveRoute() const;
     RefPtr<MediaDeviceRoute> routeForIdentifier(const std::optional<WTF::UUID>&) const;
 
-    bool handleEvent(WebMediaDevicePlatformRouteEvent *);
+    WEBCORE_EXPORT bool activateRoute(WebMediaDevicePlatformRoute *);
+    WEBCORE_EXPORT bool deactivateRoute(WebMediaDevicePlatformRoute *);
 
 private:
     MediaDeviceRouteController();
-
-    bool activateRoute(WebMediaDevicePlatformRoute *);
-    bool deactivateRoute(WebMediaDevicePlatformRoute *);
 
     RetainPtr<WebMediaDeviceRouteController> m_controller;
     RetainPtr<WebMediaDevicePlatformRouteController> m_platformController;
     ThreadSafeWeakPtr<MediaDeviceRouteControllerClient> m_client;
     Vector<Ref<MediaDeviceRoute>> m_activeRoutes;
 };
+
+WEBCORE_EXPORT void setMockMediaDeviceRouteControllerEnabled(bool);
+WEBCORE_EXPORT bool mockMediaDeviceRouteControllerEnabled();
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -68,18 +68,6 @@ RefPtr<MediaDeviceRoute> MediaDeviceRouteController::routeForIdentifier(const st
     return nullptr;
 }
 
-bool MediaDeviceRouteController::handleEvent(WebMediaDevicePlatformRouteEvent *event)
-{
-    switch (event.reason) {
-    case WebMediaDevicePlatformRouteEventReasonActivate:
-        return activateRoute(event.route);
-    case WebMediaDevicePlatformRouteEventReasonDeactivate:
-        return deactivateRoute(event.route);
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 bool MediaDeviceRouteController::activateRoute(WebMediaDevicePlatformRoute *platformRoute)
 {
     m_activeRoutes.removeAllMatching([&](auto& route) { return route->platformRoute() == platformRoute; });
@@ -100,6 +88,21 @@ bool MediaDeviceRouteController::deactivateRoute(WebMediaDevicePlatformRoute *pl
         client->activeRoutesDidChange(*this);
 
     return true;
+}
+
+static bool& mockMediaDeviceRouteControllerEnabledValue()
+{
+    static bool mockMediaDeviceRouteControllerEnabled;
+    return mockMediaDeviceRouteControllerEnabled;
+}
+
+void setMockMediaDeviceRouteControllerEnabled(bool isEnabled)
+{
+    mockMediaDeviceRouteControllerEnabledValue() = isEnabled;
+}
+bool mockMediaDeviceRouteControllerEnabled()
+{
+    return mockMediaDeviceRouteControllerEnabledValue();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <wtf/Platform.h>
 #if PLATFORM(IOS_FAMILY)
 
+#include <WebCore/MediaDeviceRouteController.h>
 #include <WebCore/MediaPlaybackTarget.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ProcessID.h>
@@ -68,7 +68,13 @@ public:
     virtual void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) = 0;
 };
 
-class WEBCORE_EXPORT MediaSessionHelper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSessionHelper> {
+class WEBCORE_EXPORT MediaSessionHelper
+#if HAVE(AVROUTING_FRAMEWORK)
+    : public MediaDeviceRouteControllerClient
+#else
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSessionHelper>
+#endif
+{
 public:
     static MediaSessionHelper& sharedHelper();
     static Ref<MediaSessionHelper> protectedSharedHelper();
@@ -112,6 +118,10 @@ public:
 
     void setActiveAudioRouteSupportsSpatialPlayback(bool);
     void updateActiveAudioRouteSupportsSpatialPlayback();
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    void activeRoutesDidChange(MediaDeviceRouteController&) final;
+#endif
 
 protected:
     void externalOutputDeviceAvailableDidChange(HasAvailableTargets);

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -108,6 +108,7 @@
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+#include "MediaDeviceRouteController.h"
 #include "MediaPlayerPrivateWirelessPlayback.h"
 #endif
 
@@ -368,7 +369,7 @@ static void buildMediaEnginesVector() WTF_REQUIRES_LOCK(mediaEngineVectorLock)
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     if (DeprecatedGlobalSettings::isWirelessPlaybackMediaPlayerEnabled()) {
-        if (registerRemoteEngine)
+        if (registerRemoteEngine && !mockMediaDeviceRouteControllerEnabled())
             registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::WirelessPlayback);
         else
             MediaPlayerPrivateWirelessPlayback::registerMediaEngine(addMediaEngine);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -429,6 +429,10 @@
 #include "ImageControlsMac.h"
 #endif
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+#import "MockMediaDeviceRouteController.h"
+#endif
+
 using JSC::CallData;
 using JSC::CodeBlock;
 using JSC::FunctionExecutable;
@@ -788,6 +792,13 @@ Internals::Internals(Document& document)
 
 #if ENABLE(DAMAGE_TRACKING)
     document.page()->chrome().client().resetDamageHistoryForTesting();
+#endif
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    if (RefPtr mockMediaDeviceRouteController = m_mockMediaDeviceRouteController) {
+        m_mockMediaDeviceRouteController->setEnabled(false);
+        m_mockMediaDeviceRouteController = nullptr;
+    }
 #endif
 }
 
@@ -8212,5 +8223,14 @@ ExceptionOr<void> Internals::copyImageAtLocation(int x, int y)
     UNUSED_PARAM(y);
     return { };
 }
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+MockMediaDeviceRouteController& Internals::mockMediaDeviceRouteController()
+{
+    if (!m_mockMediaDeviceRouteController)
+        m_mockMediaDeviceRouteController = MockMediaDeviceRouteController::create();
+    return *m_mockMediaDeviceRouteController;
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -119,6 +119,7 @@ class MessagePort;
 class MockCDMFactory;
 class MockCaptionDisplaySettingsClientCallback;
 class MockContentFilterSettings;
+class MockMediaDeviceRouteController;
 class MockPageOverlay;
 class MockPaymentCoordinator;
 class NodeList;
@@ -1662,6 +1663,10 @@ public:
 
     size_t fileConnectionHandleCount(const FileSystemHandle&) const;
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    MockMediaDeviceRouteController& mockMediaDeviceRouteController();
+#endif
+
 private:
     explicit Internals(Document&);
 
@@ -1736,6 +1741,9 @@ private:
 #if ENABLE(VIDEO)
     std::unique_ptr<CaptionUserPreferencesTestingModeToken> m_testingModeToken;
     RefPtr<MockCaptionDisplaySettingsClientCallback> m_mockCaptionDisplaySettingsClientCallback;
+#endif
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    RefPtr<MockMediaDeviceRouteController> m_mockMediaDeviceRouteController;
 #endif
 };
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1498,4 +1498,6 @@ enum ContentsFormat {
     // Navigation API rate limiter testing
     undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
     undefined resetNavigationRateLimiter(DOMWindow window);
+
+    [Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER] readonly attribute MockMediaDeviceRouteController mockMediaDeviceRouteController;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include <WebKitAdditions/MediaDeviceRouteAdditions.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+OBJC_CLASS WebMockMediaDeviceRoute;
+
+namespace WebCore {
+
+class MockMediaDeviceRoute : public RefCounted<MockMediaDeviceRoute> {
+    WTF_MAKE_TZONE_ALLOCATED(MockMediaDeviceRoute);
+public:
+    static Ref<MockMediaDeviceRoute> create();
+
+    WebMediaDevicePlatformRoute *platformRoute() const;
+
+private:
+    MockMediaDeviceRoute();
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    RetainPtr<WebMockMediaDeviceRoute> m_platformRoute;
+#endif
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    LegacyNoInterfaceObject,
+] interface MockMediaDeviceRoute {
+};

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MockMediaDeviceRoute.h"
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#import "WebMockMediaDeviceRoute.h"
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockMediaDeviceRoute);
+
+Ref<MockMediaDeviceRoute> MockMediaDeviceRoute::create()
+{
+    return adoptRef(*new MockMediaDeviceRoute());
+}
+
+MockMediaDeviceRoute::MockMediaDeviceRoute()
+#if HAVE(AVROUTING_FRAMEWORK)
+    : m_platformRoute { adoptNS([[WebMockMediaDeviceRoute alloc] init]) }
+#endif
+{
+}
+
+WebMediaDevicePlatformRoute *MockMediaDeviceRoute::platformRoute() const
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    return m_platformRoute.get();
+#else
+    return nil;
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.h
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class MockMediaDeviceRoute;
+
+class MockMediaDeviceRouteController : public RefCounted<MockMediaDeviceRouteController> {
+    WTF_MAKE_TZONE_ALLOCATED(MockMediaDeviceRouteController);
+public:
+    static Ref<MockMediaDeviceRouteController> create();
+
+    bool enabled() const;
+    void setEnabled(bool);
+
+    Ref<MockMediaDeviceRoute> createMockMediaDeviceRoute();
+    bool activateRoute(const MockMediaDeviceRoute&);
+    bool deactivateRoute(const MockMediaDeviceRoute&);
+
+private:
+    MockMediaDeviceRouteController();
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    LegacyNoInterfaceObject,
+] interface MockMediaDeviceRouteController {
+    attribute boolean enabled;
+
+    MockMediaDeviceRoute createMockMediaDeviceRoute();
+    
+    boolean activateRoute(MockMediaDeviceRoute route);
+    boolean deactivateRoute(MockMediaDeviceRoute route);
+};

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.mm
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MockMediaDeviceRouteController.h"
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#import "MediaDeviceRouteController.h"
+#import "MediaSessionHelperIOS.h"
+#import "MockMediaDeviceRoute.h"
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockMediaDeviceRouteController);
+
+Ref<MockMediaDeviceRouteController> MockMediaDeviceRouteController::create()
+{
+    return adoptRef(*new MockMediaDeviceRouteController());
+}
+
+MockMediaDeviceRouteController::MockMediaDeviceRouteController() = default;
+
+bool MockMediaDeviceRouteController::enabled() const
+{
+    return mockMediaDeviceRouteControllerEnabled();
+}
+
+void MockMediaDeviceRouteController::setEnabled(bool enabled)
+{
+    MediaDeviceRouteController::singleton().setClient(enabled ? &MediaSessionHelper::sharedHelper() : nullptr);
+    setMockMediaDeviceRouteControllerEnabled(enabled);
+}
+
+Ref<MockMediaDeviceRoute> MockMediaDeviceRouteController::createMockMediaDeviceRoute()
+{
+    return MockMediaDeviceRoute::create();
+}
+
+bool MockMediaDeviceRouteController::activateRoute(const MockMediaDeviceRoute& route)
+{
+    return MediaDeviceRouteController::singleton().activateRoute(route.platformRoute());
+}
+
+bool MockMediaDeviceRouteController::deactivateRoute(const MockMediaDeviceRoute& route)
+{
+    return MediaDeviceRouteController::singleton().deactivateRoute(route.platformRoute());
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+#import <WebKitAdditions/MediaDeviceRouteAdditions.h>
+#import <pal/spi/ios/AVRoutingSPI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WebMockMediaDeviceRoute : NSObject <WebMediaDevicePlatformRoute>
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebMockMediaDeviceRoute.h"
+
+#if HAVE(AVROUTING_FRAMEWORK)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation WebMockMediaDeviceRoute
+
+@synthesize currentAudioOption;
+@synthesize currentSegment;
+@synthesize currentSubtitleOption;
+@synthesize currentValue;
+@synthesize hasAudio;
+@synthesize isAudioOnly;
+@synthesize isPlaying;
+@synthesize maxValue;
+@synthesize minValue;
+@synthesize muted;
+@synthesize options;
+@synthesize playbackError;
+@synthesize playbackSpeed;
+@synthesize playbackType;
+@synthesize scanSpeed;
+@synthesize segments;
+@synthesize state;
+@synthesize supportedModes;
+@synthesize volume;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -38,6 +38,9 @@ class WebProcess;
 
 class RemoteMediaSessionHelper final
     : public WebCore::MediaSessionHelper
+#if HAVE(AVROUTING_FRAMEWORK)
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaSessionHelper>
+#endif
     , public IPC::MessageReceiver
     , public GPUProcessConnection::Client {
 public:


### PR DESCRIPTION
#### 4a29ae3f958842320967e784789167031a0af083
<pre>
[iOS] Introduce MockMediaDeviceRouteController
<a href="https://bugs.webkit.org/show_bug.cgi?id=303872">https://bugs.webkit.org/show_bug.cgi?id=303872</a>
<a href="https://rdar.apple.com/166169152">rdar://166169152</a>

Reviewed by Jer Noble.

Introduced MockMediaDeviceRouteController to facilitate writing layout tests for wireless playback.
MockMediaDeviceRouteController can create MockMediaDeviceRoutes and activate/deactivate them,
simulating an AirPlay route being activated or deactivated by the system. For now, a single test is
introduced that ensures that a RemotePlayback &apos;connecting&apos; event is dispatched when a
MockMediaDeviceRoute is activated. Additional tests will be added in follow-on changes.

Test: media/wireless-playback-media-player/remote-playback-connecting.html

* LayoutTests/TestExpectations:
* LayoutTests/media/wireless-playback-media-player/remote-playback-connecting-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/remote-playback-connecting.html: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/ios/AVRoutingSPI.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm:
(WebCore::mockMediaDeviceRouteControllerEnabledValue):
(WebCore::setMockMediaDeviceRouteControllerEnabled):
(WebCore::mockMediaDeviceRouteControllerEnabled):
(WebCore::MediaDeviceRouteController::handleEvent): Deleted.
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::activeRoutesDidChange):
(MediaSessionHelperIOS::activeRoutesDidChange): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::Internals):
(WebCore::Internals::mockMediaDeviceRouteController):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.h: Copied from Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h.
* Source/WebCore/testing/MockMediaDeviceRoute.idl: Added.
* Source/WebCore/testing/MockMediaDeviceRoute.mm: Added.
(WebCore::MockMediaDeviceRoute::create):
(WebCore::MockMediaDeviceRoute::MockMediaDeviceRoute):
(WebCore::MockMediaDeviceRoute::platformRoute const):
* Source/WebCore/testing/MockMediaDeviceRouteController.h: Added.
* Source/WebCore/testing/MockMediaDeviceRouteController.idl: Added.
* Source/WebCore/testing/MockMediaDeviceRouteController.mm: Added.
(WebCore::MockMediaDeviceRouteController::create):
(WebCore::MockMediaDeviceRouteController::enabled const):
(WebCore::MockMediaDeviceRouteController::setEnabled):
(WebCore::MockMediaDeviceRouteController::createMockMediaDeviceRoute):
(WebCore::MockMediaDeviceRouteController::activateRoute):
(WebCore::MockMediaDeviceRouteController::deactivateRoute):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h: Added.
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm: Added.
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:

Canonical link: <a href="https://commits.webkit.org/304305@main">https://commits.webkit.org/304305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efbb6de0c0ad134d05420bb630aedf781434d7c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86910 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103235 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70468 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/idlharness.https.any.serviceworker.html (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84089 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5584 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3195 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3199 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7175 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111972 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5416 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61108 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7227 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35531 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->