### PR TITLE
AX: live regions should respect alternative text (alt, aria-label, aria-labelledby)

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-aria-label-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-aria-label-expected.txt
@@ -1,0 +1,21 @@
+This tests that the notifications for aria-live properly handle alternative text provided via aria-label.
+
+Received announcement request:
+AnnouncementKey: Be right back{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: For your information{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FYI

--- a/LayoutTests/accessibility/mac/live-regions/live-region-aria-label.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-aria-label.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite">
+</div>
+
+<script>
+var output = "This tests that the notifications for aria-live properly handle alternative text provided via aria-label.\n\n";    
+var notificationCount = 0;
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+
+        notificationCount++;
+        if (notificationCount == 1) {
+            document.getElementById("abbreviation").textContent = "FYI";
+            document.getElementById("abbreviation").ariaLabel = "For your information";
+        } else if (notificationCount == 2)
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    const div = document.createElement("div");
+    div.ariaLabel = "Be right back";
+    div.id = "abbreviation";
+    div.textContent = "BRB";
+    
+    document.getElementById("polite-region").appendChild(div);
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-img-alt-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-img-alt-expected.txt
@@ -1,8 +1,7 @@
-This tests that the notifications for aria-relevant=removals are correct.
+This tests that alt text is properly handled in live regions.
 
 Received announcement request:
-AnnouncementKey: removed{
-} Mariners{
+AnnouncementKey: A picture of cake.{
     AXLanguage = en;
 }
 AXPriorityKey: 10
@@ -12,7 +11,4 @@ AXAnnouncementIsLiveRegionKey: true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Giants
-Cubs
-Orioles
-Tigers
+

--- a/LayoutTests/accessibility/mac/live-regions/live-region-img-alt.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-img-alt.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite">
+<img id="cake-image" src="../../resources/cake.png" alt="Undefined alt text" onload="runTest();"/>
+</div>
+
+<script>
+var output = "This tests that alt text is properly handled in live regions.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+        testFinished = true;
+    }
+}
+
+function runTest() {
+    if (accessibilityController) {
+        window.jsTestIsAsync = true;
+        accessibilityController.addNotificationListener(notificationCallback);
+        accessibilityController.accessibleElementById("cake-image");
+
+        document.getElementById("cake-image").alt = "A picture of cake."
+
+        setTimeout(async function() {
+            await waitFor(() => testFinished);
+            accessibilityController.removeNotificationListener();
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt
@@ -1,8 +1,7 @@
 This tests that an atomic region within a live region is announced together when changed.
 
 Received announcement request:
-AnnouncementKey: 1. California
-1. Cupertino
+AnnouncementKey: 1. California 1. Cupertino
 2. San Francisco
 3. Los Angeles{
     AXLanguage = en;

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -255,6 +255,7 @@ enum class AccessibilityOrientation : uint8_t {
     Horizontal
 };
 
+enum class DescendIntoContainers : bool { No, Yes };
 enum class DidTimeout : bool { No, Yes };
 enum class IncludeListMarkerText : bool { No, Yes };
 enum class IncludeImageAltText : bool { No, Yes };
@@ -271,6 +272,8 @@ struct TextUnderElementMode {
     bool includeFocusableContent { false };
     bool considerHiddenState { true };
     bool inHiddenSubtree { false };
+    IncludeListMarkerText includeListMarkers { IncludeListMarkerText::No };
+    DescendIntoContainers descendIntoContainers { DescendIntoContainers::No };
     TrimWhitespace trimWhitespace { TrimWhitespace::Yes };
     CheckedPtr<Node> ignoredChildNode { nullptr };
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -603,6 +603,10 @@ TextStream& operator<<(WTF::TextStream& stream, const TextUnderElementMode& mode
         stream << ", inHiddenSubtree: 1";
     if (!mode.considerHiddenState)
         stream << ", considerHiddenState: 0";
+    if (mode.includeListMarkers == IncludeListMarkerText::Yes)
+        stream << ", includeListMarkers: 1";
+    if (mode.descendIntoContainers == DescendIntoContainers::Yes)
+        stream << ", descendIntoContainers: 1";
     if (mode.ignoredChildNode)
         stream << ", ignoredChildNode: " << mode.ignoredChildNode;
     if (mode.trimWhitespace == TrimWhitespace::No)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -243,6 +243,10 @@ public:
     TextEmissionBehavior textEmissionBehavior() const final;
 #endif
 
+    bool usesAltForTextComputation() const;
+    bool hasTextAlternative() const;
+    String ariaAccessibilityDescription() const;
+
 protected:
     explicit AccessibilityNodeObject(AXID, Node*, AXObjectCache&);
     void detachRemoteParts(AccessibilityDetachmentType) override;
@@ -306,7 +310,6 @@ protected:
     String textForLabelElements(Vector<Ref<HTMLElement>>&&) const;
     HTMLLabelElement* labelElementContainer() const;
 
-    String ariaAccessibilityDescription() const;
     Vector<Ref<Element>> ariaLabeledByElements() const;
     String descriptionForElements(const Vector<Ref<Element>>&) const;
     LayoutRect boundingBoxRect() const override;
@@ -333,12 +336,10 @@ private:
     void visibleText(Vector<AccessibilityText>&) const;
     String alternativeTextForWebArea() const;
     void ariaLabeledByText(Vector<AccessibilityText>&) const;
-    bool usesAltForTextComputation() const;
     bool roleIgnoresTitle() const;
     bool postKeyboardKeysForValueChange(StepAction);
     void setNodeValue(StepAction, float);
     bool performDismissAction() final;
-    bool hasTextAlternative() const;
     LayoutRect checkboxOrRadioRect() const;
 
     void setNeedsToUpdateChildren() override { m_childrenDirty = true; }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -679,6 +679,11 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
     if (auto* fileUpload = dynamicDowncast<RenderFileUploadControl>(*m_renderer))
         return fileUpload->buttonValue();
 
+    if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
+        if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(*m_renderer))
+            return listMarker->textWithSuffix();
+    }
+
     // Reflect when a content author has explicitly marked a line break.
     if (m_renderer->isBR())
         return "\n"_s;


### PR DESCRIPTION
#### 2b05daadd0527630a62e38726f33ebfd6663c8d6
<pre>
AX: live regions should respect alternative text (alt, aria-label, aria-labelledby)
<a href="https://bugs.webkit.org/show_bug.cgi?id=303969">https://bugs.webkit.org/show_bug.cgi?id=303969</a>
<a href="https://rdar.apple.com/74236057">rdar://74236057</a>

Reviewed by Tyler Wilcock.

This patch allows for aria-live announcements to start respecting accessible text.

Prior to this patch, we only respected image alt text via the text iterator. But, by switching
to `textUnderElement`, and updating shouldIncludeInSnapshot and textForObject, we can properly
handle alternative text.

The shouldIncludeInSnapshot change is necessary, since alternative text should prevent
textual children from being included in an object&apos;s text.

There are two important changes to `textForObject`:
(1) Most text is computed using textUnderElement rather than using text marker ranges. This
allows us to use the alternative text handling already built into this method (with one
caveat as described in #2).
(2) `textUnderElement` only returns alt. text for descendants of its calling node. This means,
if the object we want text for has an aria-label, that won&apos;t get considered. This is why
we return the description (which accounts for alt text, aria-label, etc.) before using
textUnderElement.

`TextUnderElementMode` has two new options specifically used by live regions:
- includeListMarkers: will return list marker text for list marker objects.
- descendIntoContainers: allows textUnderElement to scoop up text for table, tree, and list
descendants.

Lastly, I added a new parameter, `prependNewline`, to appendNameToStringBuilder. This allows
textUnderElement to insert newlines when appropriate (for example, after list items). To
preserve existing behavior, if we are already inserting a space before an object, we will
not also insert a newline. In the future, we should make `textUnderElement` respect the text
emission behavior of objects, instead of inserting spaces.

Tests: accessibility/mac/live-regions/live-region-aria-label.html
       accessibility/mac/live-regions/live-region-img-alt.html

* LayoutTests/accessibility/mac/live-regions/live-region-aria-label-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-aria-label.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-img-alt-expected.txt: Copied from LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt.
* LayoutTests/accessibility/mac/live-regions/live-region-img-alt.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt:
* LayoutTests/accessibility/mac/live-regions/live-region-with-atomic-expected.txt:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::shouldIncludeInSnapshot const):
(WebCore::AXLiveRegionManager::textForObject const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::shouldUseAccessibilityObjectInnerText):
(WebCore::appendNameToStringBuilder):
(WebCore::shouldPrependNewline):
(WebCore::AccessibilityNodeObject::textUnderElement const):
(WebCore::accessibleNameForNode):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/304318@main">https://commits.webkit.org/304318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc87ba66d72c8b879a8e9b846da908dfa505f695

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86965 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103311 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70514 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84169 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3256 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7269 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5496 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117495 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->