### PR TITLE
Web Inspector: Prevent automatic searches for potentially slow short queries

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
@@ -95,8 +95,19 @@ WI.SearchSidebarPanel = class SearchSidebarPanel extends WI.NavigationSidebarPan
 
         this._inputElement.select();
 
-        if (performSearch)
-            this.performSearch(this._inputElement.value, {omitFocus: true});
+        if (performSearch) {
+            const minimumQueryLength = 3;
+            if (this._inputElement.value.length >= minimumQueryLength)
+                this.performSearch(this._inputElement.value, {omitFocus: true});
+            else {
+                // Allow the user to intentionally proceed with a potentially very slow query by pressing the Enter key.
+                // This is needed because the "change" event won't trigger on Enter if the value is already set programmatically; there is no change.
+                this._inputElement.addEventListener("keydown", (event) => {
+                    if (event.keyCode === WI.KeyboardShortcut.Key.Enter.keyCode)
+                        this.performSearch(this._inputElement.value);
+                }, {once: true});
+            }
+        }
     }
 
     performSearch(searchQuery, {omitFocus} = {})


### PR DESCRIPTION
#### 23a0a17d1c6cceb823724143fbb840ace75c6603
<pre>
Web Inspector: Prevent automatic searches for potentially slow short queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=303939">https://bugs.webkit.org/show_bug.cgi?id=303939</a>
<a href="https://rdar.apple.com/166248017">rdar://166248017</a>

Reviewed by NOBODY (OOPS!).

The previously used query is saved and automatically applied next time the Search tab is opened.
This was intentional, implemented in <a href="https://commits.webkit.org/184324@main">https://commits.webkit.org/184324@main</a>

Web Inspector doesn&apos;t handle well short queries, like single characters, that return a lot of results.
The tool can slow down or even freeze. A user needs to close and reopen Web Inspector.

But the behaviour of automatically applying the last known query gets the user in the same state.
This patch prevents automatic searches for those potentially slow queries.
If the intent is real, pressing the Enter allows the user to proceed intentionally.

This is a stop-gap solution until adressing the underlying issue with slow queries.

* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js:
(WI.SearchSidebarPanel.prototype.focusSearchField):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a0a17d1c6cceb823724143fbb840ace75c6603

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86957 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70509 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84153 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3244 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3274 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145380 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111674 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112036 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5479 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61300 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7306 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35590 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7163 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->