### PR TITLE
Web Inspector: Replace deprecated String.prototype.substr with substring for multi parameter calls

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -871,7 +871,7 @@ Object.defineProperty(String.prototype, "truncateMiddle",
             return this;
         var leftHalf = maxLength >> 1;
         var rightHalf = maxLength - leftHalf - 1;
-        return this.substr(0, leftHalf) + ellipsis + this.substr(this.length - rightHalf, rightHalf);
+        return this.substring(0, leftHalf) + ellipsis + this.substring(this.length - rightHalf);
     }
 });
 
@@ -883,7 +883,7 @@ Object.defineProperty(String.prototype, "truncateEnd",
 
         if (this.length <= maxLength)
             return this;
-        return this.substr(0, maxLength - 1) + ellipsis;
+        return this.substring(0, maxLength - 1) + ellipsis;
     }
 });
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
@@ -846,7 +846,7 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
             var lastIndex = Math.min(commonPrefix.length, completion.length);
             for (var j = prefixLength; j < lastIndex; ++j) {
                 if (commonPrefix[j] !== completion[j]) {
-                    commonPrefix = commonPrefix.substr(0, j);
+                    commonPrefix = commonPrefix.substring(0, j);
                     break;
                 }
             }

--- a/Source/WebInspectorUI/UserInterface/Debug/UncaughtExceptionReporter.js
+++ b/Source/WebInspectorUI/UserInterface/Debug/UncaughtExceptionReporter.js
@@ -217,7 +217,7 @@ function createErrorSheet() {
 
     function stringifyAndTruncateObject(object) {
         let string = JSON.stringify(object);
-        return string.length > 500 ? string.substr(0, 500) + ellipsis : string;
+        return string.length > 500 ? string.substring(0, 500) + ellipsis : string;
     }
 
     if (window.InspectorBackend && InspectorBackend.currentDispatchState) {

--- a/Source/WebInspectorUI/UserInterface/Models/SourceMap.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMap.js
@@ -266,7 +266,7 @@ WI.SourceMap = class SourceMap
         if (!urlComponents.path)
             urlComponents.path = this._sourceMappingURL || "";
 
-        urlComponents.path = urlComponents.path.substr(0, urlComponents.path.lastIndexOf(urlComponents.lastPathComponent));
+        urlComponents.path = urlComponents.path.substring(0, urlComponents.path.lastIndexOf(urlComponents.lastPathComponent));
         urlComponents.lastPathComponent = null;
         this._sourceMappingURLBasePathComponents = urlComponents;
         return this._sourceMappingURLBasePathComponents;

--- a/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
+++ b/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
@@ -333,7 +333,7 @@ TestHarness = class TestHarness extends WI.Object
         // Most frames are of the form "functionName@file:///foo/bar/File.js:345".
         // But, some frames do not have a functionName. Get rid of the file path.
         let nameAndURLSeparator = frame.indexOf("@");
-        let frameName = nameAndURLSeparator > 0 ? frame.substr(0, nameAndURLSeparator) : "(anonymous)";
+        let frameName = nameAndURLSeparator > 0 ? frame.substring(0, nameAndURLSeparator) : "(anonymous)";
 
         let lastPathSeparator = Math.max(frame.lastIndexOf("/"), frame.lastIndexOf("\\"));
         let frameLocation = lastPathSeparator > 0 ? frame.substring(lastPathSeparator + 1) : frame;


### PR DESCRIPTION
#### 7d9ebfd86167f0099f0795e0b1e4017a62a0c8d5
<pre>
Web Inspector: Replace deprecated String.prototype.substr with substring for multi parameter calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=303883">https://bugs.webkit.org/show_bug.cgi?id=303883</a>
<a href="https://rdar.apple.com/problem/166177531">rdar://problem/166177531</a>

Reviewed by Devin Rousso.

`String.prototype.substr` is deprecated and should be replaced with `substring` (which takes start and end indices).

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(get return):
* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js:
(WI.CodeMirrorCompletionController.prototype._generateJavaScriptCompletions):
* Source/WebInspectorUI/UserInterface/Debug/UncaughtExceptionReporter.js:
(stringifyAndTruncateObject):
* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap.prototype.get sourceMappingBasePathURLComponents):
* Source/WebInspectorUI/UserInterface/Test/TestHarness.js:
(TestHarness.sanitizeStackFrame):

Canonical link: <a href="https://commits.webkit.org/304225@main">https://commits.webkit.org/304225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a866fe867f6654532762b777f3659fde6ad716b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142434 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103100 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83949 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3068 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3028 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145133 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7021 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39665 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5293 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60943 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7070 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35388 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6843 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->