### PR TITLE
Regression(303516@main) Crash under CachedFontLoadRequest::fontLoaded

### DIFF
--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -121,7 +121,7 @@ public:
 
     void opportunisticallyStartFontDataURLLoading(DownloadableBinaryFontTrustedTypes);
 
-    void adoptSource(std::unique_ptr<CSSFontFaceSource>&&);
+    void adoptSource(std::unique_ptr<CSSFontFaceSource>);
     void sourcesPopulated() { m_sourcesPopulated = true; }
     size_t sourceCount() const { return m_sources.size(); }
 

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -131,7 +131,7 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
         auto& pool = owningFontSelector->protectedScriptExecutionContext()->cssValuePool();
         face->setFamily(pool.createFontFamilyValue(familyName));
         face->setFontSelectionCapabilities(item);
-        face->adoptSource(makeUnique<CSSFontFaceSource>(face.get(), familyName));
+        face->adoptSource(makeUniqueWithoutRefCountedCheck<CSSFontFaceSource>(face.get(), familyName));
         ASSERT(!face->computeFailureState());
         faces.append(WTFMove(face));
     }

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -113,6 +113,16 @@ CSSFontFaceSource::~CSSFontFaceSource()
         m_fontRequest->setClient(nullptr);
 }
 
+void CSSFontFaceSource::ref() const
+{
+    m_owningCSSFontFace->ref();
+}
+
+void CSSFontFaceSource::deref() const
+{
+    m_owningCSSFontFace->deref();
+}
+
 bool CSSFontFaceSource::shouldIgnoreFontLoadCompletions() const
 {
     return protectedCSSFontFace()->shouldIgnoreFontLoadCompletions();

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -48,13 +48,16 @@ struct FontCustomPlatformData;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFaceSource);
 class CSSFontFaceSource final : public FontLoadRequestClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSFontFaceSource, CSSFontFaceSource);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontFaceSource);
 public:
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName);
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement&);
     CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector&, Ref<FontLoadRequest>&&);
     CSSFontFaceSource(CSSFontFace& owner, Ref<JSC::ArrayBufferView>&&);
     virtual ~CSSFontFaceSource();
+
+    // FontLoadRequestClient.
+    void ref() const final;
+    void deref() const final;
 
     //                      => Success
     //                    //

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 static bool populateFontFaceWithArrayBuffer(CSSFontFace& fontFace, Ref<JSC::ArrayBufferView>&& arrayBufferView)
 {
-    auto source = makeUnique<CSSFontFaceSource>(fontFace, WTFMove(arrayBufferView));
+    auto source = makeUniqueWithoutRefCountedCheck<CSSFontFaceSource>(fontFace, WTFMove(arrayBufferView));
     fontFace.adoptSource(WTFMove(source));
     return false;
 }

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -27,8 +27,7 @@
 #pragma once
 
 #include <WebCore/FontTaggedSettings.h>
-#include <wtf/AbstractRefCounted.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -41,9 +40,8 @@ class FontDescription;
 class FontLoadRequest;
 struct FontSelectionSpecifiedCapabilities;
 
-class FontLoadRequestClient : public CanMakeWeakPtr<FontLoadRequestClient>, public CanMakeCheckedPtr<FontLoadRequestClient> {
+class FontLoadRequestClient : public AbstractRefCountedAndCanMakeWeakPtr<FontLoadRequestClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FontLoadRequestClient);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontLoadRequestClient);
 public:
     virtual ~FontLoadRequestClient() = default;
     virtual void fontLoaded(FontLoadRequest&) { }

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -107,7 +107,7 @@ private:
 
         m_fontLoadedProcessed = true;
         ASSERT_UNUSED(font, &font == m_font.get());
-        if (CheckedPtr client = m_fontLoadRequestClient.get())
+        if (RefPtr client = m_fontLoadRequestClient.get())
             client->fontLoaded(*this); // fontLoaded() might destroy this object. Don't deref its members after it.
     }
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -147,7 +147,7 @@ void WorkerFontLoadRequest::didFinishLoading(ScriptExecutionContextIdentifier, s
     m_isLoading = false;
 
     if (!m_errorOccurred) {
-        if (CheckedPtr client = m_fontLoadRequestClient.get())
+        if (RefPtr client = m_fontLoadRequestClient.get())
             client->fontLoaded(*this);
         else
             m_notifyOnClientSet = true;
@@ -157,7 +157,7 @@ void WorkerFontLoadRequest::didFinishLoading(ScriptExecutionContextIdentifier, s
 void WorkerFontLoadRequest::didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError&)
 {
     m_errorOccurred = true;
-    if (CheckedPtr client = m_fontLoadRequestClient.get())
+    if (RefPtr client = m_fontLoadRequestClient.get())
         client->fontLoaded(*this);
 }
 


### PR DESCRIPTION
#### bfec65f58317e99a714d6e47a55025e834627c0f
<pre>
Regression(303516@main) Crash under CachedFontLoadRequest::fontLoaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=303963">https://bugs.webkit.org/show_bug.cgi?id=303963</a>
<a href="https://rdar.apple.com/166072004">rdar://166072004</a>

Reviewed by Geoffrey Garen, Ryosuke Niwa, and Per Arne Vollan.

Stop using CanMakeCheckedPtr for FontLoadRequestClient and use ref-counting
instead as it appears it is possible for the client to get destroyed otherwise
in the middle of a `fontLoaded()` call.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::appendSources):
(WebCore::CSSFontFace::adoptSource):
(WebCore::CSSFontFace::opportunisticallyStartFontDataURLLoading):
(WebCore::CSSFontFace::hasSVGFontFaceSource const):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered):
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::ref const):
(WebCore::CSSFontFaceSource::deref const):
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/FontFace.cpp:
(WebCore::populateFontFaceWithArrayBuffer):
* Source/WebCore/loader/FontLoadRequest.h:
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::didFinishLoading):
(WebCore::WorkerFontLoadRequest::didFail):

Canonical link: <a href="https://commits.webkit.org/304322@main">https://commits.webkit.org/304322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16d16292a3c6ca4dd8116ec2dbbde4773f64cc46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86909 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103232 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70467 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84086 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5582 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3194 "Found 1 new API test failure: TestWebKitAPI.FormValidation.PresentingFormValidationUIWithoutViewControllerDoesNotCrash (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3198 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145302 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111604 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111969 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5414 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117370 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61107 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20852 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35527 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->