### PR TITLE
Expose to clients whether touch-action disallows panning at a given point

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -709,6 +709,10 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @property (nonatomic, readonly) BOOL _safeAreaShouldAffectObscuredInsets WK_API_AVAILABLE(ios(11.0));
 @property (nonatomic, setter=_setObscuredInsetEdgesAffectedBySafeArea:) UIRectEdge _obscuredInsetEdgesAffectedBySafeArea WK_API_AVAILABLE(ios(11.0));
 
+// Indicates if the page uses touch-action to disallow panning.
+// Whether or not a pan will actually occur depends on many other factors.
+- (BOOL)_allowsTouchPanningAtPoint:(CGPoint)point WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 // An ancestor view whose bounds will be intersected with those of this WKWebView to determine the visible region of content to render.
 @property (nonatomic, readonly) UIView *_enclosingViewForExposedRectComputation WK_API_AVAILABLE(ios(11.0));
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4081,6 +4081,11 @@ static bool isLockdownModeWarningNeeded()
     return _avoidsUnsafeArea;
 }
 
+- (BOOL)_allowsTouchPanningAtPoint:(CGPoint)point
+{
+    return [_contentView allowsTouchPanningAtPoint:[self _convertPointFromViewToContents:point]];
+}
+
 - (UIView *)_enclosingViewForExposedRectComputation
 {
     return [self _scroller];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -956,6 +956,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 @property (nonatomic, readonly) BOOL _shouldAvoidSecurityHeuristicScoreUpdates;
 @property (nonatomic, readonly) BOOL _canStartNavigationSwipeAtLastInteractionLocation;
 
+- (BOOL)allowsTouchPanningAtPoint:(CGPoint)point;
+
 - (void)_didChangeLinkPreviewAvailability;
 - (void)setContinuousSpellCheckingEnabled:(BOOL)enabled;
 - (void)setGrammarCheckingEnabled:(BOOL)enabled;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -14356,6 +14356,13 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
     return touchActions.containsAny({ Auto, PanX, Manipulation });
 }
 
+- (BOOL)allowsTouchPanningAtPoint:(CGPoint)point
+{
+    using enum WebCore::TouchAction;
+    auto touchActions = WebKit::touchActionsForPoint(self, WebCore::roundedIntPoint(point));
+    return touchActions.containsAny({ Auto, PanX, PanY, Manipulation });
+}
+
 #if ENABLE(MODEL_PROCESS)
 - (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView
 {

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
@@ -159,6 +159,16 @@ TEST(ScrollViewScrollabilityTests, ScrollableAfterNavigateToPDF)
     EXPECT_EQ([[webView scrollView] isScrollEnabled], YES);
 }
 
+TEST(ScrollViewScrollabilityTests, TouchActionPanAPI)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 414)]);
+
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='initial-scale=1'><body style='margin: 0'><div style='width: 100px; height: 100px; display: inline-block;'></div><div style='width: 100px; height: 100px; display: inline-block; touch-action: none;'></div></body>"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ([webView _allowsTouchPanningAtPoint:CGPointMake(10, 10)], YES);
+    EXPECT_EQ([webView _allowsTouchPanningAtPoint:CGPointMake(110, 10)], NO);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 0816811989195feb34d8552b04e655a8958c4d9c
<pre>
Expose to clients whether touch-action disallows panning at a given point
<a href="https://rdar.apple.com/163145549">rdar://163145549</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304020">https://bugs.webkit.org/show_bug.cgi?id=304020</a>

Reviewed by Lily Spiniolas.

Test: Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _allowsTouchPanningAtPoint:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView allowsTouchPanningAtPoint:]):
Expose to clients whether the page allows touch-based panning at a given point via the touch-action CSS.
This could be used to, for example, control whether client-owned pan gestures used for things
other than scrolling should be disabled in order to defer to the content.

* Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm:
(TestWebKitAPI::TEST(ScrollViewScrollabilityTests, TouchActionPanAPI)):
Add a test.

Canonical link: <a href="https://commits.webkit.org/304387@main">https://commits.webkit.org/304387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ec54a5fe386876c4b05af763d0b71c60f380d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87021 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5dc08420-a24b-4e0d-b078-ca79b5079738) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103371 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/743313d1-41c0-4433-998c-b8b91ba9e116) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84234 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea04688c-cac6-4710-900c-5790857b6156) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3315 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3365 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145474 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/39991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111750 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5560 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35668 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->