### PR TITLE
Trim whitespace from the end of keys for spell and grammar tests.

### DIFF
--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -72,6 +72,21 @@ static LayoutTestSpellChecker *ensureGlobalLayoutTestSpellChecker()
     return globalSpellChecker;
 }
 
+static NSString *stringByTrimmingTrailingWhitespace(NSString *string)
+{
+    NSRange range = [string rangeOfCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet] options:NSBackwardsSearch];
+
+    if (range.location == NSNotFound || range.location + range.length != string.length)
+        return string;
+
+    NSRange nonWhitespaceRange = [string rangeOfCharacterFromSet:[[NSCharacterSet whitespaceAndNewlineCharacterSet] invertedSet] options:NSBackwardsSearch];
+
+    if (nonWhitespaceRange.location == NSNotFound)
+        return @"";
+
+    return [string substringToIndex:nonWhitespaceRange.location + 1];
+}
+
 static NSTextCheckingType nsTextCheckingType(NSString *typeString)
 {
     if ([typeString isEqualToString:@"orthography"])
@@ -280,7 +295,8 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 - (NSArray<NSTextCheckingResult *> *)checkString:(NSString *)stringToCheck range:(NSRange)range types:(NSTextCheckingTypes)checkingTypes options:(NSDictionary<NSString *, id> *)options inSpellDocumentWithTag:(NSInteger)tag orthography:(NSOrthography **)orthography wordCount:(NSInteger *)wordCount
 {
     NSArray *result = [super checkString:stringToCheck range:range types:checkingTypes options:options inSpellDocumentWithTag:tag orthography:orthography wordCount:wordCount];
-    if (auto *overrideResult = [_results objectForKey:stringToCheck])
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    if (auto *overrideResult = [_results objectForKey:trimmedKey])
         return overrideResult;
 
     return result;
@@ -296,7 +312,8 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
 - (NSInteger)requestCheckingOfString:(NSString *)stringToCheck range:(NSRange)range types:(NSTextCheckingTypes)checkingTypes options:(NSDictionary<NSString *, id> *)options inSpellDocumentWithTag:(NSInteger)tag completionHandler:(TextCheckingCompletionHandler)completionHandler
 {
-    return [super requestCheckingOfString:stringToCheck range:range types:checkingTypes options:options inSpellDocumentWithTag:tag completionHandler:[overrideResult = retainPtr([_results objectForKey:stringToCheck]), completion = makeBlockPtr(completionHandler), stringToCheck = retainPtr(stringToCheck)] (NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *result, NSOrthography *orthography, NSInteger wordCount) {
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    return [super requestCheckingOfString:stringToCheck range:range types:checkingTypes options:options inSpellDocumentWithTag:tag completionHandler:[overrideResult = retainPtr([_results objectForKey:trimmedKey]), completion = makeBlockPtr(completionHandler), stringToCheck = retainPtr(stringToCheck)] (NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *result, NSOrthography *orthography, NSInteger wordCount) {
         if (overrideResult) {
             completion(sequenceNumber, overrideResult.get(), orthography, wordCount);
             return;
@@ -308,7 +325,8 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
 - (NSInteger)requestGrammarCheckingOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *results))completionHandler
 {
-    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck]) {
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    if (RetainPtr overrideResult = [_results objectForKey:trimmedKey]) {
         completionHandler(0, overrideResult.get());
         return 0; // Not currently used, so return value doesn't matter. Should be the sequence number.
     }
@@ -321,14 +339,16 @@ static const char *stringForCorrectionResponse(NSCorrectionResponse correctionRe
 
 - (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler
 {
-    if (RetainPtr overrideResult = [_results objectForKey:stringToCheck])
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    if (RetainPtr overrideResult = [_results objectForKey:trimmedKey])
         completionHandler(overrideResult.get());
     return [super requestProofreadingReviewOfString:stringToCheck range:range language:language options:options completionHandler:completionHandler];
 }
 
 static NSDictionary *swizzledGrammarDetailsForString(id, SEL, NSString *stringToCheck, NSRange range, NSString *language)
 {
-    for (LayoutTestTextCheckingResult *result in [globalSpellChecker->_results objectForKey:stringToCheck]) {
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    for (LayoutTestTextCheckingResult *result in [globalSpellChecker->_results objectForKey:trimmedKey]) {
         if (!NSEqualRanges(result.range, range))
             continue;
 
@@ -350,7 +370,8 @@ static NSDictionary *swizzledGrammarDetailsForString(id, SEL, NSString *stringTo
 
 - (NSArray<NSTextCheckingResult *> *)checkString:(NSString *)stringToCheck range:(NSRange)range types:(NSTextCheckingTypes)checkingTypes languages:(NSArray<NSString *> *)languagesArray options:(NSDictionary<NSString *, id> *)options
 {
-    if (auto *overrideResult = [_results objectForKey:stringToCheck])
+    NSString *trimmedKey = stringByTrimmingTrailingWhitespace(stringToCheck);
+    if (auto *overrideResult = [_results objectForKey:trimmedKey])
         return overrideResult;
 
     return [super checkString:stringToCheck range:range types:checkingTypes languages:languagesArray options:options];


### PR DESCRIPTION
#### d36b65c1cd0edc46c7ca337f4155e953db29a22a
<pre>
Trim whitespace from the end of keys for spell and grammar tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303966">https://bugs.webkit.org/show_bug.cgi?id=303966</a>
<a href="https://rdar.apple.com/166268991">rdar://166268991</a>

Reviewed by NOBODY (OOPS!).

When writing tests for spelling and grammar checking, and there
is a newline as a part of the test, we can fail on iOS unless
the newline version is specified.
This is because of the differences between mac and iOS in how text
is iterated, and unless you happen to know this, or happen to look
at the right test to make it work, then you can spend a lot of
time trying to debug why the test isn&apos;t working.
If we just trim the whitespace off of these keys, then it&apos;s more
likely that someone in the future will not run into this issue.

* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(stringByTrimmingTrailingWhitespace):
(-[LayoutTestSpellChecker checkString:range:types:options:inSpellDocumentWithTag:orthography:wordCount:]):
(-[LayoutTestSpellChecker requestCheckingOfString:range:types:options:inSpellDocumentWithTag:completionHandler:]):
(-[LayoutTestSpellChecker requestGrammarCheckingOfString:range:language:options:completionHandler:]):
(-[LayoutTestSpellChecker requestProofreadingReviewOfString:range:language:options:completionHandler:]):
(swizzledGrammarDetailsForString):
(-[LayoutTestSpellChecker checkString:range:types:languages:options:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36b65c1cd0edc46c7ca337f4155e953db29a22a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86915 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70479 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84093 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3414 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114800 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39257 "Found 4 new test failures: editing/spelling/document-markers-remain-after-removing-text.html editing/spelling/grammar-and-spelling-error-styling.html editing/spelling/inline-spelling-markers-hidpi.html editing/spelling/inline-spelling-markers.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145310 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7182 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39831 "Found 2 new test failures: editing/spelling/document-markers-remain-after-removing-text.html editing/spelling/grammar-and-spelling-error-styling.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111612 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7227 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6020 "Found 2 new test failures: editing/spelling/document-markers-remain-after-removing-text.html editing/spelling/grammar-and-spelling-error-styling.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111977 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5420 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61113 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7236 "Hash d36b65c1 for PR 55222 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35537 "Found 2 new test failures: editing/spelling/document-markers-remain-after-removing-text.html editing/spelling/grammar-and-spelling-error-styling.html (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6997 "Hash d36b65c1 for PR 55222 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7222 "Hash d36b65c1 for PR 55222 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7100 "Hash d36b65c1 for PR 55222 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->