### PR TITLE
[WebXR Hit Test][OpenXR] The hit test should be performed in the specified space

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -27,6 +27,19 @@
 
 namespace WebKit {
 
+std::unique_ptr<OpenXRHitTestManager> OpenXRHitTestManager::create(XrSession session)
+{
+#if defined(XR_ANDROID_trackables) && defined(XR_ANDROID_raycast)
+    if (!OpenXRExtensions::singleton().methods().xrCreateTrackableTrackerANDROID)
+        return nullptr;
+    if (!OpenXRExtensions::singleton().methods().xrRaycastANDROID)
+        return nullptr;
+    return makeUnique<OpenXRHitTestManager>(session);
+#else
+    return nullptr;
+#endif
+}
+
 OpenXRHitTestManager::OpenXRHitTestManager(XrSession session)
     : m_session(session)
 {
@@ -40,6 +53,8 @@ OpenXRHitTestManager::OpenXRHitTestManager(XrSession session)
 Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTest(const PlatformXR::Ray& ray, XrSpace space, XrTime time)
 {
 #if defined(XR_ANDROID_raycast)
+    if (space == XR_NULL_HANDLE)
+        return { };
     if (m_trackableTracker == XR_NULL_HANDLE)
         return { };
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
@@ -32,12 +32,13 @@ class OpenXRHitTestManager {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRHitTestManager);
     WTF_MAKE_NONCOPYABLE(OpenXRHitTestManager);
 public:
+    static std::unique_ptr<OpenXRHitTestManager> create(XrSession);
     OpenXRHitTestManager(XrSession);
     Vector<PlatformXR::FrameData::HitTestResult> requestHitTest(const PlatformXR::Ray&, XrSpace, XrTime);
 
 private:
     XrSession m_session { XR_NULL_HANDLE };
-#if defined(XR_ANDROID_raycast)
+#if defined(XR_ANDROID_trackables)
     XrTrackableTrackerANDROID m_trackableTracker { XR_NULL_HANDLE };
 #endif
 };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h
@@ -42,6 +42,8 @@ public:
     Vector<PlatformXR::FrameData::InputSource> collectInputSources(const XrFrameState&, XrSpace) const;
     void updateInteractionProfile();
 
+    const Vector<UniqueRef<OpenXRInputSource>>& inputSources() { return m_inputSources; }
+
 private:
     OpenXRInput(XrInstance, XrSession);
     XrResult initialize(OpenXRSystemProperties&&);

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
@@ -42,6 +42,11 @@ public:
     XrActionSet actionSet() const { return m_actionSet; }
     XrResult updateInteractionProfile();
 
+    const Vector<String>& profiles() const { return m_profiles; }
+    XrSpace pointerSpace() const { return m_pointerSpace; }
+    XrSpace gripSpace() const { return m_gripSpace; }
+    PlatformXR::InputSourceHandle handle() const { return m_handle; }
+
 private:
     OpenXRInputSource(XrInstance, XrSession, PlatformXR::XRHandedness, PlatformXR::InputSourceHandle);
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -96,6 +96,7 @@ private:
     PollResult pollEvents();
     std::unique_ptr<OpenXRSwapchain> createSwapchain(uint32_t width, uint32_t height, bool alpha) const;
     void createReferenceSpacesIfNeeded(Box<RenderState>);
+    XrSpace spaceForHitTest(const PlatformXR::NativeOriginInformation&) const;
     PlatformXR::FrameData populateFrameData(Box<RenderState>);
     void beginFrame(Box<RenderState>);
     void endFrame(Box<RenderState>, Vector<XRDeviceLayer>&&);
@@ -129,6 +130,9 @@ private:
     XrGraphicsBindingEGLMNDX m_graphicsBinding;
 #endif
     std::unique_ptr<WebCore::GLContext> m_glContext;
+#if ENABLE(WEBXR_HIT_TEST)
+    XrSpace m_viewerSpace { XR_NULL_HANDLE };
+#endif
     XrSpace m_localSpace { XR_NULL_HANDLE };
     XrSpace m_floorSpace { XR_NULL_HANDLE };
 


### PR DESCRIPTION
#### adad6bed1fc2225c67ed875cfdbf1f591bd4a931
<pre>
[WebXR Hit Test][OpenXR] The hit test should be performed in the specified space
<a href="https://bugs.webkit.org/show_bug.cgi?id=303805">https://bugs.webkit.org/show_bug.cgi?id=303805</a>

Reviewed by Sergio Villar Senin.

The hit test should be performed in the specified space. Added
OpenXRCoordinator method spaceForHitTest() which returns an corresponding
XrSpace based on a passed PlatformXR::NativeOriginInformation.

* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
(WebKit::OpenXRHitTestManager::create):
(WebKit::OpenXRHitTestManager::requestHitTest):
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h:
(WebKit::OpenXRInput::inputSources):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h:
(WebKit::OpenXRInputSource::profiles const):
(WebKit::OpenXRInputSource::pointerSpace const):
(WebKit::OpenXRInputSource::gripSpace const):
(WebKit::OpenXRInputSource::handle const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):
(WebKit::OpenXRCoordinator::cleanupSessionAndAssociatedResources):
(WebKit::OpenXRCoordinator::spaceForHitTest const):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::createReferenceSpacesIfNeeded):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/304450@main">https://commits.webkit.org/304450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecaf16d96c591b7622f4b9e0df9eed09638781d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70511 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5646 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3252 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3283 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114852 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111684 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112047 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5491 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61299 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20903 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7316 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70867 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->