### PR TITLE
[WTF] Use C++20 concepts in NativePromise.h

### DIFF
--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -409,7 +409,8 @@ private:
     }
 
 public:
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     static Ref<NativePromise> createAndResolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER)
     {
         auto p = adoptRef(*new NativePromise(resolveSite));
@@ -417,15 +418,15 @@ public:
         return p;
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
     static Ref<NativePromise> createAndResolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER)
-    {
+        requires std::is_void_v<ResolveValueT> {
         auto p = adoptRef(*new NativePromise(resolveSite));
         p->resolve(resolveSite);
         return p;
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     static Ref<NativePromise> createAndReject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER)
     {
         auto p = adoptRef(*new NativePromise(rejectSite));
@@ -433,9 +434,8 @@ public:
         return p;
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
     static Ref<NativePromise> createAndReject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER)
-    {
+        requires std::is_void_v<RejectValueT> {
         auto p = adoptRef(*new NativePromise(rejectSite));
         p->reject(rejectSite);
         return p;
@@ -465,7 +465,8 @@ private:
         dispatchAll(lock);
     }
 
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     void resolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite)
     {
         static_assert(std::is_convertible_v<ResolveValueType_, ResolveValueT>, "resolve() argument must be implicitly convertible to NativePromise's ResolveValueT");
@@ -477,15 +478,15 @@ private:
             settleImpl(std::forward<ResolveValueType_>(resolveValue), lock);
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
     void resolve(const Logger::LogSiteIdentifier& resolveSite)
-    {
+        requires std::is_void_v<ResolveValueT> {
         Locker lock { m_lock };
         PROMISE_LOG(resolveSite, " resolving ", *this);
         settleImpl(Result { }, lock);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     void reject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite)
     {
         static_assert(std::is_convertible_v<RejectValueType_, RejectValueT>, "reject() argument must be implicitly convertible to NativePromise's RejectValueT");
@@ -497,9 +498,8 @@ private:
             settleImpl(Unexpected<RejectValueT>(std::forward<RejectValueType_>(rejectValue)), lock);
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
     void reject(const Logger::LogSiteIdentifier& rejectSite)
-    {
+        requires std::is_void_v<RejectValueT> {
         Locker lock { m_lock };
         PROMISE_LOG(rejectSite, " rejecting ", *this);
         settleImpl(makeUnexpected(detail::VoidPlaceholder()), lock);
@@ -970,16 +970,20 @@ private:
     };
 
     struct LambdaReturnTrait {
-        template <typename T, typename = std::enable_if_t<IsConvertibleToNativePromise<T>>>
+        template <typename T>
+            requires IsConvertibleToNativePromise<T>
         Ref<typename T::PromiseType> lambda();
 
-        template <typename T, typename = std::enable_if_t<std::is_void_v<T>>>
+        template <typename T>
+            requires std::is_void_v<T>
         void lambda();
 
-        template <typename T, typename = std::enable_if_t<IsConvertibleToNativePromise<T>>>
+        template <typename T>
+            requires IsConvertibleToNativePromise<T>
         typename T::PromiseType type();
 
-        template <typename T, typename = std::enable_if_t<std::is_void_v<T>>>
+        template <typename T>
+            requires std::is_void_v<T>
         void type();
     };
 
@@ -1320,16 +1324,17 @@ public:
     static constexpr bool AutoReject = options & PromiseOption::AutoRejectProducer;
     static constexpr bool AutoRejectNonVoid = AutoReject && !std::is_void_v<RejectValueT>;
 
-    template<typename = std::enable_if<!AutoRejectNonVoid>>
     explicit NativePromiseProducer(PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER)
-        : m_promise(adoptRef(new PromiseType(creationSite)))
-        , m_creationSite(creationSite)
+        requires (!AutoRejectNonVoid)
+            : m_promise(adoptRef(new PromiseType(creationSite)))
+            , m_creationSite(creationSite)
     {
         if constexpr (PromiseType::IsExclusive)
             protect(m_promise)->setDispatchMode(dispatchMode, creationSite);
     }
 
-    template<typename RejectValueT_ = RejectValueT, typename = std::enable_if<AutoRejectNonVoid>>
+    template<typename RejectValueT_ = RejectValueT>
+        requires AutoRejectNonVoid
     explicit NativePromiseProducer(RejectValueT_&& defaulReject, PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER)
         : m_promise(adoptRef(new PromiseType(creationSite)))
         , m_creationSite(creationSite)
@@ -1368,7 +1373,8 @@ public:
         return m_promise && !protect(m_promise)->isSettled();
     }
 
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     void resolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) const
     {
         ASSERT(isNothing());
@@ -1379,9 +1385,8 @@ public:
         protect(m_promise)->resolve(std::forward<ResolveValueType_>(resolveValue), resolveSite);
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
     void resolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) const
-    {
+        requires std::is_void_v<ResolveValueT> {
         ASSERT(isNothing());
         if (!isNothing()) {
             PROMISE_LOG(resolveSite, " ignored already resolved or rejected ", *protect(m_promise));
@@ -1390,7 +1395,8 @@ public:
         protect(m_promise)->resolve(resolveSite);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     void reject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) const
     {
         ASSERT(isNothing());
@@ -1401,9 +1407,8 @@ public:
         protect(m_promise)->reject(std::forward<RejectValueType_>(rejectValue), rejectSite);
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
     void reject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) const
-    {
+        requires std::is_void_v<RejectValueT> {
         ASSERT(isNothing());
         if (!isNothing()) {
             PROMISE_LOG(rejectSite, " ignored already resolved or rejected ", *protect(m_promise));
@@ -1426,9 +1431,8 @@ public:
             protect(m_promise)->settle(std::forward<SettleValue>(result), site);
     }
 
-    template<typename = std::enable_if<PromiseType::IsExclusive>>
     void settleWithFunction(typename PromiseType::ResultRunnable&& resultRunnable, const Logger::LogSiteIdentifier& site = DEFAULT_LOGSITEIDENTIFIER)
-    {
+        requires PromiseType::IsExclusive {
         ASSERT(isNothing());
         if (!isNothing()) {
             PROMISE_LOG(site, " ignored already resolved or rejected ", *protect(m_promise));
@@ -1498,7 +1502,8 @@ public:
         m_promise->template chainTo<ResolveValueT2, RejectValueT2, options2>(WTF::move(chainedPromise), callSite);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<AutoRejectNonVoid>>
+    template<typename RejectValueType_>
+        requires AutoRejectNonVoid
     void setDefaultReject(RejectValueType_&& rejectValue)
     {
         m_defaultReject = std::forward<RejectValueType_>(rejectValue);

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -407,7 +407,8 @@ private:
     }
 
 public:
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     static Ref<NativePromise> createAndResolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER)
     {
         auto p = adoptRef(*new NativePromise(resolveSite));
@@ -415,15 +416,15 @@ public:
         return p;
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
-    static Ref<NativePromise> createAndResolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER)
+    static Ref<NativePromise> createAndResolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) requires (std::is_void_v<ResolveValueT>)
     {
         auto p = adoptRef(*new NativePromise(resolveSite));
         p->resolve(resolveSite);
         return p;
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     static Ref<NativePromise> createAndReject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER)
     {
         auto p = adoptRef(*new NativePromise(rejectSite));
@@ -431,8 +432,7 @@ public:
         return p;
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
-    static Ref<NativePromise> createAndReject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER)
+    static Ref<NativePromise> createAndReject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) requires (std::is_void_v<RejectValueT>)
     {
         auto p = adoptRef(*new NativePromise(rejectSite));
         p->reject(rejectSite);
@@ -447,7 +447,9 @@ public:
         return p;
     }
 
-    using AllPromiseType = NativePromise<std::conditional_t<std::is_void_v<ResolveValueType>, void, Vector<ResolveValueType>>, RejectValueType, options>;
+    // RejectValueType substitutes detail::VoidPlaceholder for a void RejectValueT; map it back to void so that the
+    // composite promise keeps a void rejection type instead of exposing the placeholder as a real reject value.
+    using AllPromiseType = NativePromise<std::conditional_t<std::is_void_v<ResolveValueType>, void, Vector<ResolveValueType>>, std::conditional_t<std::is_void_v<RejectValueT>, void, RejectValueType>, options>;
     using AllSettledPromiseType = NativePromise<Vector<Result>, bool, options>;
 
 private:
@@ -463,7 +465,8 @@ private:
         dispatchAll(lock);
     }
 
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     void resolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite)
     {
         static_assert(std::is_convertible_v<ResolveValueType_, ResolveValueT>, "resolve() argument must be implicitly convertible to NativePromise's ResolveValueT");
@@ -475,15 +478,15 @@ private:
             settleImpl(std::forward<ResolveValueType_>(resolveValue), lock);
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
-    void resolve(const Logger::LogSiteIdentifier& resolveSite)
+    void resolve(const Logger::LogSiteIdentifier& resolveSite) requires (std::is_void_v<ResolveValueT>)
     {
         Locker lock { m_lock };
         PROMISE_LOG(resolveSite, " resolving ", *this);
         settleImpl(Result { }, lock);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     void reject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite)
     {
         static_assert(std::is_convertible_v<RejectValueType_, RejectValueT>, "reject() argument must be implicitly convertible to NativePromise's RejectValueT");
@@ -495,8 +498,7 @@ private:
             settleImpl(std::unexpected<RejectValueT>(std::forward<RejectValueType_>(rejectValue)), lock);
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
-    void reject(const Logger::LogSiteIdentifier& rejectSite)
+    void reject(const Logger::LogSiteIdentifier& rejectSite) requires (std::is_void_v<RejectValueT>)
     {
         Locker lock { m_lock };
         PROMISE_LOG(rejectSite, " rejecting ", *this);
@@ -968,16 +970,18 @@ private:
     };
 
     struct LambdaReturnTrait {
-        template <typename T, typename = std::enable_if_t<IsConvertibleToNativePromise<T>>>
+        template<IsConvertibleToNativePromise T>
         Ref<typename T::PromiseType> lambda();
 
-        template <typename T, typename = std::enable_if_t<std::is_void_v<T>>>
+        template<typename T>
+            requires (std::is_void_v<T>)
         void lambda();
 
-        template <typename T, typename = std::enable_if_t<IsConvertibleToNativePromise<T>>>
+        template<IsConvertibleToNativePromise T>
         typename T::PromiseType type();
 
-        template <typename T, typename = std::enable_if_t<std::is_void_v<T>>>
+        template<typename T>
+            requires (std::is_void_v<T>)
         void type();
     };
 
@@ -1318,8 +1322,7 @@ public:
     static constexpr bool AutoReject = options & PromiseOption::AutoRejectProducer;
     static constexpr bool AutoRejectNonVoid = AutoReject && !std::is_void_v<RejectValueT>;
 
-    template<typename = std::enable_if<!AutoRejectNonVoid>>
-    explicit NativePromiseProducer(PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER)
+    explicit NativePromiseProducer(PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER) requires (!AutoRejectNonVoid)
         : m_promise(adoptRef(new PromiseType(creationSite)))
         , m_creationSite(creationSite)
     {
@@ -1327,11 +1330,12 @@ public:
             protect(m_promise)->setDispatchMode(dispatchMode, creationSite);
     }
 
-    template<typename RejectValueT_ = RejectValueT, typename = std::enable_if<AutoRejectNonVoid>>
-    explicit NativePromiseProducer(RejectValueT_&& defaulReject, PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER)
+    template<typename RejectValueT_ = RejectValueT>
+        requires (AutoRejectNonVoid)
+    explicit NativePromiseProducer(RejectValueT_&& defaultReject, PromiseDispatchMode dispatchMode = PromiseDispatchMode::Default, const Logger::LogSiteIdentifier& creationSite = DEFAULT_LOGSITEIDENTIFIER)
         : m_promise(adoptRef(new PromiseType(creationSite)))
         , m_creationSite(creationSite)
-        , m_defaultReject(std::forward<RejectValueT_>(defaulReject))
+        , m_defaultReject(std::forward<RejectValueT_>(defaultReject))
     {
         if constexpr (PromiseType::IsExclusive)
             m_promise->setDispatchMode(dispatchMode, creationSite);
@@ -1366,7 +1370,8 @@ public:
         return m_promise && !protect(m_promise)->isSettled();
     }
 
-    template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
+    template<typename ResolveValueType_>
+        requires (!std::is_void_v<ResolveValueT>)
     void resolve(ResolveValueType_&& resolveValue, const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) const
     {
         ASSERT(isNothing());
@@ -1377,8 +1382,7 @@ public:
         protect(m_promise)->resolve(std::forward<ResolveValueType_>(resolveValue), resolveSite);
     }
 
-    template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
-    void resolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) const
+    void resolve(const Logger::LogSiteIdentifier& resolveSite = DEFAULT_LOGSITEIDENTIFIER) const requires (std::is_void_v<ResolveValueT>)
     {
         ASSERT(isNothing());
         if (!isNothing()) {
@@ -1388,7 +1392,8 @@ public:
         protect(m_promise)->resolve(resolveSite);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
+    template<typename RejectValueType_>
+        requires (!std::is_void_v<RejectValueT>)
     void reject(RejectValueType_&& rejectValue, const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) const
     {
         ASSERT(isNothing());
@@ -1399,8 +1404,7 @@ public:
         protect(m_promise)->reject(std::forward<RejectValueType_>(rejectValue), rejectSite);
     }
 
-    template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
-    void reject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) const
+    void reject(const Logger::LogSiteIdentifier& rejectSite = DEFAULT_LOGSITEIDENTIFIER) const requires (std::is_void_v<RejectValueT>)
     {
         ASSERT(isNothing());
         if (!isNothing()) {
@@ -1424,8 +1428,7 @@ public:
             protect(m_promise)->settle(std::forward<SettleValue>(result), site);
     }
 
-    template<typename = std::enable_if<PromiseType::IsExclusive>>
-    void settleWithFunction(typename PromiseType::ResultRunnable&& resultRunnable, const Logger::LogSiteIdentifier& site = DEFAULT_LOGSITEIDENTIFIER)
+    void settleWithFunction(typename PromiseType::ResultRunnable&& resultRunnable, const Logger::LogSiteIdentifier& site = DEFAULT_LOGSITEIDENTIFIER) requires (PromiseType::IsExclusive)
     {
         ASSERT(isNothing());
         if (!isNothing()) {
@@ -1496,7 +1499,8 @@ public:
         m_promise->template chainTo<ResolveValueT2, RejectValueT2, options2>(WTF::move(chainedPromise), callSite);
     }
 
-    template<typename RejectValueType_, typename = std::enable_if<AutoRejectNonVoid>>
+    template<typename RejectValueType_>
+        requires (AutoRejectNonVoid)
     void setDefaultReject(RejectValueType_&& rejectValue)
     {
         m_defaultReject = std::forward<RejectValueType_>(rejectValue);

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -463,7 +463,7 @@ auto RealtimeVideoCaptureSource::takePhoto(PhotoSettings&& photoSettings) -> Ref
     ASSERT(isMainThread());
 
     if (isEnded())
-        return TakePhotoNativePromise::createAndResolve();
+        return TakePhotoNativePromise::createAndReject("Track has ended"_s);
 
     if ((photoSettings.imageHeight && !photoSettings.imageWidth) || (!photoSettings.imageHeight && photoSettings.imageWidth)) {
         IntSize sanitizedSize;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -463,7 +463,7 @@ RefPtr<LibWebRTCCodecs::FramePromise> LibWebRTCCodecs::decodeFrameInternal(Decod
     }
 
     if (!decoder.connection) {
-        FramePromise::AutoRejectProducer producer;
+        FramePromise::AutoRejectProducer producer("Decoding task did not complete"_s);
         auto promise = producer.promise();
 
         decoder.pendingFrames.append({ timeStamp, data, width, height, WTF::move(producer) });


### PR DESCRIPTION
#### ebd7f99a20297fc1044aacd4cb4fd674dbcbd2ce
<pre>
[WTF] Use C++20 concepts in NativePromise.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=303978">https://bugs.webkit.org/show_bug.cgi?id=303978</a>
<a href="https://rdar.apple.com/166281395">rdar://166281395</a>

Reviewed by NOBODY (OOPS!).

Modernize our codebase by adopting C++20 concepts in wtf/NativePromise.h

* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::takePhoto):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::decodeFrameInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd7f99a20297fc1044aacd4cb4fd674dbcbd2ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150346 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f5c722b-3b6f-4c53-bd8c-d6fbc2cd0891) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145061 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100567 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc02808d-3d24-4a20-8c97-a27f8cda78be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/394a895a-b82d-4465-92ac-c6de495c8b99) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47466 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45517 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7253 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14136 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45204 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7000 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46879 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197900 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59199 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154592 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154245 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48715 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132249 "Found 454 new failures in testing/Internals.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129163 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58379 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20226 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->