### PR TITLE
Drop unnecessary IsDeprecatedWeakRefSmartPointerException for GridTrack

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1688,7 +1688,7 @@ LayoutUnit RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets(const
     auto finalTrackPosition = positions[span.endLine() - 1];
 
     // Track Positions vector stores the 'start' grid line of each track, so we have to add last track's baseSize.
-    return finalTrackPosition - initialTrackPosition + tracks[span.endLine() - 1].baseSize();
+    return finalTrackPosition - initialTrackPosition + tracks[span.endLine() - 1]->baseSize();
 }
 
 void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction)
@@ -1721,8 +1721,8 @@ void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorith
         unsigned nextToLastLine = numberOfLines - 2;
 
         for (unsigned i = 0; i < nextToLastLine; ++i)
-            positions[i + 1] = positions[i] + offsetBetweenTracks.distributionOffset + tracks[i].unclampedBaseSize() + gap;
-        positions[lastLine] = positions[nextToLastLine] + tracks[nextToLastLine].unclampedBaseSize();
+            positions[i + 1] = positions[i] + offsetBetweenTracks.distributionOffset + tracks[i]->unclampedBaseSize() + gap;
+        positions[lastLine] = positions[nextToLastLine] + tracks[nextToLastLine]->unclampedBaseSize();
 
         if (isMasonry(direction))
             positions[lastLine] = m_masonryLayout.gridContentSize() + positions[0];


### PR DESCRIPTION
#### 13c821fd80104207b3609807a38aabb458fc2f4e
<pre>
Drop unnecessary IsDeprecatedWeakRefSmartPointerException for GridTrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=303891">https://bugs.webkit.org/show_bug.cgi?id=303891</a>

Reviewed by Alan Baradlay.

GridTrack was subclasses CanMakeWeakPtr but not CanMakeCheckedPtr or RefCounted,
which is no longer allowed for safety reasons. Given how it is used, I have
opted to have GridTrack subclass CanMakeCheckedPtr instead of CanMakeWeakPtr.
Existing was using vectors of WeakPtrs and assuming those pointers would never
be null so CheckedPtr seems better suited. Note that I had to make the object
heap-allocated because CanMakeCheckedPtr only works for heap-allocated objects.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
(WebCore::GridTrackSizingAlgorithm::spanningItemCrossesFlexibleSizedTracks const):
(WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems):
(WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry):
(WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWithFlex):
(WebCore::sortByGridTrackGrowthPotential):
(WebCore::distributeItemIncurredIncreases):
(WebCore::GridTrackSizingAlgorithm::distributeSpaceToTracks const):
(WebCore::computeGridSpanSize):
(WebCore::GridTrackSizingAlgorithm::computeFlexFactorUnitSize const):
(WebCore::GridTrackSizingAlgorithm::computeFlexSizedTracksGrowth const):
(WebCore::GridTrackSizingAlgorithm::findFrUnitSize const):
(WebCore::GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes):
(WebCore::GridTrackSizingAlgorithmStrategy::minContributionForGridItem const):
(WebCore::IndefiniteSizeStrategy::maximizeTracks):
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):
(WebCore::DefiniteSizeStrategy::maximizeTracks):
(WebCore::GridTrackSizingAlgorithm::initializeTrackSizes):
(WebCore::GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry):
(WebCore::GridTrackSizingAlgorithm::handleInfinityGrowthLimit):
(WebCore::GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes):
(WebCore::GridTrackSizingAlgorithm::stretchFlexibleTracks):
(WebCore::GridTrackSizingAlgorithm::stretchAutoTracks):
(WebCore::GridTrackSizingAlgorithm::setup):
(WebCore::removeSubgridMarginBorderPaddingFromTracks):
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
(WebCore::GridTrackSizingAlgorithm::tracksAreWiderThanMinTrackBreadth const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
(WebCore::GridTrackSizingAlgorithmStrategy::distributeSpaceToTracks const):
(WebCore::GridTrack::growthLimitIsInfinite const): Deleted.
(WebCore::GridTrack::infiniteGrowthPotential const): Deleted.
(WebCore::GridTrack::plannedSize const): Deleted.
(WebCore::GridTrack::setPlannedSize): Deleted.
(WebCore::GridTrack::tempSize const): Deleted.
(WebCore::GridTrack::infinitelyGrowable const): Deleted.
(WebCore::GridTrack::setInfinitelyGrowable): Deleted.
(WebCore::GridTrack::growthLimitCap const): Deleted.
(WebCore::GridTrack::isGrowthLimitBiggerThanBaseSize const): Deleted.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets const):
(WebCore::RenderGrid::populateGridPositionsForDirection):

Canonical link: <a href="https://commits.webkit.org/304211@main">https://commits.webkit.org/304211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e8ec2dbf385506f1cd7b83c42bb9dcf8898c9bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86759 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0670822-ece2-4880-8010-61f09017ae24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d498094-0929-4287-9cdf-38431b55c410) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83906 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9e58fc6-fdbe-40a6-a5cc-e91027f91710) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3037 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39623 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5259 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7030 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35349 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->