### PR TITLE
AX: Turn off AccessibilityStitchedTextEnabled for layout tests where it causes changes irrelevant to the behavior-under-test

### DIFF
--- a/LayoutTests/accessibility/changing-aria-hidden-with-display-none-parent.html
+++ b/LayoutTests/accessibility/changing-aria-hidden-with-display-none-parent.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/dirty-relations-and-modal-tree-update-crash.html
+++ b/LayoutTests/accessibility/dirty-relations-and-modal-tree-update-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/display-contents/dynamically-added-children.html
+++ b/LayoutTests/accessibility/display-contents/dynamically-added-children.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/empty-text-under-element-cached.html
+++ b/LayoutTests/accessibility/empty-text-under-element-cached.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/insert-children-assert.html
+++ b/LayoutTests/accessibility/insert-children-assert.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/internal-link-anchors2.html
+++ b/LayoutTests/accessibility/internal-link-anchors2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/ios-simulator/list-item-row-range.html
+++ b/LayoutTests/accessibility/ios-simulator/list-item-row-range.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/lists.html
+++ b/LayoutTests/accessibility/lists.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <script>
     if (window.testRunner)

--- a/LayoutTests/accessibility/mac/aria-tree-with-presentation-role.html
+++ b/LayoutTests/accessibility/mac/aria-tree-with-presentation-role.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/display-contents-relative-frame.html
+++ b/LayoutTests/accessibility/mac/display-contents-relative-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/mac/inherited-presentational-lists.html
+++ b/LayoutTests/accessibility/mac/inherited-presentational-lists.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/mac/nested-inline-elements-children.html
+++ b/LayoutTests/accessibility/mac/nested-inline-elements-children.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/pseudo-element-text-markers.html
+++ b/LayoutTests/accessibility/mac/pseudo-element-text-markers.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/search-predicate-immediate-descendants-only.html
+++ b/LayoutTests/accessibility/mac/search-predicate-immediate-descendants-only.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/search-predicate.html
+++ b/LayoutTests/accessibility/mac/search-predicate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/string-range-contains-listmarker.html
+++ b/LayoutTests/accessibility/mac/string-range-contains-listmarker.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/table-relative-frame.html
+++ b/LayoutTests/accessibility/mac/table-relative-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/mac/text-marker-range-selection-in-list-items.html
+++ b/LayoutTests/accessibility/mac/text-marker-range-selection-in-list-items.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/table-attributes.html
+++ b/LayoutTests/accessibility/table-attributes.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/table-cell-spans.html
+++ b/LayoutTests/accessibility/table-cell-spans.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <script>
     if (window.testRunner)

--- a/LayoutTests/accessibility/table-cells.html
+++ b/LayoutTests/accessibility/table-cells.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <script>
     if (window.testRunner)

--- a/LayoutTests/accessibility/table-one-cell.html
+++ b/LayoutTests/accessibility/table-one-cell.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
 <html>
 <script>
     if (window.testRunner)


### PR DESCRIPTION
#### 6d666f06e87c5d1ef3dc8d242ad76b4fd9beb6ef
<pre>
AX: Turn off AccessibilityStitchedTextEnabled for layout tests where it causes changes irrelevant to the behavior-under-test
<a href="https://bugs.webkit.org/show_bug.cgi?id=304038">https://bugs.webkit.org/show_bug.cgi?id=304038</a>
<a href="https://rdar.apple.com/166338542">rdar://166338542</a>

Reviewed by Joshua Hoffman.

Slight differences in static text values / accessibility tree structure caused by stitched text can cause test results
to vary per platform in ways that aren&apos;t important, greatly increasing maintenance burden. This commit turns off the
feature for these tests.

* LayoutTests/accessibility/changing-aria-hidden-with-display-none-parent.html:
* LayoutTests/accessibility/dirty-relations-and-modal-tree-update-crash.html:
* LayoutTests/accessibility/display-contents/dynamically-added-children.html:
* LayoutTests/accessibility/empty-text-under-element-cached.html:
* LayoutTests/accessibility/insert-children-assert.html:
* LayoutTests/accessibility/internal-link-anchors2.html:
* LayoutTests/accessibility/ios-simulator/list-item-row-range.html:
* LayoutTests/accessibility/lists.html:
* LayoutTests/accessibility/mac/aria-tree-with-presentation-role.html:
* LayoutTests/accessibility/mac/display-contents-relative-frame.html:
* LayoutTests/accessibility/mac/inherited-presentational-lists.html:
* LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html:
* LayoutTests/accessibility/mac/nested-inline-elements-children.html:
* LayoutTests/accessibility/mac/pseudo-element-text-markers.html:
* LayoutTests/accessibility/mac/search-predicate-immediate-descendants-only.html:
* LayoutTests/accessibility/mac/search-predicate.html:
* LayoutTests/accessibility/mac/string-range-contains-listmarker.html:
* LayoutTests/accessibility/mac/table-relative-frame.html:
* LayoutTests/accessibility/mac/text-marker-range-selection-in-list-items.html:
* LayoutTests/accessibility/table-attributes.html:
* LayoutTests/accessibility/table-cell-spans.html:
* LayoutTests/accessibility/table-cells.html:
* LayoutTests/accessibility/table-one-cell.html:

Canonical link: <a href="https://commits.webkit.org/304360@main">https://commits.webkit.org/304360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/543dd7a361094ae970c88d2fd23d5b429192d5ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c53f33b8-e1d5-46bc-99b2-3a397022959a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51be64d5-13db-4917-9a91-8a922a0db8f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138235 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5938 "layout-tests (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84250 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3327 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3381 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145490 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28464 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5571 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61284 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7411 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35682 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->