### PR TITLE
SVGImage should be created with the same deviceScalefactor as the destination context

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -753,6 +753,14 @@ bool CachedImage::useSystemDarkAppearance() const
     return false;
 }
 
+float CachedImage::deviceScaleFactor() const
+{
+    CachedResourceClientWalker<CachedImageClient> walker(*this);
+    if (RefPtr client = walker.next())
+        return client->deviceScaleFactor();
+    return 1;
+}
+
 bool CachedImage::allowsAnimation(const Image& image) const
 {
     if (&image != m_image)

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -174,6 +174,7 @@ private:
         bool allowsAnimation(const Image&) const final;
         const Settings* settings() final { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).m_settings.get() : nullptr; }
         bool useSystemDarkAppearance() const final { return !m_cachedImages.isEmptyIgnoringNullReferences() && m_cachedImages.begin()->useSystemDarkAppearance(); }
+        float deviceScaleFactor() const final { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).deviceScaleFactor() : 1; }
 
         WeakHashSet<CachedImage> m_cachedImages;
     };
@@ -187,6 +188,7 @@ private:
     void imageContentChanged(const Image&);
     void scheduleRenderingUpdate(const Image&);
     bool useSystemDarkAppearance() const;
+    float deviceScaleFactor() const;
 
     void updateBufferInternal(const FragmentedSharedBuffer&);
 

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -47,6 +47,7 @@ public:
 
     virtual bool canDestroyDecodedData() const { return true; }
     virtual bool useSystemDarkAppearance() const { return false; }
+    virtual float deviceScaleFactor() const { return 1; }
 
     // Called when a new decoded frame for a large image is available or when an animated image is ready to advance to the next frame.
     WEBCORE_EXPORT virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);

--- a/Source/WebCore/platform/graphics/ImageObserver.h
+++ b/Source/WebCore/platform/graphics/ImageObserver.h
@@ -61,6 +61,7 @@ public:
     virtual bool allowsAnimation(const Image&) const { return true; }
     virtual const Settings* settings() { return nullptr; }
     virtual bool useSystemDarkAppearance() const { return false; }
+    virtual float deviceScaleFactor() const { return 1; }
 
 protected:
     ImageObserver() = default;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1703,6 +1703,13 @@ bool RenderElement::useSystemDarkAppearance() const
     return false;
 }
 
+float RenderElement::deviceScaleFactor() const
+{
+    if (RefPtr page = document().page())
+        return page->deviceScaleFactor();
+    return 1;
+}
+
 VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)
 {
     bool isVisible = isVisibleInViewport();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -424,6 +424,7 @@ private:
 
     bool canDestroyDecodedData() const final { return !isVisibleInViewport(); }
     bool useSystemDarkAppearance() const final;
+    float deviceScaleFactor() const final;
     VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect* changeRect) final;
     VisibleInViewportState imageVisibleInViewport(const Document&) const final;
     void didRemoveCachedImageClient(CachedImage&) final;

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -1182,11 +1182,6 @@ void RenderListBox::setHasScrollbar(ScrollbarOrientation orientation)
     m_scrollbar->styleChanged();
 }
 
-float RenderListBox::deviceScaleFactor() const
-{
-    return page().deviceScaleFactor();
-}
-    
 bool RenderListBox::isVisibleToHitTesting() const
 {
     return visibleToHitTesting();

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -190,8 +190,6 @@ private:
 
     std::optional<int> optionRowIndex(const HTMLOptionElement&) const;
 
-    float deviceScaleFactor() const final;
-
     LayoutRect rectForScrollbar(const Scrollbar&) const;
 
     void paintScrollbar(PaintInfo&, const LayoutPoint&, Scrollbar&);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -3035,6 +3035,13 @@ bool RenderObject::CachedImageListener::useSystemDarkAppearance() const
     return false;
 }
 
+float RenderObject::CachedImageListener::deviceScaleFactor() const
+{
+    if (CheckedPtr renderer = m_renderer.get())
+        return renderer->deviceScaleFactor();
+    return 1;
+}
+
 bool RenderObject::CachedImageListener::canDestroyDecodedData() const
 {
     if (CheckedPtr renderer = m_renderer.get())

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1063,6 +1063,7 @@ public:
     virtual bool allowsAnimation() const { return true; }
     virtual bool canDestroyDecodedData() const { return true; }
     virtual bool useSystemDarkAppearance() const { return false; }
+    virtual float deviceScaleFactor() const { return 1; }
     virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
     virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
     virtual void didRemoveCachedImageClient(CachedImage&) { }
@@ -1155,6 +1156,7 @@ private:
         bool allowsAnimation() const final;
         bool canDestroyDecodedData() const final;
         bool useSystemDarkAppearance() const final;
+        float deviceScaleFactor() const final;
         VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*) final;
         VisibleInViewportState imageVisibleInViewport(const Document&) const final;
         void didRemoveCachedImageClient(CachedImage&) final;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -508,6 +508,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
                 m_page->settings().setCSSDPropertyEnabled(parentSettings->cssDPropertyEnabled());
             }
             m_page->setUseColorAppearance(observer->useSystemDarkAppearance(), false);
+            m_page->setDeviceScaleFactor(observer->deviceScaleFactor());
         }
 
         RefPtr localMainFrame = m_page->localMainFrame();


### PR DESCRIPTION
#### 4e8a66a74de19340d26f9d536e1c26c3309ef6f9
<pre>
SVGImage should be created with the same deviceScalefactor as the destination context
<a href="https://bugs.webkit.org/show_bug.cgi?id=304016">https://bugs.webkit.org/show_bug.cgi?id=304016</a>
<a href="https://rdar.apple.com/166320988">rdar://166320988</a>

Reviewed by NOBODY (OOPS!).

SVGImage creates a Page for layout. The deviceScalefactor of this Page is 1. When
displaying the SVGImage to a destination context, which is 2x for example, some
calculations may be incorrect. The Filter::filterScale() will be 1 while
GraphicsContext::scaleFactor() will be 2. This will make some effects scale their
parameters for CG filters incorrectly.

The fix is to propagate the Page::deviceScalefactor() to SVGImage::m_page through
the ImageObsserver.

* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::deviceScaleFactor const):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedImageClient.h:
(WebCore::CachedImageClient::deviceScaleFactor const):
* Source/WebCore/platform/graphics/ImageObserver.h:
(WebCore::ImageObserver::deviceScaleFactor const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::deviceScaleFactor const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::deviceScaleFactor const): Deleted.
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::CachedImageListener::deviceScaleFactor const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::deviceScaleFactor const):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e8a66a74de19340d26f9d536e1c26c3309ef6f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87003 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103355 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70668 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84214 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3298 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145445 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39961 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111736 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112100 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5540 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61257 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35646 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->