### PR TITLE
[JSC] DataViewGetByteLength resizable-array path is not setting OSR exit correctly

### DIFF
--- a/JSTests/stress/data-view-byte-length-oob-exit.js
+++ b/JSTests/stress/data-view-byte-length-oob-exit.js
@@ -1,0 +1,18 @@
+const crash_point= 0x41414141;
+const loop_start = crash_point&0xffffff00;
+const loop_end   = crash_point+1;
+for (let i=0; i<5000; i++){
+    const get_byte_length = arr => arr.byteLength;
+    const ab = new ArrayBuffer(99, {maxByteLength: 99});
+    const dv = new DataView(ab, 1, 44);
+    for (let counter = loop_start; counter < loop_end; counter++) {
+        if (counter == loop_end-2) {
+          ab.resize(1);
+          get_byte_length(1);
+        }else{
+          try {
+            get_byte_length(dv);
+          } catch (e) {}
+        }
+    }
+}

--- a/JSTests/wasm/stress/i32-multivalue-truncate.js
+++ b/JSTests/wasm/stress/i32-multivalue-truncate.js
@@ -1,0 +1,38 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+const wat = `
+(module
+  ;; Import JS function that returns two i32 values (to trigger multi-value path)
+  (import "imports" "getTwoI32s" (func $getTwoI32s (result i32 i32)))
+
+  (memory (export "memory") 1)
+
+  (func (export "testDirectMemoryAccess") (result i32)
+    call $getTwoI32s
+    drop  ;; drop second value
+    i32.load8_u  ;; use first value directly as offset
+  )
+)
+`;
+
+async function test() {
+    function getTwoI32s() {
+        return [-1, 99];  // First is -1, second is dummy to force multi-value result path
+    }
+
+    let instance = await instantiate(wat, { imports: { getTwoI32s: getTwoI32s }});
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        let trapped = false;
+        try {
+            instance.exports.testDirectMemoryAccess();
+        } catch (e) {
+            trapped = true;
+            assert.truthy(e instanceof WebAssembly.RuntimeError);
+        }
+        assert.truthy(trapped, "Expected trap for -1 used as memory offset");
+    }
+}
+
+await assert.asyncTest(test());

--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4-expected.txt
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4.html
+++ b/LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+#container, #iframe, object, summary {
+ float: right;
+}
+summary {
+  animation-duration: 300ms;
+  animation-name: keyframesBorder;
+}
+@keyframes keyframesBorder {
+  0% { border: solid }
+  100% { border: none; }
+}
+</style>
+<div id="container"><audio controls></audio><iframe id="iframe" width="0"></iframe><br/><object data="invalid"></object><br/>A<details id="details" open><summary></summary></details></div>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  details.addEventListener("toggle", _ => {
+    details.open = false;
+    iframe.remove();
+  }, {once: true});
+  window.addEventListener("animationend", _ => {
+    document.body.innerHTML = "PASS if no crash.";
+    window.testRunner?.notifyDone();
+  });
+</script>

--- a/LayoutTests/ipc/convert-to-luminance-mask-float16-expected.txt
+++ b/LayoutTests/ipc/convert-to-luminance-mask-float16-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/convert-to-luminance-mask-float16.html
+++ b/LayoutTests/ipc/convert-to-luminance-mask-float16.html
@@ -1,0 +1,50 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const streamConnection = CoreIPC.newStreamConnection();
+
+    const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+    const contextIdentifier = Math.floor(Math.random() * 0x1000000);
+    remoteRenderingBackend.CreateImageBuffer({
+        logicalSize : { width : 3.231004106349356e-28, height : 1.401298464e-45 },
+        renderingMode : 0,
+        renderingPurpose : 7,
+        resolutionScale : 3.650556716916852e+32,
+        colorSpace : { serializableColorSpace : { alias : { m_cgColorSpace : { alias : { variantType : 'WebCore::ColorSpace', variant : 17 } } } } },
+        bufferFormat : { pixelFormat : 3, useLosslessCompression : 0 },
+        identifier: imageBufferIdentifier,
+        contextIdentifier: contextIdentifier
+    });
+
+    const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+    remoteImageBuffer.ConvertToLuminanceMask({});
+
+    streamConnection.connection.invalidate();
+
+    // Allow some time for the GPUP to receive the ConvertToLuminanceMask message, otherwise we can finish
+    // the test before we detect a possible GPUP crash.
+    setTimeout(() => {
+        window.testRunner?.notifyDone();
+    }, 500);
+}, 20);
+
+</script>
+
+This test passes if WebKit does not crash.

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1413,7 +1413,7 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyInstance* 
         const auto& returnType = signature->returnType(index);
         switch (returnType.kind) {
         case TypeKind::I32:
-            unboxedValue = value.toInt32(globalObject);
+            unboxedValue = static_cast<uint32_t>(value.toInt32(globalObject));
             break;
         case TypeKind::I64:
             unboxedValue = value.toBigInt64(globalObject);

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -285,7 +285,7 @@ void IDBTransaction::abortInProgressOperations(const IDBError& error)
     m_transactionOperationsInProgressQueue.clear();
 
     for (auto& operation : inProgressAbortVector) {
-        m_transactionOperationsInProgressQueue.append(operation.get());
+        m_transactionOperationsInProgressQueue.append(operation);
         m_currentlyCompletingRequest = nullptr;
         operation->doComplete(IDBResultData::error(operation->identifier(), error));
     }

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -258,7 +258,7 @@ private:
     WeakHashSet<IDBRequest, WeakPtrImplWithEventTargetData> m_cursorRequests;
 
     Deque<RefPtr<IDBClient::TransactionOperation>> m_pendingTransactionOperationQueue;
-    Deque<IDBClient::TransactionOperation*> m_transactionOperationsInProgressQueue;
+    Deque<RefPtr<IDBClient::TransactionOperation>> m_transactionOperationsInProgressQueue;
     Deque<RefPtr<IDBClient::TransactionOperation>> m_abortQueue;
     HashMap<RefPtr<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
     HashMap<IDBResourceIdentifier, RefPtr<IDBClient::TransactionOperation>> m_transactionOperationMap;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -28,6 +28,7 @@
 
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
+#include "Logging.h"
 #include "NativeImage.h"
 #include "PixelBuffer.h"
 #include "PixelBufferConversion.h"
@@ -72,7 +73,14 @@ RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
     return createNativeImageReference();
 }
 
-void ImageBufferBackend::convertToLuminanceMask()
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+void ImageBufferBackend::convertToLuminanceMaskFloat16()
+{
+    LOG(Images, "convertToLuminanceMask() is not implemented for Float16 ImageBuffers.");
+}
+#endif
+
+void ImageBufferBackend::convertToLuminanceMaskUint8()
 {
     IntRect sourceRect { { }, size() };
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace() };
@@ -95,6 +103,16 @@ void ImageBufferBackend::convertToLuminanceMask()
     }
 
     putPixelBuffer(*pixelBuffer, sourceRect, IntPoint::zero(), AlphaPremultiplication::Premultiplied);
+}
+
+void ImageBufferBackend::convertToLuminanceMask()
+{
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat() == PixelFormat::RGBA16F)
+        convertToLuminanceMaskFloat16();
+    else
+#endif
+        convertToLuminanceMaskUint8();
 }
 
 void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, std::span<const uint8_t> sourceData, PixelBuffer& destinationPixelBuffer)

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -184,6 +184,11 @@ protected:
     const DestinationColorSpace& colorSpace() const { return m_parameters.colorSpace; }
     PixelFormat pixelFormat() const { return m_parameters.bufferFormat.pixelFormat; }
 
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    void convertToLuminanceMaskFloat16();
+#endif
+    void convertToLuminanceMaskUint8();
+
     WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, std::span<const uint8_t> data, PixelBuffer& destination);
     WEBCORE_EXPORT void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, std::span<uint8_t> destination);
 


### PR DESCRIPTION
#### ef1aba9e847aa7b67170048992bdfee68855728e
<pre>
[JSC] DataViewGetByteLength resizable-array path is not setting OSR exit correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=301257">https://bugs.webkit.org/show_bug.cgi?id=301257</a>
<a href="https://rdar.apple.com/160383983">rdar://160383983</a>

Reviewed by Tadeu Zagallo.

There are two issues in the implementation of resizable-array-accepting
DataViewGetByteLength. This is because this node is specially doing OSR
exit from a patchpoint. And other patchpoints are typically (1) not
having a result value and not having a complicated computation or (2)
OSR exits only when exception is thrown and exception-related-OSR-exit
is handled in a different way. This patch fixes DataViewGetByteLength
patchpoint by introducing two changes.

1. resultGPR can be modified before jumping to OSR exit. This is
   problematic since OSR exit&apos;s stackmap is capturing what we see before
   this patchpoint starts. We should def the result only after ensuring
   that we will not do OSR exit. This patch adds one scratch register
   and storing a result to that. And after OSR exit check is done, we
   move it to the resultGPR.
2. osrExitArgumentOffset is not correct as it requires result value
   offset. Adding +1 to that offset.

Test: JSTests/stress/data-view-byte-length-oob-exit.js

* JSTests/stress/data-view-byte-length-oob-exit.js: Added.
(i.counter.else.catch):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::typedArrayLength):

Originally-landed-as: 301765.85@safari-7623-branch (2432c9cc358a). <a href="https://rdar.apple.com/166338914">rdar://166338914</a>
Canonical link: <a href="https://commits.webkit.org/304411@main">https://commits.webkit.org/304411@main</a>
</pre>
----------------------------------------------------------------------
#### 9326bbd1cf1f7d3af0490338a98d1cf6544ad725
<pre>
Fix use-after-free in IDBTransaction::abortInProgressOperations
<a href="https://rdar.apple.com/161012400">rdar://161012400</a>

Reviewed by Per Arne Vollan.

Recent crashes indicate that the objects in m_transactionOperationsInProgressQueue are already freed when we try to
create RefPtr from them in IDBTransaction::abortInProgressOperations. To fix this, store RefPtr in
m_transactionOperationsInProgressQueue.

* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::abortInProgressOperations):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:

Originally-landed-as: 301765.81@safari-7623-branch (c819f0eceb0a). <a href="https://rdar.apple.com/166339113">rdar://166339113</a>
Canonical link: <a href="https://commits.webkit.org/304410@main">https://commits.webkit.org/304410@main</a>
</pre>
----------------------------------------------------------------------
#### e03b456698eabb3dcd7ba3ae9ba6bf18cd767b1a
<pre>
[JSC] operationIterateResults needs to truncate i32 results
<a href="https://bugs.webkit.org/show_bug.cgi?id=301211">https://bugs.webkit.org/show_bug.cgi?id=301211</a>
<a href="https://rdar.apple.com/153280651">rdar://153280651</a>

Reviewed by Daniel Liu.

BBQ expects that values are truncated to their proper size when
producing the value. When converting from JS signed 32-bits to
wasm i32, should be zero extending rather than sign extending.

Test: JSTests/wasm/stress/i32-multivalue-truncate.js
* JSTests/wasm/stress/i32-multivalue-truncate.js: Added.
(async test.getTwoI32s):
(async test):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Originally-landed-as: 301765.80@safari-7623-branch (dad39caa1d1c). <a href="https://rdar.apple.com/166339272">rdar://166339272</a>
Canonical link: <a href="https://commits.webkit.org/304409@main">https://commits.webkit.org/304409@main</a>
</pre>
----------------------------------------------------------------------
#### a351a136f1247124fe9b48b5cc7e1ffd43549871
<pre>
[CoreIPC] convertToLuminanceMask() is not ready to work in backend with RGBA16F pixel format
<a href="https://bugs.webkit.org/show_bug.cgi?id=300049">https://bugs.webkit.org/show_bug.cgi?id=300049</a>
<a href="https://rdar.apple.com/161079211">rdar://161079211</a>

Reviewed by Gerald Squelart.

CoreIPC can create a RemoteImageBuffer with RGBA16F pixel format then it can call
convertToLuminanceMask() for it. Currently convertToLuminanceMask() calculates
four bytes per pixel. It also deals with standard colorSpace which assumes all
the channels range from 0 to 1.

The fix is convertToLuminanceMask() should work only for 4-bytes buffers for now.

Test: ipc/convert-to-luminance-mask-float16.html
* LayoutTests/ipc/convert-to-luminance-mask-float16-expected.txt: Added.
* LayoutTests/ipc/convert-to-luminance-mask-float16.html: Added.
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::convertToLuminanceMaskFloat16):
(WebCore::ImageBufferBackend::convertToLuminanceMaskUint8):
(WebCore::ImageBufferBackend::convertToLuminanceMask):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:

Originally-landed-as: 301765.69@safari-7623-branch (dd5d2b7d6a4c). <a href="https://rdar.apple.com/166339235">rdar://166339235</a>
Canonical link: <a href="https://commits.webkit.org/304408@main">https://commits.webkit.org/304408@main</a>
</pre>
----------------------------------------------------------------------
#### 943cd9fd9d909a4019f4d840fdda8619bd611358
<pre>
Bug 300371 [WebKit][Main+SU?] [e4d4086839401519] ASAN_ILL | WTF::HashTable::lookup; WebCore::RenderBlockFlow::layoutBlockChildren; WebCore::RenderBlockFlow::layoutBlock
<a href="https://rdar.apple.com/162032638">rdar://162032638</a>

Reviewed by Alan Baradlay.

Skipped root/subtree may not have their m_floatingObjects up-to-date.
In particular this set may contain dangling pointer to destroyed renderers
causing some null pointer dereference when marking siblings/descendants
with floats for layout. This patch fixes that using the logic of (*):
we always enter skipped root/subtree when marking for layout and at the
same time skip calls to containsFloat()/removeFloatingBox().

(*) <a href="https://commits.webkit.org/293889@main.">https://commits.webkit.org/293889@main.</a>

* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4-expected.txt: Added.
* LayoutTests/fast/dynamic/stale-floating-state-after-skipped-layouts4.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::isSkippedContentRootOrSkippedContent): New helper method to test both skipped content root and subtree.
(WebCore::RenderBlockFlow::layoutBlockChildren): Force to descend into the subtree for skipped root/subtree and don&apos;t call containsFloat() on a possible dirty m_floatingObjects.
(WebCore::RenderBlockFlow::markAllDescendantsWithFloatsForLayout): Don&apos;t call removeFloatingBox() on a possibly dirty m_floatingObjects.
Instead mark the renderer as skipped during layout so that it will be rebuilt later.
Force to descend into the subtree for skipped root/subtree.
(WebCore::RenderBlockFlow::markSiblingsWithFloatsForLayout): Rewrite the code from (*) using the new helper.

Originally-landed-as: 297297.14@webkit-2025.7-embargoed (e26b1271204e). <a href="https://rdar.apple.com/166339384">rdar://166339384</a>
Canonical link: <a href="https://commits.webkit.org/304407@main">https://commits.webkit.org/304407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287a3a861ba124a0218eb9fb88b3300dd1f7a4f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87140 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de8df8ed-b6ca-4479-ad19-ed414ef76c5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103508 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3bd8f8c5-dd94-4f3b-a51c-e38bc26bd98b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6bb474f2-f5d6-400a-ace5-e7392d93c23a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3453 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3749 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127440 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133929 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7533 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111877 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/134872 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5699 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61401 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7560 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35820 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71107 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7526 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->