### PR TITLE
Simplify StructureID encoding scheme.

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20842,13 +20842,7 @@ IGNORE_CLANG_WARNINGS_END
 
     LValue encodeStructureID(LValue structure)
     {
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
-        return m_out.castToInt32(m_out.lShr(structure, m_out.constInt32(StructureID::encodeShiftAmount)));
-#elif CPU(ADDRESS64)
-        return m_out.castToInt32(m_out.bitAnd(structure, m_out.constInt64(StructureID::structureIDMask)));
-#else
         return m_out.castToInt32(structure);
-#endif
     }
 
     void storeStructure(LValue object, LValue structure)
@@ -25289,16 +25283,7 @@ IGNORE_CLANG_WARNINGS_END
 
     LValue decodeNonNullStructure(LValue structureID)
     {
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
-        return m_out.shl(m_out.zeroExtPtr(structureID), m_out.constIntPtr(StructureID::encodeShiftAmount));
-#else
-        LValue maskedStructureID = structureID;
-        if constexpr (structureHeapAddressSize < 4 * GB) {
-            static_assert(static_cast<uint32_t>(StructureID::structureIDMask) == StructureID::structureIDMask);
-            maskedStructureID = m_out.bitAnd(structureID, m_out.constInt32(static_cast<uint32_t>(StructureID::structureIDMask)));
-        }
-        return m_out.bitOr(m_out.constIntPtr(startOfStructureHeap()), m_out.zeroExtPtr(maskedStructureID));
-#endif
+        return m_out.bitOr(m_out.constIntPtr(structureIDBase()), m_out.zeroExtPtr(structureID));
     }
 
     LValue loadStructure(LValue value)

--- a/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
+++ b/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -115,12 +115,6 @@
 #define OFFLINE_ASM_ADDRESS64 1
 #else
 #define OFFLINE_ASM_ADDRESS64 0
-#endif
-
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
-#define OFFLINE_ASM_STRUCTURE_ID_WITH_SHIFT 1
-#else
-#define OFFLINE_ASM_STRUCTURE_ID_WITH_SHIFT 0
 #endif
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -691,12 +691,9 @@ macro writeBarrierOnGlobalLexicalEnvironment(size, get, valueFieldName)
 end
 
 macro structureIDToStructureWithScratch(structureIDThenStructure, scratch)
-    if STRUCTURE_ID_WITH_SHIFT
-        lshiftp (constexpr StructureID::encodeShiftAmount), structureIDThenStructure
-    elsif ADDRESS64
-        andq (constexpr StructureID::structureIDMask), structureIDThenStructure
+    if ADDRESS64
         leap _g_config, scratch
-        loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigStartOfStructureHeap[scratch], scratch
+        loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigStructureIDBase[scratch], scratch
         addp scratch, structureIDThenStructure
     end
 end

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -93,6 +93,7 @@ struct Config {
     void* endExecutableMemory;
     uintptr_t startOfFixedWritableMemoryPool;
     uintptr_t startOfStructureHeap;
+    uintptr_t structureIDBase;
     uintptr_t sizeOfStructureHeap;
     void* defaultCallThunk;
     void* arityFixupThunk;
@@ -140,12 +141,17 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 constexpr size_t offsetOfJSCConfigInitializeHasBeenCalled = offsetof(JSC::Config, initializeHasBeenCalled);
 constexpr size_t offsetOfJSCConfigGateMap = offsetof(JSC::Config, llint.gateMap);
-constexpr size_t offsetOfJSCConfigStartOfStructureHeap = offsetof(JSC::Config, startOfStructureHeap);
+constexpr size_t offsetOfJSCConfigStructureIDBase = offsetof(JSC::Config, structureIDBase);
 constexpr size_t offsetOfJSCConfigDefaultCallThunk = offsetof(JSC::Config, defaultCallThunk);
 
 ALWAYS_INLINE PURE_FUNCTION uintptr_t startOfStructureHeap()
 {
     return g_jscConfig.startOfStructureHeap;
+}
+
+ALWAYS_INLINE PURE_FUNCTION uintptr_t structureIDBase()
+{
+    return g_jscConfig.structureIDBase;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.h
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -151,11 +151,11 @@ public:
 
     MegamorphicCache() = default;
 
-#if CPU(ADDRESS64) && !ENABLE(STRUCTURE_ID_WITH_SHIFT)
+#if CPU(ADDRESS64)
     // Because Structure is allocated with 16-byte alignment, we should assume that StructureID's lower 4 bits are zeros.
     static constexpr unsigned structureIDHashShift1 = 4;
 #else
-    // When using STRUCTURE_ID_WITH_SHIFT, all bits can be different. Thus we do not need to shift the first level.
+    // With 32-bit addresses, all bits can be different. Thus we do not need to shift the first level.
     static constexpr unsigned structureIDHashShift1 = 0;
 #endif
     static constexpr unsigned structureIDHashShift2 = structureIDHashShift1 + 11;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -98,6 +98,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed"_s) \
     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
+    v(Unsigned, structureHeapSizeInKB, 0, Normal, "Override for Structure Heap size (in KBs) if non-zero"_s) \
     v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)"_s) \
     v(Size, jitMemoryReservationAddress, 0, Restricted, "If non-zero, we will attempt to allocate JIT memory at the address provided and crash if we cannot.") \
     \

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Alexey Shvayka <shvaikalesh@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -238,9 +238,7 @@ Structure::Structure(VM& vm, JSGlobalObject* globalObject, JSValue prototype, co
 
     validateFlags();
 
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
     ASSERT(WTF::roundUpToMultipleOf<Structure::atomSize>(this) == this);
-#endif
 }
 
 const ClassInfo Structure::s_info = { "Structure"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(Structure) };
@@ -286,9 +284,7 @@ Structure::Structure(VM& vm, CreatingEarlyCellTag)
     ASSERT(hasReadOnlyOrGetterSetterPropertiesExcludingProto() == m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue)));
     ASSERT(!this->typeInfo().overridesGetCallData() || m_classInfo->methodTable.getCallData != &JSCell::getCallData);
 
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
     ASSERT(WTF::roundUpToMultipleOf<Structure::atomSize>(this) == this);
-#endif
 }
 
 Structure::Structure(VM& vm, StructureVariant variant, Structure* previous)
@@ -343,9 +339,7 @@ Structure::Structure(VM& vm, StructureVariant variant, Structure* previous)
     ASSERT(hasReadOnlyOrGetterSetterPropertiesExcludingProto() || !m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue)));
     ASSERT(!this->typeInfo().overridesGetCallData() || m_classInfo->methodTable.getCallData != &JSCell::getCallData);
 
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
     ASSERT(WTF::roundUpToMultipleOf<Structure::atomSize>(this) == this);
-#endif
 }
 
 Structure::~Structure() = default;

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -205,9 +205,6 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
     static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
 
-#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
-    static constexpr size_t atomSize = 32;
-#endif
     static_assert(JSCell::atomSize >= MarkedBlock::atomSize);
 
     static constexpr int s_maxTransitionLength = 64;

--- a/Source/JavaScriptCore/tools/IntegrityInlines.h
+++ b/Source/JavaScriptCore/tools/IntegrityInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Integrity.h>
+#include <JavaScriptCore/JSCConfig.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/StructureID.h>
 #include <JavaScriptCore/VM.h>
@@ -100,8 +101,8 @@ ALWAYS_INLINE void auditCellFully(VM& vm, JSCell* cell)
 ALWAYS_INLINE void auditStructureID(StructureID structureID)
 {
     UNUSED_PARAM(structureID);
-#if CPU(ADDRESS64) && !ENABLE(STRUCTURE_ID_WITH_SHIFT)
-    ASSERT(static_cast<uintptr_t>(structureID.bits()) <= structureHeapAddressSize + StructureID::nukedStructureIDBit);
+#if CPU(ADDRESS64)
+    ASSERT(std::bit_cast<uintptr_t>(structureID.decode()) - startOfStructureHeap() <= g_jscConfig.sizeOfStructureHeap);
 #endif
 #if ENABLE(EXTRA_INTEGRITY_CHECKS) || ASSERT_ENABLED
     Structure* structure = structureID.tryDecode();


### PR DESCRIPTION
#### 6eac446be4449cb0c94d52b8ee43926a53bbb180
<pre>
Simplify StructureID encoding scheme.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304017">https://bugs.webkit.org/show_bug.cgi?id=304017</a>
<a href="https://rdar.apple.com/166322205">rdar://166322205</a>

Reviewed by Dan Hecht and Yusuke Suzuki.

We can just use a base + offset encoding scheme for all CPU(ADDRESS64) platforms.  Here are the
details:

1. There&apos;s no need to mask the StructureID before adding it to the base address.  This was
   originally introduced as a caging security mitigation.

   However, it only worked if the Structure heap size if 4GB.   On iOS (and other embedded
   platforms), this caging was never done, and cannot be done because of the STRUCTURE_ID_WITH_SHIFT
   encoding.  The caging is also of very low value as a security mitigation.  Since it does not
   add much value, we&apos;ll remove it to simplify things.

2. Previously, for macOS, we encode StructureID as a 32-bit offset from the start of that 4G
   aligned region.

   Instead of doing this, we now encode StructureID as the bottom 32-bits of the 64-bit Structure
   address.  This is partially made possible by the removal of masking in (1), and it simplifies
   the code a lot.  To decode a StructureID, we simple add structureIDBase to the StructureID,
   where structureIDBase is startOfStructureHeap with the lower 32-bits masked to 0.

3. Previously, to enable the StructureID encoding scheme in (2), we always require that the
   structure heap start address be 4GB aligned.

   Now that StructureID is just the lower 32-bits of the address, the structure heap does not
   need to start on a 4GB region.  We only require that the upper 32-bits of the entire structure
   heap region be constant.  To achieve this, we require that the structure heap size be a power
   of 2 (which was always the case), and that the structure heap start address be aligned on the
   structure heap size.  With that we guarantee that the structure heap will never span across
   two 4GB granules i.e. the top 32-bits of the Structure address is guaranteed to be the same
   for any address in the structure heap.

4. Previously, iOS (and other embedded platforms), we needed to use the STRUCTURE_ID_WITH_SHIFT
   encoding for StructureID.  This is because on these platforms, it is not always possible to
   allocate the structure heap starting at a 4G boundary.  The number of available 4G boundaries
   are few.

   However, with (3), the structure heap only need to be aligned on the heap size.  Since it is
   reasonable for the heap size to be smaller on embedded platforms, the number of such aligned
   boundaries are significantly increases, and we should be able to successfully allocate the
   structure heap on the needed boundary.  Hence, we can now switch all embedded platforms over
   to using the same StructureID encoding as macOS.  The STRUCTURE_ID_WITH_SHIFT can now be
   completely removed.

5. This also allows us to shrink Structure&apos;s atomSize back to 16 bytes.  Currently, that doesn&apos;t
   make a difference, but it opens the door for potential size optimzations.

6. Add Options::structureHeapSizeInKB() to allow us to more easily test and experiment with
   different structure heap sizes.

7. Added more dump info to the RELEASE_ASSERTs in the StructureMemoryManager constructor.
   These will help us diagnose crashes, should we get crashes due to failed structure heap
   memory reservation.

This functionality should be covered by existing JSC and WebKit tests as Structures are used
prolifically.  This patch also adds more ASSERTs and RELEASE_ASSERTs to help catch issues
sooner in those tests.

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::StructureMemoryManager):
(JSC::StructureAlignedMemoryAllocator::initializeStructureAddressSpace):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID):
(JSC::AssemblyHelpers::emitEncodeStructureID):
* Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSCConfig.h:
(JSC::structureIDBase):
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureID.h:
(JSC::StructureID::decode const):
(JSC::StructureID::tryDecode const):
(JSC::StructureID::encode):
* Source/JavaScriptCore/tools/IntegrityInlines.h:
(JSC::Integrity::auditStructureID):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::decodeNonNullStructure):
(JSC::Wasm::OMGIRGenerator::encodeStructureID):

Canonical link: <a href="https://commits.webkit.org/304344@main">https://commits.webkit.org/304344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f7fc0787a8e5b8c8e38571c60fa831f149d898

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142818 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4077ae4b-9aaa-46f7-96ce-68548cadd553) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/564058b8-ae7c-4da2-84f4-cdf5f6e51e58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121274 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c1ee5437-9773-412d-ac04-ecf742aa4e8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5741 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3404 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127310 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145513 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133799 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7379 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40026 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7421 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112151 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5589 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117574 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20862 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7434 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/166648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70980 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/166648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->