### PR TITLE
[css-grid-3] Clear m_itemOffsets in initializeMasonry to fix crash with stale WeakRef keys

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -43,6 +43,7 @@ void GridMasonryLayout::initializeMasonry(unsigned gridAxisTracks, Style::GridTr
     m_masonryAxisGridGap = m_renderGrid->gridGap(m_masonryAxisDirection);
     m_gridAxisTracksCount = gridAxisTracks;
     m_gridContentSize = 0;
+    m_itemOffsets.clear();
 
     m_renderGrid->currentGrid().setupGridForMasonryLayout();
     m_renderGrid->populateExplicitGridAndOrderIterator();


### PR DESCRIPTION
#### 19b49e75dba6391d469c7d1a0a81bf085020e3d5
<pre>
[css-grid-3] Clear m_itemOffsets in initializeMasonry to fix crash with stale WeakRef keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=304084">https://bugs.webkit.org/show_bug.cgi?id=304084</a>
<a href="https://rdar.apple.com/problem/166404830">rdar://problem/166404830</a>

Reviewed by Sammy Gill.

The m_itemOffsets HashMap uses SingleThreadWeakRef&lt;const RenderBox&gt; as keys.
When RenderBox objects are destroyed between masonry layout phases, the WeakRef
keys become stale (null pointers). When inserting a new item via set(), the
HashMap comparison logic may compare against these stale entries, triggering
an assertion failure in WeakRef::ptr().

Fix by clearing m_itemOffsets at the start of each masonry placement run,
along with the other state variables that are already being reset.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::initializeMasonry):

Canonical link: <a href="https://commits.webkit.org/304384@main">https://commits.webkit.org/304384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e55cc4ea2ed0424bb5ceb54475e2a2fb496ae68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1bfb0f4d-ac59-46ac-9fbe-7370b302f2db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1378f4a-670e-472a-aa7f-fd3d6ebdec88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3428 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3711 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145855 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111853 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6263 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5672 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117670 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61375 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7524 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35792 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->