### PR TITLE
[build.webkit.org] Bring up a clean build time measurement queue

### DIFF
--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -327,3 +327,15 @@ class SaferCPPStaticAnalyzerFactory(Factory):
 class CrossTargetDownloadAndPerfTestFactory(DownloadAndPerfTestFactory):
     shouldInstallDependencies = False
     shouldUseCrossTargetImage = True
+
+
+class BuildTimeMeasurementFactory(Factory):
+    """Factory for measuring clean build time and reporting to perf.webkit.org"""
+
+    def __init__(self, platform, configuration, architectures, additionalArguments=None, device_model=None, **kwargs):
+        # Initialize with buildOnly=True since we only need to compile
+        Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model, **kwargs)
+        self.addStep(DeleteXcodeDerivedData())
+        self.addStep(CleanBuild())
+        self.addStep(WebKitBuildTimePerf())
+        self.addStep(UploadBuildTimeToPerfDashboard())

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -51,6 +51,7 @@ if 'uat' in CURRENT_HOSTNAME:
 BUILD_WEBKIT_HOSTNAMES = ['build.webkit.org', 'build']
 TESTING_ENVIRONMENT_HOSTNAMES = ['build.webkit-uat.org', 'build-uat', 'build.webkit-dev.org', 'build-dev']
 COMMITS_INFO_URL = 'https://commits.webkit.org/'
+PERF_WEBKIT_URL = 'https://perf.webkit.org'
 RESULTS_WEBKIT_URL = 'https://results.webkit.org'
 RESULTS_SERVER_API_KEY = 'RESULTS_SERVER_API_KEY'
 S3URL = 'https://s3-us-west-2.amazonaws.com/'
@@ -312,6 +313,13 @@ class WaitForCrashCollection(shell.Compile):
     command = ["python3", "Tools/CISupport/wait-for-crash-collection", "--timeout", str(5 * 60)]
 
 
+class CleanBuild(shell.Compile):
+    name = "delete-WebKitBuild-directory"
+    description = ["deleting WebKitBuild directory"]
+    descriptionDone = ["deleted WebKitBuild directory"]
+    command = ["python3", "Tools/CISupport/clean-build", WithProperties("--platform=%(fullPlatform)s"), WithProperties("--%(configuration)s")]
+
+
 class CleanBuildIfScheduled(shell.Compile):
     name = "delete-WebKitBuild-directory"
     description = ["deleting WebKitBuild directory"]
@@ -335,6 +343,16 @@ class DeleteStaleBuildFiles(shell.Compile):
         if self.getProperty('is_clean'):  # Nothing to be done if WebKitBuild had been removed.
             self.hideStepIf = True
             return SKIPPED
+        return super().run()
+
+
+class DeleteXcodeDerivedData(shell.Compile, ShellMixin):
+    name = 'delete-xcode-derived-data'
+    description = ["deleting Xcode DerivedData contents"]
+    descriptionDone = ["deleted Xcode DerivedData contents"]
+
+    def run(self):
+        self.command = self.shell_command("rm -rf ~/Library/Developer/Xcode/DerivedData")
         return super().run()
 
 
@@ -493,6 +511,113 @@ class CompileWebKit(shell.Compile, CustomFlagsMixin, ShellMixin, AddToLogMixin):
             return {'step': MSG_FOR_EXCESSIVE_LOGS, 'build': MSG_FOR_EXCESSIVE_LOGS}
         if self.results == FAILURE:
             return {'step': f'Failed {self.name}'}
+        return super().getResultSummary()
+
+
+class WebKitBuildTimePerf(shell.Compile, CustomFlagsMixin, ShellMixin, AddToLogMixin):
+    build_command = ['/usr/bin/make']
+    time_command = ['/usr/bin/time', '-p', '-o', 'build-time.txt']
+    filter_command = ['perl', 'Tools/Scripts/filter-build-webkit', '-logfile', 'build-log.txt']
+    name = "compile-webkit"
+    description = ["compiling"]
+    descriptionDone = ["compiled"]
+    warningPattern = ".*arning: .*"
+    cancelled_due_to_huge_logs = False
+    line_count = 0
+
+    @defer.inlineCallbacks
+    def run(self):
+        additionalArguments = self.getProperty('additionalArguments')
+        configuration = self.getProperty('configuration')
+
+        self.log_observer = ParseByLineLogObserver(self.parseOutputLine)
+        self.addLogObserver('stdio', self.log_observer)
+
+        build_command = self.build_command + [f'{configuration}', 'ARGS="-showBuildTimingSummary COMPILATION_CACHE_ENABLE_CACHING=NO"']
+
+        if additionalArguments:
+            build_command += additionalArguments
+
+        full_command = f"{' '.join(self.time_command)} {' '.join(build_command)} 2>&1 | {' '.join(self.filter_command)}"
+        self.command = self.shell_command(full_command)
+
+        rc = yield super().run()
+        defer.returnValue(rc)
+
+    def __init__(self, *args, **kwargs):
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = 60 * 60
+        super().__init__(*args, **kwargs)
+
+    def parseOutputLine(self, line):
+        self.line_count += 1
+        if self.line_count == THRESHOLD_FOR_EXCESSIVE_LOGS:
+            self.handleExcessiveLogging()
+            return
+        # FIXME: Re-enable error and warning filtering from logs.
+
+    def handleExcessiveLogging(self):
+        build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
+        print(f'\n{MSG_FOR_EXCESSIVE_LOGS}, {build_url}\n')
+        self.cancelled_due_to_huge_logs = True
+        self.build.stopBuild(reason=MSG_FOR_EXCESSIVE_LOGS, results=FAILURE)
+        self.build.buildFinished([MSG_FOR_EXCESSIVE_LOGS], FAILURE)
+
+    def follow_up_steps(self):
+        return [
+            GenerateS3URL(
+                f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
+                extension='txt',
+                content_type='text/plain',
+                additions=f'{self.build.number}'
+            ), UploadFileToS3(
+                'build-log.txt',
+                links={self.name: 'Full build log'},
+                content_type='text/plain',
+            )
+        ]
+
+    def getResultSummary(self):
+        if self.cancelled_due_to_huge_logs:
+            return {'step': MSG_FOR_EXCESSIVE_LOGS, 'build': MSG_FOR_EXCESSIVE_LOGS}
+        if self.results == FAILURE:
+            return {'step': f'Failed {self.name}'}
+        return super().getResultSummary()
+
+
+class UploadBuildTimeToPerfDashboard(shell.ShellCommand):
+    name = "upload-build-time-metrics"
+    description = ["uploading build time metrics"]
+    descriptionDone = ["uploaded build time metrics"]
+
+    def __init__(self, **kwargs):
+        super().__init__(logEnviron=False, **kwargs)
+
+    @defer.inlineCallbacks
+    def run(self):
+        time_file = 'build-time.txt'
+
+        self.command = [
+            "python3", "Tools/CISupport/submit-build-time-to-perf-dashboard",
+            "--time-file", time_file,
+            "--builder-name", self.getProperty("buildername"),
+            "--build-number", self.getProperty("buildnumber"),
+            "--platform", self.getProperty("fullPlatform"),
+            "--configuration", self.getProperty("configuration"),
+            "--architecture", self.getProperty("architecture"),
+            "--worker-name", self.getProperty("workername"),
+            "--worker-config-json-path", "../../perf-test-config.json",
+            "--perf-server-url", PERF_WEBKIT_URL
+        ]
+
+        rc = yield super().run()
+        defer.returnValue(rc)
+
+    def getResultSummary(self):
+        if self.results == FAILURE:
+            return {'step': 'Failed to upload build time metrics'}
+        if self.results in [SUCCESS, WARNINGS]:
+            return {'step': 'Uploaded build time metrics'}
         return super().getResultSummary()
 
 
@@ -1443,7 +1568,7 @@ class RunAndUploadPerfTests(shell.Test):
                "--worker-config-json-path", "../../perf-test-config.json",
                "--no-show-results",
                "--reset-results",
-               "--test-results-server", "perf.webkit.org",
+               "--test-results-server", PERF_WEBKIT_URL,
                "--builder-name", WithProperties("%(buildername)s"),
                "--build-number", WithProperties("%(buildnumber)s"),
                "--platform", WithProperties("%(fullPlatform)s"),

--- a/Tools/CISupport/submit-build-time-to-perf-dashboard
+++ b/Tools/CISupport/submit-build-time-to-perf-dashboard
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+scripts = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Scripts')
+sys.path.insert(0, scripts)
+
+import webkitpy
+import requests
+
+from webkitpy.common.checkout.scm.detection import SCMDetector
+from webkitpy.common.system.filesystem import FileSystem
+from webkitpy.common.system.executive import Executive
+
+
+def read_build_time(time_file):
+    """Read the build time from the /usr/bin/time output file."""
+    if not os.path.isfile(time_file):
+        print(f'ERROR: Time file not found: {time_file}\n')
+        return None
+
+    with open(time_file, 'r') as f:
+        content = f.read()
+
+    # Parse the time output format: "real 123.45"
+    match = re.search(r'^real\s+(\d+(?:\.\d+)?)', content, re.MULTILINE)
+    if match:
+        # Perf dashboard expects miliseconds
+        return float(match.group(1)) * 1000.0
+
+    print(f'ERROR: Could not parse build time from {time_file}\n')
+    print(f'Content: {content}\n')
+    return None
+
+
+def get_repository_revisions(source_dir):
+    """Get the repository revisions for the source directory."""
+    filesystem = FileSystem()
+    executive = Executive()
+
+    try:
+        scm = SCMDetector(filesystem, executive).detect_scm_system(source_dir)
+        if not scm:
+            print(f'WARNING: Could not detect SCM system for {source_dir}\n')
+            return {}
+
+        revision = scm.native_revision(source_dir)
+        timestamp = scm.timestamp_of_native_revision(source_dir, revision)
+
+        return {
+            'WebKit': {
+                'revision': revision,
+                'timestamp': timestamp
+            }
+        }
+    except Exception as e:
+        print(f'WARNING: Could not get repository revisions: {e}\n')
+        return {}
+
+
+def load_worker_config(worker_config_path):
+    """Load and parse the worker configuration JSON file."""
+    if not worker_config_path:
+        return {}
+
+    if not os.path.isfile(worker_config_path):
+        print(f'ERROR: Worker config file not found: {worker_config_path}\n')
+        return None
+
+    try:
+        with open(worker_config_path, 'r') as f:
+            worker_config = json.load(f)
+        return worker_config
+    except Exception as e:
+        print(f'ERROR: Failed to parse worker config JSON: {e}\n')
+        return None
+
+
+def construct_report(build_duration, builder_name, build_number, platform,
+                     configuration, architecture, worker_name, revisions,
+                     worker_config=None):
+    """Construct the JSON report following the perf.webkit.org API format."""
+
+    # Format build time in ES5-compatible ISO format
+    utc_timestamp = datetime.datetime.now(datetime.timezone.utc)
+    build_time = utc_timestamp.strftime('%Y-%m-%dT%H:%M:%S.%f')
+
+    report = {
+        'builderName': builder_name,
+        'buildTag': str(build_number),
+        'buildTime': build_time,
+        'platform': platform,
+        'tests': {
+            'BuildTime': {
+                'metrics': {
+                    'Time': {
+                        'current': [[build_duration]]
+                    }
+                }
+            }
+        },
+        'revisions': revisions
+    }
+
+    # Merge worker config into report (same pattern as run-perf-tests)
+    # Keys from worker config are prefixed with 'builder' and capitalized
+    if worker_config:
+        for key in worker_config:
+            report['builder' + key.capitalize()] = worker_config[key]
+
+    has_builder_password = 'builderPassword' in report
+    has_worker_password = 'workerPassword' in report
+
+    if not has_builder_password and not has_worker_password:
+        print('ERROR: No authentication credentials found\n')
+        print('Provide --worker-config-json-path with "password" or "workerPassword" key\n')
+        return None
+
+    return report
+
+
+def upload_to_perf_dashboard(report, api_url):
+    """Upload the report to the perf.webkit.org API."""
+
+    # The API expects an array of reports
+    payload = [report]
+
+    # Convert build duration back to seconds for printing
+    build_duration = report["tests"]["BuildTime"]["metrics"]["Time"]["current"][0][0] / 1000.0
+
+
+    print(f'Uploading build time report to {api_url}\n')
+    print(f'Build duration: {build_duration} seconds\n')
+    print(f'Builder: {report["builderName"]}\n')
+    print(f'Build number: {report["buildTag"]}\n')
+    print(f'Platform: {report["platform"]}\n')
+
+    try:
+        headers = {'Content-Type': 'application/json'}
+        response = requests.post(api_url, json=payload, headers=headers, timeout=60)
+
+        print(f'Response status: {response.status_code} {response.reason}\n')
+
+        if response.status_code // 100 == 2:
+            print('Successfully uploaded build time metrics\n')
+            return 0
+        else:
+            print(f'ERROR: Upload failed with status {response.status_code}\n')
+            print(f'Response: {response.text}\n')
+            return 1
+
+    except Exception as e:
+        print(f'ERROR: Exception during upload: {e}\n')
+        return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Submit build time metrics to perf.webkit.org dashboard'
+    )
+    parser.add_argument('--time-file', required=True,
+                       help='Path to the time output file from /usr/bin/time')
+    parser.add_argument('--builder-name', required=True,
+                       help='Name of the builder')
+    parser.add_argument('--build-number', required=True,
+                       help='Build number')
+    parser.add_argument('--platform', required=True,
+                       help='Platform name (e.g., mac-sequoia)')
+    parser.add_argument('--configuration', required=True,
+                       help='Build configuration (debug or release)')
+    parser.add_argument('--architecture', required=True,
+                       help='Architecture (e.g., x86_64, arm64)')
+    parser.add_argument('--worker-name', required=True,
+                       help='Worker/bot name')
+    parser.add_argument('--worker-config-json-path',
+                       help='Path to worker configuration JSON file (contains password)')
+    parser.add_argument('--source-dir', default='.',
+                       help='Path to WebKit source directory (default: current directory)')
+    parser.add_argument('--perf-server-url', default='https://perf.webkit.org',
+                       help='URL of the perf dashboard')
+
+    args = parser.parse_args()
+
+    build_duration = read_build_time(args.time_file)
+    if build_duration is None:
+        return 1
+
+    revisions = get_repository_revisions(args.source_dir)
+
+    worker_config = load_worker_config(args.worker_config_json_path)
+    if worker_config is None:
+        return 1
+
+    report = construct_report(
+        build_duration=build_duration,
+        builder_name=args.builder_name,
+        build_number=args.build_number,
+        platform=args.platform,
+        configuration=args.configuration,
+        architecture=args.architecture,
+        worker_name=args.worker_name,
+        revisions=revisions,
+        worker_config=worker_config
+    )
+
+    if report is None:
+        return 1
+
+    api_url = f'{args.perf_server_url}/api/report'
+    return upload_to_perf_dashboard(report, api_url)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
#### a8f70339206d90c3d6e80768647c8d965c0e7b75
<pre>
[build.webkit.org] Bring up a clean build time measurement queue
<a href="https://rdar.apple.com/56299204">rdar://56299204</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304026">https://bugs.webkit.org/show_bug.cgi?id=304026</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/build-webkit-org/factories.py:
(BuildTimeMeasurementFactory): New factory that includes the necessary steps to clean
the build products (including Xcode DerivedData), build, and submit the result to perf.webkit.org.
* Tools/CISupport/build-webkit-org/steps.py:
(CleanBuild): New step that runs the clean-build script, the existing one only happens if
a specific property is set when forcing a build.
(DeleteXcodeDerivedData): Step to delete Xcode DerivedData to ensure that nothing is cached.
(WebKitBuildTimePerf): Step to build WebKit and record the time with `/usr/bin/time`. Additional
arguments are passed through to print Xcode&apos;s build time summary and disable compilation caching.
(UploadBuildTimeToPerfDashboard): Step to invoke the build time submission script.
(RunAndUploadPerfTests): Drive-by change to use a constant for the perf.webkit.org URL.
* Tools/CISupport/submit-build-time-to-perf-dashboard: Added.
(read_build_time):
(get_repository_revisions):
(load_worker_config):
(construct_report):
(upload_to_perf_dashboard):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8f70339206d90c3d6e80768647c8d965c0e7b75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135264 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142770 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8287 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e274a9e4-6b07-462b-a1e9-3013201a92e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5918 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f1c2583-03ef-4984-be5a-4cfad28e38dd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3357 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145465 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133749 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7333 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/134691 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112111 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/7387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/7142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->