### PR TITLE
Safari pauses video when leaving tab

### DIFF
--- a/LayoutTests/media/media-source/media-source-has-audio-video-gpu-expected.txt
+++ b/LayoutTests/media/media-source/media-source-has-audio-video-gpu-expected.txt
@@ -1,0 +1,11 @@
+
+RUN(video.src = URL.createObjectURL(mediaSource))
+EVENT(sourceopen)
+RUN(mediaSource.duration = loader.duration())
+RUN(sourceBuffer = mediaSource.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+EXPECTED (internals.mediaUsageState(video).hasVideo == 'true') OK
+EXPECTED (internals.mediaUsageState(video).hasAudio == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-has-audio-video-gpu.html
+++ b/LayoutTests/media/media-source/media-source-has-audio-video-gpu.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ MediaSourceUseRemoteAudioVideoRenderer=false ] -->
+<!DOCTYPE html>
+ <html>
+<head>
+    <title>media-source-has-audio-video</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    window.addEventListener('load', event => {
+        findMediaElement();
+
+        window.sourceBuffer = new MediaSource();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        loader.onload = mediaDataLoaded;
+        loader.onerror = mediaDataLoadingFailed;
+    });
+
+    function mediaDataLoadingFailed() {
+        failTest('Media data loading failed');
+    }
+
+    async function mediaDataLoaded() {
+        window.mediaSource = new MediaSource();
+        run('video.src = URL.createObjectURL(mediaSource)');
+        waitFor(video, 'error').then(failTest);
+        await waitFor(mediaSource, 'sourceopen');
+
+        run('mediaSource.duration = loader.duration()');
+        run('sourceBuffer = mediaSource.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        await testExpectedEventually('internals.mediaUsageState(video).hasVideo', true);
+        await testExpectedEventually('internals.mediaUsageState(video).hasAudio', true);
+        endTest();
+    }
+
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-restrictions-expected.txt
+++ b/LayoutTests/media/media-source/media-source-restrictions-expected.txt
@@ -7,6 +7,7 @@ RUN(sourceBuffer.appendBuffer(initSegment))
 EVENT(updateend)
 RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)
-EVENT(pause)
+EXPECTED (errorName == 'NotAllowedError') OK
+EXPECTED (true == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-restrictions.html
+++ b/LayoutTests/media/media-source/media-source-restrictions.html
@@ -9,11 +9,12 @@
     var sourceBuffer;
     var initSegment;
     var samples;
+    var errorName;
 
     if (window.internals)
         internals.initializeMockMediaSource();
 
-    function runTest() {
+    async function runTest() {
         findMediaElement();
 
         run(`internals.setMediaElementRestrictions(video, 'RequireUserGestureForAudioRateChange')`);
@@ -21,27 +22,16 @@
         source = new MediaSource();
         testExpected('source.readyState', 'closed');
 
-        waitForEventOn(source, 'sourceopen', sourceOpen);
         video.src = URL.createObjectURL(source);
-    }
+        await waitFor(source, 'sourceopen');
 
-    function handlePause() {
-        endTest();
-    }
+        waitFor(video, "ended").then(failTest);
 
-    function sourceOpen() {
         run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
-        waitForEventOn(sourceBuffer, 'updateend', loadSamples, false, true);
         initSegment = makeAInit(8, [makeATrack(1, 'mock', TRACK_KIND.AUDIO)]);
         run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
 
-        waitFor(video, 'pause', false).then(handlePause);
-        video.play().catch(function(error) {
-            failTest();
-        });
-    }
-
-    function loadSamples() {
         samples = concatenateSamples([
             makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC),
             makeASample(1, 1, 1, 1, 1, SAMPLE_FLAG.SYNC),
@@ -53,12 +43,15 @@
             makeASample(7, 7, 1, 1, 1, SAMPLE_FLAG.SYNC),
         ]);
 
-        waitFor(sourceBuffer, 'updateend', false).then(updateEnd);
         run('sourceBuffer.appendBuffer(samples)');
-    }
+        await waitFor(sourceBuffer, 'updateend');
 
-    function updateEnd() {
-        waitForEventAndFail("onended");
+        video.play().catch(function(error) {
+            errorName = error.name;
+            testExpected('errorName', "NotAllowedError");
+            testExpected(error instanceof DOMException, true);
+            endTest();
+        });
     }
     </script>
 </head>

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -66,6 +66,7 @@ public:
 #if ENABLE(MEDIA_SOURCE)
     virtual void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) = 0;
     virtual void readyStateFromMediaSourceChanged() { }
+    virtual void characteristicsFromMediaSourceChanged() { }
 #endif
 #if ENABLE(MEDIA_STREAM)
     virtual void load(MediaStreamPrivate&) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -111,7 +111,7 @@ public:
 
     void effectiveRateChanged();
     void setNaturalSize(const FloatSize&);
-    void characteristicsChanged();
+    void characteristicsFromMediaSourceChanged() final;
 
     MediaTime currentTime() const override;
     MediaTime currentOrPendingSeekTime() const final { return currentTime(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -571,7 +571,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::completeSeek(const MediaTime& seekedT
 
     m_seeking = false;
 
-    if (auto player = m_player.get()) {
+    if (RefPtr player = m_player.get()) {
         player->seeked(seekedTime);
         player->timeChanged();
     }
@@ -616,7 +616,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPreservesPitch(bool preservesPitch
 {
     assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, preservesPitch);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         m_renderer->setPreservesPitchAndCorrectionAlgorithm(preservesPitch, player->pitchCorrectionAlgorithm());
 }
 
@@ -861,7 +861,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 void MediaPlayerPrivateMediaSourceAVFObjC::notifyActiveSourceBuffersChanged()
 {
     assertIsMainThread();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->activeSourceBuffersChanged();
 }
 
@@ -913,7 +913,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setHasAvailableVideoFrame(bool flag)
     if (!m_hasAvailableVideoFrame)
         return;
 
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     if (player)
         player->firstVideoFrameAvailable();
 
@@ -935,7 +935,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::durationChanged()
     // Avoid emiting durationchanged in the case where the previous duration was unknown as that case is already handled
     // by the HTMLMediaElement.
     if (m_duration != duration && m_duration.isValid()) {
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->durationChanged();
     }
     m_duration = duration;
@@ -946,7 +946,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged()
 {
     assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, effectiveRate());
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->rateChanged();
 }
 
@@ -959,7 +959,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setNaturalSize(const FloatSize& size)
     ALWAYS_LOG(LOGIDENTIFIER, size);
 
     m_naturalSize = size;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->sizeChanged();
 }
 
@@ -987,7 +987,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::keyAdded()
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
 void MediaPlayerPrivateMediaSourceAVFObjC::keyNeeded(const SharedBuffer& initData)
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->keyNeeded(initData);
 }
 #endif
@@ -1024,14 +1024,14 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::waitingForKey() const
 void MediaPlayerPrivateMediaSourceAVFObjC::waitingForKeyChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->waitingForKeyChanged();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::initializationDataEncountered(const String& initDataType, RefPtr<ArrayBuffer>&& initData)
 {
     ALWAYS_LOG(LOGIDENTIFIER, initDataType);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->initializationDataEncountered(initDataType, WTFMove(initData));
 }
 #endif
@@ -1074,7 +1074,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState()
         return;
     }
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->readyStateChanged();
 }
 
@@ -1086,7 +1086,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setNetworkState(MediaPlayer::NetworkS
 
     ALWAYS_LOG(LOGIDENTIFIER, networkState);
     m_networkState = networkState;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->networkStateChanged();
 }
 
@@ -1120,28 +1120,28 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 void MediaPlayerPrivateMediaSourceAVFObjC::removeAudioTrack(AudioTrackPrivate& track)
 {
     assertIsMainThread();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->removeAudioTrack(track);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::removeVideoTrack(VideoTrackPrivate& track)
 {
     assertIsMainThread();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->removeVideoTrack(track);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::removeTextTrack(InbandTextTrackPrivate& track)
 {
     assertIsMainThread();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->removeTextTrack(track);
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::characteristicsChanged()
+void MediaPlayerPrivateMediaSourceAVFObjC::characteristicsFromMediaSourceChanged()
 {
     assertIsMainThread();
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->characteristicChanged();
 }
 
@@ -1187,7 +1187,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setShouldPlayToPlaybackTarget(bool sh
     ALWAYS_LOG(LOGIDENTIFIER, shouldPlayToTarget);
     m_shouldPlayToTarget = shouldPlayToTarget;
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless());
 }
 
@@ -1217,7 +1217,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime(WTF::Function<void(
 void MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged()
 {
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     if (!player)
         return;
     auto deviceId = player->audioOutputDeviceId();
@@ -1243,7 +1243,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering()
 void MediaPlayerPrivateMediaSourceAVFObjC::checkNewVideoFrameMetadata(MediaTime presentationTime, double displayTime)
 {
     assertIsMainThread();
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     if (!player)
         return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -283,9 +283,6 @@ void SourceBufferPrivateAVFObjC::processInitializationSegment(std::optional<Init
 
         setTrackChangeCallbacks(*segment, true);
     }
-    callOnMainThreadWithPlayer([](auto& player) {
-        player.characteristicsChanged();
-    });
 
     ALWAYS_LOG(LOGIDENTIFIER, "initialization segment was processed");
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -685,6 +685,13 @@ void MediaPlayerPrivateGStreamerMSE::notifyActiveSourceBuffersChanged()
         player->activeSourceBuffersChanged();
 }
 
+void MediaPlayerPrivateGStreamerMSE::characteristicsFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->characteristicChanged();
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -80,6 +80,7 @@ public:
     void setNetworkState(MediaPlayer::NetworkState);
     void readyStateFromMediaSourceChanged() final;
     void mediaSourceHasRetrievedAllData() final;
+    void characteristicsFromMediaSourceChanged() final;
 
     void setInitialVideoSize(const FloatSize&);
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -157,6 +157,13 @@ bool MockMediaPlayerMediaSource::hasAudio() const
     return mediaSourcePrivate ? mediaSourcePrivate->hasAudio() : false;
 }
 
+void MockMediaPlayerMediaSource::characteristicsFromMediaSourceChanged()
+{
+    assertIsMainThread();
+    if (RefPtr player = m_player.get())
+        player->characteristicChanged();
+}
+
 void MockMediaPlayerMediaSource::setPageIsVisible(bool)
 {
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -66,6 +66,7 @@ public:
 
     MediaPlayer::ReadyState readyState() const override;
     void readyStateFromMediaSourceChanged() final;
+    void characteristicsFromMediaSourceChanged() final;
     void setNetworkState(MediaPlayer::NetworkState);
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### 6c874bb1f7e89e61d47029449f804a800d349183
<pre>
Safari pauses video when leaving tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=303973">https://bugs.webkit.org/show_bug.cgi?id=303973</a>
<a href="https://rdar.apple.com/164514685">rdar://164514685</a>

Reviewed by Eric Carlson.

The information that the SourceBufferPrivate had created a new audio or video track
wasn&apos;t passed back to the HTMLMediaElement.
302975@main changed the order of events which would have caused MediaPlayer::characteristicsChanged
to be called before the hasAudio/hasVideo state was updated.

Fly-By fix: replace auto player = m_player.get() with RefPtr player to be in line with
current SaferCPP coding style.

Added test media/media-source/media-source-has-audio-video-gpu.html
LayoutTests/media/media-source/media-source-restrictions-expected.txt
LayoutTests/media/media-source/media-source-restrictions.html: The test assumed that
the paused event would be fired. But this was incorrect, playback should have never started
as a user gesture was required. The test only passed earlier because the MockMediaPlayerMediaSource
was never calling MediaPlayer::characteristicsChanged and so MediaPlayer::hasAudio()
was never updated.

Canonical link: <a href="https://commits.webkit.org/304336@main">https://commits.webkit.org/304336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af27e47a23c2da74ef379ec71845005fa519ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142789 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb8a53ce-1cfe-4535-852d-ec3658105dfa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d46f8af-342e-4dfe-b753-e8ef86c2edfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84242 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3323 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3376 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145485 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111758 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5570 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117545 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7406 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->