### PR TITLE
[Gardening]: NEW TEST(304070@main): [iOS] 2x TestWebKitAPI.CaptionPreferenceTests are failing/timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -513,7 +513,8 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenuHighlight)
 }
 #endif
 
-#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
+// FIXME: Re-enable this test for iOS when rdar://166158601 is resolved.
+#if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && !PLATFORM(IOS)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenuSelect)
 {
     MediaAccessibilityShim shim;
@@ -648,7 +649,12 @@ TEST_F(CaptionPreferenceTests, MenuAncestryCheck)
     EXPECT_TRUE([controller hasAncestor:parentMenu.get()]);
 }
 
+// FIXME: Re-enable this test for iOS when rdar://166158601 is resolved.
+#if PLATFORM(IOS)
+TEST_F(CaptionPreferenceTests, DISABLED_MenuItemChangesAfterSelection)
+#else
 TEST_F(CaptionPreferenceTests, MenuItemChangesAfterSelection)
+#endif
 {
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
@@ -673,8 +679,9 @@ TEST_F(CaptionPreferenceTests, MenuItemChangesAfterSelection)
     });
 }
 
+// FIXME: Re-enable this test for iOS when rdar://166158601 is resolved.
 #if PLATFORM(IOS_FAMILY)
-TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenSelected)
+TEST_F(CaptionPreferenceTests, DISABLED_ReceievedDidOpenWhenSelected)
 {
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;


### PR DESCRIPTION
#### 0f710ac19901fed4a97210e828d7f58f5b5bc023
<pre>
[Gardening]: NEW TEST(304070@main): [iOS] 2x TestWebKitAPI.CaptionPreferenceTests are failing/timeout
<a href="https://rdar.apple.com/166158601">rdar://166158601</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303858">https://bugs.webkit.org/show_bug.cgi?id=303858</a>

Reviewed by Ryan Haddad.

Skipping the tests till they are fixed.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenSelected)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, DISABLED_ReceievedDidOpenWhenSelected)):
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, MenuItemChangesAfterSelection)): Deleted.

Canonical link: <a href="https://commits.webkit.org/304368@main">https://commits.webkit.org/304368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74015c477168c31b93d48fddd0769fc1112a0ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86986 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103334 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70561 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84193 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3281 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7296 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111753 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7340 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6113 "Found 1 new test failure: inspector/unit-tests/iterableweakset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112075 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5520 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7350 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35632 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->