### PR TITLE
[JSC] Cache module evaluation errors to reject subsequent dynamic imports

### DIFF
--- a/JSTests/stress/re-execute-evaluation-error-module.js
+++ b/JSTests/stress/re-execute-evaluation-error-module.js
@@ -1,0 +1,28 @@
+var abort = $vm.abort;
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+
+(async function () {
+    {
+        let errorMessage = null;
+        try {
+            await import("./resources/evaluation-error-module.js");
+        } catch (error) {
+            errorMessage = String(error);
+        }
+        shouldBe(errorMessage, `Error: evaluation error`);
+    }
+    {
+        let errorMessage = null;
+        try {
+            await import("./resources/evaluation-error-module.js");
+        } catch (error) {
+            errorMessage = String(error);
+        }
+        shouldBe(errorMessage, `Error: evaluation error`);
+    }
+}()).catch(abort);

--- a/JSTests/stress/resources/evaluation-error-module.js
+++ b/JSTests/stress/resources/evaluation-error-module.js
@@ -1,0 +1,1 @@
+throw new Error("evaluation error");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -648,12 +648,6 @@ test/language/expressions/class/elements/nested-private-direct-eval-err-contains
 test/language/expressions/delete/super-property-uninitialized-this.js:
   default: 'Test262Error: Expected a ReferenceError but got a Test262Error'
   strict mode: 'Test262Error: Expected a ReferenceError but got a Test262Error'
-test/language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «"foo"») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «"foo"») to be true'
-test/language/expressions/dynamic-import/import-errored-module.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: The import should reject (second import) Expected a Error to be thrown asynchronously but no exception was thrown at all'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: The import should reject (second import) Expected a Error to be thrown asynchronously but no exception was thrown at all'
 test/language/expressions/new/non-ctor-err-realm.js:
   default: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/choice-of-error-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/choice-of-error-3-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Evaluation errors are cached in intermediate module scripts assert_equals: expected 5 but got 4
+PASS Evaluation errors are cached in intermediate module scripts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-script-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-script-error-expected.txt
@@ -8,6 +8,6 @@ PASS import() must reject with the same error object for each import when there 
 PASS import() must reject when there is a instantiation error
 FAIL import() must reject with different error objects for each import when there is a instantiation error assert_not_equals: The error objects must be different got disallowed value object "SyntaxError: Importing binding name 'default' cannot be resolved by star export entries."
 PASS import() must reject when there is a evaluation error
-FAIL import() must reject with the same error object for each import when there is a evaluation error assert_unreached: Should have rejected: It must reject the second time Reached unreachable code
+PASS import() must reject with the same error object for each import when there is a evaluation error
 PASS import()ing a module with an evaluation error must stop evaluation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-1-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
- assert_array_equals: lengths differ, expected array ["throw", object "[object Object]", "load", [...], "load", [...], "load", [...], "load"] length 9, got ["throw", object "[object Object]", "load", "load", "load", "load"] length 6
+PASS Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-2-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test that ill-founded cyclic dependencies cause ReferenceError during evaluation, which leads to error events on window, and that exceptions are remembered.
- assert_array_equals: lengths differ, expected array ["cycle-tdz-access-a", object "ReferenceError: Cannot access 'Y' before initialization.", "load", [...], "load", [...], "load"] length 7, got ["cycle-tdz-access-a", object "ReferenceError: Cannot access 'Y' before initialization.", "load", "load", "load"] length 5
+PASS Test that ill-founded cyclic dependencies cause ReferenceError during evaluation, which leads to error events on window, and that exceptions are remembered.
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-3-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
- assert_array_equals: lengths differ, expected array ["throw", object "[object Object]", "load", [...], "load", [...], "load", [...], "load", [...], "load"] length 11, got ["throw", object "[object Object]", "load", "load", "throw-nested", "load", "load", "load"] length 8
+PASS Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-4-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
- assert_array_equals: lengths differ, expected array ["throw", object "[object Object]", "load", [...], "load", [...], "load", [...], "load", [...], "load"] length 11, got ["throw", object "[object Object]", "load", "load", "load", "load", "load"] length 7
+PASS Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.
+
 

--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -100,6 +100,8 @@ function newRegistryEntry(key, type)
         linkError: @undefined,
         linkSucceeded: true,
         evaluated: false,
+        evaluationError: @undefined,
+        evaluationSucceeded: true,
         then: @undefined,
         isAsync: false,
     };
@@ -489,8 +491,11 @@ function moduleEvaluation(entry, fetcher)
     // http://www.ecma-international.org/ecma-262/6.0/#sec-moduleevaluation
     "use strict";
 
-    if (entry.evaluated)
+    if (entry.evaluated) {
+        if (!entry.evaluationSucceeded)
+            throw entry.evaluationError;
         return;
+    }
     entry.evaluated = true;
 
     // The contents of the [[RequestedModules]] is cloned into entry.dependencies.
@@ -498,13 +503,19 @@ function moduleEvaluation(entry, fetcher)
 
     if (!entry.isAsync) {
         // Since linking sets isAsync for any strongly connected component with an async module we should only get here if all our dependencies are also sync.
-        for (var i = 0, length = dependencies.length; i < length; ++i) {
-            var dependency = dependencies[i];
-            @assert(!dependency.isAsync);
-            this.moduleEvaluation(dependency, fetcher);
-        }
+        try {
+            for (var i = 0, length = dependencies.length; i < length; ++i) {
+                var dependency = dependencies[i];
+                @assert(!dependency.isAsync);
+                this.moduleEvaluation(dependency, fetcher);
+            }
 
-        this.evaluate(entry.key, entry.module, fetcher);
+            this.evaluate(entry.key, entry.module, fetcher);
+        } catch (error) {
+            entry.evaluationSucceeded = false;
+            entry.evaluationError = error;
+            throw error;
+        }
     } else
         return this.asyncModuleEvaluation(entry, fetcher, dependencies);
 }
@@ -514,22 +525,28 @@ async function asyncModuleEvaluation(entry, fetcher, dependencies)
 {
     "use strict";
 
-    for (var i = 0, length = dependencies.length; i < length; ++i)
-        await this.moduleEvaluation(dependencies[i], fetcher);
+    try {
+        for (var i = 0, length = dependencies.length; i < length; ++i)
+            await this.moduleEvaluation(dependencies[i], fetcher);
 
-    var resumeMode = @GeneratorResumeModeNormal;
-    while (true) {
-        var awaitedValue = this.evaluate(entry.key, entry.module, fetcher, awaitedValue, resumeMode);
-        if (@getAbstractModuleRecordInternalField(entry.module, @abstractModuleRecordFieldState) == @GeneratorStateExecuting)
-            return;
+        var resumeMode = @GeneratorResumeModeNormal;
+        while (true) {
+            var awaitedValue = this.evaluate(entry.key, entry.module, fetcher, awaitedValue, resumeMode);
+            if (@getAbstractModuleRecordInternalField(entry.module, @abstractModuleRecordFieldState) == @GeneratorStateExecuting)
+                return;
 
-        try {
-            awaitedValue = await awaitedValue;
-            resumeMode = @GeneratorResumeModeNormal;
-        } catch (e) {
-            awaitedValue = e;
-            resumeMode = @GeneratorResumeModeThrow;
+            try {
+                awaitedValue = await awaitedValue;
+                resumeMode = @GeneratorResumeModeNormal;
+            } catch (e) {
+                awaitedValue = e;
+                resumeMode = @GeneratorResumeModeThrow;
+            }
         }
+    } catch (error) {
+        entry.evaluationSucceeded = false;
+        entry.evaluationError = error;
+        throw error;
     }
 }
 


### PR DESCRIPTION
#### f9d1015125ac121129994b5ef6f71ac315527e48
<pre>
[JSC] Cache module evaluation errors to reject subsequent dynamic imports
<a href="https://bugs.webkit.org/show_bug.cgi?id=303902">https://bugs.webkit.org/show_bug.cgi?id=303902</a>

Reviewed by NOBODY (OOPS!).

According to the module evaluation spec[1], when a module is evaluated, a PromiseCapability representing
the evaluation result is set to module.[[TopLevelCapability]], and when the module is evaluated again, this
PromiseCapability is returned as-is.

In other words, module.[[TopLevelCapability]] acts as a cache. And according to the dynamic import spec[2],
dynamic import evaluates modules using the Evaluate Abstract Operation. So, in dynamic import, if a module
evaluation is rejected once, subsequent evaluations should also fail.

However, currently JSC resolves the second and subsequent evaluations even if the module was rejected once.

This patch fixes this by caching the evaluation error, similar to how link errors are cached, and re-throwing it
when the module is evaluated again.

[1]: <a href="https://tc39.es/ecma262/#sec-moduleevaluation">https://tc39.es/ecma262/#sec-moduleevaluation</a>
[2]: <a href="https://tc39.es/ecma262/#sec-ContinueDynamicImport">https://tc39.es/ecma262/#sec-ContinueDynamicImport</a>

* JSTests/stress/re-execute-evaluation-error-module.js: Added.
(shouldBe):
(async let):
* JSTests/stress/resources/evaluation-error-module.js: Added.
* JSTests/test262/expectations.yaml:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/choice-of-error-3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-script-error-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-4-expected.txt:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
(linkTimeConstant.newRegistryEntry):
(visibility.PrivateRecursive.moduleEvaluation):
(visibility.PrivateRecursive.async asyncModuleEvaluation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9d1015125ac121129994b5ef6f71ac315527e48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5494 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3107 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3078 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145180 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133471 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5332 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60992 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7114 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35434 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166353 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70686 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43474 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->