### PR TITLE
Implement script.getRealms for main window contexts

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -30,16 +30,29 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "AutomationProtocolObjects.h"
+#include "FrameTreeNodeData.h"
+#include "PageLoadState.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
 #include "WebDriverBidiProtocolObjects.h"
+#include "WebFrameMetrics.h"
+#include "WebFrameProxy.h"
 #include "WebPageProxy.h"
+#include "WebProcessPool.h"
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/SecurityOrigin.h>
+#include <WebCore/SecurityOriginData.h>
+#include <algorithm>
+#include <wtf/CallbackAggregator.h>
+#include <wtf/ProcessID.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
 
 namespace WebKit {
 
 using namespace Inspector;
 using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+using EvaluateResultType = Inspector::Protocol::BidiScript::EvaluateResultType;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiScriptAgent);
 
@@ -72,7 +85,8 @@ void BidiScriptAgent::callFunction(const String& functionDeclaration, bool await
 
     Ref<JSON::Array> argumentsArray = arguments ? arguments.releaseNonNull() : JSON::Array::create();
 
-    session->evaluateJavaScriptFunction(topLevelContextHandle, frameHandle, functionDeclaration, WTF::move(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTF::move(callback)](Inspector::CommandResult<String>&& stringResult) {
+    String realmID = generateRealmIdForBrowsingContext(*browsingContext);
+    session->evaluateJavaScriptFunction(topLevelContextHandle, frameHandle, functionDeclaration, WTF::move(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTF::move(callback), realmID](Inspector::CommandResult<String>&& stringResult) {
         // FIXME: Properly fill ExceptionDetails remaining fields once we have a way to get them instead of just the error message.
         // https://bugs.webkit.org/show_bug.cgi?id=288058
         if (!stringResult) {
@@ -91,7 +105,7 @@ void BidiScriptAgent::callFunction(const String& functionDeclaration, bool await
                     .setStackTrace(WTF::move(stackTrace))
                     .release();
 
-                callback({ { Inspector::Protocol::BidiScript::EvaluateResultType::Exception, "placeholder_realm"_s, nullptr, WTF::move(exceptionDetails) } });
+                callback({ { EvaluateResultType::Exception, realmID, nullptr, WTF::move(exceptionDetails) } });
                 return;
             }
 
@@ -108,8 +122,7 @@ void BidiScriptAgent::callFunction(const String& functionDeclaration, bool await
 
         resultObject->setValue(resultValue.releaseNonNull());
 
-        // FIXME: keep track of realm IDs that we hand out.
-        callback({ { Inspector::Protocol::BidiScript::EvaluateResultType::Success, "placeholder_realm"_s, WTF::move(resultObject), nullptr } });
+        callback({ { EvaluateResultType::Success, realmID, WTF::move(resultObject), nullptr } });
     });
 }
 
@@ -131,8 +144,9 @@ void BidiScriptAgent::evaluate(const String& expression, bool awaitPromise, Ref<
     // FIXME: handle `serializationOptions` option.
 
     String functionDeclaration = makeString("function() {\n return "_s, expression, "; \n}"_s);
-    session->evaluateJavaScriptFunction(topLevelContextHandle, frameHandle, functionDeclaration, JSON::Array::create(), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTF::move(callback)](Inspector::CommandResult<String>&& result) {
-        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
+    String realmId = generateRealmIdForBrowsingContext(*browsingContext);
+    session->evaluateJavaScriptFunction(topLevelContextHandle, frameHandle, functionDeclaration, JSON::Array::create(), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTF::move(callback), realmId](Inspector::CommandResult<String>&& result) {
+        auto evaluateResultType = result.has_value() ? EvaluateResultType::Success : EvaluateResultType::Exception;
         auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
             .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
             .release();
@@ -141,12 +155,294 @@ void BidiScriptAgent::evaluate(const String& expression, bool awaitPromise, Ref<
         if (result)
             resultObject->setValue(JSON::Value::create(WTF::move(result.value())));
 
-        // FIXME: keep track of realm IDs that we hand out.
-        callback({ { evaluateResultType, "placeholder_realm"_s, WTF::move(resultObject), nullptr } });
+        callback({ { evaluateResultType, realmId, WTF::move(resultObject), nullptr } });
     });
+}
+
+void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
+{
+    // https://w3c.github.io/webdriver-bidi/#command-script-getRealms
+
+    // FIXME: Implement worker realm support (dedicated-worker, shared-worker, service-worker, worker).
+    // https://bugs.webkit.org/show_bug.cgi?id=304300
+    // Currently only window realms (main frames and iframes) are supported.
+    // Worker realm types require tracking worker global scopes and their owner sets.
+
+    // FIXME: Implement worklet realm support (paint-worklet, audio-worklet, worklet).
+    // https://bugs.webkit.org/show_bug.cgi?id=304301
+
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // Validate browsingContext parameter if provided and resolve its owning page.
+    // Per W3C BiDi spec: the optional 'context' parameter is a browsingContext.BrowsingContext
+    // that filters realms to those associated with the specified navigable (top-level or nested/iframe).
+    std::optional<String> contextHandleFilter;
+    RefPtr<WebPageProxy> resolvedPageForContext;
+    if (!optionalBrowsingContext.isEmpty()) {
+        contextHandleFilter = optionalBrowsingContext;
+
+        // Only support page contexts in this PR - iframe support will be added later
+        if (optionalBrowsingContext.startsWith("page-"_s))
+            resolvedPageForContext = session->webPageProxyForHandle(optionalBrowsingContext);
+        else
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
+
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!resolvedPageForContext, WindowNotFound);
+    }
+
+    // Early short-circuit: if a non-window realm type is requested, return empty (we currently only support window realms).
+    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window) {
+        auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
+        callback(WTF::move(realmsArray));
+        return;
+    }
+
+    // Collect pages to process based on context filter
+    Deque<Ref<WebPageProxy>> pagesToProcess;
+
+    if (contextHandleFilter && resolvedPageForContext)
+        pagesToProcess.append(*resolvedPageForContext);
+    else {
+        // Enumerate all controlled pages; filtering by context happens during collection
+        for (Ref process : session->protectedProcessPool()->processes()) {
+            for (Ref page : process->pages()) {
+                if (page->isControlledByAutomation())
+                    pagesToProcess.append(page);
+            }
+        }
+    }
+
+    if (pagesToProcess.isEmpty()) {
+        auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
+        callback(WTF::move(realmsArray));
+        return;
+    }
+
+    // Process pages asynchronously using getAllFrameTrees
+    processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), { }, WTF::move(callback));
+}
+
+
+RefPtr<Inspector::Protocol::BidiScript::RealmInfo> BidiScriptAgent::createRealmInfoForFrame(const FrameInfoData& frameInfo)
+{
+    ASSERT(frameInfo.documentID);
+    RefPtr session = m_session.get();
+    if (!session)
+        return nullptr;
+
+    // Per W3C BiDi spec: "If you can't resolve the navigable (detached doc, bfcache edge),
+    // return null for that settings — do not synthesize partial objects."
+    auto contextHandle = contextHandleForFrame(frameInfo);
+    if (!contextHandle)
+        return nullptr;
+
+    // Generate or reuse a realm id based on the frame's execution state so it changes on navigation/reload.
+    String realmId = generateRealmIdForFrame(frameInfo);
+    String origin = originStringFromSecurityOriginData(frameInfo.securityOrigin);
+
+    auto realmInfo = Inspector::Protocol::BidiScript::RealmInfo::create()
+        .setRealm(realmId)
+        .setOrigin(origin)
+        .setType(Inspector::Protocol::BidiScript::RealmType::Window)
+        .release();
+
+    // Set optional context field (required for window realms)
+    realmInfo->setContext(*contextHandle);
+
+    return realmInfo;
+}
+
+String BidiScriptAgent::generateRealmIdForFrame(const FrameInfoData& frameInfo)
+{
+    String currentURL = frameInfo.request.url().string();
+    std::optional<String> currentDocumentID = frameInfo.documentID ? std::optional<String>(frameInfo.documentID->toString()) : std::nullopt;
+
+    if (auto it = m_frameRealmCache.find(frameInfo.frameID); it != m_frameRealmCache.end()) {
+        const auto& cachedEntry = it->value;
+
+        if (cachedEntry.url == currentURL && cachedEntry.documentID == currentDocumentID)
+            return cachedEntry.realmId;
+
+        // FIXME: This is a workaround until realm.created/realm.destroyed events are implemented.
+        // https://bugs.webkit.org/show_bug.cgi?id=304062
+        // If only the documentID changed but URL is the same, reuse the cached realm ID to keep
+        // realm IDs stable between getRealms() and evaluate()/callFunction() calls on the same document.
+        // Once realm lifecycle events are implemented, they will handle cache updates properly.
+        if (cachedEntry.url == currentURL && currentURL != "about:blank"_s) {
+            m_frameRealmCache.set(frameInfo.frameID, FrameRealmCacheEntry { currentURL, currentDocumentID, cachedEntry.realmId });
+            return cachedEntry.realmId;
+        }
+
+        // Special case: Transitioning to/from about:blank is typically not a navigation,
+        // it's either the initial page load or a new test/session starting.
+        // Don't treat this as a state change that increments the counter.
+        bool transitioningToOrFromBlank = (cachedEntry.url == "about:blank"_s) != (currentURL == "about:blank"_s);
+
+        if (transitioningToOrFromBlank) {
+            m_frameRealmCache.remove(frameInfo.frameID);
+            m_frameRealmCounters.remove(frameInfo.frameID);
+        }
+    }
+
+    // Generate a new realm ID - the state has changed or this is a new frame
+    auto contextHandle = contextHandleForFrame(frameInfo);
+
+    String newRealmId;
+
+    if (!contextHandle) {
+        // Fallback to frame-based ID if we can't get context handle
+        newRealmId = makeString("realm-frame-"_s, String::number(frameInfo.frameID.toUInt64()));
+    } else {
+        // Use the contextHandle directly - it's already unique for both main frames and iframes
+        // For the first load of a context, use just the context handle
+        // For subsequent navigations/reloads, append a counter to make it unique
+        auto counterIt = m_frameRealmCounters.find(frameInfo.frameID);
+        if (counterIt == m_frameRealmCounters.end()) {
+            // First realm for this frame - no counter suffix
+            newRealmId = makeString("realm-"_s, *contextHandle);
+            // Start counter at 1 so the NEXT navigation will use "-1" suffix
+            m_frameRealmCounters.set(frameInfo.frameID, 1);
+        } else {
+            // Subsequent realm (reload/navigation) - use and increment counter
+            uint64_t counter = counterIt->value;
+            newRealmId = makeString("realm-"_s, *contextHandle, "-"_s, String::number(counter));
+            counterIt->value = counter + 1;
+        }
+    }
+
+    // Update the cache with the new realm ID
+    m_frameRealmCache.set(frameInfo.frameID, FrameRealmCacheEntry { currentURL, currentDocumentID, newRealmId });
+
+    return newRealmId;
+}
+
+String BidiScriptAgent::generateRealmIdForBrowsingContext(const String& browsingContext)
+{
+    // For evaluate/callFunction, we need to generate consistent realm IDs based on the browsing context.
+    // This simplified version works for main window contexts (page handles).
+    // For now, we just use the browsing context handle as the realm ID base.
+    // This will match what getRealms() generates for main frames since contextHandleForFrame returns the page handle.
+
+    // The realm ID should match the format used by generateRealmIdForFrame()
+    return makeString("realm-"_s, browsingContext);
+}
+
+String BidiScriptAgent::originStringFromSecurityOriginData(const WebCore::SecurityOriginData& originData)
+{
+    if (originData.isOpaque())
+        return "null"_s;
+
+    return originData.toString();
+}
+
+void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
+{
+    if (pagesToProcess.isEmpty()) {
+        // Assemble final array with window realms only
+        auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
+        for (auto& realmInfo : accumulated) {
+            if (!realmInfo)
+                continue;
+            if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window)
+                continue; // Only window realms supported currently.
+
+            realmsArray->addItem(realmInfo.releaseNonNull());
+        }
+
+        callback(WTF::move(realmsArray));
+        return;
+    }
+
+    // Process the first page and recursively handle the rest
+    Ref<WebPageProxy> currentPage = pagesToProcess.first();
+    pagesToProcess.removeFirst();
+
+    currentPage->getAllFrameTrees([weakThis = WeakPtr { *this }, pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<FrameTreeNodeData>&& frameTrees) mutable {
+        CheckedPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        // Collect realms from main frames only (no iframes in this PR)
+        Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>> candidateRealms;
+        for (const auto& frameTree : frameTrees)
+            protectedThis->collectExecutionReadyFrameRealms(frameTree, candidateRealms, contextHandleFilter, false);
+
+        for (auto& realmInfo : candidateRealms)
+            accumulated.append(WTF::move(realmInfo));
+
+        protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+    });
+}
+
+bool BidiScriptAgent::isFrameExecutionReady(const FrameInfoData& frameInfo)
+{
+    // Per W3C BiDi spec step 1: environment settings with execution ready flag set.
+    // For enumerating realms (getRealms), we only require a committed document (documentID).
+    // Remote frames (out-of-process) must still be considered: they have realms even if we
+    // cannot execute scripts directly from the UI process.
+
+    // Must have a valid document/script execution context
+    if (!frameInfo.documentID)
+        return false;
+
+    // Do not exclude remote frames for enumeration purposes.
+
+    // We intentionally do not check errorOccurred. Per spec, iframe realms may exist despite
+    // loading errors, and tests expect realms to be present.
+
+    return true;
+}
+
+std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData& frameInfo)
+{
+    RefPtr session = m_session.get();
+    if (!session)
+        return std::nullopt;
+
+    // FIXME: Add support for iframe contexts.
+    // https://bugs.webkit.org/show_bug.cgi?id=304305
+    if (!frameInfo.isMainFrame)
+        return std::nullopt;
+
+    if (frameInfo.webPageProxyID) {
+        for (Ref process : session->protectedProcessPool()->processes()) {
+            for (Ref page : process->pages()) {
+                if (page->identifier() == *frameInfo.webPageProxyID)
+                    return session->handleForWebPageProxy(page);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+void BidiScriptAgent::collectExecutionReadyFrameRealms(const FrameTreeNodeData& frameTree, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes)
+{
+    // FIXME: Per W3C BiDi spec, when contextHandleFilter is present, we should also include
+    // worker realms whose owner set includes the active document of that context.
+    // Currently only collecting window realms (frames).
+
+    // Check if frame is execution ready per W3C BiDi spec step 1:
+    // "Let environment settings be a list of all the environment settings objects that have their execution ready flag set."
+    if (isFrameExecutionReady(frameTree.info)) {
+        auto handle = contextHandleForFrame(frameTree.info);
+        bool shouldInclude = !contextHandleFilter || (handle && *handle == *contextHandleFilter);
+        if (shouldInclude) {
+            if (auto realmInfo = createRealmInfoForFrame(frameTree.info))
+                realms.append(realmInfo);
+        }
+    }
+
+    // FIXME: The recurseSubframes parameter is currently always called with false since this PR
+    // only supports main frame contexts. When iframe support is added, this will be used to
+    // recursively collect realms from nested browsing contexts (iframes).
+    // Recurse into subframes if requested
+    if (recurseSubframes) {
+        for (const auto& child : frameTree.children)
+            collectExecutionReadyFrameRealms(child, realms, contextHandleFilter, true);
+    }
 }
 
 } // namespace WebKit
 
 #endif // ENABLE(WEBDRIVER_BIDI)
-

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -68,6 +68,27 @@
             "type": "string"
         },
         {
+            "id": "RealmInfo",
+            "description": "Contains information about a JavaScript realm.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RealmInfo",
+            "type": "object",
+            "properties": [
+                { "name": "realm", "$ref": "BidiScript.Realm", "description": "Unique identifier of the realm." },
+                { "name": "origin", "type": "string", "description": "The serialized origin of the realm." },
+                { "name": "type", "$ref": "BidiScript.RealmType", "description": "The type of the realm." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." }
+            ]
+        },
+        {
+            "id": "RealmType",
+            "description": "The type of a JavaScript realm. Currently only 'window' is supported; worker and worklet types will be added in future implementations.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RealmType",
+            "type": "string",
+            "enum": [
+                "window"
+            ]
+        },
+        {
             "id": "RemoteValue",
             "description": "A mirror object that is used to introspect values accessible from the ECMAScript runtime. The fields used and their semantics depends on the value's type (<cod>BidiScript.RemoteValueType</code>)",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue",
@@ -201,6 +222,20 @@
                 { "name": "realm", "$ref": "BidiScript.Realm" },
                 { "name": "result", "$ref": "BidiScript.RemoteValue", "optional": true },
                 { "name": "exceptionDetails", "$ref": "BidiScript.ExceptionDetails", "optional": true }
+            ]
+        },
+        {
+            "name": "getRealms",
+            "description": "Returns a list of all realms.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-getRealms",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/script/get_realms",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "If specified, only realms belonging to this browsing context will be returned." },
+                { "name": "type", "$ref": "BidiScript.RealmType", "optional": true, "description": "If specified, only realms of this type will be returned." }
+            ],
+            "returns": [
+                { "name": "realms", "type": "array", "items": { "$ref": "BidiScript.RealmInfo" }, "description": "List of realms." }
             ]
         }
     ]

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -3811,20 +3811,34 @@
     "imported/w3c/webdriver/tests/bidi/script/evaluate/user_activation.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288060"}}
     },
-    "imported/w3c/webdriver/tests/bidi/script/get_realms/context.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061"}}
-    },
     "imported/w3c/webdriver/tests/bidi/script/get_realms/get_realms.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061"}}
+        "subtests": {
+            "test_iframes": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288061 - Iframe enumeration not in scope for window realm implementation"}}
+            },
+            "test_multiple_top_level_contexts[tab]": {
+                "expected": { "all": { "status": ["PASS", "FAIL"], "bug": "webkit.org/b/288061 - Passes individually, timing issues in parallel execution"}}
+            },
+            "test_multiple_top_level_contexts[window]": {
+                "expected": { "all": { "status": ["PASS", "FAIL"], "bug": "webkit.org/b/288061 - Passes individually, timing issues in parallel execution"}}
+            },
+            "test_origin": {
+                "expected": { "all": { "status": ["PASS", "FAIL"], "bug": "webkit.org/b/288061 - Passes individually, timing issues in parallel execution"}}
+            }
+        }
     },
-    "imported/w3c/webdriver/tests/bidi/script/get_realms/invalid.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061"}}
+    "imported/w3c/webdriver/tests/bidi/script/get_realms/context.py": {
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061 - Frame context filtering not yet supported"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/get_realms/sandbox.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061"}}
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061 - Sandbox realm support not yet implemented"}}
     },
-    "imported/w3c/webdriver/tests/bidi/script/get_realms/type.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288061"}}
+    "imported/w3c/webdriver/tests/bidi/script/get_realms/invalid.py": {
+        "subtests": {
+            "test_params_type_invalid_value": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288061 - Protocol-layer enum validation for optional parameters not implemented"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/script/message/message.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288065"}}


### PR DESCRIPTION
#### 44db1f726520a1482bcbd375d5bdb588c4c3f7b5
<pre>
Implement script.getRealms for main window contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=303926">https://bugs.webkit.org/show_bug.cgi?id=303926</a>

Reviewed by BJ Burg.

This change implements the WebDriver BiDi script.getRealms command for main window browsing contexts, enabling tests to query JavaScript realms in the page.

Added RealmInfo, RealmType types to BidiScript.json protocol, implemented getRealms() in BidiScriptAgent for main window contexts with realm ID generation and navigation detection. Added basic realm ID support to evaluate() and callFunction().

Note: Realm ID consistency between evaluate() and getRealms() is not fully implemented - this will be addressed in a follow-up change.

* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::callFunction):
(WebKit::BidiScriptAgent::evaluate):
(WebKit::BidiScriptAgent::getRealms):
(WebKit::BidiScriptAgent::createRealmInfoForFrame):
(WebKit::BidiScriptAgent::generateRealmIdForFrame):
(WebKit::BidiScriptAgent::generateRealmIdForBrowsingContext):
(WebKit::BidiScriptAgent::processRealmsForPagesAsync):
(WebKit::BidiScriptAgent::contextHandleForFrame):
(WebKit::BidiScriptAgent::collectExecutionReadyFrameRealms):
* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json:
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/304800@main">https://commits.webkit.org/304800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402157a9a0b5e0784caa3d80233e322842c2710f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144222 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6619 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4299 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115937 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8548 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41087 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 flakes 1 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8565 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7186 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Skipped layout-tests; 11 flakes 4 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113074 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6556 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118621 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62545 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36672 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72171 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->