### PR TITLE
Unreviewed, reverting 304328@main (130bf1f5080f) and 304323@main (500826177f6a)

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -27,7 +27,6 @@
 
 #include <WebCore/PlatformContentFilter.h>
 #include <wtf/Compiler.h>
-#include <wtf/Condition.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -43,9 +43,9 @@ class ParentalControlsContentFilter;
 class ParentalControlsURLFilter : public ThreadSafeRefCounted<ParentalControlsURLFilter, WTF::DestructionThread::Main> {
 public:
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    WEBCORE_EXPORT static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);
+    static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);
 #else
-    WEBCORE_EXPORT static ParentalControlsURLFilter& singleton();
+    static ParentalControlsURLFilter& singleton();
     WEBCORE_EXPORT static void setGlobalFilter(Ref<ParentalControlsURLFilter>&&);
 #endif
     WEBCORE_EXPORT static void allowURL(const ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
@@ -55,8 +55,7 @@ public:
 
     WEBCORE_EXPORT virtual ~ParentalControlsURLFilter();
     virtual bool isEnabledImpl() const;
-    void isURLAllowed(const URL&, ParentalControlsContentFilter&);
-    WEBCORE_EXPORT void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
+    virtual void isURLAllowed(const URL&, ParentalControlsContentFilter&);
     virtual void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 protected:
@@ -64,8 +63,6 @@ protected:
     ParentalControlsURLFilter(const String& configurationPath);
 #endif
     WEBCORE_EXPORT ParentalControlsURLFilter();
-
-    virtual void isURLAllowedImpl(const URL&, CompletionHandler<void(bool, NSData *)>&&);
 
 private:
     WCRBrowserEngineClient* effectiveWCRBrowserEngineClient();

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -34,11 +34,6 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
-#if HAVE(WEBCONTENTRESTRICTIONS)
-#include <WebCore/ParentalControlsContentFilter.h>
-#include <WebCore/ParentalControlsURLFilter.h>
-#endif
-
 namespace IPC {
 class Connection;
 }
@@ -106,13 +101,8 @@ private:
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override;
 
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    void blockDueToContentFilter(const WebCore::ResourceResponse&, CompletionHandler<void()>&& postBlockHandler);
-#endif
-
 private:
     const Ref<NetworkLoad> m_networkLoad;
-    DownloadID m_downloadID;
     RefPtr<IPC::Connection> m_parentProcessConnection;
     bool m_isAllowedToAskUserForCredentials;
     bool m_isDownloadCancelled = false;
@@ -128,11 +118,6 @@ private:
 #else
     SandboxExtension::Handle m_progressSandboxExtension;
 #endif
-#endif
-
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    RefPtr<WebCore::ParentalControlsURLFilter> m_urlFilter;
-    bool m_wasBlockedDueToContentFilter : 1 { false };
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -136,11 +136,6 @@
 #include <WebCore/ParentalControlsURLFilter.h>
 #endif
 
-
-#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER)
-#include "WebParentalControlsURLFilter.h"
-#endif
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -367,10 +362,6 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     if (parameters.defaultRequestTimeoutInterval)
         setDefaultRequestTimeoutInterval(*parameters.defaultRequestTimeoutInterval);
-
-#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
-#endif
 
     RELEASE_LOG(Process, "%p - NetworkProcess::initializeNetworkProcess: Presenting processPID=%d", this, legacyPresentingApplicationPID());
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -288,6 +288,17 @@ void NetworkResourceLoader::startRequest(const ResourceRequest& newRequest)
 }
 
 #if ENABLE(CONTENT_FILTERING)
+static void setSharedParentalControlsURLFilterIfNecessary()
+{
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    ASSERT(isMainRunLoop());
+    static bool initialized = false;
+    if (!initialized) {
+        WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
+        initialized = true;
+    }
+#endif
+}
 
 void NetworkResourceLoader::startContentFiltering(ResourceRequest&& request, CompletionHandler<void(ResourceRequest)>&& completionHandler)
 {
@@ -295,7 +306,7 @@ void NetworkResourceLoader::startContentFiltering(ResourceRequest&& request, Com
         completionHandler(WTFMove(request));
         return;
     }
-
+    setSharedParentalControlsURLFilterIfNecessary();
     m_contentFilter = ContentFilter::create(*this);
     CheckedPtr contentFilter = m_contentFilter.get();
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
@@ -43,7 +43,7 @@ private:
 
     // WebCore::ParentalControlsURLFilter
     bool isEnabledImpl() const final;
-    void isURLAllowedImpl(const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
+    void isURLAllowed(const URL&, WebCore::ParentalControlsContentFilter&) final;
     void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
 
     BEWebContentFilter* ensureWebContentFilter();


### PR DESCRIPTION
#### c31a2131a86c3f77b734cc43844f2caec92e4939
<pre>
Unreviewed, reverting 304328@main (130bf1f5080f) and 304323@main (500826177f6a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304040">https://bugs.webkit.org/show_bug.cgi?id=304040</a>
<a href="https://rdar.apple.com/166338454">rdar://166338454</a>

REGRESSION(304323@main): Broke internal embedded builds

Reverted changes:

    Make the `setSharedParentalControlsURLFilterIfNecessary` logic simply run in NetworkProcess initialization, instead
    <a href="https://rdar.apple.com/166329114">rdar://166329114</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=304028">https://bugs.webkit.org/show_bug.cgi?id=304028</a>
    304328@main (130bf1f5080f)

    WebKit managed downloads should consult the Screen Time web allow/block list
    <a href="https://rdar.apple.com/162877418">rdar://162877418</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=303971">https://bugs.webkit.org/show_bug.cgi?id=303971</a>
    304323@main (500826177f6a)

Canonical link: <a href="https://commits.webkit.org/304329@main">https://commits.webkit.org/304329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43383194ca1c55ae98a9ecea8c71a2b8f8c0396b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135292 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/7676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137161 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/8314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/7524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/142797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/8314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/142797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/8314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/3384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/8314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145493 "Failed to checkout and rebase branch from PR 55286") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/7359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/145493 "Failed to checkout and rebase branch from PR 55286") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/7402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/7524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/145493 "Failed to checkout and rebase branch from PR 55286") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20857 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/7414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/46561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/7166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->