### PR TITLE
ASAN_ILL | WTF::HashTable::contains; WebCore::RenderBlockFlow::subtreeContainsFloat; WebCore::RenderBlockFlow::markAllDescendantsWithFloatsForLayout

### DIFF
--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2-expected.txt
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2.html
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", _ => {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    container.appendChild(marquee);
+    details.open = false;
+    document.body.scrollHeight;
+    img.align = "top";
+    details.open = true;
+    document.body.scrollHeight;
+
+    document.body.innerHTML = "PASS if no crash.";
+    window.testRunner?.notifyDone();
+  });
+</script>
+<body>
+  <div style="float: left">floating</div>
+  <img id="img" border="100" align="right"></img>
+  <div id="container"></div>
+  <div>
+    <details id="details" open="">
+      <div><marquee id="marquee"><embed></marquee></div>
+    </details>
+  </div>
+</body>

--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3-expected.txt
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3.html
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC><!-- quirks mode -->
+<style>
+  .float { float: left; }
+  #div2 { min-height: 51%;  }
+  #canvas { max-width: 1em; }
+  #header { padding-bottom: 35%; }
+</style>
+<div class="float">
+  <span>
+    <div id="div1"></div>
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    <h1 id="header"><div id="div2" class="float"></div></h1>
+    <canvas id="canvas"></canvas>
+    <details id="details" open>
+      <span class="float"></span>
+    </details>
+  </span>
+</div>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  details.addEventListener("toggle", _ => {
+    details.open = false;
+    canvas.width = 1;
+    document.body.scrollLeft;
+    div1.setAttribute("hidden", "hidden");
+    document.body.innerHTML = "PASS if no crash.";
+    window.testRunner?.notifyDone();
+  }, {once: true});
+</script>

--- a/LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash-expected.txt
+++ b/LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash-expected.txt
@@ -1,0 +1,1 @@
+ PASS if no crash.

--- a/LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash.html
+++ b/LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash.html
@@ -1,0 +1,10 @@
+<style>
+textarea::placeholder { position: absolute; }
+*:empty { color: blue; }
+</style>
+<script>
+  testRunner?.dumpAsText();
+</script>
+<textarea placeholder="foo">
+</textarea>
+<audio controls=""></audio>PASS if no crash.

--- a/LayoutTests/fast/misc/event-region-with-prohibited-frame-expected.txt
+++ b/LayoutTests/fast/misc/event-region-with-prohibited-frame-expected.txt
@@ -1,0 +1,1 @@
+ PASS if no crash or assert.

--- a/LayoutTests/fast/misc/event-region-with-prohibited-frame.html
+++ b/LayoutTests/fast/misc/event-region-with-prohibited-frame.html
@@ -1,0 +1,19 @@
+<style>
+  video { transform: rotateX(0deg); -webkit-writing-mode: vertical-lr; }
+</style>
+<script>
+  testRunner?.dumpAsText();
+  function runTest() {
+    video.poster = + "foo";
+    video.scrollIntoViewIfNeeded();
+    iframe.src = document.createElement("base").href;
+  }
+</script>
+<body onload=runTest() onwheel="foo()">
+  <video id="video" ></video>
+  <dialog>
+    <iframe id="iframe"></iframe>
+  </dialog>
+PASS if no crash or assert.
+</body>
+

--- a/LayoutTests/fast/text/text-wrap-no-hyphenation-crash-expected.txt
+++ b/LayoutTests/fast/text/text-wrap-no-hyphenation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/text/text-wrap-no-hyphenation-crash.html
+++ b/LayoutTests/fast/text/text-wrap-no-hyphenation-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+#container {
+  text-transform: full-width;
+  text-wrap: pretty;
+  width: 785px;
+  font: 16px/1 "PingFang SC";
+}
+</style>
+<div id="container">AB<span>AAAAAAAA</span><br/><span style="padding-right: 580px">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</span><span style="padding-right: 80px">AAAAAAA</span>ABAB</div>
+<script>
+window.testRunner?.dumpAsText();
+document.execCommand("selectAll",false,null);
+document.body.innerHTML = "PASS if no crash.";
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -736,6 +736,7 @@ textarea {
     pointer-events: none !important;
     text-orientation: inherit !important;
     writing-mode: inherit !important;
+    position: static !important;
 }
 
 input::placeholder {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -644,6 +644,9 @@ std::optional<Vector<LayoutUnit>> InlineContentConstrainer::prettifyRange(Inline
                 return { };
             lastValidStateIndex = std::distance(breakOpportunities.begin(), it);
             state[lastValidStateIndex.value()] = newEntry;
+            // If hyphenation does not create a valid solution, we should return early.
+            if (lastValidStateIndex.value() == state[lastValidStateIndex.value()].previousBreakIndex)
+                return { };
         }
 
         // Evaluate all possible lines that break before m_inlineItemList[end]

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2378,7 +2378,7 @@ bool RenderBlockFlow::subtreeContainsFloat(const RenderBox& renderer) const
     if (containsFloat(renderer))
         return true;
 
-    for (auto& blockFlow : childrenOfType<RenderBlockFlow>(*this)) {
+    for (auto& blockFlow : descendantsOfType<RenderBlockFlow>(*this)) {
         if (blockFlow.containsFloat(renderer))
             return true;
     }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1017,6 +1017,10 @@ void RenderLayerCompositor::updateEventRegionsRecursive(RenderLayer& layer)
 
 void RenderLayerCompositor::updateEventRegions()
 {
+    bool isProhibitedFrame = m_renderView.document().ownerElement() && !m_renderView.document().ownerElement()->renderer();
+    if (isProhibitedFrame)
+        return;
+
     updateEventRegionsRecursive(*m_renderView.layer());
     m_renderView.setNeedsEventRegionUpdateForNonCompositedFrame(false);
 }


### PR DESCRIPTION
#### b26db034dbb9667f6ff3fe208bdded1a238bed9a
<pre>
ASAN_ILL | WTF::HashTable::contains; WebCore::RenderBlockFlow::subtreeContainsFloat; WebCore::RenderBlockFlow::markAllDescendantsWithFloatsForLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=298924">https://bugs.webkit.org/show_bug.cgi?id=298924</a>
<a href="https://rdar.apple.com/158670568">rdar://158670568</a>

Reviewed by Alan Baradlay.

Add a non-regression test. This was originally fixed in
<a href="https://commits.webkit.org/297297.12@webkit-2025.7-embargoed">https://commits.webkit.org/297297.12@webkit-2025.7-embargoed</a>

* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3-expected.txt: Added.
* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts3.html: Added.

Originally-landed-as: 297297.13@webkit-2025.7-embargoed (8edee3d73524). <a href="https://rdar.apple.com/166339455">rdar://166339455</a>
Canonical link: <a href="https://commits.webkit.org/304401@main">https://commits.webkit.org/304401@main</a>
</pre>
----------------------------------------------------------------------
#### 674e82d6f06194a66bce51a7a2cf2246143de348
<pre>
ASAN_ILL | WebCore::FloatingObject::renderer; WebCore::RenderBlockFlow::styleDidChange; WebCore::RenderElement::setStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=298926">https://bugs.webkit.org/show_bug.cgi?id=298926</a>
<a href="https://rdar.apple.com/158670568">rdar://158670568</a>

Reviewed by Alan Baradlay.

In the test case some layout is skipped due to the details open attribute and later toggled
to unskip it. The skipped subtree has some FloatingObjects and when the img get recreated
by the RenderTreeUpdater some of those FloatingObjects will have a null renderer (to said img renderer).
Since 295699@main RenderBlockFlow::subtreeContainsFloat uses childrenOfType so not all descendents
are being searched, in the test case the slot element and its child are not found, leaving those FloatingObjects with
destroyed renderers and crashing when iterating over them in rebuildFloatingObjectSetFromIntrudingFloats.

To fix this revert to using descendantsOfType instead of childrenOfType.

* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2-expected.txt: Added.
* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts2.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::subtreeContainsFloat const):

Originally-landed-as: 297297.12@webkit-2025.7-embargoed (59c02d213d27). <a href="https://rdar.apple.com/166339757">rdar://166339757</a>
Canonical link: <a href="https://commits.webkit.org/304400@main">https://commits.webkit.org/304400@main</a>
</pre>
----------------------------------------------------------------------
#### 1103435b51050d0ab363cca7a7dcccea834ed4fc
<pre>
ASAN_ILL | Layout::InlineContentConstrainer::prettifyRange; Layout::InlineContentConstrainer::computeParagraphLevelConstraints; Layout::InlineFormattingContext::layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=296871">https://bugs.webkit.org/show_bug.cgi?id=296871</a>
<a href="https://rdar.apple.com/157025106">rdar://157025106</a>

Reviewed by Alan Baradlay.

In InlineContentConstrainer::prettifyRange, if the hyphenation step does
not yield a new lastValidStateIndex, treat that as hyphenation not creating
a valid solution, since continuing would result in assertion failure.

* LayoutTests/fast/text/text-wrap-no-hyphenation-crash-expected.txt: Added.
* LayoutTests/fast/text/text-wrap-no-hyphenation-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::prettifyRange):

Originally-landed-as: 297297.11@webkit-2025.7-embargoed (c18e654b85ca). <a href="https://rdar.apple.com/166339734">rdar://166339734</a>
Canonical link: <a href="https://commits.webkit.org/304399@main">https://commits.webkit.org/304399@main</a>
</pre>
----------------------------------------------------------------------
#### ae55f8de6bea6fdebe67c3abb52f9b572c59e2a0
<pre>
ASAN_ILL | WebCore::LocalFrameViewLayoutContext::performLayout; WebCore::LocalFrameViewLayoutContext::layout; WebCore::Document::updateLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=298078">https://bugs.webkit.org/show_bug.cgi?id=298078</a>
<a href="https://rdar.apple.com/157023263">rdar://157023263</a>

Reviewed by Alan Baradlay.

The placeholder text in the RenderTextControl is treated as excluded content and uses special
layout logic. This special layout logic does not consider that the placeholder can be absolutely
positioned like in the testcase, resulting in a render tree that ends up being dirty.

To prevent this problem, do not allow position values other than the default &apos;static&apos;, which
actually matches the specification [1], since it states a limited number of properties apply
to the ::placeholder pseudo-element, which does not include the position property.

[1] <a href="https://drafts.csswg.org/css-pseudo/#placeholder-pseudo">https://drafts.csswg.org/css-pseudo/#placeholder-pseudo</a>

* LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash-expected.txt: Added.
* LayoutTests/fast/forms/textarea-with-absolute-placeholder-crash.html: Added.
* Source/WebCore/css/html.css:
(::placeholder):

Originally-landed-as: 297297.10@webkit-2025.7-embargoed (b4e1ccfd7e27). <a href="https://rdar.apple.com/166339811">rdar://166339811</a>
Canonical link: <a href="https://commits.webkit.org/304398@main">https://commits.webkit.org/304398@main</a>
</pre>
----------------------------------------------------------------------
#### df20d570f133c81f92690d9744440b4ea29d5cfd
<pre>
ASAN_ILL | LayoutIntegration::LineLayout::paint; WebCore::RenderLayer::collectEventRegionForFragments; WebCore::RenderLayer::paintLayerContents
<a href="https://bugs.webkit.org/show_bug.cgi?id=296870">https://bugs.webkit.org/show_bug.cgi?id=296870</a>
<a href="https://rdar.apple.com/157023591">rdar://157023591</a>

Reviewed by Simon Fraser.

The test case contains a subframe that starts self referencing. Such subframes
are being prohibited and not guaranteed to have a laid out rendering tree. So
in that case prevent event region collecting since that would lead to various ASSERTs.

* LayoutTests/fast/misc/event-region-with-prohibited-frame-expected.txt: Added.
* LayoutTests/fast/misc/event-region-with-prohibited-frame.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateEventRegions):

Originally-landed-as: 297297.9@webkit-2025.7-embargoed (544f117e7985). <a href="https://rdar.apple.com/166339926">rdar://166339926</a>
Canonical link: <a href="https://commits.webkit.org/304397@main">https://commits.webkit.org/304397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37e812d2d1c224278e6b7fdcab35518a4f320e86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c44382cd-4873-47bc-ae7d-de758b037ca7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e66bddb0-6b56-4f2f-aabe-315dfcf9edff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/274cbcce-fa48-499b-8447-3b9c22fc1b5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3452 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3747 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145891 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111876 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5696 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61400 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7558 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35818 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->