### PR TITLE
REGRESSION (300377@main): Some CSS cursor values (move, all-scroll, ew-resize, ns-resize) do not display the expected cursors

### DIFF
--- a/Source/WebCore/platform/mac/CursorMac.mm
+++ b/Source/WebCore/platform/mac/CursorMac.mm
@@ -39,148 +39,88 @@
 #import <pal/spi/mac/HIServicesSPI.h>
 #endif
 
-@interface WebCoreCursorBundle : NSObject { }
+#if HAVE(HISERVICES)
+
+@interface WebCustomCursor : NSCursor
+
+- (instancetype)initWithType:(CoreCursorType)cursorType;
+
+@property (nonatomic) CoreCursorType cursorType;
+
 @end
 
-@implementation WebCoreCursorBundle
+@implementation WebCustomCursor
+
+- (instancetype)initWithType:(CoreCursorType)cursorType
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _cursorType = cursorType;
+    return self;
+}
+
+- (NSInteger)_coreCursorType
+{
+    return static_cast<NSInteger>(_cursorType);
+}
+
 @end
+
+#endif
 
 namespace WebCore {
 
 #if HAVE(HISERVICES)
 
-static NSCursor *busyButClickableNSCursor;
-static NSCursor *makeAliasNSCursor;
-static NSCursor *moveNSCursor;
-static NSCursor *resizeEastNSCursor;
-static NSCursor *resizeEastWestNSCursor;
-static NSCursor *resizeNorthNSCursor;
-static NSCursor *resizeNorthSouthNSCursor;
-static NSCursor *resizeNortheastNSCursor;
-static NSCursor *resizeNortheastSouthwestNSCursor;
-static NSCursor *resizeNorthwestNSCursor;
-static NSCursor *resizeNorthwestSoutheastNSCursor;
-static NSCursor *resizeSouthNSCursor;
-static NSCursor *resizeSoutheastNSCursor;
-static NSCursor *resizeSouthwestNSCursor;
-static NSCursor *resizeWestNSCursor;
-
-static NSCursor *cellNSCursor;
-static NSCursor *helpNSCursor;
-static NSCursor *zoomInNSCursor;
-static NSCursor *zoomOutNSCursor;
-
-static NSInteger WKCoreCursor_coreCursorType(id self, SEL)
-{
-    if (self == busyButClickableNSCursor)
-        return kCoreCursorBusyButClickable;
-    if (self == makeAliasNSCursor)
-        return kCoreCursorMakeAlias;
-    if (self == moveNSCursor)
-        return kCoreCursorWindowMove;
-    if (self == resizeEastNSCursor)
-        return kCoreCursorWindowResizeEast;
-    if (self == resizeEastWestNSCursor)
-        return kCoreCursorWindowResizeEastWest;
-    if (self == resizeNorthNSCursor)
-        return kCoreCursorWindowResizeNorth;
-    if (self == resizeNorthSouthNSCursor)
-        return kCoreCursorWindowResizeNorthSouth;
-    if (self == resizeNortheastNSCursor)
-        return kCoreCursorWindowResizeNorthEast;
-    if (self == resizeNortheastSouthwestNSCursor)
-        return kCoreCursorWindowResizeNorthEastSouthWest;
-    if (self == resizeNorthwestNSCursor)
-        return kCoreCursorWindowResizeNorthWest;
-    if (self == resizeNorthwestSoutheastNSCursor)
-        return kCoreCursorWindowResizeNorthWestSouthEast;
-    if (self == resizeSouthNSCursor)
-        return kCoreCursorWindowResizeSouth;
-    if (self == resizeSoutheastNSCursor)
-        return kCoreCursorWindowResizeSouthEast;
-    if (self == resizeSouthwestNSCursor)
-        return kCoreCursorWindowResizeSouthWest;
-    if (self == resizeWestNSCursor)
-        return kCoreCursorWindowResizeWest;
-    if (self == cellNSCursor)
-        return kCoreCursorCell;
-    if (self == helpNSCursor)
-        return kCoreCursorHelp;
-    if (self == zoomInNSCursor)
-        return kCoreCursorZoomIn;
-    if (self == zoomOutNSCursor)
-        return kCoreCursorZoomOut;
-    
-    return NSNotFound;
-}
-
-static Class createCoreCursorClassSingleton()
-{
-    // Class is immortable so no need to ref here.
-    SUPPRESS_UNRETAINED_LOCAL Class coreCursorClass = objc_allocateClassPair([NSCursor class], "WKCoreCursor", 0);
-    SEL coreCursorType = NSSelectorFromString(@"_coreCursorType");
-    class_addMethod(coreCursorClass, coreCursorType, (IMP)WKCoreCursor_coreCursorType, method_getTypeEncoding(class_getInstanceMethod([NSCursor class], coreCursorType)));
-    objc_registerClassPair(coreCursorClass);
-    return coreCursorClass;
-}
-
-static Class coreCursorClassSingleton()
-{
-    // Class is immortable so no need to ref here.
-    SUPPRESS_UNRETAINED_LOCAL Class coreCursorClass = objc_lookUpClass("WKCoreCursor");
-    if (!coreCursorClass)
-        coreCursorClass = createCoreCursorClassSingleton();
-    return coreCursorClass;
-}
-
 static RetainPtr<NSCursor> cursor(ASCIILiteral name)
 {
-    RetainPtr<NSCursor> slot;
-    
-    if (name == "BusyButClickable"_s)
-        slot = busyButClickableNSCursor;
-    else if (name == "MakeAlias"_s)
-        slot = makeAliasNSCursor;
-    else if (name == "Move"_s)
-        slot = moveNSCursor;
-    else if (name == "ResizeEast"_s)
-        slot = resizeEastNSCursor;
-    else if (name == "ResizeEastWest"_s)
-        slot = resizeEastWestNSCursor;
-    else if (name == "ResizeNorth"_s)
-        slot = resizeNorthNSCursor;
-    else if (name == "ResizeNorthSouth"_s)
-        slot = resizeNorthSouthNSCursor;
-    else if (name == "ResizeNortheast"_s)
-        slot = resizeNortheastNSCursor;
-    else if (name == "ResizeNortheastSouthwest"_s)
-        slot = resizeNortheastSouthwestNSCursor;
-    else if (name == "ResizeNorthwest"_s)
-        slot = resizeNorthwestNSCursor;
-    else if (name == "ResizeNorthwestSoutheast"_s)
-        slot = resizeNorthwestSoutheastNSCursor;
-    else if (name == "ResizeSouth"_s)
-        slot = resizeSouthNSCursor;
-    else if (name == "ResizeSoutheast"_s)
-        slot = resizeSoutheastNSCursor;
-    else if (name == "ResizeSouthwest"_s)
-        slot = resizeSouthwestNSCursor;
-    else if (name == "ResizeWest"_s)
-        slot = resizeWestNSCursor;
-    else if (name == "Cell"_s)
-        slot = cellNSCursor;
-    else if (name == "Help"_s)
-        slot = helpNSCursor;
-    else if (name == "ZoomIn"_s)
-        slot = zoomInNSCursor;
-    else if (name == "ZoomOut"_s)
-        slot = zoomOutNSCursor;
-    else
-        return nil;
-    
-    if (!slot)
-        return adoptNS([[coreCursorClassSingleton() alloc] init]);
-    return slot;
+    auto cursorTypeFromName = [](ASCIILiteral name) {
+        if (name == "BusyButClickable"_s)
+            return kCoreCursorBusyButClickable;
+        if (name == "MakeAlias"_s)
+            return kCoreCursorMakeAlias;
+        if (name == "Move"_s)
+            return kCoreCursorWindowMove;
+        if (name == "ResizeEast"_s)
+            return kCoreCursorWindowResizeEast;
+        if (name == "ResizeEastWest"_s)
+            return kCoreCursorWindowResizeEastWest;
+        if (name == "ResizeNorth"_s)
+            return kCoreCursorWindowResizeNorth;
+        if (name == "ResizeNorthSouth"_s)
+            return kCoreCursorWindowResizeNorthSouth;
+        if (name == "ResizeNortheast"_s)
+            return kCoreCursorWindowResizeNorthEast;
+        if (name == "ResizeNortheastSouthwest"_s)
+            return kCoreCursorWindowResizeNorthEastSouthWest;
+        if (name == "ResizeNorthwest"_s)
+            return kCoreCursorWindowResizeNorthWest;
+        if (name == "ResizeNorthwestSoutheast"_s)
+            return kCoreCursorWindowResizeNorthWestSouthEast;
+        if (name == "ResizeSouth"_s)
+            return kCoreCursorWindowResizeSouth;
+        if (name == "ResizeSoutheast"_s)
+            return kCoreCursorWindowResizeSouthEast;
+        if (name == "ResizeSouthwest"_s)
+            return kCoreCursorWindowResizeSouthWest;
+        if (name == "ResizeWest"_s)
+            return kCoreCursorWindowResizeWest;
+        if (name == "Cell"_s)
+            return kCoreCursorCell;
+        if (name == "Help"_s)
+            return kCoreCursorHelp;
+        if (name == "ZoomIn"_s)
+            return kCoreCursorZoomIn;
+        if (name == "ZoomOut"_s)
+            return kCoreCursorZoomOut;
+
+        ASSERT_NOT_REACHED();
+        return kCoreCursorFirstCursor;
+    };
+
+    return adoptNS([[WebCustomCursor alloc] initWithType:cursorTypeFromName(name)]);
 }
 
 #else


### PR DESCRIPTION
#### eb5d9f9dce46beb5496d856bc9185c7ab8148d1f
<pre>
REGRESSION (300377@main): Some CSS cursor values (move, all-scroll, ew-resize, ns-resize) do not display the expected cursors
<a href="https://bugs.webkit.org/show_bug.cgi?id=303845">https://bugs.webkit.org/show_bug.cgi?id=303845</a>
<a href="https://rdar.apple.com/166160746">rdar://166160746</a>

Reviewed by Tim Horton.

300377@main, which was Safer CPP cleanup, broke the assignment to the static NSCursor*, which then caused
`WKCoreCursor_coreCursorType()` to fail.

Fix this confusing code by making an NSCursor subclass, and storing the CoreCursorType inside it; this replaces the old swizzling.

WebCoreCursorBundle was unused, so remove it.

There&apos;s no need to cache the WebCustomCursor at this level; `Cursor` objects are already singletons.

Not testable because an API test can&apos;t warp the cursor without user annoyance.

* Source/WebCore/platform/mac/CursorMac.mm:
(-[WebCustomCursor initWithType:]):
(-[WebCustomCursor _coreCursorType]):
(WebCore::cursor):
(WebCore::WKCoreCursor_coreCursorType): Deleted.
(WebCore::createCoreCursorClassSingleton): Deleted.
(WebCore::coreCursorClassSingleton): Deleted.

Canonical link: <a href="https://commits.webkit.org/304334@main">https://commits.webkit.org/304334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617eced02fddc5bf497ec55a2368a73349ae6ddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86995 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/442d6b22-b68f-4590-bac0-527de72574d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00e1a80a-1bbd-433d-a7cd-786c5ec76928) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a39acf61-67cf-4e20-815d-fd8e42b601ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3289 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3328 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145435 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112088 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5533 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117505 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7359 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35639 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7218 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->