### PR TITLE
[GLIB] Regression(304166@main) http/tests/pasteboard/copy-image-from-context-menu.html is a constant crash

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4109,8 +4109,6 @@ webgl/2.0.y/conformance/textures/misc/texture-corner-case-videos.html [ Skip ] #
 [ Debug ] imported/blink/fast/hidpi/border-background-align.html [ ImageOnlyFailure Pass ]
 [ Debug ] imported/blink/svg/zoom/text/lowdpi-zoom-text.html [ Crash ]
 
-webkit.org/b/303928 http/tests/pasteboard/copy-image-from-context-menu.html [ Crash ]
-
 # Test causes OOM in the EWS release bots
 webkit.org/b/283558 fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html [ Skip ]
 

--- a/LayoutTests/platform/gtk/http/tests/pasteboard/copy-image-from-context-menu-expected.txt
+++ b/LayoutTests/platform/gtk/http/tests/pasteboard/copy-image-from-context-menu-expected.txt
@@ -1,0 +1,17 @@
+This tests that using the 'Copy Image' context menu item codepath does not copy the image URL.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS event.clipboardData.items.length is 2
+FAIL event.clipboardData.items[0].type should be text/html. Was text/uri-list.
+FAIL event.clipboardData.items[1].type should be image/png. Was text/html.
+To run this test manually, click "Copy Image" in the context menu with the image below, and paste in the box with the black border.
+
+NOTE: This test needs to run on a HTTP server as this bug reproduces only with hosted images.
+
+
+

--- a/LayoutTests/platform/wpe/http/tests/pasteboard/copy-image-from-context-menu-expected.txt
+++ b/LayoutTests/platform/wpe/http/tests/pasteboard/copy-image-from-context-menu-expected.txt
@@ -1,0 +1,17 @@
+This tests that using the 'Copy Image' context menu item codepath does not copy the image URL.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FAIL event.clipboardData.items.length should be 2. Was 0.
+FAIL event.clipboardData.items[0].type should be text/html. Threw exception TypeError: undefined is not an object (evaluating 'event.clipboardData.items[0].type')
+FAIL event.clipboardData.items[1].type should be image/png. Threw exception TypeError: undefined is not an object (evaluating 'event.clipboardData.items[1].type')
+To run this test manually, click "Copy Image" in the context menu with the image below, and paste in the box with the black border.
+
+NOTE: This test needs to run on a HTTP server as this bug reproduces only with hosted images.
+
+
+

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -95,7 +95,8 @@ void UIScriptControllerGtk::copyText(JSStringRef text)
 
 void UIScriptControllerGtk::paste()
 {
-    // FIXME: implement.
+    auto page = TestController::singleton().mainWebView()->page();
+    WKPageExecuteCommand(page, WKStringCreateWithUTF8CString("Paste"));
 }
 
 void UIScriptControllerGtk::dismissMenu()

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
@@ -74,6 +74,12 @@ void UIScriptControllerWPE::copyText(JSStringRef text)
     // FIXME: implement.
 }
 
+void UIScriptControllerWPE::paste()
+{
+    auto page = TestController::singleton().mainWebView()->page();
+    WKPageExecuteCommand(page, WKStringCreateWithUTF8CString("Paste"));
+}
+
 void UIScriptControllerWPE::dismissMenu()
 {
     // FIXME: implement.

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
@@ -41,6 +41,7 @@ public:
     void doAsyncTask(JSValueRef) override;
     void setContinuousSpellCheckingEnabled(bool) override;
     void copyText(JSStringRef) override;
+    void paste() override;
     void dismissMenu() override;
     bool isShowingMenu() const override;
     void activateAtPoint(long x, long y, JSValueRef callback) override;


### PR DESCRIPTION
#### 18dea0b0a05b899f367a0cbdfbd75f68cc24a5ed
<pre>
[GLIB] Regression(304166@main) http/tests/pasteboard/copy-image-from-context-menu.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=303928">https://bugs.webkit.org/show_bug.cgi?id=303928</a>

Reviewed by Michael Catanzaro.

Both GTK and WPE were missing implementations for UIScriptController::paste().
New baselines are needed as for GTK paste behavior is different than Mac&apos;s,
WPE pasting doesn&apos;t actually seem to work at all, but this is better than crashing
or timing out.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/http/tests/pasteboard/copy-image-from-context-menu-expected.txt: Added.
* LayoutTests/platform/wpe/http/tests/pasteboard/copy-image-from-context-menu-expected.txt: Added.
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp:
(WTR::UIScriptControllerGtk::paste):
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp:
(WTR::UIScriptControllerWPE::paste):
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h:

Canonical link: <a href="https://commits.webkit.org/304307@main">https://commits.webkit.org/304307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2363c264dc64e4df410c02bb6b82c9f1677fec3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103301 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84158 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3247 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3278 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111679 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5485 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117454 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7311 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->