### PR TITLE
Update Opaque Type tracking to mark AliasParam items as opaque

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -101,6 +101,10 @@
 [Legacy] AliasParam WebKit::CoreIPCNSURLRequestData::BodyParts Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>
 [Legacy] AliasParam WebKit::CoreIPCSecTrustData::ExceptionType Vector<std::pair<WebKit::CoreIPCString, Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, bool>>>
 [Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyArrayOfData Vector<WebKit::CoreIPCData>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyVariant Variant<bool, WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyArrayOfNumbers, WebKit::CoreIPCSecTrustData::PolicyArrayOfStrings, WebKit::CoreIPCSecTrustData::PolicyArrayOfData, WebKit::CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers, WebKit::CoreIPCSecTrustData::PolicyDictionaryValueIsNumber>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyOption Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyVariant>>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyValue Variant<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyOption>
+[Legacy] AliasParam WebKit::CoreIPCSecTrustData::PolicyType Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::PolicyValue>>
 [Legacy] AliasParam WebKit::ImageBufferBackendHandle Variant<WebCore::ShareableBitmapHandle, MachSendRight, WebCore::DynamicContentScalingDisplayList>
 [Legacy] AliasParam WebKit::ImageBufferBackendHandle Variant<WebCore::ShareableBitmapHandle, MachSendRight>
 [Legacy] AliasParam WebKit::ObjectValue WebKit::CoreIPCData
@@ -469,6 +473,63 @@
 [Legacy] StructureParam WebCore::DDModel::DDUpdateMeshDescriptor.vertexData Vector<Vector<uint8_t>>
 
 [UnsafeWrapper] AliasParam IPC::TransferString::IPCData Variant<std::monostate, std::span<const uint8_t>, std::span<const char16_t>, IPC::TransferString::SharedSpan8, IPC::TransferString::SharedSpan16>
+
+[UnsafeWrapper] WebCore::GraphicsContextGL::ExternalSyncSource {
+    [Legacy] MessageParam RemoteGraphicsContextGL.CreateExternalSync arg0
+}
+
+[UnsafeWrapper] IPC::TransferString::IPCData {
+    [Legacy] StructureParam IPC::TransferString.toIPCData()
+}
+
+[UnsafeWrapper] FileSystem::Salt {
+    [Legacy] StructureParam WebKit::WebProcessDataStoreParameters.mediaKeysStorageSalt
+}
+
+[UnsafeWrapper] WebKit::SharedVideoFrame::Buffer {
+    [Legacy] StructureParam WebKit::SharedVideoFrame.buffer
+}
+
+[UnsafeWrapper] UniqueRef<WebKit::CFObjectValue> {
+    [Legacy] StructureParam WebKit::CoreIPCCFType.object()
+}
+
+[UnsafeWrapper] std::optional<WebKit::ImageBufferBackendHandle> {
+    [Legacy] MessageParam RemoteImageBufferProxy.DidCreateBackend handle
+    [Legacy] MessageParamReply WebPage.TakeSnapshot image
+    [Legacy] StructureParam WebKit::RemoteLayerBackingStoreProperties.m_bufferHandle
+    [Legacy] StructureParam WebKit::BufferSetBackendHandle.bufferHandle
+    [Legacy] StructureParam WebKit::ImageBufferSetPrepareBufferForDisplayOutputData.backendHandle
+}
+
+[UnsafeWrapper] UniqueRef<WebKit::ObjectValue> {
+    [Legacy] StructureParam WebKit::CoreIPCNSCFObject.value()
+}
+
+[UnsafeWrapper] std::optional<WebKit::SharedVideoFrame::Buffer> {
+    [Legacy] MessageParam RemoteVideoFrameObjectHeapProxyProcessor.NewVideoFrameBuffer frame
+    [Legacy] MessageParam RemoteVideoFrameObjectHeapProxyProcessor.NewConvertedVideoFrameBuffer frame
+}
+
+[UnsafeWrapper] std::optional<Vector<WebKit::CoreIPCNSURLRequestData::BodyParts>> {
+    [Legacy] StructureParam WebKit::CoreIPCNSURLRequestData.bodyParts
+}
+
+[UnsafeWrapper] UniqueRef<WebKit::PlistValue> {
+    [Legacy] StructureParam WebKit::CoreIPCPlistObject.value()
+}
+
+[UnsafeWrapper] std::unique_ptr<Vector<KeyValuePair<WebKit::CoreIPCCFDictionary::KeyType, WebKit::CoreIPCCFType>>> {
+    [Legacy] StructureParam WebKit::CoreIPCCFDictionary.vector()
+}
+
+[UnsafeWrapper] std::optional<Vector<WebKit::CoreIPCSecTrustData::ExceptionType>> {
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.exceptions
+}
+
+[UnsafeWrapper] Vector<WebKit::CoreIPCSecTrustData::PolicyType> {
+    [Legacy] StructureParam WebKit::CoreIPCSecTrustData.policies
+}
 
 # GTK Specific
 [Legacy] StructureParam sk_sp<SkColorSpace>.dataReference() std::span<const uint8_t>


### PR DESCRIPTION
#### dd2ac76eede2692e22f99084c0190db83261c0c0
<pre>
Update Opaque Type tracking to mark AliasParam items as opaque
<a href="https://bugs.webkit.org/show_bug.cgi?id=304033">https://bugs.webkit.org/show_bug.cgi?id=304033</a>
<a href="https://rdar.apple.com/165769253">rdar://165769253</a>

Reviewed by Kimmo Kinnunen.

* Source/WebKit/Scripts/webkit/opaque_ipc_types.py:
(is_opaque_type):
(TestOpaqueTypes.test_opaque_ipc_types_parsing):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:

Canonical link: <a href="https://commits.webkit.org/304569@main">https://commits.webkit.org/304569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41a41070c75c6f892ce7d833ee4162b85a64df2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87466 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20906109-2e25-419d-b663-85b707c8b9f4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af4cd3bd-bd0a-4691-8db5-658a136f8fe9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84735 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135248 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3807 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4216 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115437 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146361 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7958 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112215 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6073 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61858 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8005 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36177 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7817 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->