### PR TITLE
[WebXR Hit Test] Distinguish gripSpace of an input source to targetRaySpace

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - no move - webgl2
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - no results - webgl2
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl
+PASS Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_math_utils.js"></script>
+<script src="../resources/webxr_test_asserts.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+<script src="../resources/webxr_test_constants_fake_world.js"></script>
+
+<script>
+
+// 1m above world origin.
+const VIEWER_ORIGIN_TRANSFORM = {
+  position: [0, 1, 0],
+  orientation: [0, 0, 0, 1],
+};
+
+// 0.25m above world origin.
+const FLOOR_ORIGIN_TRANSFORM = {
+  position: [0, -0.25, 0],
+  orientation: [0, 0, 0, 1],
+};
+
+const SCREEN_POINTER_TRANSFORM = {
+  position: [1, 1, 0],
+  orientation: [0, 0, 0, 1],
+};
+
+const GRIP_TRANSFORM = {
+  position: [0, 1, 0],
+  orientation: [0, 0, 0, 1],
+};
+
+const screen_controller_init = {
+    handedness: "none",
+    targetRayMode: "screen",
+    pointerOrigin: SCREEN_POINTER_TRANSFORM,
+    gripOrigin: GRIP_TRANSFORM,
+    profiles: ["generic-touchscreen"]
+};
+
+const fakeDeviceInitParams = {
+  supportedModes: ["immersive-ar"],
+  views: VALID_VIEWS,
+  floorOrigin: FLOOR_ORIGIN_TRANSFORM,
+  viewerOrigin: VIEWER_ORIGIN_TRANSFORM,
+  supportedFeatures: ALL_FEATURES,
+  world: createFakeWorld(5.0, 2.0, 5.0),  // see webxr_test_constants_fake_world.js for details
+};
+
+// Generates a test function given the parameters for the hit test.
+// |ray| - ray that will be used to subscribe to hit test.
+// |expectedPoses| - array of expected pose objects. The poses should be expressed in local space.
+//                   Null entries in the array mean that the given entry will not be validated.
+// |gripTransform| - grip transform that will be used as the input source's
+//                   gripTransform (aka grip origin) in subsequent rAF.
+// |nextFrameExpectedPoses| - array of expected pose objects. The poses should be expressed in local space.
+//                            Null entries in the array mean that the given entry will not be validated.
+let testFunctionGenerator = function(ray, expectedPoses, gripTransform, nextFrameExpectedPoses) {
+  const testFunction = function(session, fakeDeviceController, t) {
+    return session.requestReferenceSpace('local').then((localRefSpace) => new Promise((resolve, reject) => {
+
+      const input_source_controller = fakeDeviceController.simulateInputSourceConnection(screen_controller_init);
+
+      requestSkipAnimationFrame(session, (time, frame) => {
+        t.step(() => {
+          assert_equals(session.inputSources.length, 1);
+        });
+
+        const input_source = session.inputSources[0];
+        const hitTestOptionsInit = {
+          space: input_source.gripSpace,
+          offsetRay: ray,
+        };
+
+        session.requestHitTestSource(hitTestOptionsInit).then((hitTestSource) => {
+          t.step(() => {
+            assert_not_equals(hitTestSource, null);
+          });
+
+          // We got a hit test source, now get the results in subsequent rAFcb:
+          session.requestAnimationFrame((time, frame) => {
+            const results = frame.getHitTestResults(hitTestSource);
+
+            t.step(() => {
+              assert_equals(results.length, expectedPoses.length);
+              for(const [index, expectedPose] of expectedPoses.entries()) {
+                const pose = results[index].getPose(localRefSpace);
+                assert_true(pose != null, "Each hit test result should have a pose in local space");
+                if(expectedPose != null) {
+                  assert_transform_approx_equals(pose.transform, expectedPose, FLOAT_EPSILON, "before-move-pose: ");
+                }
+              }
+            });
+
+            input_source_controller.setGripOrigin(gripTransform, false);
+
+            session.requestAnimationFrame((time, frame) => {
+              const results = frame.getHitTestResults(hitTestSource);
+
+              t.step(() => {
+                assert_equals(results.length, nextFrameExpectedPoses.length);
+                for(const [index, expectedPose] of nextFrameExpectedPoses.entries()) {
+                  const pose = results[index].getPose(localRefSpace);
+                  assert_true(pose != null, "Each hit test result should have a pose in local space");
+                  if(expectedPose != null) {
+                    assert_transform_approx_equals(pose.transform, expectedPose, FLOAT_EPSILON, "after-move-pose: ");
+                  }
+                }
+              });
+
+              resolve();
+            });
+          });
+        });
+      });
+    }));
+  };
+
+  return testFunction;
+};
+
+
+// Pose of the first expected hit test result - straight ahead of the input source, viewer-facing.
+const pose_1 = {
+  position: {x: 0.0, y: 1.0, z: -2.5, w: 1.0},
+  orientation: {x: 0.0, y: -0.707, z: -0.707, w: 0.0},
+    // Hit test API will set Y axis to the surface normal at the intersection point,
+    // Z axis towards the ray origin and X axis to cross product of Y axis & Z axis.
+    // If the surface normal and Z axis would be parallel, the hit test API
+    // will attempt to use `up` vector ([0, 1, 0]) as the Z axis, and if it so happens that Z axis
+    // and the surface normal would still be parallel, it will use the `right` vector ([1, 0, 0]) as the Z axis.
+    // In this particular case, `up` vector will work so the resulting pose.orientation
+    // becomes a rotation around [0, 1, 1] vector by 180 degrees.
+};
+
+xr_session_promise_test("Ensures subscription to hit test works with an XRSpace from input source - no move",
+  testFunctionGenerator(new XRRay(), [pose_1], GRIP_TRANSFORM, [pose_1]),
+  fakeDeviceInitParams,
+  'immersive-ar', { 'requiredFeatures': ['hit-test'] });
+
+const moved_grip_transform_1 = {
+  position: [0, 1, 0],
+  orientation: [ 0.707, 0, 0, 0.707 ] // 90 degrees around X axis = facing up
+};
+
+xr_session_promise_test("Ensures subscription to hit test works with an XRSpace from input source - after move - no results",
+  testFunctionGenerator(new XRRay(), [pose_1], moved_grip_transform_1, []),
+  fakeDeviceInitParams,
+  'immersive-ar', { 'requiredFeatures': ['hit-test'] });
+
+const pose_2 = {
+  position: {x: -1.443, y: 1.0, z: -2.5, w: 1.0},
+    // Intersection point will be on the same height as the viewer, on the front
+    // wall. Distance from the front wall to viewer is 2.5m, and we are rotating
+    // to the left, so X coordinate of the intersection point will be negative
+    // & equal to -2.5 * tan(30 deg) ~= 1.443m.
+  orientation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5 },
+    // See comment for pose_1.orientation for details.
+    // In this case, the hit test pose will have Y axis facing towards world's
+    // positive Z axis ([0,0,1]), Z axis to the right ([1,0,0]) and X axis
+    // towards world's Y axis ([0,1,0]).
+    // This is equivalent to the rotation around [1, 1, 1] vector by 120 degrees.
+};
+
+const moved_grip_transform_2 = {
+  position: [0, 1, 0],
+  orientation: [ 0, 0.2588, 0, 0.9659 ] // 30 degrees around Y axis = to the left,
+                                        // creating 30-60-90 triangle with the front wall
+};
+
+xr_session_promise_test("Ensures subscription to hit test works with an XRSpace from input source - after move - 1 result",
+  testFunctionGenerator(new XRRay(), [pose_1], moved_grip_transform_2, [pose_2]),
+  fakeDeviceInitParams,
+  'immersive-ar', { 'requiredFeatures': ['hit-test'] });
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -79,8 +79,12 @@ void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::Inp
     if (auto gripOrigin = source.gripOrigin) {
         if (m_gripSpace)
             m_gripSpace->setPose(*gripOrigin);
-        else if (RefPtr document = downcast<Document>(session->scriptExecutionContext()))
+        else if (RefPtr document = downcast<Document>(session->scriptExecutionContext())) {
             m_gripSpace = WebXRInputSpace::create(*document, *session, *gripOrigin, handle());
+#if ENABLE(WEBXR_HIT_TEST)
+            m_gripSpace->setType(PlatformXR::InputSourceSpaceType::Grip);
+#endif
+        }
     } else
         m_gripSpace = nullptr;
 #if ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
@@ -62,7 +62,7 @@ std::optional<TransformationMatrix> WebXRInputSpace::nativeOrigin() const
 #if ENABLE(WEBXR_HIT_TEST)
 std::optional<PlatformXR::NativeOriginInformation> WebXRInputSpace::nativeOriginInformation() const
 {
-    return { PlatformXR::InputSourceSpaceInfo { m_handle, PlatformXR::InputSourceSpaceType::TargetRay } };
+    return { PlatformXR::InputSourceSpaceInfo { m_handle, m_type } };
 }
 #endif
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.h
@@ -48,6 +48,10 @@ public:
     std::optional<bool> isPositionEmulated() const final { return m_pose.isPositionEmulated; }
     void setPose(const PlatformXR::FrameData::InputSourcePose& pose) { m_pose = pose; }
 
+#if ENABLE(WEBXR_HIT_TEST)
+    void setType(PlatformXR::InputSourceSpaceType type) { m_type = type; }
+#endif
+
 private:
     WebXRInputSpace(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&, PlatformXR::InputSourceHandle);
     WebXRSession* session() const final { return m_session.get(); }
@@ -62,6 +66,9 @@ private:
     WeakPtr<WebXRSession> m_session;
     PlatformXR::FrameData::InputSourcePose m_pose;
     [[maybe_unused]] PlatformXR::InputSourceHandle m_handle;
+#if ENABLE(WEBXR_HIT_TEST)
+    PlatformXR::InputSourceSpaceType m_type { PlatformXR::InputSourceSpaceType::TargetRay };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -215,7 +215,10 @@ void SimulatedXRDevice::frameTimerFired()
             auto i = data.inputSources.findIf([&](auto& item) { return item.handle == inputSource.handle; });
             if (i == notFound)
                 return;
-            origin = data.inputSources[i].pointerOrigin.pose;
+            if (inputSource.type == PlatformXR::InputSourceSpaceType::TargetRay)
+                origin = data.inputSources[i].pointerOrigin.pose;
+            else
+                origin = data.inputSources[i].gripOrigin.value_or(PlatformXR::FrameData::InputSourcePose { }).pose;
         });
         if (!origin)
             continue;


### PR DESCRIPTION
#### 1802b55bf3640881f6b75e29e39ffcd6596f0f52
<pre>
[WebXR Hit Test] Distinguish gripSpace of an input source to targetRaySpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=303954">https://bugs.webkit.org/show_bug.cgi?id=303954</a>

Reviewed by Sergio Villar Senin.

WebXRInputSpace method nativeOriginInformation() always returned
PlatformXR::InputSourceSpaceType::TargetRay even for gripSpace. It should
return PlatformXR::InputSourceSpaceType::Grip for it.

Test: imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_inputSources_gripSpace.https.html: Added.
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::update):
* Source/WebCore/Modules/webxr/WebXRInputSpace.cpp:
(WebCore::WebXRInputSpace::nativeOriginInformation const):
* Source/WebCore/Modules/webxr/WebXRInputSpace.h:
(WebCore::WebXRInputSpace::setType):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):

Canonical link: <a href="https://commits.webkit.org/305117@main">https://commits.webkit.org/305117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099e4f1b35b0198b5daa5a17be2f9b5feea50f04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105129 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7815 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123212 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicy (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85986 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5168 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147987 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113852 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7371 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64152 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21183 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37504 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73131 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->