### PR TITLE
SVGLength.value doesn't update when writing-mode changes for font-relative units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,5 +1,5 @@
 
 PASS ch unit in SVGLength
 PASS Convert back to ch from new user unit value
-FAIL upright vertical ch unit in SVGLength assert_approx_equals: expected 200 +/- 0.1 but got 100
+PASS upright vertical ch unit in SVGLength
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,5 +1,0 @@
-
-PASS ch unit in SVGLength
-PASS Convert back to ch from new user unit value
-PASS upright vertical ch unit in SVGLength
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,5 +1,0 @@
-
-PASS ch unit in SVGLength
-PASS Convert back to ch from new user unit value
-FAIL upright vertical ch unit in SVGLength assert_approx_equals: expected 181.828125 +/- 0.1 but got 100
-


### PR DESCRIPTION
#### 58c53af50a29cac771a859c18c27036fc3696335
<pre>
SVGLength.value doesn&apos;t update when writing-mode changes for font-relative units
<a href="https://bugs.webkit.org/show_bug.cgi?id=303897">https://bugs.webkit.org/show_bug.cgi?id=303897</a>
<a href="https://rdar.apple.com/166190252">rdar://166190252</a>

Reviewed by Vitor Roriz.

When accessing SVGLength.value after changing style attributes like
writing-mode, font-relative units (ch, em, rem, ex) were using stale
computed styles. This caused incorrect values for units like &apos;ch&apos; which
depend on font metrics that vary with writing mode.

The fix ensures style is recalculated before resolving length values,
so font metrics reflect the current computed style.

This is performance neutral on Speedometer and MotionMark. Please refer
to performance testing on radar (Thanks to Taher for help). Additionally,
this also adds `if` conditions to only update stlye when we have length
type, which are relative [e.g., ch] (once again Thanks to Taher for help).
It does so by leveraging lambda which uses switch to list out absolute
units - which at least supported in enum `SVGLengthType` and as per CSS
specification (1-1).

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt: Progression
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt: Removed.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt: Removed.
* Source/WebCore/svg/SVGLength.cpp:
(WebCore::SVGLength::valueForBindings):

Canonical link: <a href="https://commits.webkit.org/304657@main">https://commits.webkit.org/304657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/223b44cded928995c18c0662d7cb83f4ca5d5384

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143909 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab552040-b60d-4f6c-ab58-748af78a8b24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104143 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3e76f1f-15f0-4a5c-a9b6-00c76d364635) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9e3cfece-84e3-4c71-a0ca-80599a8630ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4037 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146655 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8240 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40811 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6296 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118348 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8288 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36406 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->