### PR TITLE
REGRESSION (iOS 26.1): Frequent UI process crashes in WebCore::ElementContext::isSameElement under WKSelectPicker

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -777,6 +777,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly, getter=_isSuppressingSelectionAssistant) BOOL _suppressingSelectionAssistant;
 
 - (BOOL)_hasFocusedElement;
+- (BOOL)_isSameAsFocusedElement:(const WebCore::ElementContext&)context;
 - (void)_zoomToRevealFocusedElement;
 
 - (void)_keyboardWillShow;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -699,10 +699,9 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 {
     _isAnimatingContextMenuDismissal = YES;
     [animator addCompletion:[weakSelf = WeakObjCPtr<WKSelectPicker>(self), elementContext = _view.focusedElementInformation.elementContext] {
-        auto strongSelf = weakSelf.get();
-        if (strongSelf) {
+        if (RetainPtr strongSelf = weakSelf.get()) {
             RetainPtr view = strongSelf->_view;
-            if (elementContext.isSameElement([view focusedElementInformation].elementContext))
+            if ([view _isSameAsFocusedElement:elementContext])
                 [view accessoryDone];
             [[view webView] _didDismissContextMenu];
             strongSelf->_isAnimatingContextMenuDismissal = NO;


### PR DESCRIPTION
#### 41b65165bb54ce1b1165ceb25bb856a6504ec809
<pre>
REGRESSION (iOS 26.1): Frequent UI process crashes in WebCore::ElementContext::isSameElement under WKSelectPicker
<a href="https://bugs.webkit.org/show_bug.cgi?id=303917">https://bugs.webkit.org/show_bug.cgi?id=303917</a>
<a href="https://rdar.apple.com/163148093">rdar://163148093</a>

Reviewed by Tim Horton.

When dismissing a select menu after the changes in 300720@main, it&apos;s possible that we now crash in
the case where `WKSelectPicker` outlives the underlying web view. This is because `view` is `nil`
here:

```
[animator addCompletion:[weakSelf = WeakObjCPtr&lt;WKSelectPicker&gt;(self), elementContext = _view.focusedElementInformation.elementContext] {
    auto strongSelf = weakSelf.get();
    if (strongSelf) {
        RetainPtr view = strongSelf-&gt;_view;    // &lt;------
        if (elementContext.isSameElement([view focusedElementInformation].elementContext))
```

...which causes the `ElementContext` passed into `isSameElement` to be a **zero-initialized** C++
struct. Notably, this does not call the default constructor for the underlying `Markable`s
representing each of the element/document/page IDs, which initializes the underlying value to the
empty value (not the same as the zero-initialized value). Comparing against this zero-initialized
`Markable` subsequently crashes, since `Traits::isEmptyValue` returns `false` and we then try to
dereference the underlying value.

To fix this, we ensure that `WKSelectPicker` handles the above case gracefully by checking
`-_hasFocusedElement` (which is consistent with the other call sites in `WKContentViewInteraction`
that try to check against the focused element context). We add a new helper method that encapsulates
this logic, and deploy that in the various places where we need to check the combination of:

- Content view has a focused element.
- The focused element context is the same element as a given element context&apos;s element.

Writing a test for this is tricky without swizzling WebKit internal code, since layout tests don&apos;t
support destroying the containing web view until the test is complete, and the iOS API test harness
doesn&apos;t support showing UIKit context menus in any sensible way.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _keyboardDismissalGestureRecognized:]):
(-[WKContentView _isSameAsFocusedElement:]):

Add a helper method on the content view that returns whether or not the given element context
represents the same underlying DOM element as the currently focused element; returns NO in the case
where there is no currently focused element.

(-[WKContentView _isTextInputContextFocused:]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _didProgrammaticallyClearFocusedElement:]):
(-[WKContentView _updateFocusedElementInformation:]):
(-[WKContentView _elementForTextInputContextIsFocused:]):

Consolidate all of these `-_hasFocusedElement` checks into the new `-_isSameAsFocusedElement:`
helper method above.

* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker contextMenuInteraction:willEndForConfiguration:animator:]):

Fix the bug by adopting `-_isSameAsFocusedElement:` above.

Canonical link: <a href="https://commits.webkit.org/304320@main">https://commits.webkit.org/304320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa22a7896339acdade2e81945e05f7646629c14b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103340 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84199 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3323 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145429 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111719 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5531 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117497 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7354 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35631 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->