### PR TITLE
Push logic for skipping weak null when iterating down into HashTable

### DIFF
--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -143,7 +143,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         void skipEmptyBuckets()
         {
-            while (m_position != m_endPosition && HashTableType::isEmptyOrDeletedBucket(*m_position))
+            while (m_position != m_endPosition && HashTableType::isEmptyOrDeletedOrWeakNullBucket(*m_position))
                 ++m_position;
         }
 
@@ -516,6 +516,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         static bool isWeakNullBucket(const ValueType& value) { return isHashTraitsWeakNullValue<KeyTraits>(Extractor::extract(value)); }
         static bool isDeletedBucket(const ValueType& value) { return KeyTraits::isDeletedValue(Extractor::extract(value)); }
         static bool isEmptyOrDeletedBucket(const ValueType& value) { return isEmptyBucket(value) || isDeletedBucket(value); }
+        static bool isEmptyOrDeletedOrWeakNullBucket(const ValueType& value) { return isEmptyBucket(value) || isDeletedBucket(value) || isWeakNullBucket(value); }
 
         bool isValidKey(const ValueType& value) { return !isEmptyOrDeletedBucket(value); }
 
@@ -573,7 +574,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ValueType* expand(ValueType* entry = nullptr);
         void shrink() { rehash(tableSize() / 2, nullptr); }
         void shrinkToBestSize();
-    
+
         ValueType* rehash(unsigned newTableSize, ValueType* entry);
         ValueType* reinsert(ValueType&&);
 
@@ -1153,7 +1154,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         for (unsigned i = tableSize(); i--;) {
             ValueType& bucket = table[i];
-            if (isEmptyOrDeletedBucket(bucket))
+            if (isEmptyOrDeletedOrWeakNullBucket(bucket))
                 continue;
             
             if (!functor(bucket))
@@ -1187,7 +1188,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         for (unsigned i = tableSize(); i--;) {
             ValueType& bucket = table[i];
-            if (isEmptyOrDeletedBucket(bucket))
+            if (isEmptyOrDeletedOrWeakNullBucket(bucket))
                 continue;
 
             if (!functor(bucket))

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -204,6 +204,7 @@ public:
 
     static bool isEmptyBucket(const ValueType& value) { return isHashTraitsEmptyValue<KeyTraits>(Extractor::extract(value)); }
     static bool isEmptyOrDeletedBucket(const ValueType& value) { return isEmptyBucket(value); }
+    static bool isEmptyOrDeletedOrWeakNullBucket(const ValueType& value) { static_assert(!KeyTraits::hasIsWeakNullValueFunction); return isEmptyOrDeletedBucket(value); }
 
     template<ShouldValidateKey shouldValidateKey> ValueType* lookup(const Key& key) { return lookup<IdentityTranslatorType, shouldValidateKey>(key); }
     template<typename HashTranslator, ShouldValidateKey, typename T> ValueType* lookup(const T&);

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -75,7 +75,6 @@ public:
             , m_position { position }
             , m_endPosition { weakHashMap.m_map.end() }
         {
-            skipEmptyBuckets();
         }
     
         ~WeakHashMapIteratorBase() = default;
@@ -97,14 +96,7 @@ public:
             ASSERT(m_position != m_endPosition);
             ++m_position;
             ++m_advanceCount;
-            skipEmptyBuckets();
             m_weakHashMap.increaseOperationCountSinceLastCleanup();
-        }
-
-        void skipEmptyBuckets()
-        {
-            while (m_position != m_endPosition && !m_position->key.get())
-                ++m_position;
         }
 
         const MapType& m_weakHashMap;
@@ -354,10 +346,13 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_map, [&](auto& iterator) {
+        for (auto _ : m_map) {
+            UNUSED_VARIABLE(_);
             ++count;
-            return !iterator.key.get();
-        });
+        }
+
+        bool result = count != m_map.size();
+
         if (result)
             increaseOperationCountSinceLastCleanup(count);
         else

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -54,7 +54,6 @@ public:
             , m_position(position)
             , m_endPosition(set.m_set.end())
         {
-            skipEmptyBuckets();
         }
 
     public:
@@ -68,7 +67,6 @@ public:
         {
             ASSERT(m_position != m_endPosition);
             ++m_position;
-            skipEmptyBuckets();
             m_set->increaseOperationCountSinceLastCleanup();
             return *this;
         }
@@ -78,12 +76,6 @@ public:
             WeakHashSetConstIterator temp = *this;
             ++(*this);
             return temp;
-        }
-
-        void skipEmptyBuckets()
-        {
-            while (m_position != m_endPosition && !get())
-                ++m_position;
         }
 
         bool operator==(const WeakHashSetConstIterator& other) const
@@ -176,10 +168,13 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_set, [&](auto& value) {
+        for (auto _ : m_set) {
+            UNUSED_VARIABLE(_);
             ++count;
-            return !value;
-        });
+        }
+
+        bool result = count != m_set.size();
+
         if (result)
             increaseOperationCountSinceLastCleanup(count);
         else

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -56,7 +56,6 @@ public:
             , m_beginPosition { set.m_set.begin() }
             , m_endPosition { set.m_set.end() }
         {
-            skipEmptyBuckets();
         }
 
         WeakListHashSetIteratorBase(const ListHashSetType& set, IteratorType position)
@@ -65,7 +64,6 @@ public:
             , m_beginPosition { set.m_set.begin() }
             , m_endPosition { set.m_set.end() }
         {
-            skipEmptyBuckets();
         }
 
         ~WeakListHashSetIteratorBase() = default;
@@ -81,7 +79,6 @@ public:
         {
             ASSERT(m_position != m_endPosition);
             ++m_position;
-            skipEmptyBuckets();
             m_set.increaseOperationCountSinceLastCleanup();
         }
 
@@ -92,12 +89,6 @@ public:
             while (m_position != m_beginPosition && !get())
                 --m_position;
             m_set.increaseOperationCountSinceLastCleanup();
-        }
-
-        void skipEmptyBuckets()
-        {
-            while (m_position != m_endPosition && !get())
-                ++m_position;
         }
 
         const ListHashSetType& m_set;
@@ -320,10 +311,12 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_set, [&](auto& iterator) {
+        for (auto _ : m_set) {
+            UNUSED_VARIABLE(_);
             ++count;
-            return !iterator.get();
-        });
+        }
+
+        bool result = count != m_set.size();
         if (result)
             increaseOperationCountSinceLastCleanup(count);
         else

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -34,7 +34,9 @@
 #include <string>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringHash.h>
 
@@ -1460,6 +1462,55 @@ TEST(WTF_HashMap, RangeToChainedOperations)
     EXPECT_EQ(2U, result.size());
     EXPECT_EQ(40, result.get(2)); // 20 * 2
     EXPECT_EQ(80, result.get(4)); // 40 * 2
+}
+
+class Object : public WTF::RefCountedAndCanMakeWeakPtr<Object> {
+public:
+    static Ref<Object> create() { return adoptRef(*new Object); }
+
+private:
+    Object() = default;
+};
+
+TEST(WTF_HashMap, WeakPtr)
+{
+    HashMap<WeakPtr<Object>, int> map;
+
+    RefPtr object1 = Object::create();
+    map.add(object1.get(), 1);
+
+    Ref object2 = Object::create();
+
+    // Present when live
+    EXPECT_TRUE(map.contains(object1.get()));
+    EXPECT_EQ(map.find(object1.get())->value, 1);
+    EXPECT_EQ(1u, map.size());
+    for (auto& entry : map) {
+        EXPECT_EQ(entry.key, object1.get());
+        EXPECT_EQ(entry.value, 1);
+    }
+
+    EXPECT_FALSE(map.contains(&object2.get()));
+    EXPECT_EQ(map.find(&object2.get()), map.end());
+
+    Object* rawObject1 = object1.get();
+    object1 = nullptr;
+
+    // Absent when dead
+    EXPECT_EQ(map.get(rawObject1), 0);
+    EXPECT_FALSE(map.contains(rawObject1));
+    EXPECT_EQ(map.find(rawObject1), map.end());
+    EXPECT_EQ(map.begin(), map.end());
+
+    // Accurate size after removing weak nulls
+    EXPECT_EQ(1u, map.size());
+    map.removeWeakNullEntries();
+    EXPECT_EQ(0u, map.size());
+
+    // Bounded growth as added objects die
+    for (size_t i = 0; i < 128; ++i)
+        map.add(&Object::create().get(), 1);
+    EXPECT_LT(map.size(), 16u);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -29,7 +29,8 @@
 #include "MoveOnly.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace TestWebKitAPI {
 
@@ -578,6 +579,52 @@ TEST(WTF_ListHashSet, ClearsItemUponAssignment)
     data->setCollection(WTFMove(secondCollection));
 
     EXPECT_EQ(0u, ListHashSetReferencedItem::instances().size());
+}
+
+class Object : public WTF::RefCountedAndCanMakeWeakPtr<Object> {
+public:
+    static Ref<Object> create() { return adoptRef(*new Object); }
+
+private:
+    Object() = default;
+};
+
+TEST(WTF_ListHashSet, WeakPtr)
+{
+    ListHashSet<WeakPtr<Object>> set;
+
+    RefPtr object1 = Object::create();
+    set.add(object1.get());
+
+    Ref object2 = Object::create();
+
+    // Present when live
+    EXPECT_TRUE(set.contains(object1.get()));
+    EXPECT_EQ(set.find(object1.get())->get(), object1.get());
+    EXPECT_EQ(1u, set.size());
+    for (auto& entry : set)
+        EXPECT_EQ(entry, object1.get());
+
+    EXPECT_FALSE(set.contains(&object2.get()));
+    EXPECT_EQ(set.find(&object2.get()), set.end());
+
+    Object* rawObject1 = object1.get();
+    object1 = nullptr;
+
+    // Absent when dead
+    EXPECT_FALSE(set.contains(rawObject1));
+    EXPECT_EQ(set.find(rawObject1), set.end());
+    EXPECT_EQ(set.begin(), set.end());
+
+    // Accurate size after removing weak nulls
+    EXPECT_EQ(1u, set.size());
+    set.removeWeakNullEntries();
+    EXPECT_EQ(0u, set.size());
+
+    // Bounded growth as added objects die
+    for (size_t i = 0; i < 128; ++i)
+        set.add(&Object::create().get());
+    EXPECT_LT(set.size(), 16u);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### cd68efecfe6b9bfbf57ae08ae83710679ed9aae7
<pre>
Push logic for skipping weak null when iterating down into HashTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=303882">https://bugs.webkit.org/show_bug.cgi?id=303882</a>
&lt;<a href="https://rdar.apple.com/problem/166176904">rdar://problem/166176904</a>&gt;

Reviewed by Ryosuke Niwa.

This is the final step toward a more efficient weak pointer.

There&apos;s no longer any meaningful difference between
    WeakHashSet&lt;T&gt;      &lt;==&gt;    HashSet&lt;WeakPtr&lt;T&gt;&gt;
    WeakListHashSet&lt;T&gt;  &lt;==&gt;    ListHashSet&lt;WeakPtr&lt;T&gt;&gt;
    WeakHashMap&lt;T, U&gt;   &lt;==&gt;    HashMap&lt;WeakPtr&lt;T&gt;, U&gt;

So it should be easy to start doing
    HashSet&lt;MoreEfficientWeakPtr&lt;T&gt;&gt;
    ListHashSet&lt;MoreEfficientWeakPtr&lt;T&gt;&gt;
    HashMap&lt;MoreEfficientWeakPtr&lt;T&gt;, U&gt;

We should also be able remove the specialty weak table types over time, for
simplicity.

Canonical link: <a href="https://commits.webkit.org/304267@main">https://commits.webkit.org/304267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8dddf5ad662d5143f49e753acecb385851400f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135076 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46329 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136945 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/142581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/3177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/127094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/133570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/7156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/145280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20838 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/7206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/166449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/166449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->