### PR TITLE
AX: ariaNotify and live region notifications should not post synchronously

### DIFF
--- a/LayoutTests/accessibility/mac/aria-notify-with-options.html
+++ b/LayoutTests/accessibility/mac/aria-notify-with-options.html
@@ -18,22 +18,22 @@ function notificationCallback(object, notification, userInfo) {
     if (notification == "AXAnnouncementRequested") {
         output += `Received announcement request:\n`;
         output += formatAriaNotifyUserInfo(userInfo);
-        notificationCount++;  
+        notificationCount++;
+
+        if (notificationCount == 1) {
+            // Specify both a priority and interrupt.
+            document.ariaNotify("Chicago", { priority: "high", interrupt: "all" });
+        }
+
+        if (notificationCount == 2)
+            document.getElementById("button").ariaNotify("Boston", { priority: "high", interrupt: "pending" });
+
+        if (notificationCount == 3)
+            document.getElementById("button").ariaNotify("Boston", { priority: "high" });
+
+        if (notificationCount == 4)
+            testFinished = true;
     }
-
-    if (notificationCount == 1) {
-        // Specify both a priority and interrupt.
-        document.ariaNotify("Chicago", { priority: "high", interrupt: "all" });
-    }
-
-    if (notificationCount == 2)
-        document.getElementById("button").ariaNotify("Boston", { priority: "high", interrupt: "pending" });
-
-    if (notificationCount == 3)
-        document.getElementById("button").ariaNotify("Boston", { priority: "high" });
-	
-    if (notificationCount == 4)
-        testFinished = true;
 }
 
 if (accessibilityController) {

--- a/LayoutTests/accessibility/mac/aria-notify.html
+++ b/LayoutTests/accessibility/mac/aria-notify.html
@@ -19,13 +19,13 @@ function notificationCallback(object, notification, userInfo) {
         output += `Received announcement request:\n`;
         output += formatAriaNotifyUserInfo(userInfo);
 
-        notificationCount++;  
+        notificationCount++;
+        if (notificationCount == 1)
+            document.getElementById("button").ariaNotify("World");
+        else if (notificationCount == 2)
+            testFinished = true;
     }
 	
-    if (notificationCount == 1)
-        document.getElementById("button").ariaNotify("World");
-    else if (notificationCount == 2)
-        testFinished = true;
 }
 
 if (accessibilityController) {

--- a/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
@@ -1,11 +1,6 @@
 This tests that the notifications for aria-relevant=removals are correct.
 
 Received announcement request:
-AnnouncementKey:
-AXPriorityKey: 10
-AXAnnouncementIsLiveRegionKey: true
-
-Received announcement request:
 AnnouncementKey: removed {
 }Mariners{
     AXLanguage = en;

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -394,7 +394,7 @@ void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object,
         return;
 
     AttributedString announcement = computeAnnouncement(newSnapshot, diff);
-    if (announcement.isNull())
+    if (announcement.isNull() || announcement.string.isEmpty())
         return;
 
     if (CheckedPtr cache = m_cache)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -155,11 +155,11 @@ void AXLogger::log(const Vector<Ref<AXCoreObject>>& objects)
     }
 }
 
-void AXLogger::log(const std::pair<Ref<AccessibilityObject>, AXNotification>& notification)
+void AXLogger::log(const std::pair<Ref<AccessibilityObject>, AXNotificationWithData>& notification)
 {
     if (shouldLog()) {
         TextStream stream(TextStream::LineMode::MultipleLine);
-        stream << "Notification " << notification.second << " for object ";
+        stream << "Notification " << notification.second.notification << " for object ";
         stream << notification.first.get();
         LOG(Accessibility, "%s", stream.release().utf8().data());
     }

--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -64,7 +64,7 @@ public:
     void log(const AXCoreObject&);
     void log(RefPtr<AXCoreObject>);
     void log(const Vector<Ref<AXCoreObject>>&);
-    void log(const std::pair<Ref<AccessibilityObject>, AXNotification>&);
+    void log(const std::pair<Ref<AccessibilityObject>, AXNotificationWithData>&);
     void log(const std::pair<RefPtr<AXCoreObject>, AXNotification>&);
     void log(const AccessibilitySearchCriteria&);
     void log(AccessibilityObjectInclusion);

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -36,6 +36,7 @@ namespace WebCore {
     macro(AutofillTypeChanged) \
     macro(ARIAColumnIndexChanged) \
     macro(ARIAColumnIndexTextChanged) \
+    macro(ARIANotify) \
     macro(ARIARoleDescriptionChanged) \
     macro(ARIARowIndexChanged) \
     macro(ARIARowIndexTextChanged) \
@@ -108,6 +109,7 @@ namespace WebCore {
     macro(LiveRegionChanged) \
     macro(LiveRegionRelevantChanged) \
     macro(LiveRegionStatusChanged) \
+    macro(LiveRegionAnnouncement) \
     macro(MaximumValueChanged) \
     macro(MenuListItemSelected) \
     macro(MenuListValueChanged) \

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -394,7 +394,7 @@ void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
     }
 }
 
-void AXObjectCache::postPlatformARIANotifyNotification(const String& announcement, NotifyPriority priority, InterruptBehavior interruptBehavior, const String& language)
+void AXObjectCache::postPlatformARIANotifyNotification(const AriaNotifyData& notificationData)
 {
     ASSERT(isMainThread());
 
@@ -403,10 +403,10 @@ void AXObjectCache::postPlatformARIANotifyNotification(const String& announcemen
 #endif
 
     NSDictionary *userInfo = @{
-        NSAccessibilityARIAAnnouncementPriority: notifyPriorityToAXValueString(priority).get(),
-        NSAccessibilityARIAAnnouncementInterrupt: interruptBehaviorToAXValueString(interruptBehavior).get(),
-        NSAccessibilityAnnouncementKey: announcement.createNSString().get(),
-        NSAccessibilityAnnouncementLanguageKey: language.createNSString().get()
+        NSAccessibilityARIAAnnouncementPriority: notifyPriorityToAXValueString(notificationData.priority).get(),
+        NSAccessibilityARIAAnnouncementInterrupt: interruptBehaviorToAXValueString(notificationData.interrupt).get(),
+        NSAccessibilityAnnouncementKey: notificationData.message.createNSString().get(),
+        NSAccessibilityAnnouncementLanguageKey: notificationData.language.createNSString().get()
     };
     NSAccessibilityPostNotificationWithUserInfo(NSApp, NSAccessibilityAnnouncementRequestedNotification, userInfo);
 
@@ -416,9 +416,9 @@ void AXObjectCache::postPlatformARIANotifyNotification(const String& announcemen
     }
 }
 
-void AXObjectCache::postPlatformLiveRegionNotification(AccessibilityObject& object, LiveRegionStatus status, const AttributedString& announcement)
+void AXObjectCache::postPlatformLiveRegionNotification(AccessibilityObject& object, const LiveRegionAnnouncementData& liveRegionData)
 {
-    RetainPtr userInfo = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:announcement.nsAttributedString().get(), NSAccessibilityAnnouncementKey, @(status == LiveRegionStatus::Assertive ? NSAccessibilityPriorityHigh : NSAccessibilityPriorityLow), NSAccessibilityPriorityKey, @(YES), NSAccessibilityAnnouncementIsLiveRegionKey, nil]);
+    RetainPtr userInfo = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:liveRegionData.message.nsAttributedString().get(), NSAccessibilityAnnouncementKey, @(liveRegionData.status == LiveRegionStatus::Assertive ? NSAccessibilityPriorityHigh : NSAccessibilityPriorityLow), NSAccessibilityPriorityKey, @(YES), NSAccessibilityAnnouncementIsLiveRegionKey, nil]);
 
     NSAccessibilityPostNotificationWithUserInfo(object.wrapper(), NSAccessibilityAnnouncementRequestedNotification, userInfo.get());
 


### PR DESCRIPTION
#### cdf9fa96c26ec777edb169ab25db7dac851d000c
<pre>
AX: ariaNotify and live region notifications should not post synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=303888">https://bugs.webkit.org/show_bug.cgi?id=303888</a>
<a href="https://rdar.apple.com/166180012">rdar://166180012</a>

Reviewed by Tyler Wilcock.

Unlike postNotification, ariaNotify and live region notifications currently post synchronously.
This means that it&apos;s possible for these notifications to fire during the middle of
performDeferredCacheUpdate, leading to unexpected behaviors.

This patch uses the existing m_notificationsToPost mechanism to post these types off notifications
as well. In order to do this with rich notification data like these contain, that array now
stores a new struct, AXNotificationWithData. This struct allows for storing additional bits of
data for notifications as needed.

This patch also contins some test cleanup and the modification of one expectation that
was incorrect due to empty notification content being permitted.

* LayoutTests/accessibility/mac/aria-notify-with-options.html:
* LayoutTests/accessibility/mac/aria-notify.html:
* LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::postAnnouncementForChange):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::log):
* Source/WebCore/accessibility/AXLogger.h:
* Source/WebCore/accessibility/AXNotifications.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::postNotification):
(WebCore::AXObjectCache::postARIANotifyNotification):
(WebCore::AXObjectCache::postLiveRegionNotification):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXNotificationWithData::AXNotificationWithData):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):

Canonical link: <a href="https://commits.webkit.org/304231@main">https://commits.webkit.org/304231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dcf138aefd19454c4f96bf386924ae9f26f3a78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134968 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142477 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dcfc649b-4606-4fed-b8cb-d5a9bfc4aa23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efb159c1-2ef0-4f24-ab42-d89179b1afd0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83981 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c51eace-a130-4886-9263-c0793545af0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3103 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3074 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145176 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39706 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111869 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28386 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/5330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60986 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7110 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35430 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->