### PR TITLE
Reduce unsafeness in MediaList

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -32,7 +32,6 @@ bindings/js/JSPaintRenderingContext2DCustom.cpp
 bridge/objc/objc_runtime.h
 css/CSSStyleProperties.h
 css/CSSToLengthConversionData.h
-css/MediaList.h
 css/StyleSheetContents.cpp
 css/StyleSheetContents.h
 css/values/primitives/CSSPrimitiveData.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -15,7 +15,6 @@ css/CSSRuleList.h
 css/CSSSelector.h
 css/CSSStyleProperties.h
 css/CSSValueList.h
-css/MediaList.h
 css/SelectorChecker.h
 css/SelectorFilter.h
 css/ShorthandSerializer.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -255,7 +255,6 @@ css/DeprecatedCSSOMRGBColor.h
 css/FontFace.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp
-css/MediaList.cpp
 css/MediaQueryList.cpp
 css/MediaQueryMatcher.cpp
 css/MutableStyleProperties.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -112,7 +112,6 @@ css/CSSValueList.h
 css/DeprecatedCSSOMPrimitiveValue.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp
-css/MediaList.cpp
 css/MediaQueryMatcher.cpp
 css/SelectorChecker.cpp
 css/SelectorFilter.cpp

--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -62,25 +62,25 @@ const MQ::MediaQueryList& MediaList::mediaQueries() const
 {
     if (m_detachedMediaQueries)
         return *m_detachedMediaQueries;
-    if (auto* rule = dynamicDowncast<CSSImportRule>(m_parentRule))
+    if (RefPtr rule = dynamicDowncast<CSSImportRule>(m_parentRule.get()))
         return rule->mediaQueries();
-    if (auto* rule = dynamicDowncast<CSSMediaRule>(m_parentRule))
+    if (RefPtr rule = dynamicDowncast<CSSMediaRule>(m_parentRule.get()))
         return rule->mediaQueries();
     return m_parentStyleSheet->mediaQueries();
 }
 
 void MediaList::setMediaQueries(MQ::MediaQueryList&& queries)
 {
-    if (m_parentStyleSheet) {
-        m_parentStyleSheet->setMediaQueries(WTFMove(queries));
-        m_parentStyleSheet->didMutate();
+    if (RefPtr parentStyleSheet = m_parentStyleSheet.get()) {
+        parentStyleSheet->setMediaQueries(WTFMove(queries));
+        parentStyleSheet->didMutate();
         return;
     }
 
-    CSSStyleSheet::RuleMutationScope mutationScope(m_parentRule);
-    if (auto* rule = dynamicDowncast<CSSImportRule>(m_parentRule))
+    CSSStyleSheet::RuleMutationScope mutationScope(m_parentRule.get());
+    if (RefPtr rule = dynamicDowncast<CSSImportRule>(m_parentRule.get()))
         rule->setMediaQueries(WTFMove(queries));
-    if (auto* rule = dynamicDowncast<CSSMediaRule>(m_parentRule))
+    if (RefPtr rule = dynamicDowncast<CSSMediaRule>(m_parentRule.get()))
         rule->setMediaQueries(WTFMove(queries));
 }
 
@@ -94,6 +94,16 @@ String MediaList::mediaText() const
 void MediaList::setMediaText(const String& value)
 {
     setMediaQueries(MQ::MediaQueryParser::parse(value, strictCSSParserContext()));
+}
+
+CSSRule* MediaList::parentRule() const
+{
+    return m_parentRule.get();
+}
+
+CSSStyleSheet* MediaList::parentStyleSheet() const
+{
+    return m_parentStyleSheet.get();
 }
 
 String MediaList::item(unsigned index) const

--- a/Source/WebCore/css/MediaList.h
+++ b/Source/WebCore/css/MediaList.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WTF {
 class TextStream;
@@ -58,8 +59,8 @@ public:
     WEBCORE_EXPORT String mediaText() const;
     WEBCORE_EXPORT void setMediaText(const String&);
 
-    CSSRule* parentRule() const { return m_parentRule; }
-    CSSStyleSheet* parentStyleSheet() const { return m_parentStyleSheet; }
+    CSSRule* parentRule() const;
+    CSSStyleSheet* parentStyleSheet() const;
     void detachFromParent();
 
     const MQ::MediaQueryList& mediaQueries() const;
@@ -70,8 +71,8 @@ private:
 
     void setMediaQueries(MQ::MediaQueryList&&);
 
-    CSSStyleSheet* m_parentStyleSheet { nullptr };
-    CSSRule* m_parentRule { nullptr };
+    SingleThreadWeakPtr<CSSStyleSheet> m_parentStyleSheet;
+    WeakPtr<CSSRule> m_parentRule;
     std::optional<MQ::MediaQueryList> m_detachedMediaQueries;
 };
 


### PR DESCRIPTION
#### 213f8ffe4cf1abb03490a04abd2749d71ca7b85a
<pre>
Reduce unsafeness in MediaList
<a href="https://bugs.webkit.org/show_bug.cgi?id=303922">https://bugs.webkit.org/show_bug.cgi?id=303922</a>

Reviewed by Chris Dumez.

As per <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304292@main">https://commits.webkit.org/304292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe8b3ab8217e55286c8a2a6f9d261a97cbca7a07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142673 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103287 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84144 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3232 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3260 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111664 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112026 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5466 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117434 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35576 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70842 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7267 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->