### PR TITLE
[GLib] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in JSCValue.cpp

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -120,6 +120,12 @@ static inline std::span<char*> span(char** strv)
     return unsafeMakeSpan(strv, size);
 }
 
+static inline std::span<const char* const> span(const char* const* strv)
+{
+    auto size = g_strv_length(const_cast<char**>(strv));
+    return unsafeMakeSpan(strv, size);
+}
+
 template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
 inline std::span<T> span(GPtrArray* array)
 {


### PR DESCRIPTION
#### d2b96acf830aabd2416fc1a356f495600cfadef6
<pre>
[GLib] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in JSCValue.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=304090">https://bugs.webkit.org/show_bug.cgi?id=304090</a>

Reviewed by Carlos Garcia Campos.

Remove most uses of WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END}. There are
three left: two instances are around uses of G_VALUE_COLLECT_INIT(), a macro
defined by GLib, which we can assume are correct; the other one from adding
the offset to the base pointer of a TypedArray to return the actual pointer
to the data it references. The latter could be probably changed, but does
not seem worth it given that the code is dealing with values internal to
JSC which are expected to be valid at this point.

* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_new_string_from_bytes): Use the span(GBytes*) helper to avoid
having to manually go through span creation for the String::fromUTF8() call.
(jsc_value_new_array_from_strv): Add the new span() helper that takes a const
GStrv, switch iteration avoid indices.
(jsc_value_object_enumerate_properties): Use GMallocSpan to allocate the
memory for the result values; while at it use checked arithmetic to detect
overflows when calculating the size of the result array.
(jsc_value_object_invoke_methodv): Use a span to iterate over the
function parameters.
(jsc_value_new_functionv): Use a span to provide provide the values of
the Vector used for the function parameter types.
(jsc_value_function_callv): Use a span to iterate over the function
parameters.
(jsc_value_constructor_callv):
* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::span): Added helper that takes a const GStrv.

Canonical link: <a href="https://commits.webkit.org/304419@main">https://commits.webkit.org/304419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30531717f22c9842f4c2d538ed98afcc29a56322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87132 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3443 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3734 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127425 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145878 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133914 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5686 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117688 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61391 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35809 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166753 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71093 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->