### PR TITLE
[CSS Font Loading] Add IDL for FontFaceSetLoadEvent

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1083,6 +1083,8 @@ set(WebCore_NON_SVG_IDL_FILES
     css/ElementCSSInlineStyle.idl
     css/FontFace.idl
     css/FontFaceSet.idl
+    css/FontFaceSetLoadEvent.idl
+    css/FontFaceSetLoadEventInit.idl
     css/FontFaceSource.idl
     css/LinkStyle.idl
     css/MediaList.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1343,6 +1343,8 @@ $(PROJECT_DIR)/css/ElementCSSInlineStyle+Typedom.idl
 $(PROJECT_DIR)/css/ElementCSSInlineStyle.idl
 $(PROJECT_DIR)/css/FontFace.idl
 $(PROJECT_DIR)/css/FontFaceSet.idl
+$(PROJECT_DIR)/css/FontFaceSetLoadEvent.idl
+$(PROJECT_DIR)/css/FontFaceSetLoadEventInit.idl
 $(PROJECT_DIR)/css/FontFaceSource.idl
 $(PROJECT_DIR)/css/LinkStyle.idl
 $(PROJECT_DIR)/css/MediaList.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1162,6 +1162,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSet.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSet.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEventInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEventInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFormDataEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1055,6 +1055,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/ElementCSSInlineStyle+Typedom.idl \
     $(WebCore)/css/FontFace.idl \
     $(WebCore)/css/FontFaceSet.idl \
+    $(WebCore)/css/FontFaceSetLoadEvent.idl \
+    $(WebCore)/css/FontFaceSetLoadEventInit.idl \
     $(WebCore)/css/FontFaceSource.idl \
     $(WebCore)/css/LinkStyle.idl \
     $(WebCore)/css/MediaList.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -996,6 +996,7 @@ css/DeprecatedCSSOMValue.cpp
 css/DeprecatedCSSOMValueList.cpp
 css/FontFace.cpp
 css/FontFaceSet.cpp
+css/FontFaceSetLoadEvent.cpp
 css/ImmutableStyleProperties.cpp
 css/MediaList.cpp
 css/MediaQueryList.cpp
@@ -4111,6 +4112,8 @@ JSFocusEvent.cpp
 JSFocusOptions.cpp
 JSFontFace.cpp
 JSFontFaceSet.cpp
+JSFontFaceSetLoadEvent.cpp
+JSFontFaceSetLoadEventInit.cpp
 JSFormDataEvent.cpp
 JSFragmentDirective.cpp
 JSFullscreenOptions.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3038,6 +3038,8 @@
 		7ABB0F602CE7C170009A837D /* QuirksData.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5F2CE7C170009A837D /* QuirksData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AC09F4728C0122C004568FC /* TestReportBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AC09F4528C00E5D004568FC /* TestReportBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AD41E7E2C7607AF00ED9467 /* ScrollingPlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AD41E7D2C7607AA00ED9467 /* ScrollingPlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7AD4479E2EEC93920039F9E7 /* JSFontFaceSetLoadEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AD4479A2EEC93600039F9E7 /* JSFontFaceSetLoadEvent.h */; };
+		7AD4479F2EEC939C0039F9E7 /* JSFontFaceSetLoadEventInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AD4479C2EEC93600039F9E7 /* JSFontFaceSetLoadEventInit.h */; };
 		7ADE722610CBBB9B006B3B3A /* ContextMenuProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ADE722510CBBB9B006B3B3A /* ContextMenuProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AE335F21ACB09E200E401EF /* WheelEventTestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AE335F01ACB09E200E401EF /* WheelEventTestMonitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AE6C93C1BE0C60100E19E03 /* MainThreadSharedTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AE6C93A1BE0C60100E19E03 /* MainThreadSharedTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14317,6 +14319,15 @@
 		7AC09F4528C00E5D004568FC /* TestReportBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestReportBody.h; sourceTree = "<group>"; };
 		7AC09F4628C0120C004568FC /* TestReportBody.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestReportBody.idl; sourceTree = "<group>"; };
 		7AD41E7D2C7607AA00ED9467 /* ScrollingPlatformLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingPlatformLayer.h; sourceTree = "<group>"; };
+		7AD447952EEB9DAB0039F9E7 /* FontFaceSetLoadEventInit.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = FontFaceSetLoadEventInit.idl; sourceTree = "<group>"; };
+		7AD447962EEB9E320039F9E7 /* FontFaceSetLoadEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = FontFaceSetLoadEvent.idl; sourceTree = "<group>"; };
+		7AD447972EEBA1570039F9E7 /* FontFaceSetLoadEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FontFaceSetLoadEvent.cpp; sourceTree = "<group>"; };
+		7AD447982EEBA1D90039F9E7 /* FontFaceSetLoadEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontFaceSetLoadEvent.h; sourceTree = "<group>"; };
+		7AD447992EEBA32C0039F9E7 /* FontFaceSetLoadEventInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontFaceSetLoadEventInit.h; sourceTree = "<group>"; };
+		7AD4479A2EEC93600039F9E7 /* JSFontFaceSetLoadEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSFontFaceSetLoadEvent.h; path = JSFontFaceSetLoadEvent.h; sourceTree = "<group>"; };
+		7AD4479B2EEC93600039F9E7 /* JSFontFaceSetLoadEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSFontFaceSetLoadEvent.cpp; path = JSFontFaceSetLoadEvent.cpp; sourceTree = "<group>"; };
+		7AD4479C2EEC93600039F9E7 /* JSFontFaceSetLoadEventInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSFontFaceSetLoadEventInit.h; path = JSFontFaceSetLoadEventInit.h; sourceTree = "<group>"; };
+		7AD4479D2EEC93600039F9E7 /* JSFontFaceSetLoadEventInit.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSFontFaceSetLoadEventInit.cpp; path = JSFontFaceSetLoadEventInit.cpp; sourceTree = "<group>"; };
 		7ADE722510CBBB9B006B3B3A /* ContextMenuProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextMenuProvider.h; sourceTree = "<group>"; };
 		7AE335EF1ACB09E200E401EF /* WheelEventTestMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WheelEventTestMonitor.cpp; sourceTree = "<group>"; };
 		7AE335F01ACB09E200E401EF /* WheelEventTestMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WheelEventTestMonitor.h; sourceTree = "<group>"; };
@@ -34321,6 +34332,10 @@
 				5FC7DC26CFE2563200B85AE5 /* JSEventTarget.h */,
 				B6D9D27A14EAC0860090D75E /* JSFocusEvent.cpp */,
 				B6D9D27914EAC0860090D75E /* JSFocusEvent.h */,
+				7AD4479B2EEC93600039F9E7 /* JSFontFaceSetLoadEvent.cpp */,
+				7AD4479A2EEC93600039F9E7 /* JSFontFaceSetLoadEvent.h */,
+				7AD4479D2EEC93600039F9E7 /* JSFontFaceSetLoadEventInit.cpp */,
+				7AD4479C2EEC93600039F9E7 /* JSFontFaceSetLoadEventInit.h */,
 				0FDA7C1C188322FC00C954B5 /* JSGestureEvent.cpp */,
 				0FDA7C1D188322FC00C954B5 /* JSGestureEvent.h */,
 				8482B74F1198CB6B00BFB005 /* JSHashChangeEvent.cpp */,
@@ -40283,6 +40298,11 @@
 				1C24EEA21C729CE40080F8FC /* FontFaceSet.cpp */,
 				1C24EEA31C729CE40080F8FC /* FontFaceSet.h */,
 				1C24EEA11C729B320080F8FC /* FontFaceSet.idl */,
+				7AD447972EEBA1570039F9E7 /* FontFaceSetLoadEvent.cpp */,
+				7AD447982EEBA1D90039F9E7 /* FontFaceSetLoadEvent.h */,
+				7AD447962EEB9E320039F9E7 /* FontFaceSetLoadEvent.idl */,
+				7AD447992EEBA32C0039F9E7 /* FontFaceSetLoadEventInit.h */,
+				7AD447952EEB9DAB0039F9E7 /* FontFaceSetLoadEventInit.idl */,
 				7C3A8ABC2509A256008C477F /* FontFaceSource.idl */,
 				BC4A532E256057CD0028C592 /* FontLoadTimingOverride.h */,
 				C2AB0B031E6DE92C001348C5 /* FontSelectionValueInlines.h */,
@@ -44656,6 +44676,8 @@
 				B6D9D27B14EAC0860090D75E /* JSFocusEvent.h in Headers */,
 				C280833F1C6DC26F001451B6 /* JSFontFace.h in Headers */,
 				1C24EEA91C72A7B40080F8FC /* JSFontFaceSet.h in Headers */,
+				7AD4479E2EEC93920039F9E7 /* JSFontFaceSetLoadEvent.h in Headers */,
+				7AD4479F2EEC939C0039F9E7 /* JSFontFaceSetLoadEventInit.h in Headers */,
 				FDA15EAC12B03EE1003A583A /* JSGainNode.h in Headers */,
 				518F5002194CAC3A0081BAAE /* JSGamepad.h in Headers */,
 				518F5004194CAC3A0081BAAE /* JSGamepadButton.h in Headers */,

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -33,6 +33,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FontFace.h"
+#include "FontFaceSetLoadEvent.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "JSDOMBinding.h"
@@ -46,7 +47,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(FontFaceSet);
 
-Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, const Vector<Ref<FontFace>>& initialFaces)
+Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, const FontFaceArray& initialFaces)
 {
     Ref<FontFaceSet> result = adoptRef(*new FontFaceSet(context, initialFaces));
     result->suspendIfNeeded();
@@ -60,7 +61,7 @@ Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, CSSFontFac
     return result;
 }
 
-FontFaceSet::FontFaceSet(ScriptExecutionContext& context, const Vector<Ref<FontFace>>& initialFaces)
+FontFaceSet::FontFaceSet(ScriptExecutionContext& context, const FontFaceArray& initialFaces)
     : ActiveDOMObject(&context)
     , m_backing(CSSFontFaceSet::create())
     , m_readyPromise(makeUniqueRef<ReadyPromise>(*this, &FontFaceSet::readyPromiseResolve))
@@ -260,11 +261,26 @@ void FontFaceSet::faceFinished(CSSFontFace& face, CSSFontFace::Status newStatus)
     }
 }
 
+FontFaceArray FontFaceSet::loadingFonts() const
+{
+    FontFaceArray pendingFontFaces;
+    pendingFontFaces.reserveCapacity(m_pendingPromises.size());
+
+    for (const auto& fontFace : m_pendingPromises.keys()) {
+        if (!fontFace)
+            continue;
+
+        pendingFontFaces.append(*fontFace);
+    }
+
+    return pendingFontFaces;
+}
+
 void FontFaceSet::startedLoading()
 {
     if (m_readyPromise->isFulfilled())
         m_readyPromise = makeUniqueRef<ReadyPromise>(*this, &FontFaceSet::readyPromiseResolve);
-    queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().loadingEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, FontFaceSetLoadEvent::create(eventNames().loadingEvent, loadingFonts()));
 }
 
 void FontFaceSet::documentDidFinishLoading()

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -38,11 +38,14 @@ template<typename IDLType> class DOMPromiseDeferred;
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 
 class DOMException;
+class FontFaceSetLoadEvent;
+
+using FontFaceArray = Vector<Ref<FontFace>>;
 
 class FontFaceSet final : public RefCounted<FontFaceSet>, private FontEventClient, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FontFaceSet);
 public:
-    static Ref<FontFaceSet> create(ScriptExecutionContext&, const Vector<Ref<FontFace>>& initialFaces);
+    static Ref<FontFaceSet> create(ScriptExecutionContext&, const FontFaceArray& initialFaces);
     static Ref<FontFaceSet> create(ScriptExecutionContext&, CSSFontFaceSet& backing);
     virtual ~FontFaceSet();
 
@@ -93,18 +96,20 @@ private:
         PendingPromise(LoadPromise&&);
 
     public:
-        Vector<Ref<FontFace>> faces;
+        FontFaceArray faces;
         UniqueRef<LoadPromise> promise;
         bool hasReachedTerminalState { false };
     };
 
-    FontFaceSet(ScriptExecutionContext&, const Vector<Ref<FontFace>>&);
+    FontFaceSet(ScriptExecutionContext&, const FontFaceArray&);
     FontFaceSet(ScriptExecutionContext&, CSSFontFaceSet&);
 
     // FontEventClient
     void faceFinished(CSSFontFace&, CSSFontFace::Status) final;
     void startedLoading() final;
     void completedLoading() final;
+
+    FontFaceArray loadingFonts() const;
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FontFaceSet; }

--- a/Source/WebCore/css/FontFaceSetLoadEvent.cpp
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontFaceSetLoadEvent.h"
+
+#include "EventNames.h"
+#include "FontFace.h"
+#include "FontFaceSetLoadEventInit.h"
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(FontFaceSetLoadEvent);
+
+Ref<FontFaceSetLoadEvent> FontFaceSetLoadEvent::create(const AtomString& type, const FontFaceArray& fontfaces)
+{
+    return adoptRef(*new FontFaceSetLoadEvent(type, fontfaces));
+}
+
+Ref<FontFaceSetLoadEvent> FontFaceSetLoadEvent::create(const AtomString& type, const FontFaceSetLoadEventInit& eventInitDict, IsTrusted isTrusted)
+{
+    return adoptRef(*new FontFaceSetLoadEvent(type, eventInitDict, isTrusted));
+}
+
+FontFaceSetLoadEvent::FontFaceSetLoadEvent(const AtomString& type, const FontFaceArray& fontfaces)
+    : Event(EventInterfaceType::FontFaceSetLoadEvent, type, CanBubble::No, IsCancelable::No)
+    , m_fontFaces(fontfaces)
+{
+}
+
+FontFaceSetLoadEvent::FontFaceSetLoadEvent(const AtomString& type, const FontFaceSetLoadEventInit& eventInitDict, IsTrusted isTrusted)
+    : Event(EventInterfaceType::FontFaceSetLoadEvent, type, eventInitDict, isTrusted)
+    , m_fontFaces(eventInitDict.fontfaces)
+{
+}
+
+FontFaceSetLoadEvent::~FontFaceSetLoadEvent() = default;
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEvent.h
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class FontFace;
+struct FontFaceSetLoadEventInit;
+
+using FontFaceArray = Vector<Ref<FontFace>>;
+
+class FontFaceSetLoadEvent final : public Event {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FontFaceSetLoadEvent);
+public:
+    static Ref<FontFaceSetLoadEvent> create(const AtomString& type, const FontFaceArray& fontfaces = FontFaceArray());
+    static Ref<FontFaceSetLoadEvent> create(const AtomString& type, const FontFaceSetLoadEventInit& eventInitDict, IsTrusted = IsTrusted::No);
+    virtual ~FontFaceSetLoadEvent();
+
+    FontFaceArray fontfaces() const { return m_fontFaces; }
+
+private:
+    bool isFontFaceSetLoadEvent() const final { return true; }
+
+    FontFaceSetLoadEvent(const AtomString&, const FontFaceArray&);
+    FontFaceSetLoadEvent(const AtomString&, const FontFaceSetLoadEventInit&, IsTrusted);
+    FontFaceArray m_fontFaces;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEvent.idl
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface
+
+[
+    // FIXME: This interface should also be exposed by Workers.
+    Exposed=Window
+] interface FontFaceSetLoadEvent : Event {
+    constructor([AtomString] DOMString type, optional FontFaceSetLoadEventInit eventInitDict);
+    [SameObject] readonly attribute FrozenArray<FontFace> fontfaces;
+};

--- a/Source/WebCore/css/FontFaceSetLoadEventInit.h
+++ b/Source/WebCore/css/FontFaceSetLoadEventInit.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+
+namespace WebCore {
+
+class FontFace;
+
+using FontFaceArray = Vector<Ref<FontFace>>;
+
+struct FontFaceSetLoadEventInit : EventInit {
+    FontFaceArray fontfaces;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEventInit.idl
+++ b/Source/WebCore/css/FontFaceSetLoadEventInit.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface
+
+dictionary FontFaceSetLoadEventInit : EventInit {
+    sequence<FontFace> fontfaces = [];
+};

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -116,6 +116,7 @@ public:
     virtual bool isCompositionEvent() const { return false; }
     virtual bool isDragEvent() const { return false; }
     virtual bool isErrorEvent() const { return false; }
+    virtual bool isFontFaceSetLoadEvent() const { return false; }
     virtual bool isFocusEvent() const { return false; }
     virtual bool isGestureEvent() const { return false; }
     virtual bool isInputEvent() const { return false; }

--- a/Source/WebCore/dom/EventInterfaces.in
+++ b/Source/WebCore/dom/EventInterfaces.in
@@ -26,6 +26,7 @@ ExtendableMessageEvent
 ErrorEvent
 FetchEvent
 FocusEvent
+FontFaceSetLoadEvent interfaceName=FontFaceSetLoadEvent
 FormDataEvent
 HashChangeEvent
 InputEvent

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -108,6 +108,7 @@
     "focus": { "defaultEventHandler": true },
     "focusin": { },
     "focusout": { },
+    "fontfacesetload": { },
     "formdata": { },
     "fullscreenchange": { },
     "fullscreenerror": { },


### PR DESCRIPTION
#### 95b5e3a4a9f0f234550110a484af84914eae29eb
<pre>
[CSS Font Loading] Add IDL for FontFaceSetLoadEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=184138">https://bugs.webkit.org/show_bug.cgi?id=184138</a>
&lt;<a href="https://rdar.apple.com/problem/122586720">rdar://problem/122586720</a>&gt;

Reviewed by NOBODY (OOPS!).

Revised version of Frederic Wang&apos;s patch for current state of WebKit sources.

Tests: imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html
       imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::create):
(WebCore::FontFaceSet::FontFaceSet):
(WebCore::FontFaceSet::loadingFonts const):
(WebCore::FontFaceSet::startedLoading):
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/FontFaceSetLoadEvent.cpp: Added.
(WebCore::FontFaceSetLoadEvent::create):
(WebCore::FontFaceSetLoadEvent::FontFaceSetLoadEvent):
* Source/WebCore/css/FontFaceSetLoadEvent.h: Added.
* Source/WebCore/css/FontFaceSetLoadEvent.idl: Added.
* Source/WebCore/css/FontFaceSetLoadEventInit.h: Added.
* Source/WebCore/css/FontFaceSetLoadEventInit.idl: Added.
* Source/WebCore/dom/Event.h:
(WebCore::Event::isFontFaceSetLoadEvent const):
* Source/WebCore/dom/EventInterfaces.in:
* Source/WebCore/dom/EventNames.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95b5e3a4a9f0f234550110a484af84914eae29eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46692 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143106 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87121 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4f1e179d-6420-428c-883b-c99389643681) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7639 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/143106 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/87121 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4b10a59c-5cfb-40dc-9ee9-6141d247d30a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121377 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/143106 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/726dd93b-490f-4bfc-a02d-88c8bddb3845) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5822 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3433 "Passed tests") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3716 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39563 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145861 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7475 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40134 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/145861 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7516 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6268 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/145861 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5676 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117679 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61379 "Hash 95b5e3a4 for PR 55328 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7529 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35801 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7277 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71078 "Found 23 new failures in css/StyleRule.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->