### PR TITLE
[ews-build.webkit.org] Switch macOS JSC arm64 stress test queue to O3 debug builds

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -397,3 +397,10 @@ class PruneCoreSymbolicationdCacheIfTooLarge(shell.ShellCommand):
     haltOnFailure = False
     command = ["sudo", "python3", "Tools/Scripts/delete-if-too-large",
                "/System/Library/Caches/com.apple.coresymbolicationd"]
+
+
+class SetO3OptimizationLevel(shell.ShellCommand):
+    command = ["Tools/Scripts/set-webkit-configuration", "--force-optimization-level=O3"]
+    name = "set-o3-optimization-level"
+    description = ["set O3 optimization level"]
+    descriptionDone = ["set O3 optimization level"]

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -2285,10 +2285,3 @@ class RebootWithUpdatedCrossTargetImage(shell.ShellCommand):
         if rc == SUCCESS:
             self.build.buildFinished(['Rebooting with updated image, retrying build'], RETRY)
         defer.returnValue(rc)
-
-
-class SetO3OptimizationLevel(shell.ShellCommand):
-    command = ["Tools/Scripts/set-webkit-configuration", "--force-optimization-level=O3"]
-    name = "set-o3-optimization-level"
-    description = ["set O3 optimization level"]
-    descriptionDone = ["set O3 optimization level"]

--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -221,7 +221,7 @@ class GitHubEWS(GitHub):
                           ['webkitperl', 'ios-wk2', 'api-mac', 'api-wpe', ''],
                           ['webkitpy', 'ios-wk2-wpt', 'api-mac-debug', 'wpe-cairo-libwebrtc', ''],
                           ['jsc', 'api-ios', 'mac-wk1', 'gtk', ''],
-                          ['jsc-arm64', 'vision', 'mac-wk2', 'gtk-wk2', ''],
+                          ['jsc-debug-arm64', 'vision', 'mac-wk2', 'gtk-wk2', ''],
                           ['services', 'vision-sim', 'mac-AS-debug-wk2', 'api-gtk', ''],
                           ['merge', 'vision-wk2', 'mac-wk2-stress', 'playstation', ''],
                           ['unsafe-merge', 'tv', 'mac-intel-wk2', 'jsc-armv7', ''],

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -45,7 +45,7 @@ class StatusBubble(View):
     # Note: This list is sorted in the order of which bubbles appear in bugzilla.
     ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'vision', 'vision-sim', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'wpe-cairo-libwebrtc', 'playstation', 'win', 'win-tests',
                   'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-intel-wk2', 'mac-AS-debug-wk2', 'mac-safer-cpp', 'vision-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac',
-                  'api-mac-debug', 'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
+                  'api-mac-debug', 'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-debug-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
 
     DAYS_TO_CHECK_QUEUE_POSITION = 0.5
     DAYS_TO_HIDE_BUBBLE = 7

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -428,9 +428,9 @@
       "workernames": ["ews127", "ews128", "ews205", "ews206", "ews251", "ews252"]
     },
     {
-      "name": "JSC-Tests-arm64-EWS", "shortname": "jsc-arm64", "icon": "buildAndTest",
-      "factory": "JSCBuildAndTestsFactory", "platform": "mac-sequoia",
-      "configuration": "release", "runTests": "true",
+      "name": "JSC-Tests-O3-Debug-arm64-EWS", "shortname": "jsc-debug-arm64", "icon": "buildAndTest",
+      "factory": "JSCBuildO3AndTestsFactory", "platform": "mac-sequoia",
+      "configuration": "debug", "runTests": "true",
       "workernames": ["ews136", "ews137", "ews265", "ews266"]
     },
     {
@@ -522,7 +522,7 @@
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
             "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-26-Build-EWS", "iOS-26-Simulator-Build-EWS",
-            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
+            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-O3-Debug-arm64-EWS",
             "macOS-Tahoe-Debug-Build-EWS", "macOS-Sequoia-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
             "Services-EWS", "Style-EWS", "tvOS-26-Build-EWS", "tvOS-26-Simulator-Build-EWS", "visionOS-26-Build-EWS", "visionOS-26-Simulator-Build-EWS",
             "watchOS-26-Build-EWS", "watchOS-26-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "PlayStation-Build-EWS", "Win-Build-EWS",
@@ -537,7 +537,7 @@
       "type": "AnyBranchScheduler", "name": "pull_request",
       "builderNames": [
             "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-26-Build-EWS", "iOS-26-Simulator-Build-EWS",
-            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
+            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-O3-Debug-arm64-EWS",
             "macOS-Tahoe-Debug-Build-EWS", "macOS-Sequoia-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
             "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-26-Build-EWS", "tvOS-26-Simulator-Build-EWS", "visionOS-26-Build-EWS", "visionOS-26-Simulator-Build-EWS",
             "watchOS-26-Build-EWS", "watchOS-26-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "PlayStation-Build-EWS", "Win-Build-EWS",

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -206,6 +206,16 @@ class JSCBuildAndTestsFactory(Factory):
             self.addStep(RunJavaScriptCoreTests())
 
 
+class JSCBuildO3AndTestsFactory(Factory):
+    def __init__(self, platform, configuration='debug', architectures=None, remotes=None, additionalArguments=None, runTests='true', **kwargs):
+        Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, remotes=remotes, additionalArguments=additionalArguments, checkRelevance=True)
+        self.addStep(KillOldProcesses())
+        self.addStep(ValidateChange(addURLs=False))
+        self.addStep(SetO3OptimizationLevel())
+        self.addStep(CompileJSC(skipUpload=True))
+        self.addStep(RunJavaScriptCoreTests())
+
+
 class JSCTestsFactory(Factory):
     def __init__(self, platform, configuration='release', architectures=None, remotes=None, additionalArguments=None, **kwargs):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, remotes=remotes, additionalArguments=additionalArguments, checkRelevance=True)

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -596,7 +596,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'layout-tests',
             'set-build-summary'
         ],
-        'JSC-Tests-arm64-EWS': [
+        'JSC-Tests-O3-Debug-arm64-EWS': [
             'configure-build',
             'check-change-relevance',
             'validate-change',
@@ -612,6 +612,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-pull-request',
             'kill-old-processes',
             'validate-change',
+            'set-o3-optimization-level',
             'compile-jsc',
             'jscore-test'
         ],

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from twisted.internet import defer
 
 from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQueueFactory, Factory, GTKBuildFactory,
-                        GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
+                        GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCBuildO3AndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoLibWebRTCBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
                         macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, watchOSBuildFactory)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -45,7 +45,7 @@ import socket
 import sys
 import time
 
-from Shared.steps import ShellMixin, SetBuildSummary
+from Shared.steps import ShellMixin, SetBuildSummary, SetO3OptimizationLevel
 
 if sys.version_info < (3, 9):  # noqa: UP036
     print('ERROR: Minimum supported Python version for this code is Python 3.9')
@@ -3826,6 +3826,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
                 RevertAppliedChanges(),
                 CleanWorkingDirectory(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
+                SetO3OptimizationLevel(),
                 CompileJSCWithoutChange(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
                 KillOldProcesses(),


### PR DESCRIPTION
#### f19f9cb181c1bc9961f995da9b342c216300b8d3
<pre>
[ews-build.webkit.org] Switch macOS JSC arm64 stress test queue to O3 debug builds
<a href="https://rdar.apple.com/159975164">rdar://159975164</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303943">https://bugs.webkit.org/show_bug.cgi?id=303943</a>

Reviewed by Keith Miller.

This adds an assert-enabled JSC stress test configuration to pre-commit testing so that regressions
can be caught before landing. This configuration has been running successfully in post-commit
for the past few weeks.

Switching to O3 debug builds adds ~20 minutes to test runtime on our existing arm64 EWS hardware
(51m vs. 31m on release builds). The x86 configuration will not change at this time.

* Tools/CISupport/Shared/steps.py:
(SetO3OptimizationLevel): Move this step to share it between ews-build and build.webkit.og
* Tools/CISupport/build-webkit-org/steps.py:
(SetO3OptimizationLevel): Deleted.
* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS): Update queue name to reflect the configuration change.
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble): Ditto.
* Tools/CISupport/ews-build/config.json: Ditto.
* Tools/CISupport/ews-build/factories.py:
(JSCBuildO3AndTestsFactory): Add a new factory that includes the step to set the O3 optimization level.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps): Update unit tests.
* Tools/CISupport/ews-build/loadConfig.py: Import the SetO3OptimizationLevel step.
* Tools/CISupport/ews-build/steps.py: Ditto.
(RunJavaScriptCoreTests.evaluateCommand): Run the SetO3OptimizationLevel step before re-building
without the PR.

Canonical link: <a href="https://commits.webkit.org/305715@main">https://commits.webkit.org/305715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f82164759fbdd91242fa0ae08a210d23e9b4762c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11477 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147231 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11628 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106483 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/9201 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/87351 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8754 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6530 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7523 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118203 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150010 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11162 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114873 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/138529 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/11175 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9441 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/115185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11204 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10940 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11143 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/10992 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->