### PR TITLE
[Site Isolation] Fix when about:blank iframes call window.open()

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/post-opener-info-message-to-opener.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-opener-info-message-to-opener.html
@@ -1,0 +1,3 @@
+<script>
+    window.opener.postMessage("opener info: opener url is " + opener.location.href + " and origin is " + opener.origin, "*")
+</script>

--- a/LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe-expected.txt
@@ -1,0 +1,6 @@
+This test passes if WebKit doesn't crash and the opened window returns the correct opener url and origin
+
+--------
+Frame: '<!--frame1-->'
+--------
+opened window reported opener info: opener url is about:blank and origin is http://127.0.0.1:8000

--- a/LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe.html
@@ -1,0 +1,26 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest()
+{
+	i = document.body.appendChild(document.createElement("iframe"));
+    i.contentWindow.addEventListener("message", (event) => {
+        if (event.data.startsWith("opener info:")) {
+            i.contentWindow.document.body.appendChild(
+                i.contentWindow.document.createTextNode("\n\nopened window reported " + event.data)
+            )
+            window.testRunner?.notifyDone();
+        } 
+    });
+    i.contentWindow.open("http://127.0.0.1:8000/site-isolation/resources/post-opener-info-message-to-opener.html", "frameName");
+}
+
+</script>
+<body onload="runTest()">
+This test passes if WebKit doesn't crash and the opened window returns the correct opener url and origin
+</body>

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -26,12 +26,14 @@
 #pragma once
 
 #include "APIObject.h"
+#include "BrowsingContextGroup.h"
 #include "WebPreferencesDefaultValues.h"
 #include "WebPreferencesDefinitions.h"
 #include "WebURLSchemeHandler.h"
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ReferrerPolicy.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <WebCore/Site.h>
 #include <WebCore/WindowFeatures.h>
@@ -120,6 +122,7 @@ public:
         Ref<WebKit::WebProcessProxy> process;
         Ref<WebKit::BrowsingContextGroup> browsingContextGroup;
         WebCore::FrameIdentifier frameID;
+        WebCore::SecurityOriginData securityOrigin;
         bool operator==(const OpenerInfo&) const;
     };
     const std::optional<OpenerInfo>& openerInfo() const;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -49,6 +49,7 @@
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/SpatialBackdropSource.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/UUID.h>
@@ -445,7 +446,7 @@ public:
 
     EnhancedSecurityTracking enhancedSecurityTracker;
 
-    explicit Internals(WebPageProxy&);
+    explicit Internals(WebPageProxy&, std::optional<WebCore::SecurityOriginData>);
 
     Ref<WebPageProxy> protectedPage() const;
 
@@ -523,6 +524,8 @@ public:
     RefPtr<WebPageProxyFrameLoadStateObserver> protectedFrameLoadStateObserver() { return frameLoadStateObserver; }
 #endif
     Ref<GeolocationPermissionRequestManagerProxy> protectedGeolocationPermissionRequestManager() { return geolocationPermissionRequestManager; }
+
+    std::optional<WebCore::SecurityOriginData> openerOrigin;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 7fcf73d2aff00cac98545c4c11e11c8944bc64af
<pre>
[Site Isolation] Fix when about:blank iframes call window.open()
<a href="https://bugs.webkit.org/show_bug.cgi?id=303956">https://bugs.webkit.org/show_bug.cgi?id=303956</a>
<a href="https://rdar.apple.com/165169147">rdar://165169147</a>

Reviewed by Alex Christensen.

This patch fixes an issue where calling window.open() from the context
of an about:blank iframe. Previously, this snippet would crash with site
isolation enabled.

```
i = document.body.appendChild(document.createElement(&quot;iframe&quot;));
i.contentWindow.open();
```

This patch fixes LayoutTests/http/tests/security/xss-DENIED-synchronous-frame-load-in-javascript-url.html
with site isolation enabled.

This patch changes the site passed into BrowsingContextGroup::ensureProcessForSite
to use the same process as the opener when an about:blank page is opened with
window.open().

Test: http/tests/site-isolation/window-open-from-about-blank-iframe.html

* LayoutTests/http/tests/site-isolation/resources/post-opener-info-message-to-opener.html: Added.
* LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-open-from-about-blank-iframe.html: Added.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::Internals::Internals):
(WebKit::openerOrigin):
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::createNewPage):
(WebKit::activityStateChangeTimer): Deleted.
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/304540@main">https://commits.webkit.org/304540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92a116350682cd996646f40320b2328dc5cef8c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87024 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3f31366b-10db-454f-b351-20ca706596e9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57f2a175-d3ff-435c-a28f-bc875660393d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84239 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5715 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3319 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3370 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145479 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112122 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5565 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117549 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61276 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20927 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7400 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35676 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->