### PR TITLE
text-combine-upright should ignore letter-spacing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Writing Modes Test: text-combine-upright ignores letter-spacing (reference)</title>
+<style>
+span { text-combine-upright: all; }
+</style>
+<p style="writing-mode: vertical-rl">test <span>this</span> <span>this</span></p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Writing Modes Test: text-combine-upright ignores letter-spacing (reference)</title>
+<style>
+span { text-combine-upright: all; }
+</style>
+<p style="writing-mode: vertical-rl">test <span>this</span> <span>this</span></p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Writing Modes Test: text-combine-upright ignores letter-spacing</title>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-combine-layout">
+<link rel="match" href="text-combine-upright-letter-spacing-001-ref.html">
+<meta name="assert" content="text-combine-upright should ignore letter-spacing when composing text horizontally.">
+<style>
+span { text-combine-upright: all; }
+</style>
+<p style="writing-mode: vertical-rl">test <span style="letter-spacing: 2px">this</span> <span>this</span></p>

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -121,6 +121,7 @@ void RenderCombineText::combineTextIfNeeded()
 
     FontCascade horizontalFont(FontCascadeDescription { description }, style().fontCascade());
     horizontalFont.update(fontSelector.copyRef());
+    horizontalFont.setLetterSpacing(0);
 
     GlyphOverflow glyphOverflow;
     glyphOverflow.computeBounds = true;
@@ -131,9 +132,10 @@ void RenderCombineText::combineTextIfNeeded()
 
     m_isCombined = combinedTextWidth <= emWidth;
     
-    if (m_isCombined)
+    if (m_isCombined) {
         m_combineFontStyle->setFontDescription(WTF::move(description)); // Need to change font orientation to horizontal.
-    else {
+        m_combineFontStyle->mutableFontCascadeWithoutUpdate().setLetterSpacing(0);
+    } else {
         // Need to try compressed glyphs.
         static constexpr auto widthVariants = std::to_array<FontWidthVariant>({ FontWidthVariant::HalfWidth, FontWidthVariant::ThirdWidth, FontWidthVariant::QuarterWidth });
         for (auto widthVariant : widthVariants) {
@@ -141,6 +143,7 @@ void RenderCombineText::combineTextIfNeeded()
 
             FontCascade compressedFont(FontCascadeDescription { description }, style().fontCascade());
             compressedFont.update(fontSelector.copyRef());
+            compressedFont.setLetterSpacing(0);
             
             glyphOverflow.left = glyphOverflow.top = glyphOverflow.right = glyphOverflow.bottom = 0;
             float runWidth = width(0, text().length(), compressedFont, 0, nullptr, &glyphOverflow);
@@ -150,6 +153,7 @@ void RenderCombineText::combineTextIfNeeded()
 
                 // Replace my font with the new one.
                 m_combineFontStyle->setFontDescription(WTF::move(description));
+                m_combineFontStyle->mutableFontCascadeWithoutUpdate().setLetterSpacing(0);
                 break;
             }
             
@@ -171,12 +175,14 @@ void RenderCombineText::combineTextIfNeeded()
         
             FontCascade compressedFont(FontCascadeDescription { bestFitDescription }, style().fontCascade());
             compressedFont.update(fontSelector.copyRef());
+            compressedFont.setLetterSpacing(0);
             
             glyphOverflow.left = glyphOverflow.top = glyphOverflow.right = glyphOverflow.bottom = 0;
             float runWidth = width(0, text().length(), compressedFont, 0, nullptr, &glyphOverflow);
             if (runWidth <= emWidth) {
                 combinedTextWidth = runWidth;
                 m_isCombined = true;
+                m_combineFontStyle->mutableFontCascadeWithoutUpdate().setLetterSpacing(0);
                 break;
             }
             scaleFactor -= 0.05f;


### PR DESCRIPTION
#### 1aeae88f4b97148ed1134914951a372efe707892
<pre>
text-combine-upright should ignore letter-spacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262765">https://bugs.webkit.org/show_bug.cgi?id=262765</a>
<a href="https://rdar.apple.com/problem/116562622">rdar://problem/116562622</a>

Reviewed by Vitor Roriz and Alan Baradlay.

This patch aligns WebKit with Web Specification [1]:

&quot;the glyphs of the combined text are bidi-isolated and composed horizontally
(ignoring letter-spacing and any forced line breaks, but using the specified
font settings)&quot;

[1] <a href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-layout">https://drafts.csswg.org/css-writing-modes-3/#text-combine-layout</a>

This patch fixes it by setting letter spacing to ignore.

* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::combineTextIfNeeded):
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-letter-spacing-001.html: Added.

Canonical link: <a href="https://commits.webkit.org/305116@main">https://commits.webkit.org/305116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/469778153cca7b2f5e8a29be85995063e38816eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/33ecb06a-645e-42a1-b03b-d4f3d579123a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1611fb9-4ed3-4d1c-bcac-176a2ee32789) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b717a3be-b597-438c-ad1f-38a535e890fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7517 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41989 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7437 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64255 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9648 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37571 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9379 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->