### PR TITLE
[Temporal] Implement `with` method for PlainYearMonth

### DIFF
--- a/JSTests/stress/temporal-plainyearmonth.js
+++ b/JSTests/stress/temporal-plainyearmonth.js
@@ -107,3 +107,15 @@ shouldBe(Temporal.PlainYearMonth.prototype.valueOf.length, 0);
     let sorted = [one, two, three, four].sort(Temporal.PlainYearMonth.compare);
     shouldBe(sorted.join(' '), `1000-02 1001-01 1002-01 1003-03`);
 }
+
+shouldBe(Temporal.PlainYearMonth.prototype.with.length, 1);
+{
+    shouldBe(yearMonth.with({ year: 2025, month: 4, day: 5 }).toString(), '2025-04');
+    shouldBe(yearMonth.with({ year: 2025, month: 3 }).toString(), '2025-03');
+    shouldBe(yearMonth.with({ month: 3 }).toString(), '2025-03');
+    shouldBe(yearMonth.with({ year: 2024 }).toString(), '2024-04');
+    shouldThrow(() => yearMonth.with({ day: 5 }), TypeError);
+
+    shouldBe(yearMonth.with({ month: 13 }).toString(), '2025-12');
+    shouldThrow(() => { yearMonth.with({ month: 13 }, { overflow: 'reject' }); }, RangeError);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -316,27 +316,6 @@ skip:
     - test/built-ins/Temporal/PlainYearMonth/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js
     - test/built-ins/Temporal/PlainYearMonth/prototype/until/throws-if-year-outside-valid-iso-range.js
     - test/built-ins/Temporal/PlainYearMonth/prototype/until/year-zero.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-calendar-field.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-missing-fields.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/argument-timezone-field.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/basic.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/branding.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/builtin.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/copy-properties-not-undefined.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/infinity-throws-rangeerror.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/length.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/name.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/not-a-constructor.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-object.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-read-before-algorithmic-validation.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-undefined.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/options-wrong-type.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-invalid-string.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-undefined.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/overflow-wrong-type.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/prop-desc.js
-    - test/built-ins/Temporal/PlainYearMonth/prototype/with/subclassing-ignored.js
 
     # Depends on Temporal.Duration relativeTo option
     - test/built-ins/Temporal/Duration/compare/basic.js

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -351,6 +351,15 @@ ISO8601::PlainDate TemporalCalendar::isoDateFromFields(JSGlobalObject* globalObj
     return plainDate;
 }
 
+
+// https://tc39.es/proposal-temporal/#sec-temporal-calendaryearmonthfromfields
+ISO8601::PlainDate TemporalCalendar::yearMonthFromFields(JSGlobalObject* globalObject, int32_t year, int32_t month, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
+{
+    // 2. Let firstDayIndex be the 1-based index of the first day of the month described by fields
+    // (i.e., 1 unless the month's first day is skipped by this calendar.)
+    return isoDateFromFields(globalObject, TemporalDateFormat::YearMonth, year, month, 1, monthCode, overflow);
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdayfromfields
 ISO8601::PlainDate TemporalCalendar::monthDayFromFields(JSGlobalObject* globalObject, std::optional<int32_t> referenceYear, unsigned month, unsigned day, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -54,6 +54,7 @@ public:
     static ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, JSObject*, TemporalDateFormat, Variant<JSObject*, TemporalOverflow>, TemporalOverflow&);
     static ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, TemporalDateFormat, int32_t, unsigned, unsigned, std::optional<ParsedMonthCode>, TemporalOverflow);
     static ISO8601::PlainDate monthDayFromFields(JSGlobalObject*, std::optional<int32_t>, unsigned, unsigned, std::optional<ParsedMonthCode>, TemporalOverflow);
+    static ISO8601::PlainDate yearMonthFromFields(JSGlobalObject*, int32_t, int32_t, std::optional<ParsedMonthCode>, TemporalOverflow);
     static ISO8601::PlainDate addDurationToDate(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
     static ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
     static ISO8601::Duration isoDateDifference(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -350,6 +350,47 @@ std::optional<int32_t> TemporalPlainDate::toYear(JSGlobalObject* globalObject, J
     return year;
 }
 
+std::tuple<std::optional<int32_t>, std::optional<ParsedMonthCode>, std::optional<int32_t>>
+TemporalPlainDate::toYearMonth(JSGlobalObject* globalObject, JSObject* temporalDateLike)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    std::optional<int32_t> month;
+    JSValue monthProperty = temporalDateLike->get(globalObject, vm.propertyNames->month);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!monthProperty.isUndefined()) {
+        double doubleMonth = monthProperty.toIntegerOrInfinity(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (!std::isfinite(doubleMonth)) [[unlikely]] {
+            throwRangeError(globalObject, scope, "month property must be finite"_s);
+            return { };
+        }
+
+        if (!isInBounds<int32_t>(doubleMonth)) [[unlikely]] {
+            // Later checks will report error
+            month = ISO8601::outOfRangeYear;
+        } else
+            month = static_cast<int32_t>(doubleMonth);
+    }
+
+    std::optional<ParsedMonthCode> monthCode;
+    JSValue monthCodeProperty = temporalDateLike->get(globalObject, vm.propertyNames->monthCode);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!monthCodeProperty.isUndefined()) {
+        auto monthCodeString = monthCodeProperty.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        monthCode = ISO8601::parseMonthCode(monthCodeString);
+    }
+
+    scope.release();
+    auto year = toYear(globalObject, temporalDateLike);
+
+    return { month, monthCode, year };
+}
+
 ISO8601::PlainDate TemporalPlainDate::with(JSGlobalObject* globalObject, JSObject* temporalDateLike, JSValue optionsValue)
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -52,6 +52,7 @@ public:
     static std::tuple<int32_t, unsigned, unsigned, std::optional<ParsedMonthCode>, TemporalOverflow, TemporalAnyProperties>
     mergeDateFields(JSGlobalObject*, JSObject*, JSValue, int32_t, unsigned, unsigned);
     static std::optional<int32_t> toYear(JSGlobalObject*, JSObject*);
+    std::tuple<std::optional<int32_t>, std::optional<ParsedMonthCode>, std::optional<int32_t>> static toYearMonth(JSGlobalObject*, JSObject*);
     static TemporalPlainDate* from(JSGlobalObject*, JSValue, Variant<JSObject*, TemporalOverflow>);
 
     TemporalCalendar* calendar() { return m_calendar.get(this); }

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -58,6 +58,8 @@ public:
     JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(JSC_DEFINE_TEMPORAL_PLAIN_YEAR_MONTH_FIELD);
 #undef JSC_DEFINE_TEMPORAL_PLAIN_YEAR_MONTH_FIELD
 
+    ISO8601::PlainDate with(JSGlobalObject*, JSObject*, JSValue);
+
     String monthCode() const;
 
     String toString(JSGlobalObject*, JSValue options) const;

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -41,6 +41,7 @@ namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToString);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToJSON);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToLocaleString);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncWith);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncEquals);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncValueOf);
 static JSC_DECLARE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterCalendarId);
@@ -65,6 +66,7 @@ const ClassInfo TemporalPlainYearMonthPrototype::s_info = { "Temporal.PlainYearM
   toString         temporalPlainYearMonthPrototypeFuncToString           DontEnum|Function 0
   toJSON           temporalPlainYearMonthPrototypeFuncToJSON             DontEnum|Function 0
   toLocaleString   temporalPlainYearMonthPrototypeFuncToLocaleString     DontEnum|Function 0
+  with             temporalPlainYearMonthPrototypeFuncWith               DontEnum|Function 1
   equals           temporalPlainYearMonthPrototypeFuncEquals             DontEnum|Function 1
   valueOf          temporalPlainYearMonthPrototypeFuncValueOf            DontEnum|Function 0
   calendarId       temporalPlainYearMonthPrototypeGetterCalendarId       DontEnum|ReadOnly|CustomAccessor
@@ -113,6 +115,26 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToString, (JSGlobalO
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toString called on value that's not a PlainYearMonth"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, yearMonth->toString(globalObject, callFrame->argument(0)))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with
+JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncWith, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    if (!yearMonth) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.with called on value that's not a PlainYearMonth"_s);
+
+    JSValue temporalYearMonthLike  = callFrame->argument(0);
+    if (!temporalYearMonthLike.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "First argument to Temporal.PlainYearMonth.prototype.with must be an object"_s);
+
+    auto result = yearMonth->with(globalObject, asObject(temporalYearMonthLike), callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), WTFMove(result))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals


### PR DESCRIPTION
#### 8d66333163ffb469c2e46efa78446d2bab051c5c
<pre>
[Temporal] Implement `with` method for PlainYearMonth
<a href="https://bugs.webkit.org/show_bug.cgi?id=303899">https://bugs.webkit.org/show_bug.cgi?id=303899</a>

Reviewed by Yusuke Suzuki.

Implement this method.

Co-authored-by: SUZUKI Sosuke &lt;aosukeke@gmail.com&gt;

* JSTests/stress/temporal-plainyearmonth.js:
(shouldBe):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::TemporalCalendar::yearMonthFromFields):
* Source/JavaScriptCore/runtime/TemporalCalendar.h:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::toYearMonth):
* Source/JavaScriptCore/runtime/TemporalPlainDate.h:
* Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp:
(JSC::TemporalPlainYearMonth::with):
* Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h:
* Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/304293@main">https://commits.webkit.org/304293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d92d8a463ddb30f085c46892c89fa71d6b6b2600

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86911 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3196 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3200 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127116 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145304 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133593 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111609 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111974 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5415 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117402 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61109 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35552 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166467 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70792 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->