### PR TITLE
Testing results for enabling ES heuristics.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2744,17 +2744,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:


### PR DESCRIPTION
#### dc4aedb8961f1587a26c2e0efb912b2e7027670e
<pre>
Testing results for enabling ES heuristics.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Toggle this on by default on Apple platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4aedb8961f1587a26c2e0efb912b2e7027670e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86747 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df9b907a-fdec-4dd7-9ad5-5532caa11c1f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103057 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70338 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a0ff8ecd-f895-4ab4-9836-0613ced3d323) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6204 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120881 "Found 19 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83901 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ead3993-42b6-40f5-92be-88d8d9d883be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5979 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3029 "Found 20 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2970 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126892 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115203 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145075 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133367 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111778 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5252 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117161 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/60896 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35336 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166261 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70592 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43455 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->