### PR TITLE
[Site Isolation] Synchronize FrameView::frameRect using FrameTreeSyncData

### DIFF
--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -29,3 +29,4 @@
 FrameCanCreatePaymentSession : bool
 FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/SecurityOrigin.h>]
 FrameURLProtocol : String [Headers=<wtf/text/WTFString.h>]
+FrameRect : WebCore::IntRect [Headers=<WebCore/IntRect.h>]

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -105,7 +105,7 @@ public:
 
     virtual ~LocalFrameView();
 
-    void setFrameRect(const IntRect&) final;
+    WEBCORE_EXPORT void setFrameRect(const IntRect&) final;
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -50,7 +50,7 @@ class RemoteFrameClient : public FrameLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteFrameClient);
 public:
     virtual void frameDetached() = 0;
-    virtual void sizeDidChange(IntSize) = 0;
+    virtual void frameRectDidChange(IntRect) = 0;
     virtual void paintContents(GraphicsContext&, const IntRect&) = 0;
     virtual void postMessageToRemote(FrameIdentifier source, const SecurityOriginData& sourceOrigin, FrameIdentifier target, std::optional<SecurityOriginData> targetOrigin, const MessageWithMessagePorts&) = 0;
     virtual void changeLocation(FrameLoadRequest&&) = 0;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -40,12 +40,17 @@ RemoteFrameView::RemoteFrameView(RemoteFrame& frame)
 {
 }
 
+void RemoteFrameView::setFrameRectWithoutSync(const IntRect& newRect)
+{
+    FrameView::setFrameRect(newRect);
+}
+
 void RemoteFrameView::setFrameRect(const IntRect& newRect)
 {
     IntRect oldRect = frameRect();
-    if (newRect.size() != oldRect.size())
-        m_frame->client().sizeDidChange(newRect.size());
-    FrameView::setFrameRect(newRect);
+    setFrameRectWithoutSync(newRect);
+    if (newRect != oldRect)
+        m_frame->client().frameRectDidChange(newRect);
 }
 
 LayoutRect RemoteFrameView::layoutViewportRect() const

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -47,6 +47,11 @@ public:
     WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
     std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
 
+    // Set the frame rectangle, like setFrameRect, without synching the new rect to other Local/RemoteFrameViews.
+    // When frameRect of a RemoteFrameView changes, it syncs the new rect to other Local/RemoteFrameViews.
+    // RemoteFrameViews on the receiving end will set using this method to avoid repeating the sync.
+    WEBCORE_EXPORT void setFrameRectWithoutSync(const IntRect&);
+
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/FrameIdentifier.h>
-#include <WebCore/IntSize.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/ReferrerPolicy.h>
 
@@ -45,7 +45,7 @@ struct ProvisionalFrameCreationParameters {
     WebCore::SandboxFlags effectiveSandboxFlags;
     WebCore::ReferrerPolicy effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };
     WebCore::ScrollbarMode scrollingMode;
-    std::optional<WebCore::IntSize> initialSize;
+    std::optional<WebCore::IntRect> initialRect;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in
@@ -27,5 +27,5 @@ struct WebKit::ProvisionalFrameCreationParameters {
     WebCore::SandboxFlags effectiveSandboxFlags;
     WebCore::ReferrerPolicy effectiveReferrerPolicy;
     WebCore::ScrollbarMode scrollingMode;
-    std::optional<WebCore::IntSize> initialSize;
+    std::optional<WebCore::IntRect> initialRect;
 };

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -53,7 +53,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProc
         frame.effectiveSandboxFlags(),
         frame.effectiveReferrerPolicy(),
         frame.scrollingMode(),
-        frame.remoteFrameSize()
+        frame.remoteFrameRect()
     }), frame.frameID());
 }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -305,7 +305,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             mainFrame->effectiveSandboxFlags(),
             mainFrame->effectiveReferrerPolicy(),
             mainFrame->scrollingMode(),
-            mainFrame->remoteFrameSize()
+            mainFrame->remoteFrameRect()
         };
     }
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTF::move(creationParameters)), 0);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -664,7 +664,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, WebCore::SecurityOrigin::create(url()), url().protocol().toString());
+    return FrameTreeSyncData::create(isSecureForPaymentSession, WebCore::SecurityOrigin::create(url()), url().protocol().toString(), IntRect { });
 }
 
 void WebFrameProxy::broadcastFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)
@@ -840,12 +840,6 @@ void WebFrameProxy::updateScrollingMode(WebCore::ScrollbarMode scrollingMode)
     m_scrollingMode = scrollingMode;
     if (RefPtr page = m_page.get())
         page->sendToProcessContainingFrame(m_frameID, Messages::WebPage::UpdateFrameScrollingMode(m_frameID, scrollingMode));
-}
-
-void WebFrameProxy::updateRemoteFrameSize(WebCore::IntSize size)
-{
-    m_remoteFrameSize = size;
-    send(Messages::WebFrame::UpdateFrameSize(size));
 }
 
 void WebFrameProxy::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -30,7 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/FrameLoaderTypes.h>
-#include <WebCore/IntSize.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -251,7 +251,6 @@ public:
     bool isPendingInitialHistoryItem() const { return m_isPendingInitialHistoryItem; }
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
-    void updateRemoteFrameSize(WebCore::IntSize);
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
 
@@ -269,7 +268,8 @@ public:
     void disownOpener() { m_opener = nullptr; }
     WebFrameProxy* disownedOpener() const { return m_disownedOpener.get(); }
 
-    std::optional<WebCore::IntSize> remoteFrameSize() const { return m_remoteFrameSize; }
+    std::optional<WebCore::IntRect> remoteFrameRect() const { return m_remoteFrameRect; }
+    void setRemoteFrameRect(WebCore::IntRect rect) { m_remoteFrameRect = rect; }
 
     void takeSnapshotOfNode(WebCore::JSHandleIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
@@ -316,7 +316,7 @@ private:
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
     bool m_isPendingInitialHistoryItem { false };
-    std::optional<WebCore::IntSize> m_remoteFrameSize;
+    std::optional<WebCore::IntRect> m_remoteFrameRect;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
     WebCore::ReferrerPolicy m_effectiveReferrerPolicy { WebCore::ReferrerPolicy::EmptyString };
     WebCore::ScrollbarMode m_scrollingMode;

--- a/Source/WebKit/UIProcess/WebFrameProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFrameProxy.messages.in
@@ -26,7 +26,6 @@
     DispatchedFrom=WebContent
 ]
 messages -> WebFrameProxy {
-    [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameSize(WebCore::IntSize size)
     [EnabledBy=AppBadgeEnabled] SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
     [EnabledBy=SiteIsolationEnabled] FindFocusableElementDescendingIntoRemoteFrame(enum:uint8_t WebCore::FocusDirection direction, struct WebCore::FocusEventData focusEventData) -> (enum:bool WebCore::FoundElementInRemoteFrame foundElement)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -73,9 +73,9 @@ void WebRemoteFrameClient::frameDetached()
         ownerElement->protectedDocument()->checkCompleted();
 }
 
-void WebRemoteFrameClient::sizeDidChange(IntSize size)
+void WebRemoteFrameClient::frameRectDidChange(IntRect rect)
 {
-    m_frame->updateRemoteFrameSize(size);
+    broadcastFrameRectToOtherProcesses(rect);
 }
 
 void WebRemoteFrameClient::paintContents(GraphicsContext& context, const IntRect& rect)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -43,7 +43,7 @@ public:
 
 private:
     void frameDetached() final;
-    void sizeDidChange(WebCore::IntSize) final;
+    void frameRectDidChange(WebCore::IntRect) final;
     void paintContents(WebCore::GraphicsContext&, const WebCore::IntRect&) final;
     void postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&) final;
     void changeLocation(WebCore::FrameLoadRequest&&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -218,8 +218,7 @@ public:
     String mimeTypeForResourceWithURL(const URL&) const;
 
     void setTextDirection(const String&);
-    void updateRemoteFrameSize(WebCore::IntSize);
-    void updateFrameSize(WebCore::IntSize);
+    void updateFrameRectFromRemote(WebCore::IntRect);
 
 #if PLATFORM(COCOA)
     typedef bool (*FrameFilterFunction)(WKBundleFrameRef, WKBundleFrameRef subframe, void* context);
@@ -285,7 +284,7 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     void setLayerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier identifier) { m_layerHostingContextIdentifier = identifier; }
-    void updateLocalFrameSize(WebCore::LocalFrame&, WebCore::IntSize);
+    void updateLocalFrameRect(WebCore::LocalFrame&, WebCore::IntRect);
 
     inline WebCore::DocumentLoader* policySourceDocumentLoader() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -27,7 +27,6 @@
 ]
 messages -> WebFrame {
     GetFrameInfo() -> (struct std::optional<WebKit::FrameInfoData> data)
-    UpdateFrameSize(WebCore::IntSize newSize)
     CreateProvisionalFrame(struct WebKit::ProvisionalFrameCreationParameters creationParameters)
     DestroyProvisionalFrame();
     FindFocusableElementDescendingIntoRemoteFrame(enum:uint8_t WebCore::FocusDirection direction, struct WebCore::FocusEventData focusEventData) -> (enum:bool WebCore::FoundElementInRemoteFrame foundElement)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1299,8 +1299,12 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
     ASSERT(frame->page() == this);
 
     RefPtr coreFrame = frame->coreFrame();
-    if (coreFrame)
+    if (coreFrame) {
         coreFrame->updateFrameTreeSyncData(data);
+
+        if (data.type == FrameTreeSyncDataType::FrameRect)
+            frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
+    }
 }
 
 void WebPage::allFrameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, Ref<WebCore::FrameTreeSyncData>&& data)


### PR DESCRIPTION
#### ade4c0ac172be58182036d9ffc9d7ba37102036f
<pre>
[Site Isolation] Synchronize FrameView::frameRect using FrameTreeSyncData
<a href="https://rdar.apple.com/165786911">rdar://165786911</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303496">https://bugs.webkit.org/show_bug.cgi?id=303496</a>

Reviewed by Alex Christensen.

Previously, when the frameRect of a RemoteFrameView changes, it synchronizes the new
frameRect to other processes:
* Using a custom mechanism and messages
* Only to the LocalFrameView, not to other RemoteFrameView(s)
* Only the size is synchronized

As Intersection Observer requires the full frameRect (location and size) to calculate
the intersection rectangle, this patch reworks the synchronization mechanism to
sync the full frameRect to both the LocalFrameView as well as RemoteFrameView(s).
This patch also removes the custom sync messages, opting to use FrameTreeSyncData instead.

* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::setFrameRectWithoutSync):
(WebCore::RemoteFrameView::setFrameRect):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.h:
* Source/WebKit/Shared/ProvisionalFrameCreationParameters.serialization.in:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
(WebKit::WebFrameProxy::updateRemoteFrameSize): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::layerHostingContextIdentifier const):
(WebKit::WebFrameProxy::remoteFrameRect const):
(WebKit::WebFrameProxy::setRemoteFrameRect):
(WebKit::WebFrameProxy::remoteFrameSize const): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::frameTreePropertyIsRestrictedToFrameOwningProcess):
(WebKit::WebPageProxy::broadcastFrameTreeSyncData):
(WebKit::WebPageProxy::broadcastAllFrameTreeSyncData):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::frameRectDidChange):
(WebKit::WebRemoteFrameClient::sizeDidChange): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::updateFrameRectFromRemote):
(WebKit::WebFrame::updateLocalFrameRect):
(WebKit::WebFrame::updateRemoteFrameSize): Deleted.
(WebKit::WebFrame::updateFrameSize): Deleted.
(WebKit::WebFrame::updateLocalFrameSize): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/304792@main">https://commits.webkit.org/304792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/128d9f015437bf7257a72ea4fe9577ad4dce65d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144205 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6aa471ea-116e-4617-b455-b71df8079902) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ba2e096-4b89-44c7-819c-22da612d9849) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20649aa0-7642-4cc7-83a3-b9903bc1122b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6602 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4269 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4798 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146954 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112719 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6542 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62523 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36659 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->