### PR TITLE
[threaded-animations] `animations/resume-after-page-cache.html` crashes with "Threaded Time-based Animations" enabled

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -903,6 +903,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/isolatedtree/AXIsolatedTree.h
 
     animation/AcceleratedEffectStackUpdater.h
+    animation/AcceleratedTimelinesUpdater.h
     animation/AnimationEffect.h
     animation/AnimationEffectPhase.h
     animation/AnimationEffectTiming.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -624,6 +624,7 @@ accessibility/AccessibilityTableHeaderContainer.cpp
 accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
 animation/AcceleratedEffectStackUpdater.cpp
+animation/AcceleratedTimelinesUpdater.cpp
 animation/AnimationEffect.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationEventBase.cpp

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -29,7 +29,10 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #include "AcceleratedTimeline.h"
+#include "AcceleratedTimelinesUpdater.h"
+#include "DocumentPage.h"
 #include "KeyframeEffectStack.h"
+#include "NodeDocument.h"
 #include "RenderElement.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
@@ -45,6 +48,7 @@ void AcceleratedEffectStackUpdater::update()
     if (!hasTargetsPendingUpdate())
         return;
 
+    RefPtr<Page> page;
     HashSet<Ref<AcceleratedTimeline>> timelinesInUpdate;
 
     auto targetsPendingUpdate = std::exchange(m_targetsPendingUpdate, { });
@@ -53,6 +57,9 @@ void AcceleratedEffectStackUpdater::update()
             continue;
 
         Styleable target { *element, pseudoElementIdentifier };
+
+        if (!page)
+            page = element->protectedDocument()->page();
 
         auto* renderer = dynamicDowncast<RenderLayerModelObject>(target.renderer());
         if (!renderer || !renderer->isComposited())
@@ -63,52 +70,13 @@ void AcceleratedEffectStackUpdater::update()
         renderLayer->backing()->updateAcceleratedEffectsAndBaseValues(timelinesInUpdate);
     }
 
-    for (auto& timeline : timelinesInUpdate) {
-        auto& timelineIdentifier = timeline->identifier();
-        auto addResult = m_timelines.add(timelineIdentifier, timeline.ptr());
-        if (addResult.isNewEntry)
-            m_timelinesUpdate.created.add(timeline);
-    }
+    ASSERT(page);
+    page->ensureAcceleratedTimelinesUpdater().processTimelinesSeenDuringEffectStacksUpdate(WTFMove(timelinesInUpdate));
 }
 
 void AcceleratedEffectStackUpdater::scheduleUpdateForTarget(const Styleable& target)
 {
     m_targetsPendingUpdate.add({ &target.element, target.pseudoElementIdentifier });
-}
-
-void AcceleratedEffectStackUpdater::scrollTimelineDidChange(ScrollTimeline& timeline)
-{
-    m_scrollTimelinesPendingUpdate.add(timeline);
-}
-
-AcceleratedTimelinesUpdate AcceleratedEffectStackUpdater::takeTimelinesUpdate()
-{
-    // All known accelerated timelines that got destroyed since the last update
-    // will now be null references. Add them to the list of destroyed timelines.
-    for (auto& [timelineIdentifier, timeline] : m_timelines) {
-        if (!timeline)
-            m_timelinesUpdate.destroyed.add(timelineIdentifier);
-    }
-
-    // Prune all those destroyed timelines from our list of know accelerated timelines.
-    for (auto& identifierToRemove : m_timelinesUpdate.destroyed)
-        m_timelines.remove(identifierToRemove);
-
-    // Finally, process all timelines that were marked as requiring an update, either
-    // marking them as modified or destroyed if they no longer are accelerated.
-    auto scrollTimelinesPendingUpdate = std::exchange(m_scrollTimelinesPendingUpdate, { });
-    for (auto& scrollTimeline : scrollTimelinesPendingUpdate) {
-        auto timelineIdentifier = scrollTimeline->acceleratedTimelineIdentifier();
-        auto acceleratedTimeline = m_timelines.getOptional(timelineIdentifier);
-        if (acceleratedTimeline && scrollTimeline->canBeAccelerated()) {
-            ASSERT(*acceleratedTimeline);
-            scrollTimeline->updateAcceleratedRepresentation();
-            m_timelinesUpdate.modified.add(**acceleratedTimeline);
-        } else
-            m_timelinesUpdate.destroyed.add(timelineIdentifier);
-    }
-
-    return std::exchange(m_timelinesUpdate, { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -28,17 +28,13 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #include <WebCore/AcceleratedEffect.h>
-#include <WebCore/AcceleratedTimeline.h>
 #include <WebCore/AnimationMalloc.h>
-#include <WebCore/TimelineIdentifier.h>
 #include <wtf/HashSet.h>
 
 namespace WebCore {
 
-class AcceleratedTimeline;
 class Document;
 class Element;
-class ScrollTimeline;
 struct Styleable;
 
 class AcceleratedEffectStackUpdater {
@@ -49,16 +45,10 @@ public:
     void update();
     void scheduleUpdateForTarget(const Styleable&);
     bool hasTargetsPendingUpdate() const { return !m_targetsPendingUpdate.isEmpty(); }
-    void scrollTimelineDidChange(ScrollTimeline&);
-
-    WEBCORE_EXPORT AcceleratedTimelinesUpdate takeTimelinesUpdate();
 
 private:
     using HashedStyleable = std::pair<Element*, std::optional<Style::PseudoElementIdentifier>>;
     HashSet<HashedStyleable> m_targetsPendingUpdate;
-    HashSet<Ref<ScrollTimeline>> m_scrollTimelinesPendingUpdate;
-    HashMap<TimelineIdentifier, WeakPtr<AcceleratedTimeline>> m_timelines;
-    AcceleratedTimelinesUpdate m_timelinesUpdate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedTimelinesUpdater.h"
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+#include "ScrollTimeline.h"
+
+namespace WebCore {
+
+void AcceleratedTimelinesUpdater::scrollTimelineDidChange(ScrollTimeline& timeline)
+{
+    m_scrollTimelinesPendingUpdate.add(timeline);
+}
+
+void AcceleratedTimelinesUpdater::processTimelinesSeenDuringEffectStacksUpdate(HashSet<Ref<AcceleratedTimeline>>&& timelinesInUpdate)
+{
+    for (auto& timeline : timelinesInUpdate) {
+        auto& timelineIdentifier = timeline->identifier();
+        auto addResult = m_timelines.add(timelineIdentifier, timeline.ptr());
+        if (addResult.isNewEntry)
+            m_timelinesUpdate.created.add(timeline);
+    }
+}
+
+AcceleratedTimelinesUpdate AcceleratedTimelinesUpdater::takeTimelinesUpdate()
+{
+    // All known accelerated timelines that got destroyed since the last update
+    // will now be null references. Add them to the list of destroyed timelines.
+    for (auto& [timelineIdentifier, timeline] : m_timelines) {
+        if (!timeline)
+            m_timelinesUpdate.destroyed.add(timelineIdentifier);
+    }
+
+    // Prune all those destroyed timelines from our list of known accelerated timelines.
+    for (auto& identifierToRemove : m_timelinesUpdate.destroyed)
+        m_timelines.remove(identifierToRemove);
+
+    // Finally, process all timelines that were marked as requiring an update, either
+    // marking them as modified or destroyed if they no longer are accelerated.
+    auto scrollTimelinesPendingUpdate = std::exchange(m_scrollTimelinesPendingUpdate, { });
+    for (auto& scrollTimeline : scrollTimelinesPendingUpdate) {
+        auto timelineIdentifier = scrollTimeline->acceleratedTimelineIdentifier();
+        auto acceleratedTimeline = m_timelines.getOptional(timelineIdentifier);
+        if (acceleratedTimeline && scrollTimeline->canBeAccelerated()) {
+            ASSERT(*acceleratedTimeline);
+            scrollTimeline->updateAcceleratedRepresentation();
+            m_timelinesUpdate.modified.add(**acceleratedTimeline);
+        } else
+            m_timelinesUpdate.destroyed.add(timelineIdentifier);
+    }
+
+    return std::exchange(m_timelinesUpdate, { });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/animation/AcceleratedTimelinesUpdater.h
+++ b/Source/WebCore/animation/AcceleratedTimelinesUpdater.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATIONS)
+
+#include <WebCore/AcceleratedTimeline.h>
+#include <WebCore/AnimationMalloc.h>
+#include <WebCore/TimelineIdentifier.h>
+#include <wtf/HashSet.h>
+
+namespace WebCore {
+
+class ScrollTimeline;
+
+class AcceleratedTimelinesUpdater {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AcceleratedTimelinesUpdater, Animation);
+public:
+    AcceleratedTimelinesUpdater() = default;
+
+    void scrollTimelineDidChange(ScrollTimeline&);
+    void processTimelinesSeenDuringEffectStacksUpdate(HashSet<Ref<AcceleratedTimeline>>&&);
+    WEBCORE_EXPORT AcceleratedTimelinesUpdate takeTimelinesUpdate();
+
+private:
+    HashSet<Ref<ScrollTimeline>> m_scrollTimelinesPendingUpdate;
+    HashMap<TimelineIdentifier, WeakPtr<AcceleratedTimeline>> m_timelines;
+    AcceleratedTimelinesUpdate m_timelinesUpdate;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -419,9 +419,11 @@ bool ScrollTimeline::computeCanBeAccelerated() const
 
 void ScrollTimeline::scheduleAcceleratedRepresentationUpdate()
 {
-    if (CheckedPtr controller = this->controller()) {
-        if (auto* acceleratedEffectStackUpdater = controller->existingAcceleratedEffectStackUpdater())
-            acceleratedEffectStackUpdater->scrollTimelineDidChange(*this);
+    if (auto source = m_source.styleable()) {
+        if (RefPtr page = source->element.protectedDocument()->page()) {
+            if (auto* acceleratedTimelinesUpdater = page->acceleratedTimelinesUpdater())
+                acceleratedTimelinesUpdater->scrollTimelineDidChange(*this);
+        }
     }
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -453,6 +453,10 @@
 #include "DocumentImmersive.h"
 #endif
 
+#if ENABLE(THREADED_ANIMATIONS)
+#include "AcceleratedEffectStackUpdater.h"
+#endif
+
 #define DOCUMENT_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->toUInt64() : 0, this->isTopDocument(), ##__VA_ARGS__)
 #define DOCUMENT_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->toUInt64() : 0, this->isTopDocument(), ##__VA_ARGS__)
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -6154,4 +6154,13 @@ void Page::showCaptionDisplaySettings(HTMLMediaElement& element, const ResolvedC
 }
 #endif
 
+#if ENABLE(THREADED_ANIMATIONS)
+AcceleratedTimelinesUpdater& Page::ensureAcceleratedTimelinesUpdater()
+{
+    if (!m_acceleratedTimelinesUpdater)
+        lazyInitialize(m_acceleratedTimelinesUpdater, makeUnique<AcceleratedTimelinesUpdater>());
+    return *m_acceleratedTimelinesUpdater.get();
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -75,6 +75,10 @@
 #include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
 #endif
 
+#if ENABLE(THREADED_ANIMATIONS)
+#include <WebCore/AcceleratedTimelinesUpdater.h>
+#endif
+
 namespace JSC {
 class Debugger;
 class JSGlobalObject;
@@ -1410,6 +1414,11 @@ public:
     void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&);
 #endif
 
+#if ENABLE(THREADED_ANIMATIONS)
+    AcceleratedTimelinesUpdater* acceleratedTimelinesUpdater() const { return m_acceleratedTimelinesUpdater.get(); }
+    AcceleratedTimelinesUpdater& ensureAcceleratedTimelinesUpdater();
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1893,6 +1902,11 @@ private:
 #if ENABLE(VIDEO)
     RefPtr<CaptionDisplaySettingsClient> m_captionDisplaySettingsClientForTesting;
 #endif
+
+#if ENABLE(THREADED_ANIMATIONS)
+    const std::unique_ptr<AcceleratedTimelinesUpdater> m_acceleratedTimelinesUpdater;
+#endif
+
 }; // class Page
 
 WTF::TextStream& operator<<(WTF::TextStream&, RenderingUpdateStep);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1979,18 +1979,8 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     Ref page = *corePage();
 
 #if ENABLE(THREADED_ANIMATIONS)
-    AcceleratedTimelinesUpdate combinedTimelinesUpdate;
-    page->forEachDocument([&](const auto& document) {
-        if (CheckedPtr timelinesController = document.timelinesController()) {
-            if (auto* acceleratedEffectStackUpdater = timelinesController->existingAcceleratedEffectStackUpdater()) {
-                auto timelinesUpdate = acceleratedEffectStackUpdater->takeTimelinesUpdate();
-                combinedTimelinesUpdate.created = combinedTimelinesUpdate.created.unionWith(timelinesUpdate.created);
-                combinedTimelinesUpdate.modified = combinedTimelinesUpdate.modified.unionWith(timelinesUpdate.modified);
-                combinedTimelinesUpdate.destroyed = combinedTimelinesUpdate.destroyed.unionWith(timelinesUpdate.destroyed);
-            }
-        }
-    });
-    layerTransaction.setTimelinesUpdate(WTFMove(combinedTimelinesUpdate));
+    if (auto* acceleratedTimelinesUpdater = page->acceleratedTimelinesUpdater())
+        layerTransaction.setTimelinesUpdate(acceleratedTimelinesUpdater->takeTimelinesUpdate());
 #endif
 
     layerTransaction.setContentsSize(frameView->contentsSize());


### PR DESCRIPTION
#### cafb7b2f4caf0214ac2536f458478b636188456e
<pre>
[threaded-animations] `animations/resume-after-page-cache.html` crashes with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=303980">https://bugs.webkit.org/show_bug.cgi?id=303980</a>

Reviewed by Simon Fraser.

The test `animations/resume-after-page-cache.html` puts a page with animations
in the back/forward cache and then navigates back to it and checks that animations
are resumed.

If this test was ran twice in a row, it would crash the test runner in debug builds
due to a failed assertion in `RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues()`
indicating a failed timeline lookup.

As the animated page enters the cache, its animations are suspended, and as a result
accelerated animations are canceled. This leads to a remote a layer tree transaction
destroying layers with animations, and thus destroying associated `AcceleratedTimeline`
which are owned by layer tree animations (see 304042@main). Typically, the list of known
timelines held by `AcceleratedEffectStackUpdater` will catch the deletion of those timelines
and provide the `TimelinesUpdate` for the transaction with those removals. However, since
`AcceleratedEffectStackUpdater` is held by the `Document` (via its `AnimationTimelinesController`),
when we compile the timelines update in `WebPage::willCommitLayerTree()`, after the page
has entered the cache, the document with the expected timelines update is no longer iterated
upon by `Page::forEachDocument()` and we don&apos;t correctly remove the affected timelines from
the list of known timelines.

To address this, we move the list of known timelines to a per-`Page` object, the new class
`AcceleratedTimelinesUpdater`. Now the remote layer tree transaction, as a page enters the cache,
will contain timelines associated with documents now in the cache and the currently-active documents.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedTimeBasedAnimationsEnabled=true`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
(WebCore::AcceleratedEffectStackUpdater::scrollTimelineDidChange): Deleted.
(WebCore::AcceleratedEffectStackUpdater::takeTimelinesUpdate): Deleted.
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
(WebCore::AcceleratedEffectStackUpdater::hasTargetsPendingUpdate const):
* Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp: Added.
(WebCore::AcceleratedTimelinesUpdater::scrollTimelineDidChange):
(WebCore::AcceleratedTimelinesUpdater::processTimelinesSeenDuringEffectStacksUpdate):
(WebCore::AcceleratedTimelinesUpdater::takeTimelinesUpdate):
* Source/WebCore/animation/AcceleratedTimelinesUpdater.h: Added.
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::scheduleAcceleratedRepresentationUpdate):
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::ensureAcceleratedTimelinesUpdater):
* Source/WebCore/page/Page.h:
(WebCore::Page::acceleratedTimelinesUpdater const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/304301@main">https://commits.webkit.org/304301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de41236f1c70cbec6b2e60570e7bbbae83c4a843

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86940 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70496 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84130 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3222 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3248 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112016 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5453 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117419 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20848 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7277 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35565 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->