### PR TITLE
[JavaScriptCore] os_script_config_storage is not available when back-deploying

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -43,10 +43,6 @@ namespace JSC {
 
 class VM;
 
-#if USE(APPLE_INTERNAL_SDK) && defined(OS_SCRIPT_CONFIG_SPI_VERSION) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-#define HAVE_OS_SCRIPT_CONFIG_SPI 1
-#endif
-
 #if ENABLE(C_LOOP)
 typedef OpcodeID LLIntCode;
 #else
@@ -71,8 +67,15 @@ constexpr size_t OpcodeConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB
 
 #if HAVE(OS_SCRIPT_CONFIG_SPI)
 static_assert(OS_SCRIPT_CONFIG_STORAGE_SIZE == OpcodeConfigSizeToProtect);
+#elif PLATFORM(COCOA)
+// When targeting older versions of macOS that do not have
+// os_script_config_storage runtime support, this redeclaration clashes with
+// the declaration in the SDK that is marked as unavailable. Use a different
+// name to work around the availability diagnostic.
+extern "C" uint8_t os_script_config_storage_stub[] __asm__("_os_script_config_storage");
+#define os_script_config_storage os_script_config_storage_stub
 #else
-extern "C" WTF_EXPORT_PRIVATE uint8_t os_script_config_storage[];
+extern "C" uint8_t os_script_config_storage[];
 #endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN


### PR DESCRIPTION
#### 6d600422dd58002d6fe0b9197fdb291e7f9d9005
<pre>
[JavaScriptCore] os_script_config_storage is not available when back-deploying
<a href="https://bugs.webkit.org/show_bug.cgi?id=303933">https://bugs.webkit.org/show_bug.cgi?id=303933</a>
<a href="https://rdar.apple.com/166241210">rdar://166241210</a>

Reviewed by Mark Lam.

Fix two issues related to back-deploying from recent SDKs to Sonoma and
Sequoia downlevels:

1. We were using the presence of a macro in &lt;os/script_config_private.h&gt;
   to determine whether to compile with os_script_config_storage runtime
   support. When back deploying, that macro may exist even when the
   system being targeted does not have runtime support.

   Replace the HAVE_OS_SCRIPT_CONFIG_SPI check with one from
   WebKitAdditions based on deployment target version.

2. When we are in the fallback configuration where we allocate our own
   buffer, JSC was redeclaring a `os_script_config_storage` using the
   same name as the declaration from the system header. This confused
   the compiler into thinking that we are attempting to use a
   declaration from the SDK that is marked unavailable.

   Work around this by giving the declaration a different name
   (os_script_config_storage_stub) and manually renaming its symbol so
   that LLInt can still bind to it.

Also, do not export the stub symbol; it&apos;s only used within JSC.

* Source/JavaScriptCore/llint/LLIntData.h:

Canonical link: <a href="https://commits.webkit.org/304386@main">https://commits.webkit.org/304386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1ca05b0d92de159c26f72e3d073059bee917a0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87115 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ffc09eb-0c4f-44e0-9dde-c9afa9c51d99) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4899a585-dbe2-49b7-b770-8024490218fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3637b183-479a-4fbd-aa97-74daba40e8ac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3424 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3706 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145850 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133887 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111850 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/134830 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5666 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61372 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7519 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35784 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166727 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71068 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->