### PR TITLE
Media element volume changing from 0 to >0 does not activate audio session

### DIFF
--- a/LayoutTests/media/volume-activate-audio-session-expected.txt
+++ b/LayoutTests/media/volume-activate-audio-session-expected.txt
@@ -1,0 +1,10 @@
+
+EXPECTED (internals.audioSessionActive() == 'false') OK
+RUN(video.volume = 0)
+RUN(video.src = findMediaFile("audio", "content/silence"))
+RUN(video.play())
+EXPECTED (internals.audioSessionActive() == 'false') OK
+RUN(video.volume = 1)
+EXPECTED (internals.audioSessionActive() == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/volume-activate-audio-session.html
+++ b/LayoutTests/media/volume-activate-audio-session.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>volume-active-audio-session</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    async function runTest() {
+        testExpected('internals.audioSessionActive()', false);
+        findMediaElement();
+        run('video.volume = 0');
+        run('video.src = findMediaFile("audio", "content/silence")');
+        await run('video.play()');
+        testExpected('internals.audioSessionActive()', false);
+        run('video.volume = 1');
+        await testExpectedEventually('internals.audioSessionActive()', true, '==', 1000);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+</head>
+<body>
+    <video controls playsinline loop></video>
+</body>
+</html>

--- a/LayoutTests/media/volume-sleep-disable-expected.txt
+++ b/LayoutTests/media/volume-sleep-disable-expected.txt
@@ -1,0 +1,9 @@
+
+RUN(video.volume = 0)
+RUN(video.src = findMediaFile("video", "content/test-25fps"))
+RUN(video.play())
+EXPECTED (internals.elementIsBlockingDisplaySleep(video) == 'false') OK
+RUN(video.volume = 1)
+EXPECTED (internals.elementIsBlockingDisplaySleep(video) == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/volume-sleep-disable.html
+++ b/LayoutTests/media/volume-sleep-disable.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>volume-active-audio-session</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    async function runTest() {
+        findMediaElement();
+        run('video.volume = 0');
+        run('video.src = findMediaFile("video", "content/test-25fps")');
+        await run('video.play()');
+        testExpected('internals.elementIsBlockingDisplaySleep(video)', false);
+        run('video.volume = 1');
+        await testExpectedEventually('internals.elementIsBlockingDisplaySleep(video)', true, '==', 1000);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+</head>
+<body>
+    <video controls playsinline></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4850,6 +4850,9 @@ webkit.org/b/303863 imported/w3c/web-platform-tests/css/css-view-transitions/tra
 webkit.org/b/303865 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-fixedpos-003.html [ Pass ImageOnlyFailure ]
 webkit.org/b/303873 imported/w3c/web-platform-tests/trusted-types/navigate-to-javascript-url-csp-headers.html [ Pass Failure ]
 
+# No USE(AUDIO_SESSION) support:
+media/volume-activate-audio-session.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios/media/volume-activate-audio-session-expected.txt
+++ b/LayoutTests/platform/ios/media/volume-activate-audio-session-expected.txt
@@ -1,0 +1,10 @@
+
+EXPECTED (internals.audioSessionActive() == 'false') OK
+RUN(video.volume = 0)
+RUN(video.src = findMediaFile("audio", "content/silence"))
+RUN(video.play())
+EXPECTED (internals.audioSessionActive() == 'false'), OBSERVED 'true' FAIL
+RUN(video.volume = 1)
+EXPECTED (internals.audioSessionActive() == 'true') OK
+END OF TEST
+

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1174,6 +1174,7 @@ private:
     bool limitedMatroskaSupportEnabled() const;
 
     void maybeUpdatePlayerPreload() const;
+    void canProduceAudioChanged();
 
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;


### PR DESCRIPTION
#### 93a7e4a2234f0f41af7522f9fd4a833e9c8d7949
<pre>
Media element volume changing from 0 to &gt;0 does not activate audio session
<a href="https://rdar.apple.com/161691743">rdar://161691743</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303946">https://bugs.webkit.org/show_bug.cgi?id=303946</a>

Reviewed by Andy Estes.

Changing the volume of a media element does not trigger a call to the
PlatformMediaSession&apos;s canProduceAudioChanged() method. Because all call sites
that update canProduceAudioChanged() should also update the sleep disabler,
make a new private convenience method on HTMLMediaElement that does both.

Tests: media/volume-activate-audio-session.html
       media/volume-sleep-disable.html

* LayoutTests/media/volume-activate-audio-session-expected.txt: Added.
* LayoutTests/media/volume-activate-audio-session.html: Added.
* LayoutTests/media/volume-sleep-disable-expected.txt: Added.
* LayoutTests/media/volume-sleep-disable.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didFinishInsertingNode):
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::setVolume):
(WebCore::HTMLMediaElement::setMutedInternal):
(WebCore::HTMLMediaElement::checkForAudioAndVideo):
(WebCore::HTMLMediaElement::setIsPlayingToWirelessTarget):
(WebCore::HTMLMediaElement::canProduceAudioChanged):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/304297@main">https://commits.webkit.org/304297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88638a4af025c8ae330af9b79c50698acfc41db1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86941 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84127 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3226 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3250 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145354 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111648 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112013 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28425 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5455 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117418 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7279 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35564 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7256 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->