### PR TITLE
Layout milestone notifications should be dispatched asynchronously

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -55,6 +55,7 @@
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
 #include "DiagnosticLoggingResultType.h"
+#include "DocumentEventLoop.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
@@ -3089,7 +3090,23 @@ void FrameLoader::didReachLayoutMilestone(OptionSet<LayoutMilestone> milestones)
 {
     ASSERT(m_frame->isMainFrame());
 
-    m_client->dispatchDidReachLayoutMilestone(milestones);
+    auto queuedNavigationID = protectedActiveDocumentLoader()->navigationID();
+
+    m_client->willDispatchDidReachLayoutMilestone(milestones);
+
+    RefPtr document = m_frame->document();
+    if (!document)
+        return;
+
+    document->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [this, protectedThis = Ref { *this }, milestones, queuedNavigationID] {
+        RefPtr loader = activeDocumentLoader();
+        if (!loader)
+            return;
+
+        auto taskNavigationID = loader->navigationID();
+        if (taskNavigationID && taskNavigationID == queuedNavigationID)
+            m_client->dispatchDidReachLayoutMilestone(milestones);
+    });
 }
 
 void FrameLoader::didFirstLayout()

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -190,6 +190,7 @@ public:
 #endif
 
     virtual void dispatchDidLayout() { }
+    virtual void willDispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) { }
     virtual void dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) { }
     virtual void dispatchDidReachVisuallyNonEmptyState() { }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -122,6 +122,7 @@ private:
     void dispatchDidFailLoad(const WebCore::ResourceError&) final;
     void dispatchDidFinishDocumentLoad() final;
     void dispatchDidFinishLoad() final;
+    void willDispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>);
     void dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>) final;
 
     WebCore::LocalFrame* dispatchCreatePage(const WebCore::NavigationAction&, WebCore::NewFrameOpenerPolicy) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -782,6 +782,17 @@ void WebFrameLoaderClient::dispatchDidFinishLoad()
     [m_webFrame->_private->internalLoadDelegate webFrame:m_webFrame.get() didFinishLoadWithError:nil];
 }
 
+void WebFrameLoaderClient::willDispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
+{
+#if !PLATFORM(IOS_FAMILY)
+    if (milestones & WebCore::LayoutMilestone::DidFirstLayout) {
+        WebDynamicScrollBarsView *scrollView = [m_webFrame->_private->webFrameView _scrollView];
+        [scrollView setVerticalScrollElasticity:NSScrollElasticityAutomatic];
+        [scrollView setHorizontalScrollElasticity:NSScrollElasticityAutomatic];
+    }
+#endif
+}
+
 void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
 {
     WebView *webView = getWebView(m_webFrame.get());
@@ -809,10 +820,6 @@ void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::La
         WebDynamicScrollBarsView *scrollView = [m_webFrame->_private->webFrameView _scrollView];
         if ([getWebView(m_webFrame.get()) drawsBackground])
             [scrollView setDrawsBackground:YES];
-#if !PLATFORM(IOS_FAMILY)
-        [scrollView setVerticalScrollElasticity:NSScrollElasticityAutomatic];
-        [scrollView setHorizontalScrollElasticity:NSScrollElasticityAutomatic];
-#endif
     }
 
     if (milestones & WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm
@@ -246,16 +246,17 @@ TEST(WebKit, AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize)
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    __block bool didFinishNavigation = false;
+    __block bool didFirstLayout = false;
     didInvalidateIntrinsicContentSize = false;
-    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
-        didFinishNavigation = true;
+    [navigationDelegate setRenderingProgressDidChange:^(WKWebView *, _WKRenderingProgressEvents events) {
+        if (events & _WKRenderingProgressEventFirstLayout)
+            didFirstLayout = true;
     }];
 
     [webView setExpectingIntrinsicContentSizeChange:YES];
     [webView loadHTMLString:@"<body style='margin: 0; height: 400px;'></body>" baseURL:nil];
     TestWebKitAPI::Util::run(&didInvalidateIntrinsicContentSize);
-    TestWebKitAPI::Util::run(&didFinishNavigation);
+    TestWebKitAPI::Util::run(&didFirstLayout);
 
     NSString *script = @"document.body.style.height = '800px';"
         "document.scrollingElement.scrollTop;"


### PR DESCRIPTION
#### bf24e9a12c1769d4eaaec4c8277addfc0f02d180
<pre>
Layout milestone notifications should be dispatched asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=303958">https://bugs.webkit.org/show_bug.cgi?id=303958</a>
<a href="https://rdar.apple.com/153254633">rdar://153254633</a>

Reviewed by Ryosuke Niwa.

When a layout milestone notification fires, the layout may not be completed but client
callbacks to layout milestone notifications can trigger Javascript execution. This results
in javascript execution failing (and consequently crashing) to run during the
layout process because it is correctly not permitted to do so. We delay firing layout
milestone notifications by dispatching them asychronously in order to prevent this.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didReachLayoutMilestone):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::willDispatchDidReachLayoutMilestone):
(WebFrameLoaderClient::dispatchDidReachLayoutMilestone):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm:
(TEST(WebKit, AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize)):

Canonical link: <a href="https://commits.webkit.org/304572@main">https://commits.webkit.org/304572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abde782f70f30407f188a4b0319934f35a45ad3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135956 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143665 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c4b4a3d-a95e-4ecc-8ef4-456b5cdf0e42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84777 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3fdb33ad-d0fb-4c68-b862-a7cc965508d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6198 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4268 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112643 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6113 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118144 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20944 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36219 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->