### PR TITLE
Web Inspector: Remove raw pointer from InspectorConsoleAgent to InspectorHeapAgent

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,1 +1,0 @@
-inspector/agents/InspectorConsoleAgent.h

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "ConsoleClient.h"
+#include "InspectorHeapAgent.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -50,6 +52,7 @@ public:
 
     void setDebuggerAgent(InspectorDebuggerAgent* agent) { m_debuggerAgent = agent; }
     void setPersistentScriptProfilerAgent(InspectorScriptProfilerAgent* agent) { m_scriptProfilerAgent = agent; }
+    void setPersistentHeapAgent(InspectorHeapAgent* agent) { m_heapAgent = agent; }
 
 private:
     void messageWithTypeAndLevel(MessageType, MessageLevel, JSC::JSGlobalObject*, Ref<ScriptArguments>&&) final;
@@ -74,6 +77,7 @@ private:
 
     InspectorConsoleAgent* m_consoleAgent;
     InspectorDebuggerAgent* m_debuggerAgent { nullptr };
+    CheckedPtr<InspectorHeapAgent> m_heapAgent;
     InspectorScriptProfilerAgent* m_scriptProfilerAgent { nullptr };
     Vector<String> m_profiles;
     bool m_profileRestoreBreakpointActiveValue { false };

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -336,8 +336,7 @@ void JSGlobalObjectInspectorController::createLazyAgents()
     m_agents.append(WTF::move(scriptProfilerAgent));
 
     auto heapAgent = makeUniqueRef<InspectorHeapAgent>(context);
-    if (m_consoleAgent)
-        m_consoleAgent->setHeapAgent(heapAgent.ptr());
+    m_consoleClient->setPersistentHeapAgent(heapAgent.ptr());
     m_agents.append(WTF::move(heapAgent));
 
     m_agents.append(makeUniqueRef<JSGlobalObjectAuditAgent>(context));

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -203,16 +203,8 @@ void InspectorConsoleAgent::stopTiming(JSC::JSGlobalObject* globalObject, const 
     m_times.remove(it);
 }
 
-void InspectorConsoleAgent::takeHeapSnapshot(const String& title)
+void InspectorConsoleAgent::reportHeapSnapshot(double timestamp, const String& snapshotData, const String& title)
 {
-    if (!m_heapAgent)
-        return;
-
-    auto result = m_heapAgent->snapshot();
-    if (!result)
-        return;
-
-    auto [timestamp, snapshotData] = WTF::move(result.value());
     m_frontendDispatcher->heapSnapshot(timestamp, snapshotData, title);
 }
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -68,8 +68,6 @@ public:
     Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Console::Channel>>> getLoggingChannels() override;
     Protocol::ErrorStringOr<void> setLoggingChannelLevel(Protocol::Console::ChannelSource, Protocol::Console::ChannelLevel) override;
 
-    void setHeapAgent(InspectorHeapAgent* agent) { m_heapAgent = agent; }
-
     bool enabled() const { return m_enabled; }
     bool developerExtrasEnabled() const;
 
@@ -81,9 +79,10 @@ public:
     void startTiming(JSC::JSGlobalObject*, const String& label);
     void logTiming(JSC::JSGlobalObject*, const String& label, Ref<ScriptArguments>&&);
     void stopTiming(JSC::JSGlobalObject*, const String& label);
-    void takeHeapSnapshot(const String& title);
     void count(JSC::JSGlobalObject*, const String& label);
     void countReset(JSC::JSGlobalObject*, const String& label);
+
+    void reportHeapSnapshot(double timestamp, const String& snapshotData, const String& title);
 
 protected:
     void addConsoleMessage(std::unique_ptr<ConsoleMessage>);
@@ -92,7 +91,6 @@ protected:
     InjectedScriptManager& m_injectedScriptManager;
     const UniqueRef<ConsoleFrontendDispatcher> m_frontendDispatcher;
     const Ref<ConsoleBackendDispatcher> m_backendDispatcher;
-    InspectorHeapAgent* m_heapAgent { nullptr };
 
     Vector<std::unique_ptr<ConsoleMessage>> m_consoleMessages;
     int m_expiredConsoleMessageCount { 0 };

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -940,8 +940,15 @@ void InspectorInstrumentation::consoleCountResetImpl(InstrumentingAgents& instru
 
 void InspectorInstrumentation::takeHeapSnapshotImpl(InstrumentingAgents& instrumentingAgents, const String& title)
 {
-    if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
-        consoleAgent->takeHeapSnapshot(title);
+    if (auto* heapAgent = instrumentingAgents.persistentWebHeapAgent()) {
+        auto result = heapAgent->snapshot();
+        if (!result)
+            return;
+
+        auto [timestamp, snapshotData] = WTF::move(result.value());
+        if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
+            consoleAgent->reportHeapSnapshot(timestamp, snapshotData, title);
+    }
 }
 
 void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label)

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -129,22 +129,9 @@ void WebHeapAgent::willDestroyFrontendAndBackend(DisconnectReason reason)
     agents->setPersistentWebHeapAgent(nullptr);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::enable()
-{
-    auto result = InspectorHeapAgent::enable();
-
-    if (auto* consoleAgent = Ref { m_instrumentingAgents.get() }->webConsoleAgent())
-        consoleAgent->setHeapAgent(this);
-
-    return result;
-}
-
 Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::disable()
 {
     m_sendGarbageCollectionEventsTask->reset();
-
-    if (auto* consoleAgent = Ref { m_instrumentingAgents.get() }->webConsoleAgent())
-        consoleAgent->setHeapAgent(nullptr);
 
     return InspectorHeapAgent::disable();
 }

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -50,7 +50,6 @@ public:
     void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
 
     // HeapBackendDispatcherHandler
-    Inspector::Protocol::ErrorStringOr<void> enable() override;
     Inspector::Protocol::ErrorStringOr<void> disable() override;
 
 protected:


### PR DESCRIPTION
#### 7cccbec2edba053b51bbe7fc732a5c439dc8ec5a
<pre>
Web Inspector: Remove raw pointer from InspectorConsoleAgent to InspectorHeapAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=303962">https://bugs.webkit.org/show_bug.cgi?id=303962</a>
<a href="https://rdar.apple.com/166265245">rdar://166265245</a>

Reviewed by BJ Burg and Devin Rousso.

InspectorConsoleAgent stored a raw pointer to InspectorHeapAgent that was manually wired in
WebHeapAgent::enable() and cleared in disable(). This could lead to use-after-free if the heap
agent was destroyed without calling disable() first. This patch removes the stored pointer entirely
by adopting the service locator pattern. For WebCore, InspectorInstrumentation now queries
InstrumentingAgents for the heap agent directly and coordinates the snapshot operation. The
console agent&apos;s takeHeapSnapshot() is replaced with reportHeapSnapshot() which only handles
frontend dispatch. For JSC, the heap agent pointer moves to JSGlobalObjectConsoleClient via
setPersistentHeapAgent(), following the same pattern used for InspectorScriptProfilerAgent. This
is safe because both the console client and heap agent are owned by
JSGlobalObjectInspectorController and share the same lifetime.

* Source/JavaScriptCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp:
(Inspector::JSGlobalObjectConsoleClient::takeHeapSnapshot):
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::createLazyAgents):
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::reportHeapSnapshot):
(Inspector::InspectorConsoleAgent::takeHeapSnapshot): Deleted.
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::takeHeapSnapshotImpl):
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
(WebCore::WebHeapAgent::disable):
(WebCore::WebHeapAgent::enable):
* Source/WebCore/inspector/agents/WebHeapAgent.h:

Canonical link: <a href="https://commits.webkit.org/305202@main">https://commits.webkit.org/305202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91a23d449d1723ecad1357039224e08885aaf0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90721 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105367 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86227 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6a25ed2d-551a-4bb8-8fa4-bd4d16f1b486) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7671 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5400 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6092 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129709 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148284 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136277 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9792 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113753 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114092 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7607 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119688 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64491 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21211 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9840 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37735 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73405 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44084 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->