### PR TITLE
AX: Enable live region management by default when ENABLE(WEBKIT_MANAGED_LIVE_REGIONS) is 1

### DIFF
--- a/LayoutTests/accessibility/mac/aria-liveregion-on-image.html
+++ b/LayoutTests/accessibility/mac/aria-liveregion-on-image.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-addedelement.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-addedelement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-changedalt.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-changedalt.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-changedtext.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-changedtext.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-notifications-always-sent.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-notifications-always-sent.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-notifications.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-notifications.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/aria-liveregions-removedelement.html
+++ b/LayoutTests/accessibility/mac/aria-liveregions-removedelement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/accessibility/mac/live-region-creation-notification.html
+++ b/LayoutTests/accessibility/mac/live-region-creation-notification.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/accessibility/mac/live-region-search.html
+++ b/LayoutTests/accessibility/mac/live-region-search.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=false ] -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4280,10 +4280,13 @@ IsAriaLiveRegionManagementEnabled:
   humanReadableDescription: "Turn on ARIA live-region management within WebKit"
   defaultValue:
     WebKitLegacy:
+      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
       default: false
     WebKit:
+      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
       default: false
     WebCore:
+      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
       default: false
 
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.


### PR DESCRIPTION
#### 66e208f8ec9d697a576e6221cd147eccd480e218
<pre>
AX: Enable live region management by default when ENABLE(WEBKIT_MANAGED_LIVE_REGIONS) is 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=304075">https://bugs.webkit.org/show_bug.cgi?id=304075</a>
<a href="https://rdar.apple.com/166392603">rdar://166392603</a>

Reviewed by Tyler Wilcock.

When ENABLE(WEBKIT_MANAGED_LIVE_REGIONS) is 1, we should be enabling webkit live region
management by default.

For existing tests, this flag is explicitly set to false so we can verify the old behavior.

* LayoutTests/accessibility/mac/aria-liveregion-on-image.html:
* LayoutTests/accessibility/mac/aria-liveregions-addedelement.html:
* LayoutTests/accessibility/mac/aria-liveregions-changedalt.html:
* LayoutTests/accessibility/mac/aria-liveregions-changedtext.html:
* LayoutTests/accessibility/mac/aria-liveregions-notifications-always-sent.html:
* LayoutTests/accessibility/mac/aria-liveregions-notifications.html:
* LayoutTests/accessibility/mac/aria-liveregions-removedelement.html:
* LayoutTests/accessibility/mac/live-region-creation-notification.html:
* LayoutTests/accessibility/mac/live-region-search.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/304382@main">https://commits.webkit.org/304382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a058a91926d75dbff982b45e687262c86d1cde5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87106 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103465 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fae89492-9081-4960-98c1-5c465d33370c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/94db148e-dc50-4798-8b37-b1c5b688cfc7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3412 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3693 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127385 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145837 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133874 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111838 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5653 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61362 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7506 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35775 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166716 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71055 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->