### PR TITLE
[Glib][GStreamer] Implement GMallocString class and apply it to GStreamer code

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -7,6 +7,7 @@ list(APPEND WTF_SOURCES
     glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
+    glib/GMallocString.cpp
     glib/GRefPtr.cpp
     glib/GSocketMonitor.cpp
     glib/GSpanExtras.cpp
@@ -33,6 +34,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
+    glib/GMallocString.h
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -9,6 +9,7 @@ list(APPEND WTF_SOURCES
     glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
+    glib/GMallocString.cpp
     glib/GRefPtr.cpp
     glib/GResources.cpp
     glib/GSocketMonitor.cpp
@@ -42,6 +43,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
+    glib/GMallocString.h
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GResources.h

--- a/Source/WTF/wtf/glib/GMallocString.cpp
+++ b/Source/WTF/wtf/glib/GMallocString.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/glib/GMallocString.h>
+
+#include <wtf/PrintStream.h>
+#include <wtf/text/CStringView.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+void GMallocString::dump(PrintStream& out) const LIFETIME_BOUND {
+    out.print(span());
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/glib/GMallocString.h
+++ b/Source/WTF/wtf/glib/GMallocString.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Compiler.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/glib/GSpanExtras.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/CStringView.h>
+#include <wtf/text/StringCommon.h>
+#include <wtf/text/SuperFastHash.h>
+
+namespace WTF {
+
+class PrintStream;
+
+class GMallocString final {
+    WTF_FORBID_HEAP_ALLOCATION;
+    WTF_MAKE_NONCOPYABLE(GMallocString);
+public:
+
+    static GMallocString unsafeAdoptFromUTF8(char* string)
+    {
+        if (!string)
+            return GMallocString();
+        return GMallocString { adoptGMallocSpan<char8_t>(unsafeMakeSpan(byteCast<char8_t>(string), string ? std::char_traits<char>::length(string) + 1 : 0)) };
+    }
+
+    static GMallocString unsafeAdoptFromUTF8(GUniquePtr<char>&& pointer)
+    {
+        return unsafeAdoptFromUTF8(pointer.release());
+    }
+
+    static GMallocString unsafeAdoptFromUTF8(GUniqueOutPtr<char>&& pointer)
+    {
+        return unsafeAdoptFromUTF8(pointer.release());
+    }
+
+    static GMallocString adoptFromUTF8(std::span<char> string)
+    {
+        if (string.size() < 1)
+            return GMallocString();
+        RELEASE_ASSERT(string[string.size() - 1] == '\0');
+        return GMallocString { adoptGMallocSpan<char8_t>(byteCast<char8_t>(string)) };
+    }
+
+    explicit GMallocString(const CStringView& view)
+    {
+        m_spanWithNullTerminator = dupGMallocSpan(view.spanIncludingNullTerminator());
+    }
+
+    WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
+
+    GMallocString() = default;
+    constexpr GMallocString(std::nullptr_t)
+        : GMallocString()
+    { }
+
+    GMallocString(GMallocString&& other)
+        : m_spanWithNullTerminator(WTFMove(other.m_spanWithNullTerminator))
+    {
+    }
+    GMallocString& operator=(GMallocString&& other)
+    {
+        GMallocSpan<char8_t> otherSpan = WTFMove(other.m_spanWithNullTerminator);
+        std::swap(m_spanWithNullTerminator, otherSpan);
+        return *this;
+    }
+
+    bool isNull() const { return m_spanWithNullTerminator.span().empty(); }
+    const char* utf8() const LIFETIME_BOUND { return byteCast<char>(m_spanWithNullTerminator.span().data()); }
+    char* leakUTF8() WARN_UNUSED_RETURN { return byteCast<char>(m_spanWithNullTerminator.leakSpan().data()); }
+    size_t lengthInBytes() const { return !m_spanWithNullTerminator.span().empty() ? m_spanWithNullTerminator.span().size() - 1 : 0; }
+    std::span<const char8_t> span() const LIFETIME_BOUND { return m_spanWithNullTerminator.span().first(lengthInBytes()); }
+    std::span<const char8_t> spanIncludingNullTerminator() const LIFETIME_BOUND { return m_spanWithNullTerminator.span(); }
+    size_t isEmpty() const { return m_spanWithNullTerminator.span().size() <= 1; }
+
+    explicit operator bool() const { return !isEmpty(); }
+    bool operator!() const { return isEmpty(); }
+
+private:
+    explicit GMallocString(GMallocSpan<char8_t>&& string)
+        : m_spanWithNullTerminator(WTFMove(string))
+    {
+    }
+
+    GMallocSpan<char8_t> m_spanWithNullTerminator;
+};
+
+inline bool operator==(const GMallocString& a, const GMallocString& b)
+{
+    return equal(a.span(), b.span());
+}
+
+inline bool operator==(const GMallocString& a, ASCIILiteral b)
+{
+    return equal(a.span(), byteCast<char8_t>(b.span()));
+}
+
+inline bool operator==(const GMallocString& a, CStringView b)
+{
+    return equal(a.span(), b.span());
+}
+
+// GMallocString is null terminated
+inline const char* safePrintfType(const GMallocString& string) { return string.utf8(); }
+
+inline CStringView toCStringView(const GMallocString& string LIFETIME_BOUND) { return CStringView::fromUTF8(string.spanIncludingNullTerminator()); }
+
+} // namespace WTF
+
+using WTF::GMallocString;
+using WTF::toCStringView;

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -67,18 +67,12 @@ GMallocSpan<T, Malloc> adoptGMallocSpan(std::span<T> span)
     return adoptMallocSpan<T, Malloc>(span);
 }
 
-template<typename Malloc = GMalloc>
-GMallocSpan<char, Malloc> adoptGMallocString(char* str, size_t length)
+template<typename T, typename Malloc = GMalloc>
+GMallocSpan<T, Malloc> dupGMallocSpan(std::span<const T> span)
 {
-    return adoptGMallocSpan<char, Malloc>(unsafeMakeSpan(str, length));
-}
-
-template<typename Malloc = GMalloc>
-GMallocSpan<char, Malloc> adoptGMallocString(char* str)
-{
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return adoptGMallocSpan<char, Malloc>(unsafeMakeSpan(str, str ? strlen(str) : 0));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto duplicate = GMallocSpan<T, Malloc>::malloc(span.size_bytes());
+    memcpySpan(duplicate.mutableSpan(), span);
+    return duplicate;
 }
 
 WTF_EXPORT_PRIVATE Expected<GMallocSpan<char>, GUniquePtr<GError>> gFileGetContents(CStringView);
@@ -144,7 +138,6 @@ inline std::span<T> span(GRefPtr<GPtrArray>& array)
 } // namespace WTF
 
 using WTF::GMallocSpan;
-using WTF::adoptGMallocString;
 using WTF::gFileGetContents;
 using WTF::gKeyFileGetKeys;
 using WTF::gObjectClassGetProperties;

--- a/Source/WTF/wtf/text/CStringView.h
+++ b/Source/WTF/wtf/text/CStringView.h
@@ -53,6 +53,14 @@ public:
         return CStringView(unsafeMakeSpan(byteCast<char8_t>(string), std::char_traits<char>::length(string) + 1));
     }
 
+    static CStringView fromUTF8(std::span<const char8_t> spanWithNullTerminator LIFETIME_BOUND)
+    {
+        if (spanWithNullTerminator.size() < 1)
+            return CStringView();
+        RELEASE_ASSERT(spanWithNullTerminator[spanWithNullTerminator.size() - 1] == '\0');
+        return CStringView(spanWithNullTerminator);
+    }
+
     WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
 
     CStringView() = default;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -32,6 +32,7 @@
 
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GMallocString.h>
 
 GST_DEBUG_CATEGORY(webkit_webrtc_data_channel_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_data_channel_debug
@@ -304,8 +305,8 @@ bool GStreamerDataChannelHandler::checkState()
     }
 
 #ifndef GST_DISABLE_GST_DEBUG
-    GUniquePtr<char> stateString(g_enum_to_string(GST_TYPE_WEBRTC_DATA_CHANNEL_STATE, channelState));
-    DC_DEBUG("Dispatching state change to %s on channel %p", stateString.get(), m_channel.get());
+    auto stateString = GMallocString::unsafeAdoptFromUTF8(g_enum_to_string(GST_TYPE_WEBRTC_DATA_CHANNEL_STATE, channelState));
+    DC_DEBUG("Dispatching state change to %s on channel %p", stateString.utf8(), m_channel.get());
 #endif
     postTask([client = m_client, state] {
         if (!*client) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -26,6 +26,7 @@
 #include "GStreamerWebRTCUtils.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
@@ -70,8 +71,8 @@ void GStreamerDtlsTransportBackendObserver::stateChanged()
         g_object_get(m_backend.get(), "state", &state, nullptr);
 
 #ifndef GST_DISABLE_GST_DEBUG
-        GUniquePtr<char> desc(g_enum_to_string(GST_TYPE_WEBRTC_DTLS_TRANSPORT_STATE, state));
-        GST_DEBUG_OBJECT(m_backend.get(), "DTLS transport state changed to %s", desc.get());
+        auto desc = GMallocString::unsafeAdoptFromUTF8(g_enum_to_string(GST_TYPE_WEBRTC_DTLS_TRANSPORT_STATE, state));
+        GST_DEBUG_OBJECT(m_backend.get(), "DTLS transport state changed to %s", desc.utf8());
 #endif
 
         Vector<Ref<JSC::ArrayBuffer>> certificates;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -42,6 +42,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GThreadSafeWeakPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/StringBuilder.h>
@@ -792,8 +793,7 @@ void webkitGstWebRTCIceAgentGatheringDoneForStream(WebKitGstIceAgent* agent, uns
 void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentGatheredCandidate& candidate)
 {
     findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
-        GUniquePtr<char> sdpCandidate(rice_candidate_to_sdp_string(&candidate.gathered.candidate));
-        auto sdp = CStringView::unsafeFromUTF8(sdpCandidate.get());
+        auto sdp = GMallocString::unsafeAdoptFromUTF8(rice_candidate_to_sdp_string(&candidate.gathered.candidate));
         ASSERT(startsWith(sdp.span(), "a="_s));
         String strippedSdp(sdp.span().subspan(2));
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -27,6 +27,7 @@
 #include "RTCIceTcpCandidateType.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
@@ -98,8 +99,8 @@ void GStreamerIceTransportBackend::registerClient(RTCIceTransportBackendClient& 
             return;
 
 #ifndef GST_DISABLE_GST_DEBUG
-        GUniquePtr<char> desc(g_enum_to_string(GST_TYPE_WEBRTC_ICE_CONNECTION_STATE, transportState));
-        GST_DEBUG_OBJECT(weakThis->m_backend.get(), "Initial ICE transport state: %s", desc.get());
+        auto desc = GMallocString::unsafeAdoptFromUTF8(g_enum_to_string(GST_TYPE_WEBRTC_ICE_CONNECTION_STATE, transportState));
+        GST_DEBUG_OBJECT(weakThis->m_backend.get(), "Initial ICE transport state: %s", desc.utf8());
 #endif
 
         // We start observing a bit late and might miss the checking state. Synthesize it as needed.
@@ -126,8 +127,8 @@ void GStreamerIceTransportBackend::stateChanged() const
     g_object_get(m_iceTransport.get(), "state", &transportState, nullptr);
 
 #ifndef GST_DISABLE_GST_DEBUG
-    GUniquePtr<char> desc(g_enum_to_string(GST_TYPE_WEBRTC_ICE_CONNECTION_STATE, transportState));
-    GST_DEBUG_OBJECT(m_backend.get(), "ICE transport state changed to %s", desc.get());
+    auto desc = GMallocString::unsafeAdoptFromUTF8(g_enum_to_string(GST_TYPE_WEBRTC_ICE_CONNECTION_STATE, transportState));
+    GST_DEBUG_OBJECT(m_backend.get(), "ICE transport state changed to %s", desc.utf8());
 #endif
 
     callOnMainThread([weakThis = WeakPtr { *this }, transportState] {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -28,6 +28,7 @@
 #include "GStreamerWebRTCUtils.h"
 #include "RTCRtpCodecCapability.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GUniquePtr.h>
 
 GST_DEBUG_CATEGORY(webkit_webrtc_transceiver_debug);
@@ -93,8 +94,8 @@ void GStreamerRtpTransceiverBackend::setDirection(RTCRtpTransceiverDirection dir
 {
     auto gstDirection = fromRTCRtpTransceiverDirection(direction);
 #ifndef GST_DISABLE_GST_DEBUG
-    GUniquePtr<char> directionString(g_enum_to_string(GST_TYPE_WEBRTC_RTP_TRANSCEIVER_DIRECTION, gstDirection));
-    GST_DEBUG_OBJECT(m_rtcTransceiver.get(), "Setting direction to %s", directionString.get());
+    auto directionString = GMallocString::unsafeAdoptFromUTF8(g_enum_to_string(GST_TYPE_WEBRTC_RTP_TRANSCEIVER_DIRECTION, gstDirection));
+    GST_DEBUG_OBJECT(m_rtcTransceiver.get(), "Setting direction to %s", directionString.utf8());
 #endif
     g_object_set(m_rtcTransceiver.get(), "direction", gstDirection, nullptr);
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -722,9 +722,9 @@ void setSsrcAudioLevelVadOn(GstStructure* structure)
         g_value_set_static_string(&stringValue, "vad=on");
         gst_value_array_append_and_take_value(&arrayValue, &stringValue);
 
-        GUniquePtr<char> fieldNamePtr(g_strdup(fieldName.utf8()));
-        gst_structure_remove_field(structure, fieldNamePtr.get());
-        gst_structure_take_value(structure, fieldNamePtr.get(), &arrayValue);
+        GMallocString fieldNameCopy(fieldName);
+        gst_structure_remove_field(structure, fieldNameCopy.utf8());
+        gst_structure_take_value(structure, fieldNameCopy.utf8(), &arrayValue);
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -33,6 +33,7 @@
 #include "MediaPlayerPrivateGStreamer.h"
 #include <gst/pbutils/pbutils.h>
 #include <wtf/Scope.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -134,9 +135,9 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
     });
 
 #if GST_CHECK_VERSION(1, 20, 0)
-    GUniquePtr<char> mimeCodec(gst_codec_utils_caps_get_mime_codec(caps.get()));
+    auto mimeCodec = GMallocString::unsafeAdoptFromUTF8(gst_codec_utils_caps_get_mime_codec(caps.get()));
     if (mimeCodec)
-        configuration.codec = unsafeSpan(mimeCodec.get());
+        configuration.codec = mimeCodec.span();
 #endif
 
     if (areEncryptedCaps(caps.get())) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -29,6 +29,7 @@
 #include <gst/pbutils/gstpluginsbaseversion.h>
 #include <mutex>
 #include <wtf/PrintStream.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
@@ -102,8 +103,8 @@ private:
     static bool checkIsNeeded()
     {
 #ifndef GST_DISABLE_GST_DEBUG
-        GUniquePtr<char> versionString(gst_version_string());
-        GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: running %s, the bug was fixed in 1.24.", versionString.get());
+        auto versionString = GMallocString::unsafeAdoptFromUTF8(gst_version_string());
+        GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: running %s, the bug was fixed in 1.24.", versionString.utf8());
 #endif
         WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH"_s,
             ASCIILiteral::fromLiteralUnsafe(WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH_DEFAULT_MODE));
@@ -208,8 +209,8 @@ private:
         }
 
 #ifndef GST_DISABLE_GST_DEBUG
-        GUniquePtr<char> version(gst_plugins_base_version_string());
-        GST_DEBUG("AppSinkFlushCapsWorkaroundProbe: gst-plugins-base version is %s, bug was fixed in 1.21.1 and backported to 1.20.3.", version.get());
+        auto version = GMallocString::unsafeAdoptFromUTF8(gst_plugins_base_version_string());
+        GST_DEBUG("AppSinkFlushCapsWorkaroundProbe: gst-plugins-base version is %s, bug was fixed in 1.21.1 and backported to 1.20.3.", version.utf8());
 #endif
         WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS"_s,
             ASCIILiteral::fromLiteralUnsafe(WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS_DEFAULT_MODE));

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -34,6 +34,7 @@
 #include "VP9Utilities.h"
 #include <gst/pbutils/pbutils.h>
 #include <wtf/Scope.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -135,9 +136,9 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
     });
 
 #if GST_CHECK_VERSION(1, 20, 0)
-    GUniquePtr<char> mimeCodec(gst_codec_utils_caps_get_mime_codec(caps.get()));
-    if (mimeCodec) {
-        String codec = unsafeSpan(mimeCodec.get());
+    auto mimeCodec = GMallocString::unsafeAdoptFromUTF8(gst_codec_utils_caps_get_mime_codec(caps.get()));
+    if (!mimeCodec.isEmpty()) {
+        String codec(mimeCodec.span());
         if (!gst_check_version(1, 22, 8)) {
             // The gst_codec_utils_caps_get_mime_codec() function will return all the codec parameters,
             // including the default ones, so to strip them away, re-parse the returned string, using

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -23,6 +23,7 @@
 #include "GStreamerCommon.h"
 
 #include <gst/pbutils/pbutils.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/MakeString.h>
 
@@ -70,8 +71,7 @@ String GStreamerMediaDescription::extractCodecName(const GRefPtr<GstCaps>& caps)
         });
     }
 
-    GUniquePtr<gchar> description(gst_pb_utils_get_codec_description(originalCaps.get()));
-    auto codecName = String::fromLatin1(description.get());
+    auto codecName = String(GMallocString::unsafeAdoptFromUTF8(gst_pb_utils_get_codec_description(originalCaps.get())).span());
 
     // Report "H.264 (Main Profile)" and "H.264 (High Profile)" just as "H.264" to allow changes between both variants
     // go unnoticed to the SourceBuffer layer.

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -29,6 +29,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
+#include <wtf/text/CStringView.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ public:
     GRefPtr<GVariant> getProperty(ASCIILiteral name);
 
     using ResponseCallback = CompletionHandler<void(GVariant*)>;
-    void waitResponseSignal(ASCIILiteral objectPath, ResponseCallback&& = [](auto*) { });
+    void waitResponseSignal(CStringView objectPath, ResponseCallback&& = [](auto*) { });
 
     void notifyResponse(GVariant* parameters) { m_currentResponseCallback(parameters); }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1377,8 +1377,8 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
         data, reinterpret_cast<GDestroyNotify>(destroyProbeData));
 
 #ifndef GST_DISABLE_GST_DEBUG
-    GUniquePtr<char> objectPath(gst_object_get_path_string(GST_OBJECT_CAST(self)));
-    GST_DEBUG_OBJECT(self, "%s Ghosting %" GST_PTR_FORMAT, objectPath.get(), pad.get());
+    auto objectPath = GMallocString::unsafeAdoptFromUTF8(gst_object_get_path_string(GST_OBJECT_CAST(self)));
+    GST_DEBUG_OBJECT(self, "%s Ghosting %" GST_PTR_FORMAT, objectPath.utf8(), pad.get());
 #endif
 
     auto* ghostPad = webkitGstGhostPadFromStaticTemplate(padTemplate, CStringView::unsafeFromUTF8(padName.utf8().data()), pad.get());

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -14,6 +14,7 @@ add_dependencies(TestWebKitAPIInjectedBundle TestWebKitAPI-forwarding-headers)
 # TestWTF
 list(APPEND TestWTF_SOURCES
     Tests/WTF/glib/ActivityObserver.cpp
+    Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -18,6 +18,7 @@ list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
     Tests/WTF/glib/ActivityObserver.cpp
+    Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp

--- a/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
@@ -88,15 +88,37 @@ TEST(WTF, CStringViewFrom)
     EXPECT_EQ(string.lengthInBytes(), 4UZ);
     EXPECT_TRUE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
+    string = CStringView::fromUTF8(byteCast<char8_t>(unsafeSpanIncludingNullTerminator(stringPtr)));
+    EXPECT_EQ(string.lengthInBytes(), 4UZ);
+    EXPECT_TRUE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
+
+    stringPtr = nullptr;
+    string = CStringView::unsafeFromUTF8(stringPtr);
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_FALSE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
+    string = CStringView::fromUTF8(byteCast<char8_t>(unsafeSpanIncludingNullTerminator(stringPtr)));
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_FALSE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
 
     stringPtr = "";
     string = CStringView::unsafeFromUTF8(stringPtr);
     EXPECT_EQ(string.lengthInBytes(), 0UZ);
     EXPECT_FALSE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
+    string = CStringView::fromUTF8(byteCast<char8_t>(unsafeSpanIncludingNullTerminator(stringPtr)));
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_FALSE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
 
     stringPtr = "water🍉melon";
     string = CStringView::unsafeFromUTF8(stringPtr);
+    EXPECT_EQ(string.lengthInBytes(), 14UZ);
+    EXPECT_TRUE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
+    string = CStringView::fromUTF8(byteCast<char8_t>(unsafeSpanIncludingNullTerminator(stringPtr)));
     EXPECT_EQ(string.lengthInBytes(), 14UZ);
     EXPECT_TRUE(string);
     EXPECT_EQ(string.utf8(), stringPtr);

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ * Copyright (C) 2025 Comcast Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/glib/GMallocString.h>
+
+#include "Test.h"
+#include <wtf/glib/GSpanExtras.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_GMallocString, NullAndEmpty)
+{
+    GMallocString string;
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), nullptr);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    string = GMallocString(nullptr);
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), nullptr);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    const char* literal = nullptr;
+    char* cString = g_strdup(literal);
+    string = GMallocString::unsafeAdoptFromUTF8(cString);
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    cString = g_strdup(literal);
+    auto gUniquePtr = GUniquePtr<char>(cString);
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+    EXPECT_FALSE(gUniquePtr);
+
+    cString = g_strdup(literal);
+    GUniqueOutPtr<char> gUniqueOutPtr;
+    gUniqueOutPtr.outPtr() = cString;
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+    EXPECT_FALSE(gUniqueOutPtr);
+
+    literal = "";
+    cString = g_strdup(literal);
+    string = GMallocString::unsafeAdoptFromUTF8(cString);
+    EXPECT_FALSE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    cString = g_strdup(literal);
+    gUniquePtr = GUniquePtr<char>(cString);
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    EXPECT_FALSE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+    EXPECT_FALSE(gUniquePtr);
+
+    cString = g_strdup(literal);
+    gUniqueOutPtr.outPtr() = cString;
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    EXPECT_FALSE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+    EXPECT_FALSE(gUniqueOutPtr);
+
+    literal = "test";
+    cString = g_strdup(literal);
+    string = GMallocString::unsafeAdoptFromUTF8(cString);
+    EXPECT_FALSE(string.isNull());
+    EXPECT_FALSE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_FALSE(!string);
+    EXPECT_TRUE(string);
+
+    cString = g_strdup(literal);
+    gUniquePtr = GUniquePtr<char>(cString);
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    EXPECT_FALSE(string.isNull());
+    EXPECT_FALSE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_FALSE(!string);
+    EXPECT_TRUE(string);
+    EXPECT_FALSE(gUniquePtr);
+
+    cString = g_strdup(literal);
+    gUniqueOutPtr.outPtr() = cString;
+    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    EXPECT_FALSE(string.isNull());
+    EXPECT_FALSE(string.isEmpty());
+    EXPECT_EQ(string.utf8(), cString);
+    EXPECT_FALSE(!string);
+    EXPECT_TRUE(string);
+    EXPECT_FALSE(gUniqueOutPtr);
+}
+
+TEST(WTF_GMallocString, Move)
+{
+    GMallocString emptyString1;
+    EXPECT_TRUE(emptyString1.isNull());
+    GMallocString emptyString2(WTFMove(emptyString1));
+    EXPECT_TRUE(emptyString1.isNull());
+    EXPECT_TRUE(emptyString2.isNull());
+    emptyString1 = WTFMove(emptyString2);
+    EXPECT_TRUE(emptyString1.isNull());
+    EXPECT_TRUE(emptyString2.isNull());
+
+    GMallocString nullString1(nullptr);
+    EXPECT_TRUE(nullString1.isNull());
+    GMallocString nullString2(WTFMove(nullString1));
+    EXPECT_TRUE(nullString1.isNull());
+    EXPECT_TRUE(nullString2.isNull());
+    nullString1 = WTFMove(nullString2);
+    EXPECT_TRUE(nullString1.isNull());
+    EXPECT_TRUE(nullString2.isNull());
+
+    auto nonEmptyString1 = GMallocString::unsafeAdoptFromUTF8(g_strdup("test"));
+    EXPECT_FALSE(nonEmptyString1.isNull());
+    GMallocString nonEmptyString2(WTFMove(nonEmptyString1));
+    EXPECT_TRUE(nonEmptyString1.isNull());
+    EXPECT_FALSE(nonEmptyString2.isNull());
+    nonEmptyString1 = WTFMove(nonEmptyString2);
+    EXPECT_FALSE(nonEmptyString1.isNull());
+    EXPECT_TRUE(nonEmptyString2.isNull());
+}
+
+TEST(WTF_GMallocString, Length)
+{
+    GMallocString string;
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_EQ(string.span().size(), 0UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 0UZ);
+
+    char* cString = g_strdup("");
+    string = GMallocString::unsafeAdoptFromUTF8(cString);
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_EQ(string.span().size(), 0UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 1UZ);
+
+    cString = g_strdup("test");
+    string = GMallocString::unsafeAdoptFromUTF8(cString);
+    EXPECT_EQ(string.lengthInBytes(), 4UZ);
+    EXPECT_EQ(string.span().size(), 4UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 5UZ);
+}
+
+TEST(WTF_GMallocString, Equality)
+{
+    GMallocString string = GMallocString::unsafeAdoptFromUTF8(g_strdup("Test"));
+    GMallocString sameString = GMallocString::unsafeAdoptFromUTF8(g_strdup("Test"));
+    GMallocString anotherString = GMallocString::unsafeAdoptFromUTF8(g_strdup("another test"));
+    GMallocString emptyString;
+    GMallocString nullString(nullptr);
+    GMallocString lowerCaseString = GMallocString::unsafeAdoptFromUTF8(g_strdup("test"));
+    EXPECT_TRUE(string != emptyString);
+    EXPECT_EQ(string, string);
+    EXPECT_EQ(string, sameString);
+    EXPECT_EQ(string, CStringView::unsafeFromUTF8("Test"));
+    EXPECT_EQ(string, "Test"_s);
+    EXPECT_TRUE(string != anotherString);
+    EXPECT_EQ(emptyString, nullString);
+}
+
+TEST(WTF_GMallocString, CStringView)
+{
+    CStringView nullCStringView;
+    GMallocString nullGMallocString(nullCStringView);
+    EXPECT_TRUE(nullCStringView.isNull());
+    EXPECT_TRUE(nullGMallocString.isNull());
+    EXPECT_TRUE(nullCStringView.isNull());
+    EXPECT_TRUE(nullGMallocString.isNull());
+
+    CStringView cStringView = CStringView::unsafeFromUTF8("Test");
+    GMallocString gMallocString(cStringView);
+    EXPECT_TRUE(WTF::equal(cStringView.span(), gMallocString.span()));
+    EXPECT_FALSE(cStringView.isNull());
+    EXPECT_FALSE(gMallocString.isNull());
+    EXPECT_FALSE(cStringView.isNull());
+    EXPECT_FALSE(gMallocString.isNull());
+}
+
+TEST(WTF_GMallocString, LeakUTF8)
+{
+    char* bareString = g_strdup("test");
+    GMallocString string = GMallocString::unsafeAdoptFromUTF8(bareString);
+    EXPECT_FALSE(string.isEmpty());
+    char* leakedString = string.leakUTF8();
+    EXPECT_TRUE(string.isNull());
+    EXPECT_EQ(bareString, leakedString);
+    g_free(leakedString);
+}
+
+TEST(WTF_GMallocString, ToCStringView)
+{
+    GMallocString gMallocString;
+    CStringView cStringView = toCStringView(gMallocString);
+    EXPECT_TRUE(cStringView.isNull());
+    EXPECT_TRUE(cStringView.isEmpty());
+    EXPECT_EQ(cStringView.utf8(), nullptr);
+    EXPECT_EQ(cStringView.lengthInBytes(), 0UZ);
+
+    gMallocString = GMallocString::unsafeAdoptFromUTF8(g_strdup(""));
+    cStringView = toCStringView(gMallocString);
+    EXPECT_FALSE(cStringView.isNull());
+    EXPECT_TRUE(cStringView.isEmpty());
+    EXPECT_EQ(gMallocString, cStringView);
+    EXPECT_EQ(gMallocString.utf8(), cStringView.utf8());
+    EXPECT_EQ(cStringView.lengthInBytes(), 0UZ);
+
+    gMallocString = GMallocString::unsafeAdoptFromUTF8(g_strdup("test"));
+    cStringView = toCStringView(gMallocString);
+    EXPECT_FALSE(cStringView.isNull());
+    EXPECT_FALSE(cStringView.isEmpty());
+    EXPECT_EQ(gMallocString, cStringView);
+    EXPECT_EQ(gMallocString.utf8(), cStringView.utf8());
+    EXPECT_EQ(cStringView.lengthInBytes(), 4UZ);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/GStreamerElementHarness.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
+#include <wtf/glib/GMallocString.h>
 #include <wtf/glib/GUniquePtr.h>
 
 using namespace WebCore;
@@ -257,8 +258,8 @@ TEST_F(GStreamerTest, harnessParseMP4)
     });
 
     // Feed the contents of a MP4 file to the harnessed parsebin.
-    GUniquePtr<char> filePath(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
-    auto handle = FileSystem::openFile(unsafeSpan(filePath.get()), FileSystem::FileOpenMode::Read);
+    auto filePath = GMallocString::unsafeAdoptFromUTF8(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
+    auto handle = FileSystem::openFile(filePath.span(), FileSystem::FileOpenMode::Read);
 
     size_t totalRead = 0;
     auto size = handle.size().value_or(0);
@@ -345,8 +346,8 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
 
     // Feed the contents of a MP4 file to the harnessed decodebin3, until it is able to figure out
     // the stream topology.
-    GUniquePtr<char> filePath(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
-    auto handle = FileSystem::openFile(unsafeSpan(filePath.get()), FileSystem::FileOpenMode::Read);
+    auto filePath = GMallocString::unsafeAdoptFromUTF8(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
+    auto handle = FileSystem::openFile(filePath.span(), FileSystem::FileOpenMode::Read);
 
     size_t totalRead = 0;
     auto size = handle.size().value_or(0);


### PR DESCRIPTION
#### f27346baf833b1134f43b57d859570103117aa87
<pre>
[Glib][GStreamer] Implement GMallocString class and apply it to GStreamer code
<a href="https://bugs.webkit.org/show_bug.cgi?id=303909">https://bugs.webkit.org/show_bug.cgi?id=303909</a>

Reviewed by Adrian Perez de Castro.

When interfacing with Glib APIs there was no way to wrap an owned malloced char* so GMallocString was created. It can
adopt C strings in several ways, providing then easy ways to interface with the WebKit strings the same way CStringView
does and also preserving the original null terminated C string without performing any copy.

I applied this to the GStreamer code.

Tests: Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
       Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp
       Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
       Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/glib/GMallocString.cpp: Added.
* Source/WTF/wtf/glib/GMallocString.h: Added.
(WTF::operator==):
(WTF::safePrintfType):
(WTF::toCStringView):
* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::dupGMallocSpan):
(WTF::adoptGMallocString): Deleted.
* Source/WTF/wtf/text/CStringView.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::checkState):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
(WebCore::GStreamerDtlsTransportBackendObserver::stateChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCIceAgentLocalCandidateGatheredForStream):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::GStreamerIceTransportBackend::registerClient):
(WebCore::GStreamerIceTransportBackend::stateChanged const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::fetchDescription):
(WebCore::fetchSignalingState):
(WebCore::toGStreamerMediaEndpointTransceiverState):
(WebCore::transceiverStatesFromWebRTCBin):
(WebCore::GStreamerMediaEndpoint::linkOutgoingSources):
(WebCore::GStreamerMediaEndpoint::setDescription):
(WebCore::GStreamerMediaEndpoint::processSDPMessage):
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):
(WebCore::GStreamerMediaEndpoint::onIceGatheringChange):
(WebCore::GStreamerMediaEndpoint::collectTransceivers):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::setDirection):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::setSsrcAudioLevelVadOn):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::initialize):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getStreamIdFromPad):
(WebCore::registerActivePipeline):
(WebCore::unregisterPipeline):
(WebCore::videoColorSpaceFromInfo):
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::BaseSinkPositionFlushWorkaroundProbe::checkIsNeeded):
(WebCore::AppSinkFlushCapsWorkaroundProbe::checkIsNeeded):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::elementIdChanged const):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::updateBufferingStatus):
(WebCore::MediaPlayerPrivateGStreamer::configureParsebin):
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::configureDownloadBuffer):
(WebCore::MediaPlayerPrivateGStreamer::downloadBufferFileCreatedCallback):
(WebCore::MediaPlayerPrivateGStreamer::setupCodecProbe):
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
(WebCore::MediaPlayerPrivateGStreamer::getVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcSetProperty):
(webKitWebSrcGetProperty):
(webKitWebSrcSetExtraHeader):
(webKitWebSrcMakeRequest):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp:
(WebCore::GStreamerMediaDescription::extractCodecName const):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcLoop):
(webKitMediaSrcGetUri):
(webKitMediaSrcSetUri):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::describeCaps):
(WebCore::GStreamerElementHarness::dumpGraph):
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp:
(WebCore::DesktopPortal::waitResponseSignal):
(WebCore::DesktopPortalScreenCast::createScreencastSession):
(WebCore::DesktopPortalScreenCast::ScreencastSession::openPipewireRemote):
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h:
(WebCore::DesktopPortal::waitResponseSignal):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::sortDevices):
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp:
(WebCore::GStreamerDisplayCaptureDeviceManager::createDisplayCaptureSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::mediaStreamIdFromPad):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcAddTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::checkMid):
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp:
(TestWebKitAPI::TEST(WTF, CStringViewFrom)):
* Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp: Added.
(TestWebKitAPI::TEST(WTF_GMallocString, NullAndEmpty)):
(TestWebKitAPI::TEST(WTF_GMallocString, Move)):
(TestWebKitAPI::TEST(WTF_GMallocString, Length)):
(TestWebKitAPI::TEST(WTF_GMallocString, Equality)):
(TestWebKitAPI::TEST(WTF_GMallocString, CStringView)):
(TestWebKitAPI::TEST(WTF_GMallocString, LeakUTF8)):
(TestWebKitAPI::TEST(WTF_GMallocString, ToCStringView)):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, capsFromCodecString)):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, harnessParseMP4)):
(TestWebKitAPI::TEST_F(GStreamerTest, harnessDecodeMP4Video)):

Canonical link: <a href="https://commits.webkit.org/304343@main">https://commits.webkit.org/304343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d219842546defe9c86b7912a1d702040d0a7bbf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103262 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3214 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3232 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127138 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145337 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133622 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111635 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5441 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61129 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7262 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35554 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166487 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70814 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->