### PR TITLE
WebKit managed downloads should consult the Screen Time web allow/block list

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/PlatformContentFilter.h>
 #include <wtf/Compiler.h>
+#include <wtf/Condition.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -43,9 +43,9 @@ class ParentalControlsContentFilter;
 class ParentalControlsURLFilter : public ThreadSafeRefCounted<ParentalControlsURLFilter, WTF::DestructionThread::Main> {
 public:
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);
+    WEBCORE_EXPORT static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);
 #else
-    static ParentalControlsURLFilter& singleton();
+    WEBCORE_EXPORT static ParentalControlsURLFilter& singleton();
     WEBCORE_EXPORT static void setGlobalFilter(Ref<ParentalControlsURLFilter>&&);
 #endif
     WEBCORE_EXPORT static void allowURL(const ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
@@ -55,7 +55,8 @@ public:
 
     WEBCORE_EXPORT virtual ~ParentalControlsURLFilter();
     virtual bool isEnabledImpl() const;
-    virtual void isURLAllowed(const URL&, ParentalControlsContentFilter&);
+    void isURLAllowed(const URL&, ParentalControlsContentFilter&);
+    WEBCORE_EXPORT void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
     virtual void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 protected:
@@ -63,6 +64,8 @@ protected:
     ParentalControlsURLFilter(const String& configurationPath);
 #endif
     WEBCORE_EXPORT ParentalControlsURLFilter();
+
+    virtual void isURLAllowedImpl(const URL&, CompletionHandler<void(bool, NSData *)>&&);
 
 private:
     WCRBrowserEngineClient* effectiveWCRBrowserEngineClient();

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -164,20 +164,37 @@ bool ParentalControlsURLFilter::isEnabled() const
 
 void ParentalControlsURLFilter::isURLAllowed(const URL& url, ParentalControlsContentFilter& filter)
 {
+    isURLAllowedImpl(url, { [protectedThis = Ref { *this }, weakFilter = ThreadSafeWeakPtr { filter }] (bool allowed, NSData *replacementData) mutable {
+        ASSERT(!isMainThread());
+        if (RefPtr filter = weakFilter.get())
+            filter->didReceiveAllowDecisionOnQueue(allowed, replacementData);
+    }, CompletionHandlerCallThread::AnyThread });
+}
+
+void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+{
+    isURLAllowedImpl(url, { [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (bool allowed, NSData *replacementData) mutable {
+        ASSERT(!isMainThread());
+        callOnMainRunLoop([completionHandler = WTFMove(completionHandler), allowed, replacementData = RetainPtr { replacementData }]() mutable {
+            completionHandler(allowed, replacementData.get());
+        });
+    }, CompletionHandlerCallThread::AnyThread });
+}
+
+void ParentalControlsURLFilter::isURLAllowedImpl(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+{
     ASSERT(isMainThread());
 
     RetainPtr wcrBrowserEngineClient = effectiveWCRBrowserEngineClient();
     if (!wcrBrowserEngineClient) {
-        workQueueSingleton().dispatch([weakFilter = ThreadSafeWeakPtr { filter }]() mutable {
-            if (RefPtr filter = weakFilter.get())
-                filter->didReceiveAllowDecisionOnQueue(true, nullptr);
+        workQueueSingleton().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(true, nullptr);
         });
         return;
     }
 
-    [wcrBrowserEngineClient evaluateURL:url.createNSURL().get() withCompletion:makeBlockPtr([weakFilter = ThreadSafeWeakPtr { filter }](BOOL shouldBlock, NSData *replacementData) mutable {
-        if (RefPtr filter = weakFilter.get())
-            filter->didReceiveAllowDecisionOnQueue(!shouldBlock, replacementData);
+    [wcrBrowserEngineClient evaluateURL:url.createNSURL().get() withCompletion:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+        completionHandler(!shouldBlock, replacementData);
     }).get() onCompletionQueue:workQueueSingleton().dispatchQueue()];
 }
 

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -33,6 +33,7 @@
 #include "NetworkLoad.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
+#include "WebErrors.h"
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -43,22 +44,53 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PendingDownload);
 
 PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, NetworkLoadParameters&& parameters, DownloadID downloadID, NetworkSession& networkSession, const String& suggestedName, FromDownloadAttribute fromDownloadAttribute, std::optional<WebCore::ProcessIdentifier> webProcessID)
     : m_networkLoad(NetworkLoad::create(*this, WTFMove(parameters), networkSession))
+    , m_downloadID(downloadID)
     , m_parentProcessConnection(parentProcessConnection)
     , m_fromDownloadAttribute(fromDownloadAttribute)
     , m_webProcessID(webProcessID)
 {
-    m_networkLoad->start();
-    m_isAllowedToAskUserForCredentials = parameters.clientCredentialPolicy == ClientCredentialPolicy::MayAskClientForCredentials;
+    relaxAdoptionRequirement();
 
-    m_networkLoad->setPendingDownloadID(downloadID);
-    m_networkLoad->setPendingDownload(*this);
-    m_networkLoad->setSuggestedFilename(suggestedName);
+#if ENABLE(CONTENT_FILTERING)
+    NetworkProcess::setSharedParentalControlsURLFilterIfNecessary();
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    m_urlFilter = ParentalControlsURLFilter::filterWithConfigurationPath(networkSession.webContentRestrictionsConfigurationFile());
+#else
+    m_urlFilter = ParentalControlsURLFilter::singleton();
+#endif // HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+#endif // HAVE(WEBCONTENTRESTRICTIONS)
+
+    auto startNetworkLoad = [this, protectedThis = Ref { *this }, downloadID, suggestedName] () {
+        m_networkLoad->start();
+        m_isAllowedToAskUserForCredentials = m_networkLoad->parameters().clientCredentialPolicy == ClientCredentialPolicy::MayAskClientForCredentials;
+
+        m_networkLoad->setPendingDownloadID(downloadID);
+        m_networkLoad->setPendingDownload(*this);
+        m_networkLoad->setSuggestedFilename(suggestedName);
+    };
 
     send(Messages::DownloadProxy::DidStart(m_networkLoad->currentRequest(), suggestedName));
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    m_urlFilter->isURLAllowed(m_networkLoad->currentRequest().url(), [this, protectedThis = Ref { *this }, startNetworkLoad = WTFMove(startNetworkLoad)] (bool allowed, NSData *) mutable {
+        if (!allowed) {
+            blockDueToContentFilter(ResourceResponse { m_networkLoad->currentRequest().url(), "application/octet-stream"_s, 0, ""_s }, nullptr);
+            return;
+        }
+
+        startNetworkLoad();
+    });
+#else
+    startNetworkLoad();
+#endif
 }
 
 PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& completionHandler, DownloadID downloadID, const ResourceRequest& request, const ResourceResponse& response)
     : m_networkLoad(WTFMove(networkLoad))
+    , m_downloadID(downloadID)
     , m_parentProcessConnection(parentProcessConnection)
 {
     m_isAllowedToAskUserForCredentials = m_networkLoad->isAllowedToAskUserForCredentials();
@@ -95,7 +127,22 @@ void PendingDownload::willSendRedirectedRequest(WebCore::ResourceRequest&&, WebC
             m_networkLoad->networkProcess()->protectedWebProcessConnection(*m_webProcessID)->loadCancelledDownloadRedirectRequestInFrame(redirectRequest, *m_networkLoad->webFrameID(), *m_networkLoad->webPageID());
         return;
     }
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    auto requestURL = redirectRequest.url();
+    m_urlFilter->isURLAllowed(requestURL, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), redirectRequest = WTFMove(redirectRequest), redirectResponse = WTFMove(redirectResponse)] (bool allowed, NSData *) mutable {
+        if (allowed) {
+            sendWithAsyncReply(Messages::DownloadProxy::WillSendRequest(WTFMove(redirectRequest), WTFMove(redirectResponse)), WTFMove(completionHandler));
+            return;
+        }
+
+        blockDueToContentFilter(redirectResponse, [completionHandler = WTFMove(completionHandler)] () mutable {
+            completionHandler(ResourceRequest { });
+        });
+    });
+#else
     sendWithAsyncReply(Messages::DownloadProxy::WillSendRequest(WTFMove(redirectRequest), WTFMove(redirectResponse)), WTFMove(completionHandler));
+#endif // HAVE(WEBCONTENTRESTRICTIONS)
 };
 
 void PendingDownload::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler)
@@ -156,7 +203,34 @@ void PendingDownload::didReceiveResponse(WebCore::ResourceResponse&& response, P
 
 uint64_t PendingDownload::messageSenderDestinationID() const
 {
-    return m_networkLoad->pendingDownloadID()->toUInt64();
+    return m_downloadID.toUInt64();
 }
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+void PendingDownload::blockDueToContentFilter(const WebCore::ResourceResponse& response, CompletionHandler<void()>&& postBlockHandler)
+{
+    if (m_wasBlockedDueToContentFilter) {
+        postBlockHandler();
+        return;
+    }
     
+    m_wasBlockedDueToContentFilter = true;
+
+    auto currentRequest = m_networkLoad->currentRequest();
+
+    // Whenever the content filter blocks a PendingDownload, the download hasn't made it to the stage
+    // where the UI client is asked to decide a filename.
+    // Therefore the UI client doesn't even know about the download yet, and can't track its
+    // status of being "blocked"
+    // So we ask it to decide the filename, after which we can report it being blocked.
+    sendWithAsyncReply(Messages::DownloadProxy::DecideDestinationWithSuggestedFilename(response, response.suggestedFilename()), [this, protectedThis = Ref { *this }, currentRequest, postBlockHandler = WTFMove(postBlockHandler)] (String&& name, SandboxExtension::Handle&&, AllowOverwrite, WebKit::UseDownloadPlaceholder, URL&&, SandboxExtension::Handle&&, std::span<const uint8_t>, std::span<const uint8_t>) mutable {
+        didFailLoading(blockedByContentFilterError(currentRequest));
+
+        m_networkLoad->cancel();
+        if (postBlockHandler)
+            postBlockHandler();
+    }, m_downloadID);
+}
+#endif // HAVE(WEBCONTENTRESTRICTIONS)
+
 }

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -34,6 +34,11 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+#include <WebCore/ParentalControlsContentFilter.h>
+#include <WebCore/ParentalControlsURLFilter.h>
+#endif
+
 namespace IPC {
 class Connection;
 }
@@ -101,8 +106,13 @@ private:
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override;
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    void blockDueToContentFilter(const WebCore::ResourceResponse&, CompletionHandler<void()>&& postBlockHandler);
+#endif
+
 private:
     const Ref<NetworkLoad> m_networkLoad;
+    DownloadID m_downloadID;
     RefPtr<IPC::Connection> m_parentProcessConnection;
     bool m_isAllowedToAskUserForCredentials;
     bool m_isDownloadCancelled = false;
@@ -118,6 +128,11 @@ private:
 #else
     SandboxExtension::Handle m_progressSandboxExtension;
 #endif
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    RefPtr<WebCore::ParentalControlsURLFilter> m_urlFilter;
+    bool m_wasBlockedDueToContentFilter : 1 { false };
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -136,6 +136,11 @@
 #include <WebCore/ParentalControlsURLFilter.h>
 #endif
 
+
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER)
+#include "WebParentalControlsURLFilter.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -193,6 +198,18 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
 }
 
 NetworkProcess::~NetworkProcess() = default;
+
+void NetworkProcess::setSharedParentalControlsURLFilterIfNecessary()
+{
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    ASSERT(isMainRunLoop());
+    static bool initialized = false;
+    if (!initialized) {
+        WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
+        initialized = true;
+    }
+#endif
+}
 
 AuthenticationManager& NetworkProcess::authenticationManager()
 {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -155,6 +155,8 @@ public:
     using DomainInNeedOfStorageAccess = WebCore::RegistrableDomain;
     using OpenerDomain = WebCore::RegistrableDomain;
 
+    static void setSharedParentalControlsURLFilterIfNecessary();
+
     NetworkProcess(AuxiliaryProcessInitializationParameters&&);
     ~NetworkProcess();
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Network;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -288,17 +288,6 @@ void NetworkResourceLoader::startRequest(const ResourceRequest& newRequest)
 }
 
 #if ENABLE(CONTENT_FILTERING)
-static void setSharedParentalControlsURLFilterIfNecessary()
-{
-#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    ASSERT(isMainRunLoop());
-    static bool initialized = false;
-    if (!initialized) {
-        WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
-        initialized = true;
-    }
-#endif
-}
 
 void NetworkResourceLoader::startContentFiltering(ResourceRequest&& request, CompletionHandler<void(ResourceRequest)>&& completionHandler)
 {
@@ -306,7 +295,7 @@ void NetworkResourceLoader::startContentFiltering(ResourceRequest&& request, Com
         completionHandler(WTFMove(request));
         return;
     }
-    setSharedParentalControlsURLFilterIfNecessary();
+    NetworkProcess::setSharedParentalControlsURLFilterIfNecessary();
     m_contentFilter = ContentFilter::create(*this);
     CheckedPtr contentFilter = m_contentFilter.get();
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
@@ -43,7 +43,7 @@ private:
 
     // WebCore::ParentalControlsURLFilter
     bool isEnabledImpl() const final;
-    void isURLAllowed(const URL&, WebCore::ParentalControlsContentFilter&) final;
+    void isURLAllowedImpl(const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
     void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
 
     BEWebContentFilter* ensureWebContentFilter();

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -61,18 +61,16 @@ bool WebParentalControlsURLFilter::isEnabledImpl() const
     return [BEWebContentFilter shouldEvaluateURLs];
 }
 
-void WebParentalControlsURLFilter::isURLAllowed(const URL& url, WebCore::ParentalControlsContentFilter& filter)
+void WebParentalControlsURLFilter::isURLAllowedImpl(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
 {
-    workQueueSingleton().dispatch([this, protectedThis = Ref { *this }, currentIsEnabled = isEnabled(), url = crossThreadCopy(url), weakFilter = ThreadSafeWeakPtr { filter }]() mutable {
-        RefPtr filter = weakFilter.get();
-        if (!currentIsEnabled && filter) {
-            filter->didReceiveAllowDecisionOnQueue(true, nullptr);
+    workQueueSingleton().dispatch([this, protectedThis = Ref { *this }, currentIsEnabled = isEnabled(), url = crossThreadCopy(url), completionHandler = WTFMove(completionHandler)]() mutable {
+        if (!currentIsEnabled) {
+            completionHandler(true, nullptr);
             return;
         }
 
-        [ensureWebContentFilter() evaluateURL:url.createNSURL().get() completionHandler:makeBlockPtr([weakFilter = WTFMove(weakFilter)](BOOL shouldBlock, NSData *replacementData) mutable {
-            if (RefPtr filter = weakFilter.get())
-                filter->didReceiveAllowDecisionOnQueue(!shouldBlock, replacementData);
+        [ensureWebContentFilter() evaluateURL:url.createNSURL().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+            completionHandler(!shouldBlock, replacementData);
         }).get()];
     });
 }


### PR DESCRIPTION
#### 9bfee6dfdf24eb1b9d0a8e3b1f232d9147a99249
<pre>
WebKit managed downloads should consult the Screen Time web allow/block list
<a href="https://rdar.apple.com/162877418">rdar://162877418</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304044">https://bugs.webkit.org/show_bug.cgi?id=304044</a>

Reviewed by Per Arne Vollan and Sihui Liu.

When a navigation occurs, WebKit will automatically subject that navigation to a few different
methods of content filtering defined by the platform.

One such method of filtering is Screen Time&apos;s parental controls based on URL block/allow lists.

When a navigation turns into a download, then further redirects of the URL should continue to
consult the URL block/allow lists.

The same is true for downloads started directly via WKWebView/WKDownload APIs.

Most of the change here is in PendingDownload, which always sits between the actual network load
and clients being informed of download-related decisions and progress.

PendingDownload will now consult its initial URL against the block/allow lists, as well as any redirects.

If it is informed that the URL is blocked, it will cancel the network load and schedule its own
failure with an appropriate error to notify the WebKit API client.

* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::isURLAllowed):
(WebCore::ParentalControlsURLFilter::isURLAllowedImpl):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::PendingDownload):
(WebKit::PendingDownload::willSendRedirectedRequest):
(WebKit::PendingDownload::messageSenderDestinationID const):
(WebKit::PendingDownload::blockDueToContentFilter):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setSharedParentalControlsURLFilterIfNecessary):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
(WebKit::setSharedParentalControlsURLFilterIfNecessary): Deleted.
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::isURLAllowedImpl):
(WebKit::WebParentalControlsURLFilter::isURLAllowed): Deleted.

Canonical link: <a href="https://commits.webkit.org/304378@main">https://commits.webkit.org/304378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540da35fc3c151e642c6ebb537664f847cfc04f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143086 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8010b73e-bf84-4c0d-b563-aaabebeaf277) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff0608ce-0570-4512-aa4b-cd897731f817) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5808 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3698 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145842 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7457 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40112 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7498 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5659 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61365 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7511 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35780 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->