### PR TITLE
Reduce unsafeness in SVGTRefElement & SVGSMILElement

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -74,8 +74,6 @@ rendering/svg/SVGRenderTreeAsText.cpp
 rendering/svg/SVGTextQuery.cpp
 svg/SVGFELightElement.cpp
 svg/SVGPathSegListSource.cpp
-svg/SVGTRefElement.cpp
-svg/animation/SVGSMILElement.cpp
 svg/properties/SVGAnimatedDecoratedProperty.h
 svg/properties/SVGAnimatedPrimitiveProperty.h
 svg/properties/SVGAnimatedPropertyAccessorImpl.h

--- a/Source/WebCore/svg/SVGPathSegListSource.cpp
+++ b/Source/WebCore/svg/SVGPathSegListSource.cpp
@@ -42,17 +42,15 @@ bool SVGPathSegListSource::hasMoreData() const
 SVGPathSegType SVGPathSegListSource::nextCommand(SVGPathSegType)
 {
     m_segment = m_pathSegList->at(m_itemCurrent);
-    SVGPathSegType pathSegType = static_cast<SVGPathSegType>(m_segment->pathSegType());
     ++m_itemCurrent;
-    return pathSegType;
+    return m_segment->pathSegType();
 }
 
 std::optional<SVGPathSegType> SVGPathSegListSource::parseSVGSegmentType()
 {
     m_segment = m_pathSegList->at(m_itemCurrent);
-    SVGPathSegType pathSegType = static_cast<SVGPathSegType>(m_segment->pathSegType());
     ++m_itemCurrent;
-    return pathSegType;
+    return m_segment->pathSegType();
 }
 
 std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSegment(FloatPoint)

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -58,11 +58,6 @@ public:
         return adoptRef(*new SVGTRefTargetEventListener(trefElement));
     }
 
-    static const SVGTRefTargetEventListener* cast(const EventListener* listener)
-    {
-        return listener->type() == SVGTRefTargetEventListenerType ? static_cast<const SVGTRefTargetEventListener*>(listener) : nullptr;
-    }
-
     void attach(RefPtr<Element>&& target);
     void detach();
     bool isAttached() const { return m_target.get(); }
@@ -109,7 +104,7 @@ void SVGTRefTargetEventListener::detach()
 
 bool SVGTRefTargetEventListener::operator==(const EventListener& listener) const
 {
-    if (const SVGTRefTargetEventListener* targetListener = SVGTRefTargetEventListener::cast(&listener))
+    if (auto* targetListener = dynamicDowncast<SVGTRefTargetEventListener>(listener))
         return &m_trefElement == &targetListener->m_trefElement;
     return false;
 }
@@ -274,4 +269,11 @@ void SVGTRefElement::removedFromAncestor(RemovalType removalType, ContainerNode&
         protectedTargetListener()->detach();
 }
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGTRefTargetEventListener)
+    static bool isType(const WebCore::EventListener& listener)
+    {
+        return listener.type() == WebCore::EventListener::SVGTRefTargetEventListenerType;
+    }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -82,13 +82,6 @@ public:
         return adoptRef(*new ConditionEventListener(animation, condition));
     }
 
-    static const ConditionEventListener* cast(const EventListener* listener)
-    {
-        return listener->type() == ConditionEventListenerType
-            ? static_cast<const ConditionEventListener*>(listener)
-            : nullptr;
-    }
-
     bool operator==(const EventListener& other) const final;
     
     void disconnectAnimation()
@@ -112,7 +105,7 @@ private:
 
 bool ConditionEventListener::operator==(const EventListener& listener) const
 {
-    if (const ConditionEventListener* conditionEventListener = ConditionEventListener::cast(&listener))
+    if (auto* conditionEventListener = dynamicDowncast<ConditionEventListener>(listener))
         return m_animation == conditionEventListener->m_animation && m_condition == conditionEventListener->m_condition;
     return false;
 }
@@ -1275,4 +1268,11 @@ void SVGSMILElement::dispatchPendingEvent(SMILEventSender* eventSender, const At
     dispatchEvent(Event::create(eventType, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ConditionEventListener)
+    static bool isType(const WebCore::EventListener& listener)
+    {
+        return listener.type() == WebCore::EventListener::ConditionEventListenerType;
+    }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 65d68fb3d3613fde9d26bb2d3ee2017fad5dc1c4
<pre>
Reduce unsafeness in SVGTRefElement &amp; SVGSMILElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=303987">https://bugs.webkit.org/show_bug.cgi?id=303987</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304340@main">https://commits.webkit.org/304340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c9f74b5b1ee5c0036ee551f882eafbcd94aa59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86987 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84194 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3282 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145426 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111714 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112078 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5523 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61243 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35653 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->