### PR TITLE
[JSC] Parenthesized assignment target should not infer function name

### DIFF
--- a/JSTests/stress/function-name-assignment-lhs-paren.js
+++ b/JSTests/stress/function-name-assignment-lhs-paren.js
@@ -1,0 +1,10 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+  var foo;
+  (foo) = function () { };
+  shouldBe(foo.name, "");
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -787,9 +787,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«"param"», «undefined») to be true'
-test/language/expressions/assignment/fn-name-lhs-cover.js:
-  default: "Test262Error: obj['name'] descriptor value should be ; obj['name'] value should be "
-  strict mode: "Test262Error: obj['name'] descriptor value should be ; obj['name'] value should be "
 test/language/expressions/call/tco-non-eval-function-dynamic.js:
   default: 'RangeError: Maximum call stack size exceeded.'
 test/language/expressions/call/tco-non-eval-function.js:

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -998,6 +998,7 @@ public:
     PropertyNode::Type getType(const Property& property) const { return property->type(); }
     bool isUnderscoreProtoSetter(const Property& property) const { return PropertyNode::isUnderscoreProtoSetter(m_vm, *property); }
     bool isResolve(ExpressionNode* expr) const { return expr->isResolveNode(); }
+    void setExpressionIsParenthesized(ExpressionNode* expr) { expr->setIsParenthesized(); }
 
     ExpressionNode* createDestructuringAssignment(const JSTokenLocation& location, DestructuringPattern pattern, ExpressionNode* initializer)
     {
@@ -1626,24 +1627,29 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
 
     if (loc->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(loc);
+        bool shouldInferName = !loc->isParenthesized();
 
         if (op == Operator::Equal) {
-            if (expr->isBaseFuncExprNode()) {
-                auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
-                metadata->setEcmaName(resolve->identifier());
-            } else if (expr->isClassExprNode())
-                static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
+            if (shouldInferName) {
+                if (expr->isBaseFuncExprNode()) {
+                    auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
+                    metadata->setEcmaName(resolve->identifier());
+                } else if (expr->isClassExprNode())
+                    static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
+            }
             AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, resolve->identifier(), expr, AssignmentContext::AssignmentExpression);
             setExceptionLocation(node, start, divot, end);
             return node;
         }
 
         if (op == Operator::CoalesceEq || op == Operator::OrEq || op == Operator::AndEq) {
-            if (expr->isBaseFuncExprNode()) {
-                auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
-                metadata->setEcmaName(resolve->identifier());
-            } else if (expr->isClassExprNode())
-                static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
+            if (shouldInferName) {
+                if (expr->isBaseFuncExprNode()) {
+                    auto metadata = static_cast<BaseFuncExprNode*>(expr)->metadata();
+                    metadata->setEcmaName(resolve->identifier());
+                } else if (expr->isClassExprNode())
+                    static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
+            }
             return new (m_parserArena) ShortCircuitReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
         }
 

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -231,9 +231,13 @@ namespace JSC {
         bool isOptionalChainBase() const { return m_isOptionalChainBase; }
         void setIsOptionalChainBase() { m_isOptionalChainBase = true; }
 
+        bool isParenthesized() const { return m_isParenthesized; }
+        void setIsParenthesized() { m_isParenthesized = true; }
+
     private:
         ResultType m_resultType;
         bool m_isOptionalChainBase { false };
+        bool m_isParenthesized { false };
     };
 
     class StatementNode : public Node {

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -5172,6 +5172,8 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
         TreeExpression result = parseExpression(context);
         handleProductionOrFail(CLOSEPAREN, ")", "end", "compound expression");
+        if (result)
+            context.setExpressionIsParenthesized(result);
         return result;
     }
     case THISTOKEN: {

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -344,6 +344,7 @@ public:
     PropertyNode::Type getType(const Property& property) const { return property.type; }
     bool isUnderscoreProtoSetter(const Property& property) const { return property.isUnderscoreProtoSetter; }
     bool isResolve(ExpressionType expr) const { return expr == ResolveExpr || expr == ResolveEvalExpr; }
+    void setExpressionIsParenthesized(ExpressionType) { }
     ExpressionType createDestructuringAssignment(const JSTokenLocation&, int, ExpressionType)
     {
         return DestructuringAssignment;


### PR DESCRIPTION
#### 69b2074a85039e57a212430357168b4bfa2a8218
<pre>
[JSC] Parenthesized assignment target should not infer function name
<a href="https://bugs.webkit.org/show_bug.cgi?id=304041">https://bugs.webkit.org/show_bug.cgi?id=304041</a>

Reviewed by NOBODY (OOPS!).

According to ECMAScript specification, a parenthesized expression is not
an IdentifierRef[1]. So, NamedEvaluation should not apply when the assignment
target is parenthesized.

Please see the `fn-name-lhs-cover.js` from test262[2] for more details.

This patch adds new field to `ExpressionNode` but `sizeof(ExpressionNode)` remains
unchanged as 32.

[1]: <a href="https://tc39.es/ecma262/#sec-static-semantics-isidentifierref">https://tc39.es/ecma262/#sec-static-semantics-isidentifierref</a>
[2]: <a href="https://github.com/tc39/test262/blob/3154e7131da7ffbd8c1e5ae12d008932af0a92df/test/language/expressions/assignment/fn-name-lhs-cover.js">https://github.com/tc39/test262/blob/3154e7131da7ffbd8c1e5ae12d008932af0a92df/test/language/expressions/assignment/fn-name-lhs-cover.js</a>

Test: JSTests/stress/function-name-assignment-lhs-paren.js

* JSTests/stress/function-name-assignment-lhs-paren.js: Added.
(shouldBe):
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::setExpressionIsParenthesized):
(JSC::ASTBuilder::makeAssignNode):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ExpressionNode::isParenthesized const):
(JSC::ExpressionNode::setIsParenthesized):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::operatorStackPop):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b2074a85039e57a212430357168b4bfa2a8218

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104184 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82625 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18462 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135238 "Found 1 new API test failure: TestWebKitAPI.ColorInputTests.SetColorUsingColorPicker (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17559 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7320 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142733 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161946 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11548 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5067 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14718 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124353 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79687 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11719 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86712 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->