### PR TITLE
REGRESSION (289928@main): Svelte transition fade + transition scale results in flashing

### DIFF
--- a/LayoutTests/webanimations/simultaneous-animations-removed-separately-expected.txt
+++ b/LayoutTests/webanimations/simultaneous-animations-removed-separately-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Simultaneous animations cancelled mid-flight
+

--- a/LayoutTests/webanimations/simultaneous-animations-removed-separately.html
+++ b/LayoutTests/webanimations/simultaneous-animations-removed-separately.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test simultaneous animations removed mid-flight</title>
+<style>
+    #target {
+        position: absolute;
+        top: 100px;
+        left: 100px;
+        width: 100px;
+        height: 100px;
+        background-color: blue;
+    }
+</style>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById('target');
+
+    const fadeAnimation = target.animate(
+        [{opacity: 1}, {opacity: 0}],
+        {duration: 100, fill: 'forwards'}
+    );
+
+    const scaleAnimation = target.animate(
+        [{transform: 'scale(1)'}, {transform: 'scale(0)'}],
+        {duration: 100, fill: 'forwards'}
+    );
+
+    await Promise.all([fadeAnimation.ready, scaleAnimation.ready]);
+    await renderingFrames(1);
+
+    let acceleratedAnimations = internals.acceleratedAnimationsForElement(target);
+    assert_equals(acceleratedAnimations.length, 2, 'Both animations should be accelerated');
+
+    fadeAnimation.cancel();
+    let afterFirstCancel = internals.acceleratedAnimationsForElement(target);
+
+    scaleAnimation.cancel();
+    let afterBothCancel = internals.acceleratedAnimationsForElement(target);
+
+    assert_not_equals(afterFirstCancel.length, afterBothCancel.length,
+        'Both animations should transition separately');
+
+}, 'Simultaneous animations cancelled mid-flight');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -46,6 +46,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "Element.h"
+#include "EventLoop.h"
 #include "EventTargetInlines.h"
 #include "FontCascade.h"
 #include "GeometryUtilities.h"
@@ -2238,6 +2239,37 @@ void KeyframeEffect::wasAddedToEffectStack()
 void KeyframeEffect::wasRemovedFromEffectStack()
 {
     m_inTargetEffectStack = false;
+
+    if (!canBeAccelerated())
+        return;
+
+#if ENABLE(THREADED_ANIMATIONS)
+    if (canHaveAcceleratedRepresentation())
+        return;
+#endif
+
+    // If the effect was running accelerated, we need to mark it for removal straight away
+    // since it will not be invalidated by a future call to KeyframeEffectStack::applyPendingAcceleratedActions().
+    ASSERT(animation());
+    if (isRunningAccelerated() || isAboutToRunAccelerated()) {
+        Ref animation = *this->animation();
+        bool isFinishingNaturally = animation->hasPendingFinishNotification() || animation->playState() == WebAnimation::PlayState::Finished;
+
+        m_pendingAcceleratedActions.clear();
+        m_pendingAcceleratedActions.append(AcceleratedAction::Stop);
+
+        if (isFinishingNaturally) {
+            // Don't immediately stop animations that are finishing naturally - delay cleanup via microtask
+            // to allow the finished promise callback to observe the final animation state (e.g., layer tree).
+            // Only immediately stop animations removed mid-flight.
+            if (RefPtr context = animation->scriptExecutionContext()) {
+                context->eventLoop().queueMicrotask([protectedThis = Ref { *this }] {
+                    protectedThis->applyPendingAcceleratedActions();
+                });
+            }
+        } else
+            applyPendingAcceleratedActions();
+    }
 }
 
 void KeyframeEffect::willChangeRenderer()

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -167,6 +167,7 @@ public:
     void willChangeRenderer();
 
     bool isRelevant() const { return m_isRelevant; }
+    bool hasPendingFinishNotification() const { return m_finishNotificationStepsMicrotaskPending; }
     void updateRelevance();
     void effectTimingDidChange();
     void suspendEffectInvalidation();


### PR DESCRIPTION
#### 42b3f8d9178498cd6a992ee304cdaf0bf215f936
<pre>
REGRESSION (289928@main): Svelte transition fade + transition scale results in flashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303217">https://bugs.webkit.org/show_bug.cgi?id=303217</a>
<a href="https://rdar.apple.com/165583864">rdar://165583864</a>

Reviewed by Antoine Quint.

289928@main centralized effect stack membership updates but inadvertently
removed immediate stopping of accelerated animations when effects are removed
from the stack. This patch restores that, preventing a visible flash. It also
ensures that when animations are removed, they are allowed to finish before
removal.

* LayoutTests/webanimations/simultaneous-animations-removed-separately-expected.txt: Added.
* LayoutTests/webanimations/simultaneous-animations-removed-separately.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::wasRemovedFromEffectStack):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::hasPendingFinishNotification const):

Canonical link: <a href="https://commits.webkit.org/304710@main">https://commits.webkit.org/304710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078f2a0f714a81f465ba6fdea78ceff4743188c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144022 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6458 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4120 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8349 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112912 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6389 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118449 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8397 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36506 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71956 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->