### PR TITLE
[WTF] Use C++20 concepts in WeakPtr

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -53,32 +53,36 @@ public:
     template<typename U> WeakPtr(const WeakRef<U, WeakPtrImpl>&);
     template<typename U> WeakPtr(WeakRef<U, WeakPtrImpl>&&);
 
-    template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(object ? &object->weakImpl() : nullptr)
+    WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        requires (!IsSmartPtr<T>::value)
+            : m_impl(object ? &object->weakImpl() : nullptr)
 #if ASSERT_ENABLED
-        , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
+            , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
         UNUSED_PARAM(shouldEnableAssertions);
         ASSERT(!object || object == m_impl->template get<T>());
     }
 
-    template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>> WeakPtr(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(&object.weakImpl())
+    WeakPtr(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        requires (!IsSmartPtr<T>::value && !std::is_pointer_v<T>)
+            : m_impl(&object.weakImpl())
 #if ASSERT_ENABLED
-        , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
+            , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
         UNUSED_PARAM(shouldEnableAssertions);
         ASSERT(&object == m_impl->template get<T>());
     }
 
-    template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const Ref<T>& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : WeakPtr(object.get(), shouldEnableAssertions)
+    WeakPtr(const Ref<T>& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        requires (!IsSmartPtr<T>::value)
+            : WeakPtr(object.get(), shouldEnableAssertions)
     { }
 
-    template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const RefPtr<T>& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : WeakPtr(object.get(), shouldEnableAssertions)
+    WeakPtr(const RefPtr<T>& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        requires (!IsSmartPtr<T>::value)
+            : WeakPtr(object.get(), shouldEnableAssertions)
     { }
 
     template<typename OtherPtrTraits>
@@ -370,16 +374,20 @@ template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inlin
     return a.get() == b;
 }
 
-template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+template<class T>
+    requires (!IsSmartPtr<T>::value)
 WeakPtr(const T* value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 
-template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
+template<class T>
+    requires (!IsSmartPtr<T>::value && !std::is_pointer_v<T>)
 WeakPtr(const T& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 
-template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+template<class T>
+    requires (!IsSmartPtr<T>::value)
 WeakPtr(const Ref<T>& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 
-template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+template<class T>
+    requires (!IsSmartPtr<T>::value)
 WeakPtr(const RefPtr<T>& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 
 template<typename T, typename PtrTraits = RawPtrTraits<SingleThreadWeakPtrImpl>> using SingleThreadWeakPtr = WeakPtr<T, SingleThreadWeakPtrImpl, PtrTraits>;


### PR DESCRIPTION
#### f7440bd8c1b057e04ad964ede3baa6634146c208
<pre>
[WTF] Use C++20 concepts in WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=304022">https://bugs.webkit.org/show_bug.cgi?id=304022</a>
<a href="https://rdar.apple.com/166326603">rdar://166326603</a>

Reviewed by NOBODY (OOPS!).

Modernize our codebase by adopting C++20 concepts in wtf/WeakPtr.h

* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::requires):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7440bd8c1b057e04ad964ede3baa6634146c208

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135283 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7668 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87028 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e6d10057-8024-4d23-8b9b-4a07907848ee) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8305 "Hash f7440bd8 for PR 55281 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7516 "Hash f7440bd8 for PR 55281 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103385 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/timingconditions.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70734 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d1845e6-ef6a-4f0e-bfff-8899448ba19a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138229 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/8305 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84248 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c724eb4-5cef-4d1a-a15f-da0b041e0111) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/8305 "Hash f7440bd8 for PR 55281 does not build (failure)") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3375 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127285 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/8305 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145484 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133768 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7351 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111766 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7394 "Hash f7440bd8 for PR 55281 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/7516 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112134 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61280 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7405 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35679 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166624 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7158 "Hash f7440bd8 for PR 55281 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70952 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43536 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7380 "Hash f7440bd8 for PR 55281 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7261 "Hash f7440bd8 for PR 55281 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->