### PR TITLE
[WebKit][Main] [ef80f3f18e6df299] ASAN_SEGV | WebCore::RenderView::zoomFactor; WebCore::Style::adjustValueForPageZoom; WebCore::Style::computeNonCalcLengthDouble

### DIFF
--- a/LayoutTests/fast/css/checkVisibility-no-renderer-crash-expected.txt
+++ b/LayoutTests/fast/css/checkVisibility-no-renderer-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/checkVisibility-no-renderer-crash.html
+++ b/LayoutTests/fast/css/checkVisibility-no-renderer-crash.html
@@ -1,0 +1,28 @@
+<style>* { display: block; } ::first-line { color: green; } </style>
+<script>
+(async () => {
+  testRunner?.dumpAsText();
+  testRunner?.waitUntilDone();
+  let cssStyleRule = document.styleSheets[0].cssRules[1];
+  let output = document.createElement('output');
+  document.documentElement.append(output);
+  let styleElement = document.createElement('style');
+  document.documentElement.append(styleElement);
+  let base = document.createElement('base');
+  document.documentElement.appendChild(base);
+  let svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  base.appendChild(svg);
+  await history.back();
+  styleElement.innerText = `@scope { @container (block-size: 260ex) } * { border-inline-end-width: calc((9.45dvmax)); `;
+  if (frames.caches)
+    await frames.caches.has("foo");
+  document.styleSheets[0].disabled = true;
+  if (!window.cookieStore)
+    await window.cookieStore.set("foo", "bar");
+  await output.checkVisibility( { checkVisibilityCSS: false });
+  cssStyleRule.selectorText = `:dir(ltr)`;
+  await svg.checkVisibility( { checkVisibilityCSS: true });
+  document.write("PASS if no crash.");
+  testRunner?.notifyDone();
+})();
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6268,6 +6268,9 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
 {
     document().updateStyleIfNeeded();
 
+    if (!renderer())
+        return false;
+
     auto* style = computedStyle();
 
     // Disconnected node, not rendered.


### PR DESCRIPTION
#### 43662ccbd5af77371233091757679bdb191aaf1e
<pre>
[WebKit][Main] [ef80f3f18e6df299] ASAN_SEGV | WebCore::RenderView::zoomFactor; WebCore::Style::adjustValueForPageZoom; WebCore::Style::computeNonCalcLengthDouble
<a href="https://bugs.webkit.org/show_bug.cgi?id=302379">https://bugs.webkit.org/show_bug.cgi?id=302379</a>

Reviewed by Tim Nguyen.

In checkVisibility computedStyle is used, however this could use calc()
in the computed style determination, and this may crash if the document has
no RenderView associated.

We can avoid this problem by implementing rule 1 from the specification [1].

[1] <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility">https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility</a>

Test: fast/css/checkVisibility-no-renderer-crash.html

* LayoutTests/fast/css/checkVisibility-no-renderer-crash-expected.txt: Added.
* LayoutTests/fast/css/checkVisibility-no-renderer-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkVisibility):

Canonical link: <a href="https://commits.webkit.org/304319@main">https://commits.webkit.org/304319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d7c301ac47c4f0ae66cc460c79f76cfd6352c2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142753 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7485 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5906 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84216 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3342 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145449 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39963 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7363 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5541 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117514 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7373 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7129 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->