### PR TITLE
[JSC] Add an Air::TmpMap accessor with bank as a template parameter

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirTmpMap.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpMap.h
@@ -71,6 +71,15 @@ public:
         return m_fp[tmp];
     }
 
+    template<Bank bank>
+    const Value& get(Tmp tmp) const
+    {
+        ASSERT(bank == tmp.bank());
+        if constexpr (bank == GP)
+            return m_gp[tmp];
+        return m_fp[tmp];
+    }
+
     Value& operator[](Tmp tmp)
     {
         if (tmp.isGP())
@@ -78,6 +87,15 @@ public:
         return m_fp[tmp];
     }
     
+    template<Bank bank>
+    Value& get(Tmp tmp)
+    {
+        ASSERT(bank == tmp.bank());
+        if constexpr (bank == GP)
+            return m_gp[tmp];
+        return m_fp[tmp];
+    }
+
     template<typename PassedValue>
     void append(Tmp tmp, PassedValue&& value)
     {


### PR DESCRIPTION
#### 91e5a4e38acf8e6d02edf9ca8d84ca8737ef430c
<pre>
[JSC] Add an Air::TmpMap accessor with bank as a template parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=303942">https://bugs.webkit.org/show_bug.cgi?id=303942</a>
<a href="https://rdar.apple.com/166252589">rdar://166252589</a>

Reviewed by Yusuke Suzuki.

The register allocator wants to do initial analysis over the IR without
respect to the register bank (to avoid repeated IR passes) when bank is
irrelevant. The allocator also needs to be able to create new Tmps as
it runs. So, the allocator uses Air::TmpMap rather than a flat vector.

However, the core register allocation algorithm is run over each bank
independently. So, introduce a templated on bank accessor to TmpMap so
that the bank branch in the TmpMap lookup can be resolved at compile time.

This seems to speed up register allocation by about 1-2% (though it&apos;s
hard to measure exactly).

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::groupForTmp):
(JSC::B3::Air::Greedy::GreedyAllocator::assignedReg):
(JSC::B3::Air::Greedy::GreedyAllocator::validateAssignments):
(JSC::B3::Air::Greedy::GreedyAllocator::finalizeGroups):
(JSC::B3::Air::Greedy::GreedyAllocator::initSpillCosts):
(JSC::B3::Air::Greedy::GreedyAllocator::allocateRegisters):
(JSC::B3::Air::Greedy::GreedyAllocator::tryAllocate):
(JSC::B3::Air::Greedy::GreedyAllocator::tryEvict):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplit):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitGroup):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitIntraBlock):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
* Source/JavaScriptCore/b3/air/AirTmpMap.h:
(JSC::B3::Air::TmpMap::get const):
(JSC::B3::Air::TmpMap::get):

Canonical link: <a href="https://commits.webkit.org/304300@main">https://commits.webkit.org/304300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d558fdd7f1ee1317ac6ef59329e67500aeaed19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86877 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70444 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5558 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3164 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3153 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127070 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114767 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39198 "Too many flaky failures: fast/table/018.html, http/tests/navigation/https-no-store-subframe-in-page-cache.html, http/tests/navigation/page-cache-expired-entry.html, http/tests/navigation/page-cache-failed-xhr.html, http/tests/navigation/page-cache-fontfaceset.html, http/tests/navigation/page-cache-fragment-referrer.html, http/tests/navigation/page-cache-mediakeysession.html, http/tests/navigation/page-cache-pending-image-load-cache-partition.html, http/tests/navigation/page-cache-pending-image-load.html, http/tests/navigation/page-cache-pending-load.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145255 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133547 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111570 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111930 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5388 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61073 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7182 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35492 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70754 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43490 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7182 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7057 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->