### PR TITLE
instagram.com: Some reels get resized back and forth while playing.

### DIFF
--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -289,6 +289,8 @@ public:
     enum class TikTokOverflowingContentQuirkType : bool { VideoSectionQuirk, CommentsSectionQuirk };
     std::optional<TikTokOverflowingContentQuirkType> needsTikTokOverflowingContentQuirk(const Element&, const RenderStyle& parentStyle) const;
 
+    bool needsInstagramResizingReelsQuirk(const Element&, const RenderStyle& elementStyle, const RenderStyle& parentStyle) const;
+
     bool needsWebKitMediaTextTrackDisplayQuirk() const;
 
     bool shouldSupportHoverMediaQueries() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -233,6 +233,7 @@ struct QuirksData {
         ShouldUnloadHeavyFrames,
         ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
         ShouldAllowNotificationPermissionWithoutUserGesture,
+        NeedsInstagramResizingReelsQuirk,
 
         NumberOfQuirks
     };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1171,6 +1171,9 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
             style.setBackgroundColor({ WebCore::Color::transparentBlack });
     }
 #endif
+
+    if (documentQuirks.needsInstagramResizingReelsQuirk(*m_element, style, m_parentStyle))
+        style.setFlexGrow(1);
 }
 
 void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)


### PR DESCRIPTION
#### 33c9b945680254575bde2d4f6711d0735043c4ee
<pre>
instagram.com: Some reels get resized back and forth while playing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304073">https://bugs.webkit.org/show_bug.cgi?id=304073</a>
<a href="https://rdar.apple.com/164573070">rdar://164573070</a>

Reviewed by Brent Fulgham, Brandon Stewart, and Vitor Roriz.

It seems that when some users go to Instagram and try to view reels,
they may experience some behavior where the reels get abruptly resized
during their playback. The most common manifestation of this seems to be
that the reel starts with a small size and then in the middle of the
playback (from observation this seems to be around the first five
seconds of the reel), and then gets resized to become larger. This
larger size is likely what is supposed to be the expected size since it
seems to match the rest of the content/page.

From an investigation this appears to be an issue with the content that
Instagram is sending us rather than a WebKit bug. There are two main
observations that led me to this conclusion:

1.) Some logging in SourceBufferParserAVFObjC::didProvideMediaDataForTrackID
indicates that we receive two types of video content at different points
in time. For the first five seconds, we get video content that is the
smaller size

12631190667774328833 presentationSize width=360 height=640presentationTime {&quot;value&quot;:0,&quot;numerator&quot;:0,&quot;denominator&quot;:15360,&quot;flags&quot;:1}

then later on we get video content that is the larger size
12631190667774328833 presentationSize width=720 height=1280presentationTime {&quot;value&quot;:5,&quot;numerator&quot;:76800,&quot;denominator&quot;:15360,&quot;flags&quot;:1}

2.) The styling of the page results in a rendering that I would expect
with regards to the size of the video that we are seeing. Here is some
simplified markup from the page

&lt;div class=&quot;x78zum5 xedcshv&quot; style=&quot;height: 1046px; width: 588.375px;&quot;&gt; [1]
    &lt;div class=&quot;x78zum5 xl56j7k x1n2onr6 xh8yej3&quot;&gt; [2]
        &lt;div class=&quot;x1i5p2am x1whfx0g xr2y4jy x1ihp6rs x1yxe93k x6ikm8r x10wlt62&quot;&gt; [3]
            &lt;div class=&quot;x1lliihq x5yr21d x1n2onr6 xh8yej3 x1ja2u2z&quot;&gt;
                &lt;div class=&quot;x5yr21d x1n2onr6 xh8yej3&quot;&gt;
                    &lt;div class=&quot;x5yr21d x1n2onr6 xh8yej3&quot;&gt;
                        &lt;div class=&quot;x5yr21d x1uhb9sk xh8yej3&quot;&gt;
                          &lt;video class=&quot;x1lliihq x5yr21d xh8yej3&quot; playsinline=&quot;&quot; preload=&quot;none&quot; src=&quot;&quot; style=&quot;display: block;&quot;&gt;&lt;/video&gt; [4]
                        &lt;/div&gt;
                    &lt;/div&gt;
                &lt;/div&gt;
            &lt;/div&gt;
        &lt;/div&gt;
    &lt;/div&gt;
&lt;/div&gt;

[1] is a flexbox with a fixed width and height. This inline style seems
to come from the page.
[2] is also a flexbox but has width: 100%. The used size of this box
is the same as its parent.
[3] is a flex item with width: auto. When the video is narrow the size
of this box matches the narrow size of the video and when it is larger
it matches the larger size of the video.
[4] and everything up to here has width: 100%. The sizes match the size
of the video.

The interesting bit of the layout starts at [3]. Since this is a flex
item with an automatic width, flex layout is going to compute this box&apos;s
base size using the max content size. The max-content size of the flex
item ends up coming from the size of the video. Even though the video
has width: 100% we cannot resolve this size so it ends up coming from
the size of the content. You can see this occurring if you use the web
inspector and add some content like &lt;div&gt;aaaaaa....&lt;/div&gt; (add enough
text content so that the max-content size of the div is larger than the
video) then the size of the flex item changes. This resulting base size
becomes the used size of the flex item and defines the available space
for the rest of the descendant content, like the video, that gets used
to resolve width: 100%.

The above implies that the rendering, and specifically the resizing
behavior, is correct with respect to the content we are getting. To
improve the user experience we can create a quirk that stops the
resizing from occuring. This can be done by setting flex-grow: 1 on [3]
above to cause it to take up the remaining space during flex layout.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsInstagramResizingReelsQuirk const):
General heuristic to try and determine that the element is the flex item
we are trying to apply flex-grow on. This is done by trying to match the
styling of the element and the parent with a certain combination that
matches this specific piece of content. Also make sure that there is a
descendant video element.

(WebCore::handleInstagramQuirks):
This was compiled only on IOS_FAMILY before but we will need this on Mac
as well but make sure to keep the iOS quirk restricted still.

Canonical link: <a href="https://commits.webkit.org/304389@main">https://commits.webkit.org/304389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09565043c3411f96069d74684280ff7af0048d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103491 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00cfad1a-2bae-47bb-8fc4-52c1b5ade439) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/760330d4-603c-4e29-ac10-bb261cccae6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5828 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3436 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3725 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7482 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40135 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112233 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5679 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7536 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7502 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->