### PR TITLE
REGRESSION (301471@main): replay.music.apple.com highlight reels has missing assets

### DIFF
--- a/LayoutTests/fast/text/FontFaceSet-status-after-style-update-expected.txt
+++ b/LayoutTests/fast/text/FontFaceSet-status-after-style-update-expected.txt
@@ -4,7 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS fonts.status is "loaded"
+Loading font
 PASS fonts.status is "loading"
+Deleting style
 PASS fonts.status is "loaded"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/text/FontFaceSet-status-after-style-update.html
+++ b/LayoutTests/fast/text/FontFaceSet-status-after-style-update.html
@@ -14,16 +14,28 @@ if (window.internals) {
 }
 </style>
 <script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
-<script>
-description("This function makes sure document.fonts.status gets updated after style changes.");
+<script>    
+
+jsTestIsAsync = true;
 let fonts = document.fonts;
-shouldBeEqualToString("fonts.status", "loaded");
-fonts.values().next().value.load();
-shouldBeEqualToString("fonts.status", "loading");
-document.getElementById("head").removeChild(document.getElementById("style"));
-shouldBeEqualToString("fonts.status", "loaded");
+(async () => {
+    description("This function makes sure document.fonts.status gets updated after style changes.");
+    shouldBeEqualToString("fonts.status", "loaded");
+    debug("Loading font");
+    fonts.values().next().value.load();
+    shouldBeEqualToString("fonts.status", "loading");
+    debug("Deleting style");
+    document.getElementById("head").removeChild(document.getElementById("style"));
+
+    await UIHelper.renderingUpdate();
+
+    shouldBeEqualToString("fonts.status", "loaded");
+    finishJSTest();
+})();
+
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/text/css-font-loading-arraybuffer-expected.txt
+++ b/LayoutTests/fast/text/css-font-loading-arraybuffer-expected.txt
@@ -3,8 +3,8 @@ This test makes sure that an ArrayBufferView can be successfully passed to the F
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS fontFace1.status is "loaded"
-PASS fontFace2.status is "loaded"
+PASS fontFace1.status is "unloaded"
+PASS fontFace2.status is "unloaded"
 PASS document.getElementById('probe1').getBoundingClientRect().width is 100
 PASS document.getElementById('probe2').getBoundingClientRect().width is 100
 PASS successfullyParsed is true

--- a/LayoutTests/fast/text/css-font-loading-arraybuffer.html
+++ b/LayoutTests/fast/text/css-font-loading-arraybuffer.html
@@ -21,8 +21,8 @@ fontRequest.addEventListener("load", function() {
 		var byteArray = new Uint8Array(arrayBuffer);
 		fontFace1 = new FontFace("WebFont1", arrayBuffer, {});
 		fontFace2 = new FontFace("WebFont2", byteArray, {});
-		shouldBeEqualToString("fontFace1.status", "loaded");
-		shouldBeEqualToString("fontFace2.status", "loaded");
+		shouldBeEqualToString("fontFace1.status", "unloaded");
+		shouldBeEqualToString("fontFace2.status", "unloaded");
 		document.fonts.add(fontFace1);
 		document.fonts.add(fontFace2);
 		document.getElementById("probe1").style.fontFamily = "WebFont1";

--- a/LayoutTests/fast/text/font-face-set-javascript.html
+++ b/LayoutTests/fast/text/font-face-set-javascript.html
@@ -1,181 +1,197 @@
 <!DOCTYPE html><!-- webkit-test-runner [ FontFaceSetConstructorEnabled=true ] -->
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
 if (window.internals)
     internals.clearMemoryCache();
 
-var fontFace1 = new FontFace("family1", "url('asdf')", {});
-var fontFace2 = new FontFace("family2", "url('asdf')", {});
-var fontFace3 = new FontFace("family3", "url('../../resources/Ahem.ttf')", {});
-var fontFace4 = new FontFace("family3", "url('../../resources/Ahem.ttf')", {'weight': 'bold'});
-var fontFace5 = new FontFace("family5", "url('../../resources/Ahem.otf')", {});
+jsTestIsAsync = true;
 
-shouldThrow("new FontFaceSet()");
-shouldBe("new FontFaceSet([]).size", "0");
-shouldBe("new FontFaceSet([fontFace1]).size", "1");
-shouldThrowErrorName("new FontFaceSet(1)", "TypeError");
-shouldThrowErrorName("new FontFaceSet('hello')", "TypeError");
-shouldBe("new FontFaceSet(new Set([fontFace1])).size", "1");
-shouldBe("x = { [Symbol.iterator]: function*() { yield fontFace1; yield fontFace2; } }; new FontFaceSet(x).size", "2");
-shouldThrowErrorName("x = { [Symbol.iterator]: 1 }; new FontFaceSet(x)", "TypeError");
-shouldThrowErrorName("x = { [Symbol.iterator]: null }; new FontFaceSet(x)", "TypeError");
-shouldThrowErrorName("x = { [Symbol.iterator]: function*() { yield fontFace1; throw {name: 'SomeError', toString: () => 'Some error'}; } }; new FontFaceSet(x)", "SomeError");
+let fontFaceSet;
+let fontFace1;
+let fontFace2;
+let fontFace3;
+let fontFace4;
+let fontFace5;
 
-var fontFaceSet = new FontFaceSet([]);
-shouldBeEqualToString("fontFaceSet.status", "loaded");
-fontFaceSet.add(fontFace1);
+let item;
+let set;
+let value1, value2;
 
-// FIXME: FontFaceSet should use setlike<FontFace>, not iterable<FontFace> and should not have an entries() method.
-var iterator = fontFaceSet.entries();
-var item = iterator.next();
-shouldBeFalse("item.done");
-shouldBe("item.value", "fontFace1");
-item = iterator.next();
-shouldBeTrue("item.done");
-shouldBe("item.value", "undefined");
+// Waiting for the load event is necessary because of webkit.org/b/304381.
+(async () => {
+    await new Promise((resolve) => { window.onload = resolve; });
+    await new Promise((resolve) => { setTimeout(resolve); });
 
-iterator = fontFaceSet.keys();
-item = iterator.next();
-shouldBeFalse("item.done");
-shouldBe("item.value", "fontFace1");
-item = iterator.next();
-shouldBeTrue("item.done");
+    fontFace1 = new FontFace("family1", "url('asdf')", {});
+    fontFace2 = new FontFace("family2", "url('asdf')", {});
+    fontFace3 = new FontFace("family3", "url('../../resources/Ahem.ttf')", {});
+    fontFace4 = new FontFace("family3", "url('../../resources/Ahem.ttf')", {'weight': 'bold'});
+    fontFace5 = new FontFace("family5", "url('../../resources/Ahem.otf')", {});
 
-iterator = fontFaceSet.values();
-item = iterator.next();
-shouldBeFalse("item.done");
-shouldBe("item.value", "fontFace1");
-item = iterator.next();
-shouldBeTrue("item.done");
+    shouldThrow("new FontFaceSet()");
+    shouldBe("new FontFaceSet([]).size", "0");
+    shouldBe("new FontFaceSet([fontFace1]).size", "1");
+    shouldThrowErrorName("new FontFaceSet(1)", "TypeError");
+    shouldThrowErrorName("new FontFaceSet('hello')", "TypeError");
+    shouldBe("new FontFaceSet(new Set([fontFace1])).size", "1");
+    shouldBe("x = { [Symbol.iterator]: function*() { yield fontFace1; yield fontFace2; } }; new FontFaceSet(x).size", "2");
+    shouldThrowErrorName("x = { [Symbol.iterator]: 1 }; new FontFaceSet(x)", "TypeError");
+    shouldThrowErrorName("x = { [Symbol.iterator]: null }; new FontFaceSet(x)", "TypeError");
+    shouldThrowErrorName("x = { [Symbol.iterator]: function*() { yield fontFace1; throw {name: 'SomeError', toString: () => 'Some error'}; } }; new FontFaceSet(x)", "SomeError");
 
-var value1, value2, set;
-fontFaceSet.forEach(function(v1, v2, s){
-    value1 = v1;
-    value2 = v2;
-    set = s;
-    shouldBe("fontFaceSet", "set");
-    shouldBe("value1", "value2");
-});
+    fontFaceSet = new FontFaceSet([]);
+    shouldBeEqualToString("fontFaceSet.status", "loaded");
+    fontFaceSet.add(fontFace1);
 
-shouldBe("fontFaceSet.add(fontFace2)", "fontFaceSet");
-shouldBe("fontFaceSet.size", "2");
+    // FIXME: FontFaceSet should use setlike<FontFace>, not iterable<FontFace> and should not have an entries() method.
+    var iterator = fontFaceSet.entries();
+    item = iterator.next();
+    shouldBeFalse("item.done");
+    shouldBe("item.value", "fontFace1");
+    item = iterator.next();
+    shouldBeTrue("item.done");
+    shouldBe("item.value", "undefined");
 
-shouldThrow("fontFaceSet.add(null)");
+    iterator = fontFaceSet.keys();
+    item = iterator.next();
+    shouldBeFalse("item.done");
+    shouldBe("item.value", "fontFace1");
+    item = iterator.next();
+    shouldBeTrue("item.done");
 
-iterator = fontFaceSet.keys();
-item = iterator.next();
-shouldBeFalse("item.done");
-shouldBe("item.value", "fontFace1");
-item = iterator.next();
-shouldBeFalse("item.done");
-shouldBe("item.value", "fontFace2");
-item = iterator.next();
-shouldBeTrue("item.done");
+    iterator = fontFaceSet.values();
+    item = iterator.next();
+    shouldBeFalse("item.done");
+    shouldBe("item.value", "fontFace1");
+    item = iterator.next();
+    shouldBeTrue("item.done");
 
-shouldBe("fontFaceSet.delete(fontFace1)", "true");
-shouldBe("fontFaceSet.delete(fontFace3)", "false");
+    fontFaceSet.forEach(function(v1, v2, s){
+        value1 = v1;
+        value2 = v2;
+        set = s;
+        shouldBe("fontFaceSet", "set");
+        shouldBe("value1", "value2");
+    });
 
-shouldThrow("fontFaceSet.delete(null)");
+    shouldBe("fontFaceSet.add(fontFace2)", "fontFaceSet");
+    shouldBe("fontFaceSet.size", "2");
 
-shouldBeFalse("fontFaceSet.has(fontFace1)");
-shouldBeTrue("fontFaceSet.has(fontFace2)");
-shouldThrow("fontFaceSet.has(null)");
+    shouldThrow("fontFaceSet.add(null)");
 
-fontFaceSet.clear();
+    iterator = fontFaceSet.keys();
+    item = iterator.next();
+    shouldBeFalse("item.done");
+    shouldBe("item.value", "fontFace1");
+    item = iterator.next();
+    shouldBeFalse("item.done");
+    shouldBe("item.value", "fontFace2");
+    item = iterator.next();
+    shouldBeTrue("item.done");
 
-shouldBe("fontFaceSet.size", "0");
-shouldBeTrue("fontFaceSet.values().next().done");
-shouldThrow("fontFaceSet.check('garbage')");
-shouldBeTrue("fontFaceSet.check('16px garbage')");
+    shouldBe("fontFaceSet.delete(fontFace1)", "true");
+    shouldBe("fontFaceSet.delete(fontFace3)", "false");
 
-self.jsTestIsAsync = true;
-fontFaceSet.add(fontFace1);
-shouldBeFalse("fontFaceSet.check('16px family1')");
-var item;
-fontFaceSet.load("garbage").then(function(arg) {
-    testFailed("Should not be able to parse garbage");
-    finishJSTest();
-}, function(arg) {
-    item = arg;
-    shouldBe("item.code", "item.SYNTAX_ERR");
+    shouldThrow("fontFaceSet.delete(null)");
+
+    shouldBeFalse("fontFaceSet.has(fontFace1)");
+    shouldBeTrue("fontFaceSet.has(fontFace2)");
+    shouldThrow("fontFaceSet.has(null)");
+
+    fontFaceSet.clear();
+
+    shouldBe("fontFaceSet.size", "0");
+    shouldBeTrue("fontFaceSet.values().next().done");
+    shouldThrow("fontFaceSet.check('garbage')");
+    shouldBeTrue("fontFaceSet.check('16px garbage')");
+
+    fontFaceSet.add(fontFace1);
     shouldBeFalse("fontFaceSet.check('16px family1')");
-    return fontFaceSet.load("16px garbage");
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "[]");
-    return fontFaceSet.load("16px family1");
-}, function(arg) {
-    testFailed("Should not be able to parse garbage");
-    finishJSTest();
-}).then(function(arg) {
-    testFailed("Bogus URL should not load");
-    finishJSTest();
-}, function(arg) {
-    item = arg;
-    shouldBe("item.code", "item.NETWORK_ERR");
-    fontFaceSet.add(fontFace3);
-    shouldBeFalse("fontFaceSet.check('16px family3')");
-    var result = fontFaceSet.load("16px family3");
-    shouldBeEqualToString("fontFaceSet.status", "loading");
-    return result;
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "[fontFace3]");
-    shouldBeTrue("fontFaceSet.check('16px family3')");
+    fontFaceSet.load("garbage").then(function(arg) {
+        testFailed("Should not be able to parse garbage");
+        finishJSTest();
+    }, function(arg) {
+        item = arg;
+        shouldBe("item.code", "item.SYNTAX_ERR");
+        shouldBeFalse("fontFaceSet.check('16px family1')");
+        return fontFaceSet.load("16px garbage");
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "[]");
+        return fontFaceSet.load("16px family1");
+    }, function(arg) {
+        testFailed("Should not be able to parse garbage");
+        finishJSTest();
+    }).then(function(arg) {
+        testFailed("Bogus URL should not load");
+        finishJSTest();
+    }, function(arg) {
+        item = arg;
+        shouldBe("item.code", "item.NETWORK_ERR");
+        fontFaceSet.add(fontFace3);
+        shouldBeFalse("fontFaceSet.check('16px family3')");
+        var result = fontFaceSet.load("16px family3");
+        shouldBeEqualToString("fontFaceSet.status", "loading");
+        return result;
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "[fontFace3]");
+        shouldBeTrue("fontFaceSet.check('16px family3')");
+        shouldBeEqualToString("fontFaceSet.status", "loaded");
+        var result = fontFaceSet.load("16px family3"); // Test when it's in the cache.
+        shouldBeEqualToString("fontFaceSet.status", "loaded");
+        return result;
+    }, function(arg) {
+        testFailed("Real URL should load");
+        finishJSTest();
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "[fontFace3]");
+        fontFaceSet.add(fontFace4);
+        return fontFaceSet.load("16px family3");
+    }, function(arg) {
+        testFailed("Real URL should load");
+        finishJSTest();
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "[fontFace3]");
+        fontFaceSet.add(fontFace4);
+        fontFaceSet.load("16px family3");
+        return fontFaceSet.ready;
+    }, function(arg) {
+        testFailed("Multiple matching faces should load");
+        finishJSTest();
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "fontFaceSet");
+        fontFaceSet.add(fontFace5);
+        shouldBeEqualToString("fontFaceSet.status", "loaded");
+        fontFaceSet.load("16px family5");
+        shouldBeEqualToString("fontFaceSet.status", "loading");
+        return fontFaceSet.ready;
+    }, function(arg) {
+        testFailed("Ready attribute should never fail");
+        finishJSTest();
+    }).then(function(arg) {
+        item = arg;
+        shouldBe("item", "fontFaceSet");
+    }, function(arg) {
+        testFailed("Ready attribute should never fail");
+    }).then(function() {
+        return Object.getOwnPropertyDescriptor(Object.getPrototypeOf(fontFaceSet), 'ready').get.apply(fontFace5);
+    }).then(function(arg) {
+        testFailed("Ready attribute should be rejected when used with an object which is not FontFaceSet");
+        finishJSTest();
+    }, function(arg) {
+        testPassed("" + arg);
+        finishJSTest();
+    });
     shouldBeEqualToString("fontFaceSet.status", "loaded");
-    var result = fontFaceSet.load("16px family3"); // Test when it's in the cache.
-    shouldBeEqualToString("fontFaceSet.status", "loaded");
-    return result;
-}, function(arg) {
-    testFailed("Real URL should load");
-    finishJSTest();
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "[fontFace3]");
-    fontFaceSet.add(fontFace4);
-    return fontFaceSet.load("16px family3");
-}, function(arg) {
-    testFailed("Real URL should load");
-    finishJSTest();
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "[fontFace3]");
-    fontFaceSet.add(fontFace4);
-    fontFaceSet.load("16px family3");
-    return fontFaceSet.ready;
-}, function(arg) {
-    testFailed("Multiple matching faces should load");
-    finishJSTest();
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "fontFaceSet");
-    fontFaceSet.add(fontFace5);
-    shouldBeEqualToString("fontFaceSet.status", "loaded");
-    fontFaceSet.load("16px family5");
-    shouldBeEqualToString("fontFaceSet.status", "loading");
-    return fontFaceSet.ready;
-}, function(arg) {
-    testFailed("Ready attribute should never fail");
-    finishJSTest();
-}).then(function(arg) {
-    item = arg;
-    shouldBe("item", "fontFaceSet");
-}, function(arg) {
-    testFailed("Ready attribute should never fail");
-}).then(function() {
-    return Object.getOwnPropertyDescriptor(Object.getPrototypeOf(fontFaceSet), 'ready').get.apply(fontFace5);
-}).then(function(arg) {
-    testFailed("Ready attribute should be rejected when used with an object which is not FontFaceSet");
-    finishJSTest();
-}, function(arg) {
-    testPassed("" + arg);
-    finishJSTest();
-});
-shouldBeEqualToString("fontFaceSet.status", "loaded");
+})();
+
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/text/font-loading-multiple-documents.html
+++ b/LayoutTests/fast/text/font-loading-multiple-documents.html
@@ -22,11 +22,16 @@ if (window.testRunner)
 <script>
 var font = new FontFace("WebFont", "url('../../resources/Ahem.ttf') format('truetype')");
 document.fonts.add(font);
-document.getElementById("target").contentWindow.document.fonts.add(font);
-font.load().then(function() {
+try {
+	document.getElementById("target").contentWindow.document.fonts.add(font);
+	font.load().then(function() {
+	    if (window.testRunner)
+	        testRunner.notifyDone();
+	});
+} catch (e) {
     if (window.testRunner)
         testRunner.notifyDone();
-});
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/text/font-loading-multiple-sets.html
+++ b/LayoutTests/fast/text/font-loading-multiple-sets.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><!-- webkit-test-runner [ FontFaceSetConstructorEnabled=true ] -->
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -10,34 +10,44 @@ if (window.internals) {
     internals.invalidateFontCache();
 }
 window.jsTestIsAsync = true;
-var font = new FontFace("WebFont", "url('../../resources/Ahem.ttf') format('truetype')");
-shouldBeEqualToString("font.status", "unloaded");
-var set1 = new FontFaceSet([font]);
-var set2 = new FontFaceSet([font]);
-shouldBeEqualToString("set1.status", "loaded");
-shouldBeEqualToString("set2.status", "loaded");
-font.load();
-shouldBeEqualToString("font.status", "loading");
-shouldBeEqualToString("set1.status", "loading");
-shouldBeEqualToString("set2.status", "loading");
-var count = 0;
-set1.ready.then(function() {
-    ++count;
-    if (count == 2)
+
+let font;
+let set1;
+let set2;
+
+// Waiting for the load event is necessary because of webkit.org/b/304381.
+(async () => {
+    await new Promise((resolve) => { window.onload = resolve; });
+    await new Promise((resolve) => { setTimeout(resolve); });
+
+    font = new FontFace("WebFont", "url('../../resources/Ahem.ttf') format('truetype')");
+    shouldBeEqualToString("font.status", "unloaded");
+    set1 = new FontFaceSet([font]);
+    set2 = new FontFaceSet([font]);
+    shouldBeEqualToString("set1.status", "loaded");
+    shouldBeEqualToString("set2.status", "loaded");
+    font.load();
+    shouldBeEqualToString("font.status", "loading");
+    shouldBeEqualToString("set1.status", "loading");
+    shouldBeEqualToString("set2.status", "loading");
+    let count = 0;
+    set1.ready.then(function() {
+        ++count;
+        if (count == 2)
+            finishJSTest();
+    }, function() {
+        testFailed("Promise should not be rejected.");
         finishJSTest();
-}, function() {
-    testFailed("Promise should not be rejected.");
-    finishJSTest();
-});
-set1.ready.then(function() {
-    ++count;
-    if (count == 2)
+    });
+    set2.ready.then(function() {
+        ++count;
+        if (count == 2)
+            finishJSTest();
+    }, function() {
+        testFailed("Promise should not be rejected.");
         finishJSTest();
-}, function() {
-    testFailed("Promise should not be rejected.");
-    finishJSTest();
-});
+    });
+})();
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-expected.txt
@@ -1,0 +1,7 @@
+Font loading test
+
+PASS The initial ready promise fired
+PASS Loading a font should fire a `loadingdone` event with the correct `fontfaceset`
+PASS Loading a second font should fire a `loadingdone` event with the correct `fontfaceset`
+PASS Loading a missing font should fire a `loadingerror` event with the correct `fontfaceset`
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer-expected.txt
@@ -1,0 +1,5 @@
+Font loading test
+
+PASS The initial ready promise fired
+PASS Loading a font from an ArrayBuffer should fire a `loadingdone` event with the correct `fontfaceset`
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>Test font loading from an ArrayBuffer</title>
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#font-face-constructor">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.initial {
+  font-family: "AhemTest", sans-serif;
+  font-size: 20px;
+}
+</style>
+<div>Font loading test</div>
+<script>  
+  let expectedDoneFace = "AhemTest";
+  let expectedErrorFace = "";
+
+  const fontSet = document.fonts;
+
+  promise_test(t => {
+    return fontSet.ready;
+  }, 'The initial ready promise fired');
+
+  promise_test(async t => {
+    const eventPromise = new Promise(resolve => {
+      fontSet.addEventListener('loadingdone', t.step_func(event => {
+        assert_equals(event.fontfaces.length, 1, `'loadingdone' FontFaceSet should have one font; it has ${event.fontfaces.length}`);
+        assert_equals(event.fontfaces[0].family, expectedDoneFace, `'loadingdone' FontFaceSet fontFamily is ${expectedDoneFace}`);
+        resolve();
+      }));
+    }, { once: true });
+
+    const response = await fetch('/fonts/Ahem.ttf');
+    const buffer = await response.arrayBuffer();
+
+    expectedDoneFace = 'data-font';
+    const dataFont = new FontFace('data-font', buffer);
+    
+    assert_equals(dataFont.status, "unloaded", "Initial status should be 'unloaded'");
+    fontSet.add(dataFont);
+    dataFont.load();
+
+    return Promise.all([fontSet.ready, eventPromise]);
+  }, 'Loading a font from an ArrayBuffer should fire a `loadingdone` event with the correct `fontfaceset`');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<title>Test document.fonts.ready loading with two fonts</title>
+<link rel="help" href="https://www.w3.org/TR/css-font-loading/#eventdef-fontfaceset-loadingdone">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.initial {
+  font-family: "AhemTest", sans-serif;
+  font-size: 20px;
+}
+</style>
+<div>Font loading test</div>
+<script>  
+  let expectedDoneFace = "AhemTest";
+  let expectedErrorFace = "";
+
+  const fontSet = document.fonts;
+
+  promise_test(t => {
+    return fontSet.ready;
+  }, 'The initial ready promise fired');
+
+  promise_test(t => {
+    const eventPromise = new Promise(resolve => {
+      fontSet.addEventListener('loadingdone', t.step_func(event => {
+        assert_equals(event.fontfaces.length, 1, `'loadingdone' FontFaceSet should have one font; it has ${event.fontfaces.length}`);
+        assert_equals(event.fontfaces[0].family, expectedDoneFace, `'loadingdone' FontFaceSet fontFamily is ${expectedDoneFace}`);
+        resolve();
+      }));
+    }, { once: true });
+
+    expectedDoneFace = "AhemTest";
+    const fontFace = new FontFace("AhemTest", "url(/fonts/Ahem.ttf)");
+    fontSet.add(fontFace);
+    fontFace.load();
+
+    return Promise.all([fontSet.ready, eventPromise]);
+  }, 'Loading a font should fire a `loadingdone` event with the correct `fontfaceset`');
+
+  promise_test(t => {
+    const eventPromise = new Promise(resolve => {
+      fontSet.addEventListener('loadingdone', t.step_func(event => {
+        assert_equals(event.fontfaces.length, 1, `'loadingdone' FontFaceSet should have one font; it has ${event.fontfaces.length}`);
+        assert_equals(event.fontfaces[0].family, expectedDoneFace, `'loadingdone' FontFaceSet fontFamily is ${expectedDoneFace}`);
+        resolve();
+      }));
+    }, { once: true });
+
+    expectedDoneFace = "AhemTest2";
+    const fontFace = new FontFace("AhemTest2", "url(/fonts/Ahem.ttf)");
+    fontSet.add(fontFace);
+    fontFace.load();
+
+    return Promise.all([fontSet.ready, eventPromise]);
+  }, 'Loading a second font should fire a `loadingdone` event with the correct `fontfaceset`');
+
+  promise_test(t => {
+    const eventPromise = new Promise(resolve => {
+      fontSet.addEventListener('loadingerror', t.step_func(event => {
+        assert_equals(event.fontfaces.length, 1, `'loadingerror' FontFaceSet should have one font; it has ${event.fontfaces.length}`);
+        assert_equals(event.fontfaces[0].family, expectedErrorFace, `'loadingerror' FontFaceSet fontFamily is ${expectedErrorFace}`);
+        resolve();
+      }));
+    }, { once: true });
+
+    expectedErrorFace = "DoesNotExist";
+    const fontFace = new FontFace("DoesNotExist", "url(/fonts/DoesNotExist.ttf)");
+    fontSet.add(fontFace);
+    fontFace.load().catch(() => {});
+
+    return Promise.all([fontSet.ready, eventPromise]);
+  }, 'Loading a missing font should fire a `loadingerror` event with the correct `fontfaceset`');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt
@@ -1,3 +1,3 @@
 
-PASS FontFaceSet fires correct loading event
+PASS FontFaceSet fires correct loading event, with the loading fontfaces
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
@@ -8,14 +8,20 @@ promise_test(async t => {
   const fontSet = document.fonts;
   let loadingFired = false;
 
-  fontSet.addEventListener("loading", () => {
+  fontSet.addEventListener("loading", (e) => {
+    assert_not_equals(e.fontfaces.findIndex(fontface => fontface.family === "TestFont1"), -1, "The 'loading' event.fontfaces contained `TestFont1`");
+    assert_not_equals(e.fontfaces.findIndex(fontface => fontface.family === "TestFont2"), -1, "The 'loading' event.fontfaces contained `TestFont2`");
     loadingFired = true;
   });
   
-  const TestFont = new FontFace("GoodFont", "url(/fonts/Ahem.ttf)");
-  fontSet.add(TestFont);
-  await TestFont.load();
+  const testFont1 = new FontFace("TestFont1", "url(/fonts/Ahem.ttf)");
+  const testFont2 = new FontFace("TestFont2", "url(/fonts/Ahem.ttf)");
+  fontSet.add(testFont1);
+  fontSet.add(testFont2);
+
+  await Promise.all([testFont1.load(), testFont2.load()]);
+
   await fontSet.ready;
   assert_true(loadingFired, "The 'loading' event should have fired");
-}, "FontFaceSet fires correct loading event");
+}, "FontFaceSet fires correct loading event, with the loading fontfaces");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-add-css-connected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-add-css-connected-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fontfaceset-add-css-connected
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL FontFaceSetLoadEvent constructor without FontFaceSetLoadEventInit dictionary Can't find variable: FontFaceSetLoadEvent
-FAIL FontFaceSetLoadEvent constructor with FontFaceSetLoadEventInit dictionary Can't find variable: FontFaceSetLoadEvent
+PASS FontFaceSetLoadEvent constructor without FontFaceSetLoadEventInit dictionary
+PASS FontFaceSetLoadEvent constructor with FontFaceSetLoadEventInit dictionary
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: FontFaceSetLoadEvent"
+PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface FontFace: original interface defined
 PASS Partial interface FontFace: member names are unique
@@ -97,16 +97,16 @@ FAIL FontFacePalettes interface: existence and properties of interface prototype
 FAIL FontFacePalettes interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "FontFacePalettes" expected property "FontFacePalettes" missing
 FAIL FontFacePalettes interface: iterable<FontFacePalette> undefined is not an object (evaluating 'this.get_interface_object().prototype')
 FAIL FontFacePalettes interface: attribute length assert_own_property: self does not have own property "FontFacePalettes" expected property "FontFacePalettes" missing
-FAIL FontFaceSetLoadEvent interface: existence and properties of interface object assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface object length assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface object name assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent interface: attribute fontfaces assert_own_property: self does not have own property "FontFaceSetLoadEvent" expected property "FontFaceSetLoadEvent" missing
-FAIL FontFaceSetLoadEvent must be primary interface of fontFaceSetLoadEvent assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: fontFaceSetLoadEvent"
-FAIL Stringification of fontFaceSetLoadEvent assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: fontFaceSetLoadEvent"
-FAIL FontFaceSetLoadEvent interface: fontFaceSetLoadEvent must inherit property "fontfaces" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: fontFaceSetLoadEvent"
+PASS FontFaceSetLoadEvent interface: existence and properties of interface object
+PASS FontFaceSetLoadEvent interface object length
+PASS FontFaceSetLoadEvent interface object name
+PASS FontFaceSetLoadEvent interface: existence and properties of interface prototype object
+PASS FontFaceSetLoadEvent interface: existence and properties of interface prototype object's "constructor" property
+PASS FontFaceSetLoadEvent interface: existence and properties of interface prototype object's @@unscopables property
+PASS FontFaceSetLoadEvent interface: attribute fontfaces
+PASS FontFaceSetLoadEvent must be primary interface of fontFaceSetLoadEvent
+PASS Stringification of fontFaceSetLoadEvent
+PASS FontFaceSetLoadEvent interface: fontFaceSetLoadEvent must inherit property "fontfaces" with the proper type
 PASS FontFaceSet interface: existence and properties of interface object
 FAIL FontFaceSet interface object length assert_equals: wrong value for FontFaceSet.length expected 0 but got 1
 PASS FontFaceSet interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative-expected.txt
@@ -1,0 +1,5 @@
+Hello
+
+
+PASS Adding a FontFace to the FontFaceSet in a different document throws
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Tests that moving a FontFace between documents throws an exception</title>
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/13251">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+    <div style="font: 32px 'Ahem';">Hello</div>
+    <iframe id="target" srcdoc="
+    <!DOCTYPE html>
+    <html>
+    <head>
+    </head>
+    <body>
+    <div style='font: 32px Ahem;'>Hello</div>
+    </body>
+    </html>"></iframe>
+<script>
+test(function(t) {
+    const fontFace = new FontFace("Ahem", "url(/fonts/Ahem.ttf)");
+    document.fonts.add(fontFace);
+    const iframeWindow = document.getElementById("target").contentWindow;
+    assert_throws_dom("WrongDocumentError", iframeWindow.DOMException, function () {
+        iframeWindow.document.fonts.add(fontFace);
+    });
+}, "Adding a FontFace to the FontFaceSet in a different document throws");
+</script>
+</body>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1086,6 +1086,8 @@ set(WebCore_NON_SVG_IDL_FILES
     css/ElementCSSInlineStyle.idl
     css/FontFace.idl
     css/FontFaceSet.idl
+    css/FontFaceSetLoadEvent.idl
+    css/FontFaceSetLoadEventInit.idl
     css/FontFaceSource.idl
     css/LinkStyle.idl
     css/MediaList.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1343,6 +1343,8 @@ $(PROJECT_DIR)/css/ElementCSSInlineStyle+Typedom.idl
 $(PROJECT_DIR)/css/ElementCSSInlineStyle.idl
 $(PROJECT_DIR)/css/FontFace.idl
 $(PROJECT_DIR)/css/FontFaceSet.idl
+$(PROJECT_DIR)/css/FontFaceSetLoadEvent.idl
+$(PROJECT_DIR)/css/FontFaceSetLoadEventInit.idl
 $(PROJECT_DIR)/css/FontFaceSource.idl
 $(PROJECT_DIR)/css/LinkStyle.idl
 $(PROJECT_DIR)/css/MediaList.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1163,6 +1163,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSet.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSet.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEventInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSetLoadEventInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFontFaceSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFormDataEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1055,6 +1055,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/ElementCSSInlineStyle+Typedom.idl \
     $(WebCore)/css/FontFace.idl \
     $(WebCore)/css/FontFaceSet.idl \
+    $(WebCore)/css/FontFaceSetLoadEvent.idl \
+    $(WebCore)/css/FontFaceSetLoadEventInit.idl \
     $(WebCore)/css/FontFaceSource.idl \
     $(WebCore)/css/LinkStyle.idl \
     $(WebCore)/css/MediaList.idl \

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "HTMLMediaElementEnums.h"
 #include "JSValueInWrappedObject.h"
 #include "MediaSession.h"
 #include <wtf/Ref.h>

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_AUTHN)
 #include <WebCore/AuthenticationExtensionsClientInputsJSON.h>
+#include <WebCore/AuthenticatorSelectionCriteria.h>
 #include <WebCore/PublicKeyCredentialRpEntity.h>
 #include <WebCore/PublicKeyCredentialUserEntityJSON.h>
 #include <wtf/Forward.h>
@@ -35,7 +36,6 @@ namespace WebCore {
 
 enum class AuthenticatorAttachment : uint8_t;
 enum class AttestationConveyancePreference : uint8_t;
-struct AuthenticatorSelectionCriteria;
 struct PublicKeyCredentialDescriptorJSON;
 struct PublicKeyCredentialParameters;
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -19,6 +19,7 @@ animation/KeyframeEffect.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
 css/CSSValue.cpp
+css/StyleRule.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/RejectedPromiseTracker.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -713,6 +713,7 @@ bindings/js/JSEventTargetCustom.cpp
 bindings/js/JSExecState.cpp
 bindings/js/JSExtendableMessageEventCustom.cpp
 bindings/js/JSFetchEventCustom.cpp
+bindings/js/JSFontFaceSetLoadEventCustom.cpp
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp
@@ -992,6 +993,7 @@ css/DeprecatedCSSOMValue.cpp
 css/DeprecatedCSSOMValueList.cpp
 css/FontFace.cpp
 css/FontFaceSet.cpp
+css/FontFaceSetLoadEvent.cpp
 css/ImmutableStyleProperties.cpp
 css/MediaList.cpp
 css/MediaQueryList.cpp
@@ -4131,6 +4133,8 @@ JSFocusEvent.cpp
 JSFocusOptions.cpp
 JSFontFace.cpp
 JSFontFaceSet.cpp
+JSFontFaceSetLoadEvent.cpp
+JSFontFaceSetLoadEventInit.cpp
 JSFormDataEvent.cpp
 JSFragmentDirective.cpp
 JSFullscreenOptions.cpp

--- a/Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSFontFaceSetLoadEvent.h"
+
+#include "FontFace.h"
+#include "FontFaceSetLoadEvent.h"
+#include "WebCoreOpaqueRootInlines.h"
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSFontFaceSetLoadEvent::visitAdditionalChildren(Visitor& visitor)
+{
+    for (auto& face : wrapped().fontfaces())
+        addWebCoreOpaqueRoot(visitor, face.get());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSFontFaceSetLoadEvent);
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -43,12 +43,14 @@
 #include "FontDescription.h"
 #include "FontFace.h"
 #include "FontPaletteValues.h"
+#include "Logging.h"
 #include "SVGFontFaceElement.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
 #include "StyleProperties.h"
 #include "StyleResolveForFont.h"
 #include "StyleRule.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -157,7 +159,7 @@ void CSSFontFace::setFamily(CSSValue& family)
     });
 }
 
-FontFace* CSSFontFace::existingWrapper()
+FontFace* CSSFontFace::existingWrapper() const
 {
     return m_wrapper.get();
 }
@@ -614,7 +616,9 @@ void CSSFontFace::setStatus(Status newStatus)
 void CSSFontFace::fontLoaded(CSSFontFaceSource&)
 {
     Ref<CSSFontFace> protectedThis(*this);
-    
+
+    LOG_WITH_STREAM(Fonts, stream << "CSSFontFace::fontLoaded - " << family() << " " << style() << " " << weight());
+
     fontLoadEventOccurred();
 }
 
@@ -684,6 +688,8 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
 
 void CSSFontFace::load()
 {
+    LOG_WITH_STREAM(Fonts, stream << "CSSFontFace::load - " << family() << " " << style() << " " << weight());
+
     pump(ExternalResourceDownloadPolicy::Allow);
 }
 

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -138,7 +138,7 @@ public:
     // We don't guarantee that the FontFace wrapper will be the same every time you ask for it.
     Ref<FontFace> wrapper(ScriptExecutionContext*);
     void setWrapper(FontFace&);
-    FontFace* existingWrapper();
+    FontFace* existingWrapper() const;
 
     struct FontLoadTiming {
         Seconds blockPeriod;

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -43,7 +43,13 @@ template<typename> class ExceptionOr;
 
 struct FontEventClient : public AbstractRefCountedAndCanMakeWeakPtr<FontEventClient> {
     virtual ~FontEventClient() = default;
-    virtual void faceFinished(CSSFontFace&, CSSFontFace::Status) = 0;
+
+    virtual void faceDidStartLoading(CSSFontFace&) = 0;
+    virtual void faceDidFinishLoading(CSSFontFace&, CSSFontFace::Status) = 0;
+
+    virtual void didAddFace(CSSFontFace&) = 0;
+    virtual void didDeletedFace(CSSFontFace&) = 0;
+
     virtual void startedLoading() = 0;
     virtual void completedLoading() = 0;
 };
@@ -70,7 +76,7 @@ public:
     bool hasFace(const CSSFontFace&) const;
     size_t faceCount() const { return m_faces.size(); }
     void add(CSSFontFace&);
-    void remove(const CSSFontFace&);
+    void remove(CSSFontFace&);
     void purge();
     void emptyCaches();
     void clear();
@@ -81,11 +87,6 @@ public:
     ExceptionOr<bool> check(ScriptExecutionContext&, const String& font, const String& text);
 
     CSSSegmentedFontFace* fontFace(FontSelectionRequest, const AtomString& family);
-
-    enum class Status { Loading, Loaded };
-    Status status() const { return m_status; }
-
-    bool hasActiveFontFaces() { return status() == Status::Loading; }
 
     size_t facesPartitionIndex() const { return m_facesPartitionIndex; }
 
@@ -129,7 +130,7 @@ private:
     HashMap<String, FontSelectionHashMap, ASCIICaseInsensitiveHash> m_cache;
     HashMap<StyleRuleFontFace*, CSSFontFace*> m_constituentCSSConnections;
     size_t m_facesPartitionIndex { 0 }; // All entries in m_faces before this index are CSS-connected.
-    Status m_status { Status::Loaded };
+
     WeakHashSet<FontModifiedObserver> m_fontModifiedObservers;
     WeakHashSet<FontEventClient> m_fontEventClients;
     WeakPtr<CSSFontSelector> m_owningFontSelector;

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -39,6 +39,8 @@ class ArrayBufferView;
 
 namespace WebCore {
 
+class Document;
+
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 template<typename> class ExceptionOr;
 
@@ -110,5 +112,7 @@ private:
     const UniqueRef<LoadedPromise> m_loadedPromise;
     bool m_mayLoadedPromiseBeScriptObservable { false };
 };
+
+WebCoreOpaqueRoot root(FontFace*);
 
 }

--- a/Source/WebCore/css/FontFaceSetLoadEvent.cpp
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontFaceSetLoadEvent.h"
+
+#include "FontFaceSetLoadEventInit.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FontFaceSetLoadEvent);
+
+FontFaceSetLoadEvent::FontFaceSetLoadEvent(const AtomString& eventType, const FontFaceSetLoadEventInit& init, IsTrusted isTrusted)
+    : Event(EventInterfaceType::FontFaceSetLoadEvent, eventType, init, isTrusted)
+    , m_fontfaces(init.fontfaces)
+{
+}
+
+FontFaceSetLoadEvent::~FontFaceSetLoadEvent() = default;
+
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEvent.h
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/Event.h>
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class FontFace;
+struct FontFaceSetLoadEventInit;
+
+class FontFaceSetLoadEvent final : public Event {
+    WTF_MAKE_TZONE_ALLOCATED(FontFaceSetLoadEvent);
+public:
+    static Ref<FontFaceSetLoadEvent> create(const AtomString& eventType, const FontFaceSetLoadEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)
+    {
+        return adoptRef(*new FontFaceSetLoadEvent(eventType, initializer, isTrusted));
+    }
+
+    ~FontFaceSetLoadEvent();
+
+    const Vector<Ref<FontFace>> fontfaces() const { return m_fontfaces; }
+
+private:
+    FontFaceSetLoadEvent(const AtomString& eventType, const FontFaceSetLoadEventInit&, IsTrusted);
+
+    Vector<Ref<FontFace>> m_fontfaces;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEvent.idl
+++ b/Source/WebCore/css/FontFaceSetLoadEvent.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface
+
+typedef USVString CSSOMString;
+
+[
+    JSCustomMarkFunction,
+    Exposed=(Window,Worker)
+]
+interface FontFaceSetLoadEvent : Event {
+    constructor([AtomString] DOMString type, optional FontFaceSetLoadEventInit eventInitDict);
+
+    [SameObject] readonly attribute FrozenArray<FontFace> fontfaces;
+};

--- a/Source/WebCore/css/FontFaceSetLoadEventInit.h
+++ b/Source/WebCore/css/FontFaceSetLoadEventInit.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+#include "FontFace.h"
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct FontFaceSetLoadEventInit : EventInit {
+    Vector<Ref<FontFace>> fontfaces;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/FontFaceSetLoadEventInit.idl
+++ b/Source/WebCore/css/FontFaceSetLoadEventInit.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface
+
+dictionary FontFaceSetLoadEventInit : EventInit {
+    sequence<FontFace> fontfaces = [];
+};

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4410,6 +4410,7 @@ void Document::implicitClose()
 
     m_processingLoadEvent = false;
 
+    // FIXME: This needs to notify all FontFaceSet objects, not just the one owned by the CSSFontSelector: webkit.org/b/304381.
     if (RefPtr fontSelector = fontSelectorIfExists()) {
         if (RefPtr fontFaceSet = fontSelector->fontFaceSetIfExists())
             fontFaceSet->documentDidFinishLoading();

--- a/Source/WebCore/dom/EventInterfaces.in
+++ b/Source/WebCore/dom/EventInterfaces.in
@@ -26,6 +26,7 @@ ExtendableMessageEvent
 ErrorEvent
 FetchEvent
 FocusEvent
+FontFaceSetLoadEvent
 FormDataEvent
 HashChangeEvent
 InputEvent


### PR DESCRIPTION
#### 4058ab9ae8caa5fbd518f6c081c15c6173e94959
<pre>
REGRESSION (301471@main): replay.music.apple.com highlight reels has missing assets
<a href="https://bugs.webkit.org/show_bug.cgi?id=304091">https://bugs.webkit.org/show_bug.cgi?id=304091</a>
<a href="https://rdar.apple.com/166322852">rdar://166322852</a>

Reviewed by Brent Fulgham and Ryosuke Niwa.

301471@main made FontFaceSet promises work, but broke replay.music.apple.com which also requires
`loadingdone` events firing.

To fix this we need to implement more of the CSS Fonts Loading spec, specifically firing
`loadingdone` and `loadingerror` events, which has a `fontfaces` property. For this we need
an `Event` subclass, and FontFaceSetLoadEventInit per spec, so add IDL and implementations
for those. FontFaceSetLoadEvent has `JSCustomMarkFunction` and implements `visitAdditionalChildren`
to keep the referenced FontFaces alive.

The spec is rather confused[2] about the timing of event firing, but match the other browsers
by firing events before the promise resolves. Because this can happen during layout as
a result of font fallback, we need to run both the event dispatch and promise resolution
in a queued task. This also requires that `FontFaceSet` maintains the LoadingStatus, because
its state changes in queued tasks, which CSSFontFaceSet knows nothing about. The status
also depends on the contents of the `loadingFonts` list; `FontFaceSet` now maintains
the three font lists per spec.

We now eagerly create FontFace wrappers for CSSFontFace objects, since we add them
to the `loading` and `loadingdone` events anyway.

FontFaceSetLoadEvents are treated as opaque roots for GC, so they keep the FontFaces alive.

Explicitly prevent FontFaces from moving between documents by throwing a `WrongDocumentError`,
since this didn&apos;t really work, and it&apos;s complex to move the FontFace&apos;s Sources to the new document
and keep everything working. This follows my proposal in [3], and a tentative WPT is added for it.

Implement more of the spec language, around &quot;switch the state to loading/loaded&quot;,
and &quot;stuck on the environment&quot;. fast/text/font-loading-multiple-sets.html needs to work
around webkit.org/b/304381 to avoid remaining stuck.

Add a test which loads a font from an ArrayBuffer, and fix `FontFace::create()` to correctly
queue a task for this, which ensures we fire the loading event, which we did not before.

Some of this is based on code written by Frédéric Wang in webkit.org/b/184138.

[1] <a href="https://www.w3.org/TR/css-font-loading/">https://www.w3.org/TR/css-font-loading/</a>
[2] <a href="https://github.com/w3c/csswg-drafts/issues/13209">https://github.com/w3c/csswg-drafts/issues/13209</a>
[3] <a href="https://github.com/w3c/csswg-drafts/issues/13251">https://github.com/w3c/csswg-drafts/issues/13251</a>

Tests: imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer.html
       imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events.html
       imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative.html

* LayoutTests/fast/text/FontFaceSet-status-after-style-update-expected.txt:
* LayoutTests/fast/text/FontFaceSet-status-after-style-update.html:
* LayoutTests/fast/text/css-font-loading-arraybuffer-expected.txt:
* LayoutTests/fast/text/css-font-loading-arraybuffer.html:
* LayoutTests/fast/text/font-face-set-javascript.html:
* LayoutTests/fast/text/font-loading-multiple-documents.html:
* LayoutTests/fast/text/font-loading-multiple-sets.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events-font-from-arraybuffer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loading-events.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-add-css-connected-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/moving-fontface-between-document-throws.tentative.html: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp: Added.
(WebCore::JSFontFaceSetLoadEvent::visitAdditionalChildren):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::existingWrapper const):
(WebCore::CSSFontFace::fontLoaded):
(WebCore::CSSFontFace::load):
(WebCore::CSSFontFace::existingWrapper): Deleted.
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::incrementActiveCount):
(WebCore::CSSFontFaceSet::decrementActiveCount):
(WebCore::CSSFontFaceSet::add):
(WebCore::CSSFontFaceSet::remove):
(WebCore::CSSFontFaceSet::clear):
(WebCore::CSSFontFaceSet::fontStateChanged):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create):
(WebCore::root):
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::Iterator::Iterator):
(WebCore::FontFaceSet::Iterator::next):
(WebCore::FontFaceSet::PendingPromise::PendingPromise):
(WebCore::FontFaceSet::create):
(WebCore::FontFaceSet::FontFaceSet):
(WebCore::FontFaceSet::setInitialState):
(WebCore::FontFaceSet::documentDidFinishLoading):
(WebCore::FontFaceSet::isPendingOnEnvironment const):
(WebCore::FontFaceSet::stopPendingOnEnvironment):
(WebCore::FontFaceSet::clear):
(WebCore::FontFaceSet::load):
(WebCore::FontFaceSet::faceDidStartLoading):
(WebCore::FontFaceSet::faceDidFinishLoading):
(WebCore::FontFaceSet::didAddFace):
(WebCore::FontFaceSet::didDeletedFace):
(WebCore::FontFaceSet::startedLoading):
(WebCore::FontFaceSet::completedLoading):
(WebCore::FontFaceSet::switchStateToLoading):
(WebCore::FontFaceSet::switchStateToLoaded):
(WebCore::FontFaceSet::status const): Deleted.
(WebCore::FontFaceSet::faceFinished): Deleted.
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/FontFaceSetLoadEvent.cpp: Added.
(WebCore::FontFaceSetLoadEvent::FontFaceSetLoadEvent):
* Source/WebCore/css/FontFaceSetLoadEvent.h: Added.
* Source/WebCore/css/FontFaceSetLoadEvent.idl:
* Source/WebCore/css/FontFaceSetLoadEventInit.h: Added.
* Source/WebCore/css/FontFaceSetLoadEventInit.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
* Source/WebCore/dom/EventInterfaces.in:

Canonical link: <a href="https://commits.webkit.org/305367@main">https://commits.webkit.org/305367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea90243b7f5c74319eb44e42afa22ff1facdde1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138224 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b25c7ee0-8d06-4727-acd8-9c221e988496) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8450 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1be88b6b-dfb7-4ffa-8426-b62508081524) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8044 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5810 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6585 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117455 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/42118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149012 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10271 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8012 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65008 "Hash dea90243 for PR 55333 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10318 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10049 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->