### PR TITLE
Migrate RenderLayer to WeakKey hash tables

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -198,6 +198,22 @@ template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> cl
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 class NativePromiseRequest;
+
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg>>, typename HashTraitsArg = HashTraits<WeakPtr<ValueArg>>, typename HashTableTraitsArg = HashTableTraits>
+using WeakKeyHashSet = HashSet<WeakPtr<ValueArg>, HashArg, HashTraitsArg, HashTableTraitsArg>;
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg>>, typename HashTraitsArg = HashTraits<WeakPtr<ValueArg>>, typename HashTableTraitsArg = HashTableTraits>
+using WeakKeyHashMap = HashSet<WeakPtr<ValueArg>, HashArg, HashTraitsArg, HashTableTraitsArg>;
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg>>>
+using WeakKeyListHashSet = ListHashSet<WeakPtr<ValueArg>, HashArg>;
+
+class SingleThreadWeakPtrImpl;
+
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>>, typename HashTraitsArg = HashTraits<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>>, typename HashTableTraitsArg = HashTableTraits>
+using SingleThreadWeakKeyHashSet = HashSet<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>, HashArg, HashTraitsArg, HashTableTraitsArg>;
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>>, typename HashTraitsArg = HashTraits<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>>, typename HashTableTraitsArg = HashTableTraits>
+using SingleThreadWeakKeyHashMap = HashSet<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>, HashArg, HashTraitsArg, HashTableTraitsArg>;
+template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>>>
+using SingleThreadWeakKeyListHashSet = ListHashSet<WeakPtr<ValueArg, SingleThreadWeakPtrImpl>, HashArg>;
 }
 
 namespace JSON {
@@ -233,6 +249,7 @@ using WTF::FixedVector;
 using WTF::Function;
 using WTF::FunctionDispatcher;
 using WTF::GenericPromise;
+using WTF::GuaranteedSerialFunctionDispatcher;
 using WTF::HashCountedSet;
 using WTF::HashMap;
 using WTF::HashSet;
@@ -246,7 +263,6 @@ using WTF::MachSendRight;
 using WTF::MachSendRightAnnotated;
 using WTF::MainThreadDispatcher;
 using WTF::MarkableTraits;
-using WTF::makeUniqueRef;
 using WTF::MonotonicTime;
 using WTF::NativePromise;
 using WTF::NativePromiseRequest;
@@ -261,12 +277,14 @@ using WTF::PrintStream;
 using WTF::RawPtrTraits;
 using WTF::RawValueTraits;
 using WTF::Ref;
-using WTF::GuaranteedSerialFunctionDispatcher;
 using WTF::RefPtr;
 using WTF::RetainPtr;
 using WTF::SHA1;
 using WTF::ScopedLambda;
 using WTF::SerialFunctionDispatcher;
+using WTF::SingleThreadWeakKeyHashMap;
+using WTF::SingleThreadWeakKeyHashSet;
+using WTF::SingleThreadWeakKeyListHashSet;
 using WTF::String;
 using WTF::StringBuffer;
 using WTF::StringBuilder;
@@ -282,9 +300,13 @@ using WTF::UncheckedKeyHashSet;
 using WTF::UniqueRef;
 using WTF::Vector;
 using WTF::WallTime;
+using WTF::WeakKeyHashMap;
+using WTF::WeakKeyHashSet;
+using WTF::WeakKeyListHashSet;
 using WTF::WeakPtr;
 using WTF::WeakRef;
 using WTF::WorkQueue;
+using WTF::makeUniqueRef;
 
 template<class T, class E> using Expected = std::experimental::expected<T, E>;
 template<class E> using Unexpected = std::experimental::unexpected<E>;

--- a/Source/WTF/wtf/GetPtr.h
+++ b/Source/WTF/wtf/GetPtr.h
@@ -43,6 +43,9 @@ template<typename T>
 concept SmartPtr = IsSmartPtrV<T>;
 
 template<typename T>
+concept NullableSmartPtr = SmartPtr<T> && IsSmartPtrNullableV<T>;
+
+template<typename T>
 concept NonNullableSmartPtr = SmartPtr<T> && !IsSmartPtrNullableV<T>;
 
 template <typename T, bool isSmartPtr>

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -36,6 +36,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <type_traits>
 #include <utility>
@@ -1560,6 +1561,12 @@ struct SizedUnsignedTrait<8> {
 template<typename T>
 using SameSizeUnsignedInteger = SizedUnsignedTrait<sizeof(T)>::Type;
 
+namespace Views {
+
+static constexpr auto dereferenceView = std::views::transform([](auto&& x) -> decltype(auto) { return *x; });
+
+}
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1636,5 +1643,7 @@ using WTF::SameSizeUnsignedInteger;
 using WTF::SizedUnsignedTrait;
 using WTF::VariantWrapper;
 using WTF::VariantOrSingle;
+
+using WTF::Views::dereferenceView;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1711,7 +1711,7 @@ void LocalFrameView::addSlowRepaintObject(RenderElement& renderer)
     bool hadSlowRepaintObjects = hasSlowRepaintObjects();
 
     if (!m_slowRepaintObjects)
-        m_slowRepaintObjects = makeUnique<SingleThreadWeakHashSet<RenderElement>>();
+        m_slowRepaintObjects = makeUnique<SingleThreadWeakKeyHashSet<RenderElement>>();
 
     auto addResult = m_slowRepaintObjects->add(renderer);
     if (addResult.isNewEntry) {
@@ -2954,7 +2954,7 @@ void LocalFrameView::repaintSlowRepaintObjects()
 
     // Renderers with fixed backgrounds may be in compositing layers, so we need to explicitly
     // repaint them after scrolling.
-    for (auto& renderer : *m_slowRepaintObjects)
+    for (auto& renderer : *m_slowRepaintObjects | dereferenceView)
         renderer.repaintSlowRepaintObject();
 }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -356,7 +356,7 @@ public:
     void removeSlowRepaintObject(RenderElement&);
     bool hasSlowRepaintObject(const RenderElement& renderer) const;
     bool hasSlowRepaintObjects() const;
-    SingleThreadWeakHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
+    SingleThreadWeakKeyHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
@@ -995,7 +995,7 @@ private:
 
     HashSet<SingleThreadWeakRef<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<SingleThreadWeakRef<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
-    std::unique_ptr<SingleThreadWeakHashSet<RenderElement>> m_slowRepaintObjects;
+    std::unique_ptr<SingleThreadWeakKeyHashSet<RenderElement>> m_slowRepaintObjects;
 
     HashMap<ScrollingNodeID, WeakPtr<ScrollableArea>> m_scrollingNodeIDToPluginScrollableAreaMap;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2760,7 +2760,7 @@ static RenderLayer* findCommonAncestor(const RenderLayer& firstLayer, const Rend
     if (&firstLayer == &secondLayer)
         return const_cast<RenderLayer*>(&firstLayer);
 
-    SingleThreadWeakHashSet<const RenderLayer> ancestorChain;
+    SingleThreadWeakKeyHashSet<const RenderLayer> ancestorChain;
     for (auto* currLayer = &firstLayer; currLayer; currLayer = currLayer->parent())
         ancestorChain.add(*currLayer);
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -81,8 +81,8 @@ public:
     RenderLayer& owningLayer() const { return m_owningLayer; }
 
     // Included layers are non-z-order descendant layers that are painted into this backing.
-    const SingleThreadWeakListHashSet<RenderLayer>& backingSharingLayers() const { return m_backingSharingLayers; }
-    void setBackingSharingLayers(SingleThreadWeakListHashSet<RenderLayer>&&);
+    const SingleThreadWeakKeyListHashSet<RenderLayer>& backingSharingLayers() const { return m_backingSharingLayers; }
+    void setBackingSharingLayers(SingleThreadWeakKeyListHashSet<RenderLayer>&&);
 
     bool hasBackingSharingLayers() const { return !m_backingSharingLayers.isEmptyIgnoringNullReferences(); }
 
@@ -446,7 +446,7 @@ private:
     RenderLayer& m_owningLayer;
     
     // A list other layers that paint into this backing store, later than m_owningLayer in paint order.
-    SingleThreadWeakListHashSet<RenderLayer> m_backingSharingLayers;
+    SingleThreadWeakKeyListHashSet<RenderLayer> m_backingSharingLayers;
 
     std::unique_ptr<LayerAncestorClippingStack> m_ancestorClippingStack; // Only used if we are clipped by an ancestor which is not a stacking context.
     std::unique_ptr<LayerAncestorClippingStack> m_overflowControlsHostLayerAncestorClippingStack; // Used when we have an overflow controls host layer which was reparented, and needs clipping by ancestors.

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -148,8 +148,8 @@ private:
 
     ChromeClient& m_chromeClient;
 
-    SingleThreadWeakHashSet<RenderLayer> m_scrollingLayers;
-    SingleThreadWeakHashSet<RenderLayer> m_viewportConstrainedLayers;
+    SingleThreadWeakKeyHashSet<RenderLayer> m_scrollingLayers;
+    SingleThreadWeakKeyHashSet<RenderLayer> m_viewportConstrainedLayers;
 
     const bool m_coordinateViewportConstrainedLayers;
 };
@@ -695,7 +695,7 @@ private:
     Color m_rootExtendedBackgroundColor;
 
     HashMap<ScrollingNodeID, SingleThreadWeakPtr<RenderLayer>> m_scrollingNodeToLayerMap;
-    SingleThreadWeakHashSet<RenderLayer> m_layersWithUnresolvedRelations;
+    SingleThreadWeakKeyHashSet<RenderLayer> m_layersWithUnresolvedRelations;
 #if PLATFORM(IOS_FAMILY)
     std::unique_ptr<LegacyWebKitScrollingLayerCoordinator> m_legacyScrollingLayerCoordinator;
 #endif

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -424,7 +424,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
 
         // We also have to repaint any descendant composited layers that have fixed backgrounds.
         if (auto slowRepaintObjects = view.frameView().slowRepaintObjects()) {
-            for (auto& renderer : *slowRepaintObjects) {
+            for (auto& renderer : *slowRepaintObjects | dereferenceView) {
                 if (isScrolledBy(renderer, m_layer))
                     renderer.repaint();
             }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -126,7 +126,7 @@ void LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded(Inv
     bool markForInvalidation = mode != ParentOnlyInvalidation;
     auto* root = SVGRenderSupport::findTreeRootObject(*this);
 
-    for (auto& client : m_clients) {
+    for (auto& client : m_clients | dereferenceView) {
         // We should not mark any client outside the current root for invalidation
         if (root != SVGRenderSupport::findTreeRootObject(client))
             continue;
@@ -150,12 +150,12 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
     if (m_clientLayers.isEmptyIgnoringNullReferences())
         return;
 
-    Ref document = (*m_clientLayers.begin()).renderer().document();
+    Ref document = (*m_clientLayers.begin())->renderer().document();
     if (!document->view() || document->renderTreeBeingDestroyed())
         return;
 
     auto inLayout = document->view()->layoutContext().isInLayout();
-    for (auto& clientLayer : m_clientLayers) {
+    for (auto& clientLayer : m_clientLayers | dereferenceView) {
         // FIXME: We should not get here while in layout. See webkit.org/b/208903.
         // Repaint should also be triggered through some other means.
         if (inLayout) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -75,8 +75,8 @@ private:
     void registerResource();
 
     AtomString m_id;
-    SingleThreadWeakHashSet<RenderElement> m_clients;
-    SingleThreadWeakHashSet<RenderLayer> m_clientLayers;
+    SingleThreadWeakKeyHashSet<RenderElement> m_clients;
+    SingleThreadWeakKeyHashSet<RenderLayer> m_clientLayers;
     bool m_registered { false };
     bool m_isInvalidating { false };
 };


### PR DESCRIPTION
#### 5ef0287a820b4ff1f131496361719b29759a9e89
<pre>
Migrate RenderLayer to WeakKey hash tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=304034">https://bugs.webkit.org/show_bug.cgi?id=304034</a>
<a href="https://rdar.apple.com/166334471">rdar://166334471</a>

Reviewed by Sam Weinig.

This decouples RenderLayer from any particular WeakPtr implementation, so it can
switch to a more efficient implementation.

* Source/WTF/wtf/Forward.h: Declare canonical names for our new WeakKey hash
table types.

* Source/WTF/wtf/GetPtr.h:
* Source/WTF/wtf/HashMap.h:
(WTF::M&gt;::computeSize const):
(WTF::M&gt;::isEmptyIgnoringNullReferences const):
(WTF::M&gt;::removeWeakNullEntries):
* Source/WTF/wtf/HashSet.h:
(WTF::shouldValidateKey&gt;::computeSize const):
(WTF::shouldValidateKey&gt;::isEmptyIgnoringNullReferences const):
(WTF::shouldValidateKey&gt;::removeWeakNullEntries):
* Source/WTF/wtf/HashTable.h: Pushed weak table helper functions into HashTable
to create a single choke point where we decide to shrink a weak table based on
weak null keys.

(WTF::Malloc&gt;::computeSize const):
(WTF::Malloc&gt;::isEmptyIgnoringNullReferences const):
(WTF::Malloc&gt;::removeWeakNullEntries const):
(WTF::Malloc&gt;::removeIf):
(WTF::Malloc&gt;::takeIf):
(WTF::Malloc&gt;::computeBestTableSize):
(WTF::Malloc&gt;::checkTableConsistencyExceptSize const):
(WTF::Malloc&gt;::removeWeakNullEntries): Deleted.
* Source/WTF/wtf/ListHashSet.h: Boilerplate changes to make interfaces agnostic
about whether you look up by RenderLayer* or RenderLayer&amp;. This reduces
RenderLayer code churn in this patch.

Canonical link: <a href="https://commits.webkit.org/304372@main">https://commits.webkit.org/304372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/008cd93157cd873121e59255302f984c74ceb253

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143078 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9edab6c-4b2d-44b6-8030-1c5a56ac2697) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7613 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8a325ae-3e1b-4563-ac0f-9931708f1857) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84338 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3411 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3690 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127382 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145834 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133871 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7449 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40107 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112211 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5658 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61359 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20878 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7503 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35776 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166713 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71052 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->