### PR TITLE
[Inspector] Add validation for optional enum parameters in backend di…

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
@@ -256,6 +256,10 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
                     parameter_enum_resolutions.append('')
                 parameter_enum_resolutions.append('    auto %(enumVariableName)s = Protocol::%(helpersNamespace)s::parseEnumValueFromString<%(enumType)s>(%(stringVariableName)s);' % enum_args)
                 if parameter.is_optional:
+                    parameter_enum_resolutions.append('    if (!%(stringVariableName)s.isEmpty() && !%(enumVariableName)s) {' % enum_args)
+                    parameter_enum_resolutions.append('        m_backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, makeString("Unknown %(parameterKey)s: "_s, %(stringVariableName)s));' % enum_args)
+                    parameter_enum_resolutions.append('        return;')
+                    parameter_enum_resolutions.append('    }')
                     parameter_expression = 'WTFMove(%s)' % variable_name
                 else:
                     parameter_enum_resolutions.append('    if (!%(enumVariableName)s) {' % enum_args)

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -312,6 +312,10 @@ void DatabaseBackendDispatcher::executeAllOptionalParameters(long protocol_reque
 #endif // ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
     auto in_opt_screenColor = Protocol::TestHelpers::parseEnumValueFromString<Protocol::Database::PrimaryColors>(in_opt_screenColor_json);
+    if (!in_opt_screenColor_json.isEmpty() && !in_opt_screenColor) {
+        m_backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, makeString("Unknown screenColor: "_s, in_opt_screenColor_json));
+        return;
+    }
 
     auto result = m_agent->executeAllOptionalParameters(WTFMove(in_opt_columnNames), in_opt_notes, WTFMove(in_opt_timestamp), WTFMove(in_opt_values), WTFMove(in_opt_payload), WTFMove(in_opt_databaseId), WTFMove(in_opt_sqlError), WTFMove(in_opt_screenColor), WTFMove(in_opt_alternateColors), in_opt_printColor);
     if (!result) {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -327,6 +327,10 @@ void CommandDomainBackendDispatcher::command(long protocol_requestId, RefPtr<JSO
     }
 
     auto in_opt_enumOptional = Protocol::TestHelpers::parseEnumValueFromString<Protocol::TypeDomain::Enum>(in_opt_enumOptional_json);
+    if (!in_opt_enumOptional_json.isEmpty() && !in_opt_enumOptional) {
+        m_backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, makeString("Unknown enumOptional: "_s, in_opt_enumOptional_json));
+        return;
+    }
 
     auto result = m_agent->command(*in_enumRequired, WTFMove(in_opt_enumOptional), in_parameterRequired, in_opt_parameterOptional);
     if (!result) {

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -7552,6 +7552,18 @@
    },
    {
       "emails" : [
+         "serge.deh@gitstart.dev",
+         "sergedeh@gmail.com"
+      ],
+      "expertise" : "WebDriver",
+      "github" : "sergedeh",
+      "name" : "Serge Deh",
+      "nicks" : [
+         "sergedeh"
+      ]
+   },
+   {
+      "emails" : [
          "chi187@gmail.com"
       ],
       "expertise" : "WebAssembly",


### PR DESCRIPTION
Add validation for optional enum parameters in backend dispatcher
https://bugs.webkit.org/show_bug.cgi?id=304062

Reviewed by NOBODY (OOPS!).

Optional enum parameters were not being validated when provided with invalid
values, unlike optional primitive types (number, boolean, string) which are
properly validated. This inconsistency could lead to null optional values
being passed to handlers without reporting a protocol error.

This change adds validation for optional enum parameters to match the behavior
of optional primitive types:
- If the parameter is missing: No error (valid for optional parameters)
- If the parameter is provided with a valid enum value: Works correctly
- If the parameter is provided with an invalid enum value: Reports ServerError

The validation checks if the string parameter is not empty AND parsing failed,
then reports: "Unknown [parameterKey]: [invalidValue]"

This fix is needed for proper validation in BiDi protocol implementations,
particularly for bug 303926 (script.getRealms).

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py:
(CppBackendDispatcherImplementationGenerator._generate_backend_dispatcher_implementation_for_domain):
Add validation for optional enum parameters.

* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
Update test expectations.
* metadata/contributors.json:
Add Serge Deh as contributor.

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c716d1c3fd3fb303e563d744f554e5e389a3b25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103448 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70827 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84313 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/134715 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3392 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3669 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127362 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/114987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145813 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133851 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6228 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112189 "Found 18 new API test failures: TestWebKit:WebKit.ResizeWindowAfterCrash, TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, TestWebKit:WebKit.GeolocationTransitionToLowAccuracy, WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, TestWebKit:WebKit.GeolocationWatchMultiprocess, TestWebKit:WebKit.OnDeviceChangeCrash, TestWebKit:WebKit.RestoreSessionStateContainingFormData, TestWebKit:WebKit.UserMediaBasic, TestWebKit:WebKit.CanHandleRequest, WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5637 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117646 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61344 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7485 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35771 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166695 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71032 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43547 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->