### PR TITLE
AX: Inform assistive technologies that WebKit performs it's own text stitching

### DIFF
--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -627,7 +627,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         // AppKit needs to know the screen height in order to do the coordinate conversion.
         NSAccessibilityPrimaryScreenHeightAttribute,
         // All objects should expose the ARIA busy attribute (ARIA 1.1 with ISSUE-538).
-        NSAccessibilityElementBusyAttribute
+        NSAccessibilityElementBusyAttribute,
+        // This exists to tell assistive technologies that WebKit stitches adjacent text
+        // elements together in the accessibility tree — thus, assistive technologies know
+        // they don't need to.
+        @"AXPerformsOwnTextStitching"
     ];
     static NeverDestroyed spinButtonCommonAttributes = [] {
         auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:attributes.get().get()]);

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -171,6 +171,11 @@ static NSString* attributesOfElement(id accessibilityObject)
         if ([attribute isEqualToString:@"_AXPrimaryScreenHeight"] || [attribute isEqualToString:@"AXRelativeFrame"])
             continue;
 
+        if ([attribute isEqualToString:@"AXPerformsOwnTextStitching"]) {
+            // Exposing this in tests is not valuable, so remove it to decrease test maintenance burden.
+            continue;
+        }
+
         // accessibilityAttributeValue: can throw an if an attribute is not returned.
         // For DumpRenderTree's purpose, we should ignore those exceptions
         BEGIN_AX_OBJC_EXCEPTIONS

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -138,11 +138,13 @@ bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
 
 RetainPtr<NSArray> supportedAttributes(id element)
 {
-    RetainPtr<NSArray> attributes;
+    RetainPtr<NSMutableArray> attributes;
 
     BEGIN_AX_OBJC_EXCEPTIONS
     AccessibilityUIElement::s_controller->executeOnAXThreadAndWait([&attributes, &element] {
-        attributes = [element accessibilityAttributeNames];
+        attributes = [[element accessibilityAttributeNames] mutableCopy];
+        // Exposing this in tests is not valuable, so remove it to decrease test maintenance burden.
+        [attributes removeObject:@"AXPerformsOwnTextStitching"];
     });
     END_AX_OBJC_EXCEPTIONS
 


### PR DESCRIPTION
#### a342e5ab7102cf6c189f682b8872e4a0e4b098b0
<pre>
AX: Inform assistive technologies that WebKit performs it&apos;s own text stitching
<a href="https://bugs.webkit.org/show_bug.cgi?id=304071">https://bugs.webkit.org/show_bug.cgi?id=304071</a>
<a href="https://rdar.apple.com/166390461">rdar://166390461</a>

Reviewed by Joshua Hoffman.

Return AXPerformsOwnTextStitching in accessibilityAttributeNames to inform assistive technologies that they do not need
to perform text stitching because WebKit does it for them. accessibilityAttributeNames was chosen because the key AT
in question (VoiceOver) already requests and caches this for every element, so adding this new attribute there is as
low of a performance cost as can be achieved.

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):

Canonical link: <a href="https://commits.webkit.org/304469@main">https://commits.webkit.org/304469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df8a417b29855c73190ce895140a07e9bbcc82d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87122 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72e306e0-a3f1-4b4e-9070-d6d265db1dcd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103484 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84351 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/283353e5-53e0-4a35-a49a-fab6aae0650b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5838 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3432 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111856 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5673 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61380 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7530 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35799 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->