### PR TITLE
[GTK][GStreamer] REGRESSION(303623@main) webrtc/ephemeral-certificates-and-cnames.html is timing out

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -102,18 +102,8 @@ webkit.org/b/303375 inspector/debugger/async-stack-trace-truncate.html [ Crash T
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 
-webkit.org/b/303366 webrtc/datachannel/multiple-connections.html [ Crash Pass ]
-
 webkit.org/b/303924 webrtc/peer-connection-audio-mute2.html [ Failure ]
 webkit.org/b/303925 webrtc/audio-replace-track.html [ Failure ]
-webkit.org/b/303924 webrtc/ephemeral-certificates-and-cnames.html [ Timeout ]
-
-# Caused by an assertion, so it happens also in Release EWS.
-webkit.org/b/304130 imported/w3c/web-platform-tests/webrtc/protocol/dtls-fingerprint-validation.html [ Crash ]
-webkit.org/b/304130 fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html [ Crash ]
-webkit.org/b/304130 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https.html [ Crash ]
-webkit.org/b/304130 imported/w3c/web-platform-tests/webrtc/protocol/split.https.html [ Crash ]
-webkit.org/b/304130 imported/w3c/web-platform-tests/webrtc/protocol/handover.html [ Crash ]
 
 # Skia-related
 webkit.org/b/304134 imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html [ Pass Crash ]

--- a/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
@@ -88,7 +88,10 @@ Vector<String> RiceBackendProxy::gatherSocketAddresses(unsigned streamId)
 {
     Vector<String> addresses;
     callOnMainRunLoopAndWait([&] {
-        auto sendResult = m_connection->sendSync(Messages::RiceBackend::GatherSocketAddresses { streamId }, messageSenderDestinationID());
+        auto sendResult = m_connection->sendSync(Messages::RiceBackend::GatherSocketAddresses { streamId }, messageSenderDestinationID(), 3_s);
+        if (!sendResult.succeeded())
+            return;
+
         auto [reply] = sendResult.takeReply();
         addresses = reply;
     });


### PR DESCRIPTION
#### 14447d29ae4fe76488fae11174dfda6422221f9c
<pre>
[GTK][GStreamer] REGRESSION(303623@main) webrtc/ephemeral-certificates-and-cnames.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=304065">https://bugs.webkit.org/show_bug.cgi?id=304065</a>

Reviewed by Xabier Rodriguez-Calvar.

The timeout was actually a crash, the mediastreamsrc element being disposed from a non-main thread.

Driving-by, set a 3 seconds timeout for the RiceBackend::GatherSocketAddresses sync IPC, and unflag
webrtc/datachannel/multiple-connections.html now that bug 303366 is fixed.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::prepareForClose):
(WebCore::GStreamerMediaEndpoint::close):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource):
* Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp:
(WebKit::RiceBackendProxy::gatherSocketAddresses):

Canonical link: <a href="https://commits.webkit.org/304446@main">https://commits.webkit.org/304446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9351017676d57b20e4f4a9bfe01669e89d8676cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103570 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5914 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3525 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145973 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111934 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5772 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7643 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35901 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71189 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->