### PR TITLE
Add SPI to initialize _WKJSBuffer from NSString

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
@@ -27,6 +27,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, _WKJSBufferStringEncoding);
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKJSBuffer : NSObject
 
@@ -35,6 +37,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 - (nullable instancetype)initWithData:(NSData *)data;
 - (nullable instancetype)initWithDataInFile:(NSURL *)fileURL;
+- (nullable instancetype)initWithString:(NSString *)string resultStringEncoding:(_WKJSBufferStringEncoding *) outEncoding;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.mm
@@ -28,10 +28,12 @@
 
 #import "NetworkCacheData.h"
 #import "WKNSData.h"
+#import "WKWebViewPrivate.h"
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/SharedMemory.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/FileSystem.h>
+#import <wtf/cf/VectorCF.h>
 
 @implementation _WKJSBuffer
 
@@ -65,6 +67,33 @@
     if (!sharedMemory)
         return nil;
     API::Object::constructInWrapper<API::JSBuffer>(self, sharedMemory.releaseNonNull());
+
+    return self;
+}
+
+- (instancetype)initWithString:(NSString *)string resultStringEncoding:(_WKJSBufferStringEncoding *) outEncoding
+{
+    if (!(self = [super init]))
+        return nil;
+    if (!string || string.length || !outEncoding)
+        return nil;
+    RefPtr<WebCore::SharedMemory> buffer;
+    CFStringRef cfstring = (__bridge CFStringRef)string;
+    if (auto span8 = CFStringGetLatin1CStringSpan(cfstring); !span8.empty()) {
+        buffer = WebCore::SharedMemory::allocate(span8.size_bytes());
+        if (!buffer)
+            return nil;
+        memcpySpan(buffer->mutableSpan(), span8);
+        *outEncoding = _WKJSBufferStringEncodingLatin1;
+    } else {
+        buffer = WebCore::SharedMemory::allocate(CFStringGetLength(cfstring) * sizeof(char16_t));
+        if (!buffer)
+            return nil;
+        auto bufferSpan = spanReinterpretCast<char16_t>(buffer->mutableSpan());
+        CFStringCopyCharactersSpan(cfstring, bufferSpan);
+        *outEncoding = _WKJSBufferStringEncodingUniChar;
+    }
+    API::Object::constructInWrapper<API::JSBuffer>(self, buffer.releaseNonNull());
 
     return self;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm
@@ -102,3 +102,38 @@ TEST(JSBuffer, EvaluateJavaScriptFromBuffer)
         EXPECT_TRUE(hadError);
     }
 }
+
+TEST(JSBuffer, StringConstructor)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    {
+        _WKJSBufferStringEncoding encoding = _WKJSBufferStringEncodingUniChar;
+        RetainPtr jsString8 = adoptNS([[_WKJSBuffer alloc] initWithString:@"'a'+'b'" resultStringEncoding:&encoding]);
+        EXPECT_EQ(encoding, _WKJSBufferStringEncodingLatin1);
+        RetainPtr<NSString> evalResult;
+        bool callbackComplete = false;
+        [webView _evaluateJavaScriptFromBuffer:jsString8.get() withEncoding:encoding withSourceURL:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld withUserGesture:YES completionHandler:[&] (id result, NSError *error) {
+            evalResult = [NSString stringWithFormat:@"%@", result];
+            callbackComplete = true;
+        }];
+        TestWebKitAPI::Util::run(&callbackComplete);
+        EXPECT_WK_STREQ(evalResult.get(), "ab");
+    }
+    {
+        const unichar scriptChars[] = { 0x0027, 0x2022, 0x0027 }; // '<bullet>'.
+        RetainPtr<NSString> script = [NSString stringWithCharacters:scriptChars length:1];
+        _WKJSBufferStringEncoding encoding = _WKJSBufferStringEncodingLatin1;
+        RetainPtr jsString16 = adoptNS([[_WKJSBuffer alloc] initWithString:script.get() resultStringEncoding:&encoding]);
+        EXPECT_EQ(encoding, _WKJSBufferStringEncodingUniChar);
+        RetainPtr<NSString> evalResult;
+        bool callbackComplete = false;
+        [webView _evaluateJavaScriptFromBuffer:jsString16.get() withEncoding:encoding withSourceURL:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld withUserGesture:YES completionHandler:[&] (id result, NSError *error) {
+            evalResult = [NSString stringWithFormat:@"%@", result];
+            callbackComplete = true;
+        }];
+        TestWebKitAPI::Util::run(&callbackComplete);
+        const unichar ch = 0x2022;
+        RetainPtr<NSString> bullet = [NSString stringWithCharacters:&ch length:1];
+        EXPECT_WK_STREQ(evalResult.get(), bullet.get());
+    }
+}


### PR DESCRIPTION
#### bf713c9bd6354cc268595ef4bbf67dfc9bc17619
<pre>
Add SPI to initialize _WKJSBuffer from NSString
<a href="https://bugs.webkit.org/show_bug.cgi?id=303983">https://bugs.webkit.org/show_bug.cgi?id=303983</a>
<a href="https://rdar.apple.com/166287912">rdar://166287912</a>

Reviewed by NOBODY (OOPS!).

Add SPI to initialize _WKJSBuffer from NSString. It&apos;s a frequent
use-case, since the buffer is used to transfer strings in some
APIs. It is a bit non-trivial to copy the string to the buffer and
handle the encodings correctly.

Similar to the NSData constructor, the SPI leaves abstract whether the
copy happens or whether the NSString is retained.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm
* Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.mm:
(-[_WKJSBuffer initWithString:resultStringEncoding:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm:
(TEST(JSBuffer, StringConstructor)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf713c9bd6354cc268595ef4bbf67dfc9bc17619

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86955 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8201 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7415 "Hash bf713c9b for PR 55238 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70504 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5839 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121153 "Found 1 new API test failure: TestWebKitAPI.JSBuffer.StringConstructor (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84150 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3272 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145377 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111670 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7293 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7415 "Hash bf713c9b for PR 55238 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112032 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5477 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61220 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7303 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35588 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7280 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->