### PR TITLE
On caption menu item doesn't enable text tracks

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt
+++ b/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt
@@ -1,0 +1,53 @@
+
+RUN(video.src = findMediaFile("audio", "../../content/test"))
+EVENT(loadedmetadata)
+--
+Test basic menu structure:
+EXPECTED (contextMenu.length == '7') OK
+EXPECTED (contextMenu[0].title == 'Subtitles') OK
+EXPECTED (contextMenu[1].title == 'On') OK
+EXPECTED (contextMenu[2].title == 'Off') OK
+EXPECTED (contextMenu[3].title == 'undefined') OK
+EXPECTED (contextMenu[4].title == 'Languages') OK
+EXPECTED (contextMenu[4].children.length == '4') OK
+EXPECTED (contextMenu[4].children[0].title == 'English Captions') OK
+EXPECTED (contextMenu[4].children[1].title == 'French Captions') OK
+EXPECTED (contextMenu[4].children[2].title == 'German Captions') OK
+EXPECTED (contextMenu[4].children[3].title == 'Spanish Captions') OK
+EXPECTED (contextMenu[5].title == 'undefined') OK
+EXPECTED (contextMenu[6].title == 'Styles') OK
+--
+Test default menu selection states
+EXPECTED (contextMenu[1].checked == 'false') OK
+EXPECTED (contextMenu[2].checked == 'true') OK
+EXPECTED (contextMenu[4].children[0].checked == 'true') OK
+EXPECTED (contextMenu[4].children[1].checked == 'false') OK
+EXPECTED (contextMenu[4].children[2].checked == 'false') OK
+EXPECTED (contextMenu[4].children[3].checked == 'false') OK
+--
+Test On menu item behavior
+RUN(controlsHost.setSelectedTextTrack(onItem))
+EXPECTED (video.textTracks[0].mode == 'showing') OK
+EXPECTED (contextMenu[1].checked == 'true') OK
+EXPECTED (contextMenu[2].checked == 'false') OK
+EXPECTED (internals.captionDisplayMode == 'alwayson') OK
+--
+Test Off menu item behavior
+RUN(controlsHost.setSelectedTextTrack(offItem))
+EXPECTED (video.textTracks[0].mode == 'disabled') OK
+EXPECTED (contextMenu[1].checked == 'false') OK
+EXPECTED (contextMenu[2].checked == 'true') OK
+EXPECTED (internals.captionDisplayMode == 'forcedonly') OK
+--
+Test Language menu item behavior
+RUN(controlsHost.setSelectedTextTrack(video.textTracks[1]))
+EXPECTED (video.textTracks[1].mode == 'showing') OK
+EXPECTED (contextMenu[1].checked == 'true') OK
+EXPECTED (contextMenu[2].checked == 'false') OK
+EXPECTED (contextMenu[4].children[0].checked == 'false') OK
+EXPECTED (contextMenu[4].children[1].checked == 'true') OK
+EXPECTED (contextMenu[4].children[2].checked == 'false') OK
+EXPECTED (contextMenu[4].children[3].checked == 'false') OK
+EXPECTED (internals.captionDisplayMode == 'alwayson') OK
+END OF TEST
+

--- a/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html
+++ b/LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true ] -->
+<html>
+<head>
+    <title>on-auto-text-track</title>
+    <style>
+        video { width: 600px; }
+    </style>
+    <script src="../resources/media-controls-utils.js"></script>
+    <script src="../../video-test.js"></script>
+    <script src="../../media-file.js"></script>
+    <script>
+        window.addEventListener('load', event => {
+            runTest().then(endTest)//.catch(failTest)
+        });
+
+        var shadowRoot;
+        var controlsHost;
+        var contextMenu;
+
+        window.internals.setCaptionDisplayMode('automatic');
+        window.internals.settings.setShouldDisplayTrackKind('Captions', true);
+
+        function getContextMenuItems() {
+            const options = { includeLanguages: true, includeSubtitles: true };
+            return controlsHost.mediaControlsContextMenuItems(options)
+        }
+
+        async function runTest() {
+            findMediaElement();
+
+            run('video.src = findMediaFile("audio", "../../content/test")');
+            await waitFor(video, 'loadedmetadata');
+
+            controlsHost = internals.controlsHostForMediaElement(video);
+            contextMenu = getContextMenuItems();
+
+            consoleWrite('--');
+            consoleWrite('Test basic menu structure:');
+            testExpected('contextMenu.length', 7);
+            testExpected('contextMenu[0].title', 'Subtitles');
+            testExpected('contextMenu[1].title', 'On');
+            testExpected('contextMenu[2].title', 'Off');
+            testExpected('contextMenu[3].title', undefined);
+            testExpected('contextMenu[4].title', 'Languages');
+            testExpected('contextMenu[4].children.length', '4');
+            testExpected('contextMenu[4].children[0].title', 'English Captions');
+            testExpected('contextMenu[4].children[1].title', 'French Captions');
+            testExpected('contextMenu[4].children[2].title', 'German Captions');
+            testExpected('contextMenu[4].children[3].title', 'Spanish Captions');
+            testExpected('contextMenu[5].title', undefined);
+            testExpected('contextMenu[6].title', 'Styles');
+
+            consoleWrite('--');
+            consoleWrite('Test default menu selection states');
+            testExpected('contextMenu[1].checked', false);
+            testExpected('contextMenu[2].checked', true);
+            testExpected('contextMenu[4].children[0].checked', true);
+            testExpected('contextMenu[4].children[1].checked', false);
+            testExpected('contextMenu[4].children[2].checked', false);
+            testExpected('contextMenu[4].children[3].checked', false);
+
+            consoleWrite('--');
+            consoleWrite('Test On menu item behavior');
+
+            onItem = controlsHost.captionMenuOnItem;
+            offItem = controlsHost.captionMenuOffItem;
+            autoItem = controlsHost.captionMenuAutomaticItem;
+
+            run('controlsHost.setSelectedTextTrack(onItem)');
+            await testExpectedEventually('video.textTracks[0].mode', 'showing', '==', 100);
+
+            contextMenu = getContextMenuItems();
+            testExpected('contextMenu[1].checked', true);
+            testExpected('contextMenu[2].checked', false);
+            testExpected('internals.captionDisplayMode', 'alwayson');
+
+            consoleWrite('--');
+            consoleWrite('Test Off menu item behavior');
+
+            run('controlsHost.setSelectedTextTrack(offItem)');
+            await testExpectedEventually('video.textTracks[0].mode', 'disabled', '==', 100);
+
+            contextMenu = getContextMenuItems();
+            testExpected('contextMenu[1].checked', false);
+            testExpected('contextMenu[2].checked', true);
+            testExpected('internals.captionDisplayMode', 'forcedonly');
+
+            consoleWrite('--');
+            consoleWrite('Test Language menu item behavior');
+
+            run('controlsHost.setSelectedTextTrack(video.textTracks[1])');
+            await testExpectedEventually('video.textTracks[1].mode', 'showing', '==', 100);
+
+            contextMenu = getContextMenuItems();
+            testExpected('contextMenu[1].checked', true);
+            testExpected('contextMenu[2].checked', false);
+            testExpected('contextMenu[4].children[0].checked', false);
+            testExpected('contextMenu[4].children[1].checked', true);
+            testExpected('contextMenu[4].children[2].checked', false);
+            testExpected('contextMenu[4].children[3].checked', false);
+            testExpected('internals.captionDisplayMode', 'alwayson');
+        }
+    </script>
+</head>
+<body>
+    <video controls muted playsinline disableremoteplayback preload="metadata">
+        <track src="../../content/lorem-ipsum.vtt" kind="captions" srclang="en">
+        <track src="../../content/lorem-ipsum.vtt" kind="captions" srclang="fr">
+        <track src="../../content/lorem-ipsum.vtt" kind="captions" srclang="de">
+        <track src="../../content/lorem-ipsum.vtt" kind="captions" srclang="es">
+    </video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4850,6 +4850,7 @@ http/tests/performance/performance-resource-timing-redirection-cross-origin-medi
 webkit.org/b/304053 imported/w3c/web-platform-tests/trusted-types/SharedWorker-eval.html [ Pass Crash ]
 
 webkit.org/b/304054 webgl/1.0.x/conformance/textures/image_data/tex-2d-alpha-alpha-unsigned_byte.html [ Pass Crash ]
+webkit.org/b/304180 media/modern-media-controls/tracks-support/on-off-text-track.html [ Failure ]
 
 # End: Common failures between GTK and WPE.
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -490,6 +490,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl
 
     Modules/mediacontrols/DOMWindow+MediaControls.idl
+    Modules/mediacontrols/MediaControlsContextMenuItem.idl
     Modules/mediacontrols/MediaControlsHost.idl
     Modules/mediacontrols/MediaControlsUtils.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -554,6 +554,7 @@ $(PROJECT_DIR)/Modules/mediacapabilities/TransferFunction.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/VideoConfiguration.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl
 $(PROJECT_DIR)/Modules/mediacontrols/DOMWindow+MediaControls.idl
+$(PROJECT_DIR)/Modules/mediacontrols/MediaControlsContextMenuItem.idl
 $(PROJECT_DIR)/Modules/mediacontrols/MediaControlsHost.idl
 $(PROJECT_DIR)/Modules/mediacontrols/MediaControlsUtils.idl
 $(PROJECT_DIR)/Modules/mediarecorder/BlobEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1869,6 +1869,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaConfiguration.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaConfiguration.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaController.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaController.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsContextMenuItem.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsContextMenuItem.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsHost.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsHost.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsUtils.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -415,6 +415,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediacapabilities/VideoConfiguration.idl \
     $(WebCore)/Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl \
     $(WebCore)/Modules/mediacontrols/DOMWindow+MediaControls.idl \
+	$(WebCore)/Modules/mediacontrols/MediaControlsContextMenuItem.idl \
     $(WebCore)/Modules/mediacontrols/MediaControlsHost.idl \
     $(WebCore)/Modules/mediacontrols/MediaControlsUtils.idl \
     $(WebCore)/Modules/mediarecorder/BlobEvent.idl \

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsContextMenuItem.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsContextMenuItem.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_CONTROLS_CONTEXT_MENUS,
+    JSGenerateToJSObject,
+    EnabledBySetting=MediaControlsContextMenusEnabled
+] dictionary MediaControlsContextMenuItem {
+    unsigned long long id;
+    DOMString title;
+    DOMString icon;
+    boolean checked;
+    sequence<MediaControlsContextMenuItem> children;
+};

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -43,6 +43,7 @@ enum DeviceType {
     Conditional=VIDEO,
     JSCustomMarkFunction,
     LegacyNoInterfaceObject,
+    ExportMacro=WEBCORE_EXPORT,
 ] interface MediaControlsHost {
     readonly attribute DOMString layoutTraitsClassName;
     readonly attribute DOMString mediaControlsContainerClassName;
@@ -53,6 +54,7 @@ enum DeviceType {
     DOMString displayNameForTrack((TextTrack or AudioTrack)? track);
     readonly attribute TextTrack captionMenuOffItem;
     readonly attribute TextTrack captionMenuAutomaticItem;
+    readonly attribute TextTrack captionMenuOnItem;
     readonly attribute DOMString captionDisplayMode;
     undefined setSelectedTextTrack(TextTrack? track);
     readonly attribute HTMLElement textTrackContainer;
@@ -85,6 +87,7 @@ enum DeviceType {
     readonly attribute sequence<DOMString> shadowRootStyleSheets;
     DOMString base64StringForIconNameAndType(DOMString iconName, DOMString iconType);
     [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled] boolean showMediaControlsContextMenu(HTMLElement target, JSON options, VoidCallback callback);
+    [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled, ImplementedAs=mediaControlsContextMenuItemsForBindings] sequence<MediaControlsContextMenuItem> mediaControlsContextMenuItems(JSON options);
 
     [Conditional=MEDIA_SESSION] undefined ensureMediaSessionObserver();
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4432,6 +4432,7 @@ JSMediaCapabilitiesDecodingInfo.cpp
 JSMediaCapabilitiesEncodingInfo.cpp
 JSMediaCapabilitiesInfo.cpp
 JSMediaController.cpp
+JSMediaControlsContextMenuItem.cpp
 JSMediaControlsHost.cpp
 JSMediaControlsUtils.cpp
 JSMediaDecodingConfiguration.cpp

--- a/Source/WebCore/html/Origin.cpp
+++ b/Source/WebCore/html/Origin.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "Origin.h"
 
+#include "ExceptionOr.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMBindingSecurityInlines.h"
 #include "JSDOMGlobalObject.h"
@@ -39,6 +40,7 @@
 #include "JSOrigin.h"
 #include "JSWorkerGlobalScope.h"
 #include "LocalDOMWindow.h"
+#include "SecurityOrigin.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -47,6 +49,8 @@ Origin::Origin(Ref<SecurityOrigin>&& securityOrigin)
     : m_origin(WTFMove(securityOrigin))
 {
 }
+
+Origin::~Origin() = default;
 
 Ref<Origin> Origin::create()
 {

--- a/Source/WebCore/html/Origin.h
+++ b/Source/WebCore/html/Origin.h
@@ -25,15 +25,23 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
-#include "SecurityOrigin.h"
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
+
+template<typename T> class ExceptionOr;
+class ScriptExecutionContext;
+class SecurityOrigin;
 
 class Origin final : public RefCounted<Origin> {
 public:
     static Ref<Origin> create();
+    ~Origin();
 
     static ExceptionOr<Ref<Origin>> from(ScriptExecutionContext&, JSC::JSValue);
 

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -64,8 +64,9 @@ public:
     virtual CaptionDisplayMode captionDisplayMode() const;
     virtual void setCaptionDisplayMode(CaptionDisplayMode);
 
-    virtual int textTrackSelectionScore(TextTrack*, HTMLMediaElement*) const;
-    virtual int textTrackLanguageSelectionScore(TextTrack*, const Vector<String>&) const;
+    virtual int textTrackSelectionScore(TextTrack&, CaptionDisplayMode, AudioTrack* enabledAudioTrack = nullptr) const;
+    virtual int textTrackSelectionScore(TextTrack&, HTMLMediaElement&) const;
+    virtual int textTrackLanguageSelectionScore(TextTrack&, const Vector<String>&) const;
 
     virtual bool userPrefersCaptions() const;
     virtual void setUserPrefersCaptions(bool);

--- a/Source/WebCore/page/MediaControlsContextMenuItem.h
+++ b/Source/WebCore/page/MediaControlsContextMenuItem.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 struct MediaControlsContextMenuItem {
+    using Item = MediaControlsContextMenuItem;
     using ID = uint64_t;
     static constexpr ID invalidID = 0;
 
@@ -45,4 +46,4 @@ struct MediaControlsContextMenuItem {
 
 } // namespace WebCore
 
-#endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+#endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -152,6 +152,7 @@
 #include "LocalizedStrings.h"
 #include "Location.h"
 #include "MallocStatistics.h"
+#include "MediaControlsHost.h"
 #include "MediaDevices.h"
 #include "MediaEngineConfigurationFactory.h"
 #include "MediaKeySession.h"
@@ -643,6 +644,7 @@ void Internals::resetToConsistentState(Page& page)
 #if ENABLE(VIDEO)
     page.group().ensureCaptionPreferences().setCaptionDisplayMode(CaptionUserPreferences::CaptionDisplayMode::ForcedOnly);
     page.group().ensureCaptionPreferences().setCaptionsStyleSheetOverride(emptyString());
+    page.group().ensureCaptionPreferences().setPreferredLanguage(emptyString());
 
     sessionManager->resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
     sessionManager->resetRestrictions();
@@ -4849,6 +4851,27 @@ ExceptionOr<void> Internals::setCaptionDisplayMode(const String& mode)
     return { };
 }
 
+String Internals::captionDisplayMode() const
+{
+    Document* document = contextDocument();
+    if (!document || !document->page())
+        return emptyString();
+
+#if ENABLE(VIDEO)
+    switch (document->page()->group().ensureCaptionPreferences().captionDisplayMode()) {
+    case CaptionUserPreferences::CaptionDisplayMode::Automatic:
+        return "automatic"_s;
+    case CaptionUserPreferences::CaptionDisplayMode::ForcedOnly:
+        return "forcedonly"_s;
+    case CaptionUserPreferences::CaptionDisplayMode::AlwaysOn:
+        return "alwayson"_s;
+    case CaptionUserPreferences::CaptionDisplayMode::Manual:
+        return "manual"_s;
+    }
+#endif
+    return emptyString();
+}
+
 #if ENABLE(VIDEO)
 RefPtr<TextTrackCueGeneric> Internals::createGenericCue(double startTime, double endTime, String text)
 {
@@ -4914,6 +4937,10 @@ MockCaptionDisplaySettingsClientCallback* Internals::mockCaptionDisplaySettingsC
     return m_mockCaptionDisplaySettingsClientCallback.get();
 }
 
+RefPtr<MediaControlsHost> Internals::controlsHostForMediaElement(HTMLMediaElement& mediaElement)
+{
+    return mediaElement.mediaControlsHost();
+}
 #endif
 
 ExceptionOr<Ref<DOMRect>> Internals::selectionBounds()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -111,6 +111,7 @@ class InternalsSetLike;
 class LocalFrame;
 class Location;
 class MallocStatistics;
+class MediaControlsHost;
 class MediaSessionManagerInterface;
 class MediaStream;
 class MediaStreamTrack;
@@ -847,6 +848,7 @@ public:
     ExceptionOr<void> setCaptionsStyleSheetOverride(const String&);
     ExceptionOr<void> setPrimaryAudioTrackLanguageOverride(const String&);
     ExceptionOr<void> setCaptionDisplayMode(const String&);
+    String captionDisplayMode() const;
 #if ENABLE(VIDEO)
     RefPtr<TextTrackCueGeneric> createGenericCue(double startTime, double endTime, String text);
     ExceptionOr<String> textTrackBCP47Language(TextTrack&);
@@ -858,6 +860,7 @@ public:
 
     void setMockCaptionDisplaySettingsClientCallback(RefPtr<MockCaptionDisplaySettingsClientCallback>&&);
     MockCaptionDisplaySettingsClientCallback* mockCaptionDisplaySettingsClientCallback() const;
+    RefPtr<MediaControlsHost> controlsHostForMediaElement(HTMLMediaElement&);
 #endif
 
     ExceptionOr<Ref<DOMRect>> selectionBounds();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1027,6 +1027,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined setCaptionsStyleSheetOverride(DOMString override);
     [Conditional=VIDEO] undefined setPrimaryAudioTrackLanguageOverride(DOMString language);
     [Conditional=VIDEO] undefined setCaptionDisplayMode(DOMString mode);
+    [Conditional=VIDEO] readonly attribute DOMString captionDisplayMode;
     [Conditional=VIDEO] TextTrackCueGeneric createGenericCue(double startTime, double endTime, DOMString text);
     [Conditional=VIDEO] DOMString textTrackBCP47Language(TextTrack track);
 
@@ -1037,6 +1038,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined setMockCaptionDisplaySettingsClientCallback(MockCaptionDisplaySettingsClientCallback? callback);
+    [Conditional=VIDEO] MediaControlsHost controlsHostForMediaElement(HTMLMediaElement element);
 
     boolean isSelectPopupVisible(HTMLSelectElement element);
 


### PR DESCRIPTION
#### 443099fc5edfef2ed777e71bcfd754567f910d7a
<pre>
On caption menu item doesn&apos;t enable text tracks
<a href="https://rdar.apple.com/166158394">rdar://166158394</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304048">https://bugs.webkit.org/show_bug.cgi?id=304048</a>

Reviewed by Eric Carlson.

Make &quot;On&quot; behave similarly to &quot;Auto&quot;, which is to enable the highest
scoring text track available. Additionally, mark languages in the subtitle
menu as checked when they will be enabled by the &quot;On&quot; menu item.

Drive-by fix: Pass track and element parameters into CaptionUserPreferences
by reference rather than by pointer value.

Test: media/modern-media-controls/tracks-support/on-off-text-track.html

* LayoutTests/media/modern-media-controls/resources/media-controls-utils.js:
* LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track-expected.txt: Added.
* LayoutTests/media/modern-media-controls/tracks-support/on-off-text-track.html: Added.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::captionMenuOnItem):
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::configureTextTrackGroup):
(WebCore::HTMLMediaElement::setSelectedTextTrack):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::textTrackSelectionScore const):
(WebCore::CaptionUserPreferences::textTrackLanguageSelectionScore const):
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::controlsHostForMediaElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/304462@main">https://commits.webkit.org/304462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc50903b64348abe774a7d260ac128dcf3405a5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87293 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a624ff61-ccc3-46cc-85ec-a4b71565a8fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2dd0dd82-c6b5-4be2-a544-2216b76ebe83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84517 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f282300d-90eb-4bfc-8117-e97271f9e316) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3607 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3946 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146086 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7717 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5856 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61649 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7732 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35989 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7578 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->