### PR TITLE
REGRESSION (iPadOS 26): Closing the sidebar or resizing the window unnecessarily zooms the page

### DIFF
--- a/LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets-expected.txt
+++ b/LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that setting the left obscured inset to zero does not cause the web view to unnecessarily zoom in. To run manually, pinch in and out, and then open and then close the sidebar on iPad; verify that the zoom scale stays at 1.0
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS visualViewport.scale.toFixed(3) became '1.000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hi
+
+

--- a/LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets.html
+++ b/LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+.tall {
+    height: 300vh;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+async function pinchOut() {
+    await UIHelper.pinch(250, pageYOffset + 100, 50, pageYOffset + 400, 150, pageYOffset + 250, 150,  pageYOffset + 300);
+    await UIHelper.ensureStablePresentationUpdate();
+}
+
+addEventListener("load", async () => {
+    description(`This test verifies that setting the left obscured inset to zero does not cause the
+        web view to unnecessarily zoom in. To run manually, pinch in and out, and then open and then
+        close the sidebar on iPad; verify that the zoom scale stays at 1.0`);
+
+    await pinchOut();
+
+    await UIHelper.setObscuredInsets(0, 100, 0, 0);
+    await UIHelper.ensureStablePresentationUpdate();
+
+    await UIHelper.setObscuredInsets(0, 0, 0, 0);
+    await UIHelper.ensureStablePresentationUpdate();
+
+    await shouldBecomeEqual("visualViewport.scale.toFixed(3)", "'1.000'");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<h1>Hi</h1>
+<div class="tall"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7614,6 +7614,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_internals->lastTransactionIDWithScaleChange = firstTransactionIDAfterDidCommitLoad;
     m_scaleWasSetByUIProcess = false;
     m_userHasChangedPageScaleFactor = false;
+    m_previousViewportConfigurationMinimumScale = { };
     m_estimatedLatency = Seconds(1.0 / 60);
     m_shouldRevealCurrentSelectionAfterInsertion = true;
     m_internals->lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage = std::nullopt;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -3023,6 +3023,7 @@ private:
     bool m_isInStableState { true };
     bool m_shouldRevealCurrentSelectionAfterInsertion { true };
     bool m_screenIsBeingCaptured { false };
+    std::optional<double> m_previousViewportConfigurationMinimumScale;
     MonotonicTime m_oldestNonStableUpdateVisibleContentRectsTimestamp;
     Seconds m_estimatedLatency { 0 };
     WebCore::FloatSize m_screenSize;


### PR DESCRIPTION
#### 049bb0acc54f10a21aa3b139e2ec9804893894ee
<pre>
REGRESSION (iPadOS 26): Closing the sidebar or resizing the window unnecessarily zooms the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=303968">https://bugs.webkit.org/show_bug.cgi?id=303968</a>
<a href="https://rdar.apple.com/157676989">rdar://157676989</a>

Reviewed by Aditya Keerthi.

When manually adjusting the scale (e.g. pinching in and then out) with the sidebar open on iPad and
then closing the sidebar, the page will become zoomed in. This happens because:

1.  When closing the sidebar, the leading obscured inset is decreased to zero, which increases the
    viewport layout width (unobscured content width) of the page.

2.  When recomputing the new target scale due to changing viewport configuration, we compute the
    minimum scale to be *greater than 1*, because we haven&apos;t performed layout yet (and so the
    content width is still the same as it was when the sidebar was open, with a nonzero obscured
    inset). As such, we fit the old content width to the new viewport width (sans sidebar), and
    attempt to zoom in (let&apos;s suppose the scale is set to 1.3, in this example).

3.  Later, after the next layout, we update the viewport configuration&apos;s content size to reflect
    the new viewport width. Here, the minimum scale is computed to be equal to 1, but because the
    scale of 1.3 fits within the min/max scale. As a result, we&apos;re now stuck at 1.3 scale.

To fix this, we adjust the target scale computation heuristic so that if we&apos;re already at or near
minimum scale and the minimum scale changes as a result of the viewport configuration changing,
we&apos;ll automatically target the new minimum scale instead of remaining at the current scale.

Test: fast/viewport/ios/scale-after-changing-horizontal-obscured-insets.html

* LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets-expected.txt: Added.
* LayoutTests/fast/viewport/ios/scale-after-changing-horizontal-obscured-insets.html: Added.

Add a layout test that exercises this bug by simulating opening and closing the sidebar (by setting
and then unsetting a left obscured inset). Verify that the final scale is equal to 1.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::viewportConfigurationChanged):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/304277@main">https://commits.webkit.org/304277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14bbc692edf84227ae548879e7d29c5f951ee316

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142619 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103245 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5790 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84101 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3213 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7189 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28411 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5426 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117395 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61116 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7242 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70799 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7225 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->