### PR TITLE
Add Swift IPC layout test

### DIFF
--- a/LayoutTests/ipc/swift-receiver-expected.txt
+++ b/LayoutTests/ipc/swift-receiver-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IPC message delivered OK to Swift (or C++).
+

--- a/LayoutTests/ipc/swift-receiver.html
+++ b/LayoutTests/ipc/swift-receiver.html
@@ -1,0 +1,28 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that a Swift receiver handles a message.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ipc.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+    IPC.addTesterReceiver('UI');
+    try {
+        let result = await IPC.sendWithPromisedReply('UI', 0, IPC.messages.IPCTester_SendAsyncMessageToReceiverRequestingReply.name, [{type: 'int32_t', value: 42}]);
+        if (result.arguments[1].value) {
+            // Swift handled this, and should have added 3
+            assert_equals(result.arguments[0].value, 45);
+        } else {
+            // C++ handled this, and should have added 2
+            assert_equals(result.arguments[0].value, 44);
+        }
+    } finally {
+        IPC.removeTesterReceiver('UI');
+    }
+    done();
+}, "IPC message delivered OK to Swift (or C++).");
+</script>
+</body>

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -77,7 +77,7 @@ private:
     void sendSameSemaphoreBack(IPC::Connection&, IPC::Semaphore&&);
     void sendSemaphoreBackAndSignalProtocol(IPC::Connection&, IPC::Semaphore&&);
     void sendAsyncMessageToReceiver(IPC::Connection&, uint32_t);
-    void sendAsyncMessageToSwiftReceiver(IPC::Connection&, uint32_t);
+    void sendAsyncMessageToReceiverRequestingReply(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t, bool)>&&);
     void asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionHandler<void()>&&);

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -45,7 +45,7 @@ messages -> IPCTester {
     SyncPingEmptyReply(uint32_t value) -> () Synchronous
 
     SendAsyncMessageToReceiver(uint32_t arg0)
-    SendAsyncMessageToSwiftReceiver(uint32_t arg0)
+    SendAsyncMessageToReceiverRequestingReply(uint32_t value) -> (uint32_t nextValue, bool swiftUsed)
     AsyncOptionalExceptionData(bool sendEngaged) -> (struct std::optional<WebCore::ExceptionData> exceptionData, String other)
 
     EmptyMessage()

--- a/Source/WebKit/Shared/IPCTesterReceiverSwift.swift
+++ b/Source/WebKit/Shared/IPCTesterReceiverSwift.swift
@@ -43,7 +43,7 @@ final class IPCTesterReceiverSwift {
     }
 
     func asyncMessage(data: UInt32, completionHandler: CompletionHandlers.IPCTesterReceiverSwift.AsyncMessageCompletionHandler) {
-        completionHandler.pointee(data + 1)
+        completionHandler.pointee(data + 2)
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2761,6 +2761,9 @@ JSValueRef JSIPC::removeTesterReceiver(JSContextRef context, JSObjectRef, JSObje
     }
 
     WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName());
+#if ENABLE(IPC_TESTING_SWIFT)
+    WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiverSwift::messageReceiverName());
+#endif
     return JSValueMakeUndefined(context);
 }
 


### PR DESCRIPTION
#### 18770b8cdeffcaf19ead1809dc694b1d8bd37f1a
<pre>
Add Swift IPC layout test
<a href="https://bugs.webkit.org/show_bug.cgi?id=303989">https://bugs.webkit.org/show_bug.cgi?id=303989</a>
<a href="https://rdar.apple.com/166293273">rdar://166293273</a>

Reviewed by Richard Robinson.

We previously landed an ability for CoreIPC to call directly into Swift message
handlers, and we added a test message handler within the IPCTester
infrastructure. However, we landed no automated test to exercise this new code.
That&apos;s what this PR does.

This will only have any effect in builds where ENABLE_IPC_TESTING is true, which
as standard is ASAN or debug builds.

In all such builds, we&apos;ll now exercise a code path to call into C++ and receive
an asynchronous reply. If additionally ENABLE_IPC_TESTING_SWIFT is enabled,
we&apos;ll also call into a Swift message receiver.

As well as adding the new layout test (HTML) it also makes a tiny change to the
recently-added IPCTester logic, to ensure the C++ logic behaves slightly
differently to the Swift logic, as an extra layer of proof that the Swift
receiver was called. It also adds a missing call to removeMessageReceiver.

Test: ipc/swift-receiver.html
Canonical link: <a href="https://commits.webkit.org/304693@main">https://commits.webkit.org/304693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1f35f12f970fa3252d4e60961a41c0b167e2b2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143982 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbc84c72-6c97-4021-bbf9-01b520472a81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104193 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b56c5ad-de64-4a8c-a9d5-61252d8be547) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85026 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87a28b7a-63ef-448a-9073-442850076dbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4114 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112876 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6356 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118411 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8358 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36468 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->