### PR TITLE
[Cocoa] Adopt MACaptionAppearanceCopyPreviewText

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -80,3 +80,8 @@ cleanup = "rdar://161402756"
 symbols = [
     "FPFontCreateMemorySafeFontsFromData",
 ]
+
+[[staging]]
+symbols = [
+    "MACaptionAppearanceCopyPreviewText",
+]

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -1060,6 +1060,10 @@ String CaptionUserPreferencesMediaAF::captionPreviewTitle() const
         return CaptionUserPreferences::captionPreviewTitle();
 
     String activeProfileID = platformActiveProfileID();
+
+    if (canLoad_MediaAccessibility_MACaptionAppearanceCopyPreviewText())
+        return adoptCF(MACaptionAppearanceCopyPreviewText(activeProfileID.createCFString().get(), nullptr)).get();
+
     String activeProfileName = nameForProfileID(activeProfileID);
     if (activeProfileName.isEmpty())
         return CaptionUserPreferences::captionPreviewTitle();

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
@@ -60,5 +60,7 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileIDs, CFArrayRef, (), (), WEBCORE_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceSetActiveProfileID, void, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileName, CFStringRef, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyPreviewText, CFStringRef, (CFStringRef profileID, CFStringRef trackLanguage), (profileID, trackLanguage), WEBCORE_EXPORT);
+
 
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
@@ -89,6 +89,8 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionApp
 #define MACaptionAppearanceCopyActiveProfileID softLink_MediaAccessibility_MACaptionAppearanceCopyActiveProfileID
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileName, CFStringRef, (CFStringRef profileID), (profileID))
 #define MACaptionAppearanceCopyProfileName softLink_MediaAccessibility_MACaptionAppearanceCopyProfileName
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyPreviewText, CFStringRef, (CFStringRef profileID, CFStringRef trackLanguage), (profileID, trackLanguage));
+#define MACaptionAppearanceCopyPreviewText softLink_MediaAccessibility_MACaptionAppearanceCopyPreviewText
 
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 


### PR DESCRIPTION
#### 6a45a14d2c2da6f0be9da9faebd026305edf319a
<pre>
[Cocoa] Adopt MACaptionAppearanceCopyPreviewText
<a href="https://rdar.apple.com/166226577">rdar://166226577</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303923">https://bugs.webkit.org/show_bug.cgi?id=303923</a>

Reviewed by Eric Carlson.

MediaAccessibility has added API to generate the string to be shown
when caption styles are previewed via default media controls and
HTMLVideoElement.showCaptionDisplaySettings().

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionPreviewTitle const):
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h:

Canonical link: <a href="https://commits.webkit.org/304359@main">https://commits.webkit.org/304359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5938bfb7e4f667c22afd98b69bb89aeacab647e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86989 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103339 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70545 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84198 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3286 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3322 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7299 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28463 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5525 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7353 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35633 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->