### PR TITLE
[GTK] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WKTextCheckerSetSpellCheckingLanguages()

### DIFF
--- a/Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.cpp
+++ b/Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.cpp
@@ -65,14 +65,12 @@ void WKTextCheckerChangeSpellingToWord(WKPageRef page, WKStringRef word)
     WebTextChecker::singleton()->changeSpellingToWord(toImpl(page), toWTFString(word));
 }
 
-void WKTextCheckerSetSpellCheckingLanguages(const char* const* languages)
+void WKTextCheckerSetSpellCheckingLanguages(const char* const* languages, const size_t length)
 {
 #if ENABLE(SPELLCHECK)
     Vector<String> spellCheckingLanguages;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-    for (size_t i = 0; languages[i]; ++i)
-        spellCheckingLanguages.append(String::fromUTF8(languages[i]));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    for (auto language : unsafeMakeSpan(languages, length))
+        spellCheckingLanguages.append(String::fromUTF8(language));
     WebKit::TextChecker::setSpellCheckingLanguages(spellCheckingLanguages);
 #endif
 }

--- a/Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.h
+++ b/Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.h
@@ -88,7 +88,7 @@ WK_EXPORT void WKTextCheckerGrammarCheckingEnabledStateChanged(bool);
 WK_EXPORT void WKTextCheckerCheckSpelling(WKPageRef page, bool startBeforeSelection);
 WK_EXPORT void WKTextCheckerChangeSpellingToWord(WKPageRef page, WKStringRef word);
 
-WK_EXPORT void WKTextCheckerSetSpellCheckingLanguages(const char* const* languages);
+WK_EXPORT void WKTextCheckerSetSpellCheckingLanguages(const char* const* languages, const size_t length);
 
 #endif // PLATFORM(GTK)
 

--- a/Tools/WebKitTestRunner/gtk/main.cpp
+++ b/Tools/WebKitTestRunner/gtk/main.cpp
@@ -62,8 +62,7 @@ int main(int argc, char** argv)
 
     GRefPtr<GPtrArray> languages = adoptGRef(g_ptr_array_new());
     g_ptr_array_add(languages.get(), const_cast<gpointer>(static_cast<const void*>("en_US")));
-    g_ptr_array_add(languages.get(), nullptr);
-    WKTextCheckerSetSpellCheckingLanguages(reinterpret_cast<const char* const*>(languages->pdata));
+    WKTextCheckerSetSpellCheckingLanguages(reinterpret_cast<const char* const*>(languages->pdata), languages->len);
 
     // Prefer the not installed web and plugin processes.
     WTR::TestController controller(argc, const_cast<const char**>(argv));


### PR DESCRIPTION
#### 668d691e977fc8b2a9fa437efd76bbe1a5f09066
<pre>
[GTK] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from WKTextCheckerSetSpellCheckingLanguages()
<a href="https://bugs.webkit.org/show_bug.cgi?id=303997">https://bugs.webkit.org/show_bug.cgi?id=303997</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

We don&apos;t expose the C API so it should be OK to change this method
to pass the length to simplify using a span with it.

* Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.cpp:
(WKTextCheckerSetSpellCheckingLanguages):
* Source/WebKit/UIProcess/API/C/glib/WKTextCheckerGLib.h:
* Tools/WebKitTestRunner/gtk/main.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/304314@main">https://commits.webkit.org/304314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dc909c757b6dd785e98d25efaabdb0e53b15a92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/86966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3258 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3291 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145398 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5497 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117470 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35604 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70875 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->