### PR TITLE
Remove unused defaultMenu instance variable from WebDefaultUIDelegate

### DIFF
--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -6,7 +6,6 @@ WebCoreSupport/WebCryptoClient.h
 [ iOS ] ios/WebView/WebPDFViewIOS.mm
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.h
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
-[ Mac ] mac/DefaultDelegates/WebDefaultUIDelegate.h
 mac/History/BackForwardList.h
 mac/History/WebBackForwardList.h
 mac/History/WebHistory.h

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.h
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.h
@@ -29,10 +29,5 @@
 #import "WebUIDelegate.h"
 
 @interface WebDefaultUIDelegate : NSObject <WebUIDelegate>
-{
-#if PLATFORM(MAC)
-    IBOutlet NSMenu *defaultMenu;
-#endif
-}
 + (WebDefaultUIDelegate *)sharedUIDelegate;
 @end


### PR DESCRIPTION
#### 4aff456197e4bd5aed5ad99bc71604147341e7aa
<pre>
Remove unused defaultMenu instance variable from WebDefaultUIDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=303957">https://bugs.webkit.org/show_bug.cgi?id=303957</a>

Reviewed by Wenson Hsieh and Timothy Hatcher.

Deleted the unused ivar from WebDefaultUIDelegate.

* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.h:

Canonical link: <a href="https://commits.webkit.org/304373@main">https://commits.webkit.org/304373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8180cddbd57e3637e867ce9f7437a4806a192f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86920 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70477 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84103 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3205 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3216 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145320 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7193 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111620 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111987 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5427 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61118 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20879 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35539 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->