### PR TITLE
Measure PerformanceTests/Canvas 2D context tests in uniform way

### DIFF
--- a/PerformanceTests/Canvas/drawImageSourceCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceCanvas2D.html
@@ -20,16 +20,24 @@ target.width = source.width;
 target.height = source.height;
 var ctx2 = target.getContext("2d");
 ctx2.globalCompositeOperation = "copy";
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
-    ctx1.fillRect(0, 0, source.width, source.height);
-    i += 1;
-   if (i > 255)
-        i = 0;
-    ctx2.drawImage(source, 0, 0);   
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+        ctx1.fillRect(0, 0, source.width, source.height);
+        ctx2.drawImage(source, 0, 0);   
+    }
     ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
-}});
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
 </script>
 </body>
 </html>

--- a/PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html
@@ -19,15 +19,24 @@ target.width = source.width;
 target.height = source.height;
 var ctx = target.getContext("2d");
 ctx.globalCompositeOperation = "copy";
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    gl.clearColor(0, i, 0, 0.5);
-    i += 0.01;
-    if (i > 1.0)
-        i = 0;
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    ctx.drawImage(source, 0, 0);   
-}});
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        ctx.drawImage(source, 0, 0);   
+    }
+    ctx.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
 </script>
 </body>
 </html>

--- a/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html
@@ -17,7 +17,6 @@ target.width = source.width;
 target.height = source.height;
 var ctx = target.getContext("2d");
 ctx.globalCompositeOperation = "copy";
-
 var isDone = false;
 PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
 function done() {
@@ -31,6 +30,7 @@ async function runTest() {
         let imageBitmap = await createImageBitmap(source);
         ctx.drawImage(imageBitmap, 0, 0);
     }
+    ctx.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
     PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
     if (!isDone)
         setTimeout(runTest, 0);

--- a/PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html
@@ -18,16 +18,26 @@ target.width = source.width;
 target.height = source.height;
 var ctx2 = target.getContext("2d");
 ctx2.globalCompositeOperation = "copy";
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
-    ctx1.fillRect(0, 0, source.width, source.height);
-    i += 1;
-   if (i > 255)
-        i = 0;
-    ctx2.drawImage(source, 0, 0);   
+
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+        ctx1.fillRect(0, 0, source.width, source.height);
+        ctx2.drawImage(source, 0, 0);   
+    }
     ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
-}});
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+
 </script>
 </body>
 </html>

--- a/PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html
@@ -17,15 +17,24 @@ target.width = source.width;
 target.height = source.height;
 var ctx = target.getContext("2d");
 ctx.globalCompositeOperation = "copy";
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    gl.clearColor(0, i, 0, 0.5);
-    i += 0.01;
-    if (i > 1.0)
-        i = 0;
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    ctx.drawImage(source, 0, 0);   
-}});
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        ctx.drawImage(source, 0, 0);   
+    }
+    ctx.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
 </script>
 </body>
 </html>

--- a/PerformanceTests/Canvas/drawImageSourceVideoFrameCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceVideoFrameCanvasWebGL.html
@@ -11,30 +11,34 @@ canvas {
 <canvas id="target"></canvas>
 <script src="../resources/runner.js"></script>
 <script>
-source.width = 7680;
-source.height = 4320;
+source.width = 2000;
+source.height = 2000;
 var gl = source.getContext("webgl2");
-gl.globalCompositeOperation = "copy";
 
 target.width = source.width;
 target.height = source.height;
 var ctx = target.getContext("2d");
 ctx.globalCompositeOperation = "copy";
-
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    gl.clearColor(0, i, 0, 0.5);
-    i += 0.01;
-    if (i > 1.0)
-        i = 0;
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    const frame = new VideoFrame(source, {
-      timestamp: performance.now(),
-    });
-    ctx.drawImage(frame, 0, 0);
-    frame.close();
-}});
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        const frame = new VideoFrame(source, { timestamp: performance.now() });
+        ctx.drawImage(frame, 0, 0);
+        frame.close();
+    }
+    ctx.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
 </script>
 </body>
 </html>

--- a/PerformanceTests/Canvas/drawImageSourceVideoFrameOffscreenCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceVideoFrameOffscreenCanvasWebGL.html
@@ -10,29 +10,33 @@ canvas {
 <canvas id="target"></canvas>
 <script src="../resources/runner.js"></script>
 <script>
-const source = new OffscreenCanvas(7680, 4320)
+const source = new OffscreenCanvas(2000, 2000)
 var gl = source.getContext("webgl2");
-gl.globalCompositeOperation = "copy";
 
 target.width = source.width;
 target.height = source.height;
 var ctx = target.getContext("2d");
 ctx.globalCompositeOperation = "copy";
-
-var i = 0;
-PerfTestRunner.measureRunsPerSecond({run: function() {
-    gl.clearColor(0, i, 0, 0.5);
-    i += 0.01;
-    if (i > 1.0)
-        i = 0;
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    const frame = new VideoFrame(source, {
-      timestamp: performance.now(),
-    });
-    ctx.drawImage(frame, 0, 0);
-    frame.close();
-}});
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        const frame = new VideoFrame(source, { timestamp: performance.now() });
+        ctx.drawImage(frame, 0, 0);
+        frame.close();
+    }
+    ctx.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 0a7cb8948b067fa78de53b601b94552e112c7ca2
<pre>
Measure PerformanceTests/Canvas 2D context tests in uniform way
<a href="https://bugs.webkit.org/show_bug.cgi?id=304061">https://bugs.webkit.org/show_bug.cgi?id=304061</a>
<a href="https://rdar.apple.com/166380301">rdar://166380301</a>

Reviewed by Simon Fraser.

Make all tests use asynchronous measurement mechanism, so that
they produce a similar value (milliseconds).

Make all tests use similar dimensions and structure, so that the values
are somewhat comparable across tests without more detailed
investigation.

* PerformanceTests/Canvas/drawImageSourceCanvas2D.html:
* PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html:
* PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html:
* PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html:
* PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html:
* PerformanceTests/Canvas/drawImageSourceVideoFrameCanvasWebGL.html:
* PerformanceTests/Canvas/drawImageSourceVideoFrameOffscreenCanvasWebGL.html:

Canonical link: <a href="https://commits.webkit.org/304438@main">https://commits.webkit.org/304438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c2443456ea5d08ef633d8115f597ed8682e0163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87077 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7bcc61d1-8968-45b0-b237-6b7015d08357) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103440 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b14786fd-f013-4ac2-87c0-86d0e972e1d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6d4d11b-ea45-4b43-9de5-b11ba1647da2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3379 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3658 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114982 "Passed tests") | | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145625 "Failed to checkout and rebase branch from PR 55307") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40072 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/145625 "Failed to checkout and rebase branch from PR 55307") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6216 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/145625 "Failed to checkout and rebase branch from PR 55307") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5629 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61333 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20897 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35744 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->