### PR TITLE
Remove invalid DATA_ADDRESS_IS_SANE checks.

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -665,12 +665,3 @@ using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = in
 #define WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ClassName) \
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName) \
 using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
-
-#if HAVE(36BIT_ADDRESS)
-#define WTF_DATA_ADDRESS_IS_SANE(p) (reinterpret_cast<uintptr_t>(p) < (1ull << 36))
-#define RELEASE_ASSERT_DATA_ADDRESS_IS_SANE(p) RELEASE_ASSERT(WTF_DATA_ADDRESS_IS_SANE(p))
-#else
-#define WTF_DATA_ADDRESS_IS_SANE(p) (UNUSED_PARAM(p), true)
-#define RELEASE_ASSERT_DATA_ADDRESS_IS_SANE(p) UNUSED_PARAM(p)
-#endif
-

--- a/Source/WTF/wtf/MmapSpan.h
+++ b/Source/WTF/wtf/MmapSpan.h
@@ -45,7 +45,6 @@ public:
         auto* data = ::mmap(addr, size, pageProtection, options, fileDescriptor, 0);
         if (data == MAP_FAILED)
             return { };
-        RELEASE_ASSERT((pageProtection & PROT_EXEC) || WTF_DATA_ADDRESS_IS_SANE(data));
         return MmapSpan { data, size };
     }
 

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -279,7 +279,6 @@ public:
                 return nullptr;
             RELEASE_ASSERT_NOT_REACHED();
         }
-        RELEASE_ASSERT_DATA_ADDRESS_IS_SANE(p);
         auto* gran = reinterpret_cast<GranuleHeader*>(p);
         gran->additionalPageCount = bytes / pageSize() - 1;
         return gran;

--- a/Source/bmalloc/bmalloc/BAssert.h
+++ b/Source/bmalloc/bmalloc/BAssert.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,14 +102,6 @@
 #endif
 
 #define BUNUSED(x) ((void)x)
-
-#if BHAVE(36BIT_ADDRESS)
-#define BDATA_ADDRESS_IS_SANE(p) ((uintptr_t)(p) < (1ull << 36))
-#define RELEASE_BASSERT_DATA_ADDRESS_IS_SANE(p) RELEASE_BASSERT(BDATA_ADDRESS_IS_SANE(p))
-#else
-#define BDATA_ADDRESS_IS_SANE(p) (BUNUSED(p), true)
-#define RELEASE_BASSERT_DATA_ADDRESS_IS_SANE(p) BUNUSED(p)
-#endif
 
 // ===== Release build =====
 

--- a/Source/bmalloc/bmalloc/VMAllocate.cpp
+++ b/Source/bmalloc/bmalloc/VMAllocate.cpp
@@ -44,7 +44,6 @@ static void zeroFillLatchIfMadvZeroIsSupported()
     size_t pageSize = vmPageSize();
     void* base = mmap(NULL, pageSize, PROT_NONE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, static_cast<int>(VMTag::Malloc), 0);
     BASSERT(base);
-    RELEASE_BASSERT_DATA_ADDRESS_IS_SANE(p);
 
     int rc = madvise(base, pageSize, MADV_ZERO);
     if (rc)

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -250,7 +250,6 @@ inline void* tryVMAllocate(size_t vmSize, VMTag usage)
     void* result = mmap(0, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
     if (result == MAP_FAILED)
         return nullptr;
-    RELEASE_BASSERT_DATA_ADDRESS_IS_SANE(result);
     return result;
 }
 
@@ -290,7 +289,7 @@ inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
     // MAP_ANON guarantees the memory is zeroed. This will also cause
     // page faults on accesses to this range following this call.
     void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, flags, tag, 0);
-    RELEASE_BASSERT(result == p && BDATA_ADDRESS_IS_SANE(result));
+    RELEASE_BASSERT(result == p);
 }
 
 inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -165,7 +165,6 @@ pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
         return NULL;
     }
 
-    PAS_ASSERT_DATA_ADDRESS_IS_SANE(mmap_result);
     return mmap_result;
 #endif
 }
@@ -269,7 +268,6 @@ static void pas_page_malloc_zero_fill_latch_if_madv_zero_is_supported(void)
     size = PAS_SMALL_PAGE_DEFAULT_SIZE;
     base = mmap(NULL, PAS_SMALL_PAGE_DEFAULT_SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANON | PAS_NORESERVE, PAS_VM_TAG, 0);
     PAS_ASSERT(base);
-    PAS_ASSERT_DATA_ADDRESS_IS_SANE(base);
 
     int rc = madvise(base, size, MADV_ZERO);
     if (rc)
@@ -316,7 +314,6 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
     PAS_MTE_HANDLE(ZERO_FILL_PAGE, base, size, flags, tag);
     result_ptr = mmap(base, size, PROT_READ | PROT_WRITE, flags, tag, 0);
     PAS_ASSERT(result_ptr == base);
-    PAS_ASSERT_DATA_ADDRESS_IS_SANE(result_ptr);
 #endif /* PAS_OS(WINDOWS) */
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -469,13 +469,8 @@ kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_range(ta
 #if PAS_CPU(ADDRESS64)
 
 #if PAS_ARM
-#if PAS_HAVE(36BIT_ADDRESS)
-        if (!PAS_DATA_ADDRESS_IS_SANE(candidate_pointer))
-            continue;
-#else
         if (candidate_pointer > MACH_VM_MAX_ADDRESS_RAW)
             continue;
-#endif
 #else
         if (candidate_pointer > (1ULL << 48))
             continue;

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -482,14 +482,6 @@ PAS_IGNORE_WARNINGS_END
 
 #define PAS_ASSERT_NOT_REACHED(...) PAS_ASSERT(!"Should not be reached", __VA_ARGS__)
 
-#if PAS_HAVE(36BIT_ADDRESS)
-#define PAS_DATA_ADDRESS_IS_SANE(p) ((uintptr_t)(p) < (1ull << 36))
-#define PAS_ASSERT_DATA_ADDRESS_IS_SANE(p) PAS_ASSERT_IF(1, PAS_DATA_ADDRESS_IS_SANE(p))
-#else
-#define PAS_DATA_ADDRESS_IS_SANE(p) (PAS_UNUSED_PARAM(p), 1)
-#define PAS_ASSERT_DATA_ADDRESS_IS_SANE(p) PAS_UNUSED_PARAM(p)
-#endif
-
 static inline bool pas_is_power_of_2(uintptr_t value)
 {
     return value && !(value & (value - 1));


### PR DESCRIPTION
#### d0a78533e3d3df68be095fa057dae1e094376c1f
<pre>
Remove invalid DATA_ADDRESS_IS_SANE checks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304031">https://bugs.webkit.org/show_bug.cgi?id=304031</a>
<a href="https://rdar.apple.com/166329603">rdar://166329603</a>

Reviewed by Dan Hecht.

Previous in 301407@main, I added DATA_ADDRESS_IS_SANE checks when we HAVE(36BIT_ADDRESS).
Turns out that we may not be able to guarantee that addresses are 36-bits.  Hence, these
checks are invalid.  This patch will remove the checks, while leaving the
HAVE(36BIT_ADDRESS) macro alone for now.

No new tests because this patch only removes invalid assertions.
.
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/MmapSpan.h:
(WTF::MmapSpan::mmap):
* Source/WTF/wtf/SequesteredImmortalHeap.h:
* Source/bmalloc/bmalloc/BAssert.h:
* Source/bmalloc/bmalloc/VMAllocate.cpp:
(bmalloc::zeroFillLatchIfMadvZeroIsSupported):
* Source/bmalloc/bmalloc/VMAllocate.h:
(bmalloc::tryVMAllocate):
(bmalloc::vmZeroAndPurge):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_try_map_pages):
(pas_page_malloc_zero_fill_latch_if_madv_zero_is_supported):
(pas_page_malloc_zero_fill):
* Source/bmalloc/libpas/src/libpas/pas_root.c:
(pas_root_visit_conservative_candidate_pointers_in_address_range):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/304341@main">https://commits.webkit.org/304341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ab8ebe4f55e4c26449ca46e85e891fd2c5aba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87017 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/950e6e1b-f608-495c-81f6-a61c72cedbb1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103369 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5927 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84231 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e06c80d-b612-4641-8bc4-522645172178) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3312 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3359 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127269 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145467 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133751 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111749 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112116 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5559 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117572 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7389 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166611 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70937 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7247 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->