### PR TITLE
SpeculationRules - do not prefetch hidden links

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test selector_matches with link inside display locked container assert_equals: expected 0 but got 1
+PASS test selector_matches with link inside display locked container
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test selector_matches with link inside display:none container assert_equals: expected 0 but got 1
+PASS test selector_matches with link inside display:none container
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test that unslotted link never matches document rule assert_equals: expected 0 but got 1
+PASS test that unslotted link never matches document rule
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -716,10 +716,17 @@ ReferrerPolicy HTMLAnchorElement::referrerPolicy() const
 
 Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     protectedDocument()->processInternalResourceLinks(this);
+    if (document().settings().speculationRulesPrefetchEnabled())
+        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return InsertedIntoAncestorResult::Done;
+}
+
+void HTMLAnchorElement::didFinishInsertingNode()
+{
+    HTMLElement::didFinishInsertingNode();
     checkForSpeculationRules();
-    return result;
 }
 
 void HTMLAnchorElement::setFullURL(const URL& fullURL)

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -83,6 +83,7 @@ public:
     ReferrerPolicy referrerPolicy() const;
 
     Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) override;
+    void didFinishInsertingNode() override;
 
     AtomString target() const override;
 


### PR DESCRIPTION
#### 652c5fd0762ece7b5f77ec1d7b99dba35199f8fd
<pre>
SpeculationRules - do not prefetch hidden links
<a href="https://bugs.webkit.org/show_bug.cgi?id=303981">https://bugs.webkit.org/show_bug.cgi?id=303981</a>

Reviewed by Alex Christensen.

The speculation rules spec states that hidden links should not be prefetched.
This PR aligns the implementation to the spec on that front.

No new tests, but progression on existing tests.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt: Progression.
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::isUnslottedElement): Return true if the element is part of a shadow DOM and has no slot.
(WebCore::SpeculationRulesMatcher::hasMatchingRule): Check the element visibility and if it&apos;s unslotted before prefetching its url.
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::insertedIntoAncestor): Schedule post-insertaion callback.
(WebCore::HTMLAnchorElement::didFinishInsertingNode): Check speculation rules post-insertion.
* Source/WebCore/html/HTMLAnchorElement.h:

Canonical link: <a href="https://commits.webkit.org/304472@main">https://commits.webkit.org/304472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b2610b78f82da48bc5af4b844e68a2b93f57193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84531 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3622 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3967 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146107 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112394 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5870 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61669 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7752 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7499 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71304 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->