### PR TITLE
AX: Accessibility text stitching should not stitch the disclosure triangle generated by summary / details (current behavior breaks accessibility/missing-content-inside-expanded-details.html)

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -3964,7 +3964,7 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
     std::optional<AXID> representativeID;
     for (auto lineBox = inlineLayout->firstLineBox(); lineBox && !shouldStop; lineBox.traverseNext()) {
         for (auto box = lineBox->logicalLeftmostLeafBox(); box; box.traverseLogicalRightwardOnLine()) {
-            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(box->renderer())) {
+            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(box->renderer()); renderListMarker && !renderListMarker->isDisclosureMarker()) {
                 if (RefPtr object = cache->getOrCreate(const_cast<RenderListMarker&>(*renderListMarker)))
                     currentGroup.append(object->objectID());
                 continue;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -424,6 +424,16 @@ bool RenderListMarker::isInside() const
     return style().listStylePosition() == ListStylePosition::Inside;
 }
 
+bool RenderListMarker::isDisclosureMarker() const
+{
+    auto& listStyleType = style().listStyleType();
+    if (std::optional counterStyle = listStyleType.tryCounterStyle()) {
+        AtomString& identifier = counterStyle->identifier.value;
+        return identifier == "disclosure-open"_s || identifier == "disclosure-closed"_s;
+    }
+    return false;
+}
+
 const RenderListItem* RenderListMarker::listItem() const
 {
     return m_listItem.get();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -63,6 +63,7 @@ public:
     String textWithSuffix() const { return m_textContent.textWithSuffix; };
 
     bool isInside() const;
+    bool isDisclosureMarker() const;
 
     void updateInlineMarginsAndContent();
 


### PR DESCRIPTION
#### c3cdf09dca55fd19b35cc84ae53b2d156ce5f181
<pre>
AX: Accessibility text stitching should not stitch the disclosure triangle generated by summary / details (current behavior breaks accessibility/missing-content-inside-expanded-details.html)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304039">https://bugs.webkit.org/show_bug.cgi?id=304039</a>
<a href="https://rdar.apple.com/166338805">rdar://166338805</a>

Reviewed by Joshua Hoffman.

With this commit, we stop adding the disclosure triangle generated by summary / details to any stitch group. This was
a side effect of <a href="https://commits.webkit.org/303962@main">https://commits.webkit.org/303962@main</a>, which added list marker stitching. As an implementation detail
of rendering, disclosure triangles are generated via RenderListMarker, which is why that commit introduced the issue.

Fixes accessibility/missing-content-inside-expanded-details.html with AccessibilityTextStitchingEnabled.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::isDisclosureMarker const):
* Source/WebCore/rendering/RenderListMarker.h:

Canonical link: <a href="https://commits.webkit.org/304361@main">https://commits.webkit.org/304361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a370858667dff4951b347442af38ad444fe0e856

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87035 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84249 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5728 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3329 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3383 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40010 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111764 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5573 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61286 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7413 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35685 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/70960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->