### PR TITLE
[appearance: base] Add default `base` properties for checkbox and radio button in UA style sheet

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
@@ -1,24 +1,23 @@
-<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <style>
     input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 200px;
+        height: 200px;
         font: 11px system-ui;
-        height: -internal-auto-base(unset, 2em);
-        width: -internal-auto-base(unset, 2em);
-        border: -internal-auto-base(unset, 0.3em solid currentColor);
-        background-color: -internal-auto-base(unset, transparent);
+        border: 0.3em solid currentColor;
     }
 
-    input:is([type=checkbox]:not([switch])) {
-        border-radius: -internal-auto-base(unset, 0.5em);
+    input[type="checkbox"] {
+        border-radius: 0.5em;
     }
 
-    input[type=radio] {
-        border-radius: -internal-auto-base(unset, 100%);
+    input:is([type="checkbox"], [type="radio"]):disabled {
+        border-color: color-mix(in srgb, currentColor 30%, transparent);
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
     }
 
-    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
-        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
-        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
+        background-color: color-mix(in srgb, currentColor 30%, transparent);
     }
 
     .enabled input:is([type=checkbox]:not([switch]), [type=radio]) {
@@ -27,12 +26,6 @@
 
     .disabled input:is([type=checkbox]:not([switch]), [type=radio]) {
         color: darkgreen;
-    }
-
-    input:is([type=checkbox]:not([switch]), [type=radio]) {
-        appearance: base;
-        width: 200px;
-        height: 200px;
     }
 </style>
 <body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
@@ -1,25 +1,19 @@
-<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <style>
-    /* This is supposed to be UA sheet. */
     input:is([type="radio"], [type="checkbox"]) {
         margin: 3px 2px;
         box-sizing: border-box;
-        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        border: 0.3em solid currentColor;
         padding: initial;
-        background-color: -internal-auto-base(initial, transparent);
-    }
-
-    input:is([type=checkbox]:not([switch])) {
-        border-radius: -internal-auto-base(unset, 0.5em);
+        background-color: transparent;
     }
 
     input[type=radio] {
-        border-radius: -internal-auto-base(unset, 100%);
+        border-radius: 50%;
     }
 
     input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
-        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
-        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+        border-color: color-mix(in srgb, currentColor 30%, transparent);
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
@@ -42,7 +36,6 @@
         background-color: color-mix(in srgb, currentColor 30%, transparent);
     }
 
-    /* This is the beginning of the author sheet. */
     input:is([type=checkbox]:not([switch]), [type=radio]) {
         width: 50px;
         height: 50px;

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
@@ -1,38 +1,26 @@
-<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1330" />
 <style>
-    /* This is supposed to be UA sheet. */
-    input:is([type="radio"], [type="checkbox"]) {
-        margin: 3px 2px;
-        box-sizing: border-box;
-        border: -internal-auto-base(initial, 0.3em solid currentColor);
-        padding: initial;
-        background-color: -internal-auto-base(initial, transparent);
-    }
-
-    input:is([type=checkbox]:not([switch])) {
-        border-radius: -internal-auto-base(unset, 0.5em);
-    }
-
-    input[type=radio] {
-        border-radius: -internal-auto-base(unset, 100%);
-    }
-
-    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
-        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
-        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        width: 50px;
+        height: 50px;
+        color: darkgreen;
+        font: 11px system-ui;
+        border: 0.3em solid currentColor;
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
         height: 100%;
         width: 100%;
-        display: inline-block;
-        background-color: currentColor;
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
     }
 
     input[type=radio]:checked::checkmark {
-        background-color: currentColor;
-        display: inline-block;
-        border-radius: inherit;
         margin: 10%;
         height: 80%;
         width: 80%;
@@ -40,25 +28,6 @@
 
     input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
         background-color: color-mix(in srgb, currentColor 30%, transparent);
-    }
-
-    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
-        display: none;
-    }
-
-    /* This is the beginning of the author sheet. */
-    input:is([type=checkbox]:not([switch]), [type=radio]) {
-        width: 50px;
-        height: 50px;
-        color: darkgreen;
-    }
-
-    input[type=checkbox]:not([switch]):checked::checkmark {
-        mask: url("data:image/svg+xml, \
-            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
-                <path style='fill:black;' \
-                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
-            </svg>");
     }
 </style>
 <body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
@@ -1,39 +1,35 @@
-<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-2486" />
 <style>
-    /* This is supposed to be UA sheet. */
-    input:is([type="radio"], [type="checkbox"]) {
-        margin: 3px 2px;
-        box-sizing: border-box;
-        border: -internal-auto-base(initial, 0.3em solid currentColor);
-        padding: initial;
-        background-color: -internal-auto-base(initial, transparent);
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 50px;
+        height: 50px;
+        font: 11px system-ui;
+        border: 0.3em solid currentColor;
     }
 
-    input:is([type=checkbox]:not([switch])) {
-        border-radius: -internal-auto-base(unset, 0.5em);
+    input[type="checkbox"] {
+        border-radius: 0.5em;
     }
 
-    input[type=radio] {
-        border-radius: -internal-auto-base(unset, 100%);
-    }
-
-    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
-        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
-        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
+    input:is([type="checkbox"], [type="radio"]):disabled {
+        border-color: color-mix(in srgb, currentColor 30%, transparent);
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
         height: 100%;
         width: 100%;
-        display: inline-block;
-        background-color: currentColor;
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
     }
 
     input[type=radio]:checked::checkmark {
-        background-color: currentColor;
-        display: inline-block;
-        border-radius: inherit;
         margin: 10%;
         height: 80%;
         width: 80%;
@@ -41,26 +37,6 @@
 
     input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
         background-color: color-mix(in srgb, currentColor 30%, transparent);
-    }
-
-    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
-        display: none;
-    }
-
-    /* This is the beginning of the author sheet. */
-    input:is([type=checkbox]:not([switch]), [type=radio]) {
-        appearance: base;
-        width: 50px;
-        height: 50px;
-        font: 11px system-ui;
-    }
-
-    input[type=checkbox]:not([switch]):checked::checkmark {
-        mask: url("data:image/svg+xml, \
-            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
-                <path style='fill:black;' \
-                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
-            </svg>");
     }
 
     .container {

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -799,12 +799,14 @@ input:is([type="radio"], [type="checkbox"]) {
     box-sizing: border-box;
     border: initial;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    width: 16px;
-    height: 16px;
-    padding: 0px;
+    width: -internal-auto-base(16px, 1em);
+    height: -internal-auto-base(16px, 1em);
+    padding: -internal-auto-base(0px, unset);
     /* We want to be as close to background:transparent as possible without actually being transparent */
     background-color: rgba(255, 255, 255, 0.01);
 #else
+    width: -internal-auto-base(unset, 1em);
+    height: -internal-auto-base(unset, 1em);
     padding: initial;
     background-color: initial;
 #endif
@@ -819,6 +821,8 @@ input[type="checkbox"] {
 input[type="radio"] {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border-radius: 50%;
+#else
+    border-radius: -internal-auto-base(unset, 50%);
 #endif
 }
 
@@ -852,6 +856,22 @@ input:is([type="checkbox"], [type="radio"]):checked:disabled {
     opacity: initial;
     background: rgba(0, 0, 0, 0.8);
 #endif
+}
+
+input[type=checkbox]:not([switch]):checked::checkmark {
+    content: '\2713' / '';
+}
+
+input[type=radio]:checked::checkmark {
+    background-color: currentColor;
+    display: inline-block;
+    border-radius: inherit;
+    height: 100%;
+    width: 100%;
+}
+
+input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
+    display: none;
 }
 
 input:is([type="button"], [type="submit"], [type="reset"]) {


### PR DESCRIPTION
#### e71b8ba98c83ea0d254d3fbd2f8f1a5f8c8476f5
<pre>
[appearance: base] Add default `base` properties for checkbox and radio button in UA style sheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=304092">https://bugs.webkit.org/show_bug.cgi?id=304092</a>
<a href="https://rdar.apple.com/166415728">rdar://166415728</a>

Reviewed by Anne van Kesteren.

-internal-auto-base() can only be parsed in the UA style sheet. Adding conditional
properties to html.css will allow setting some of the CSS properties for checkbox
and radio button when they are styled with &quot;appearance: base&quot;.

Remove all `-internal-auto-base()` properties from the existing layout tests. No
need anymore to enable `CSSInternalAutoBaseParsingEnabled` in these layout tests.

Specs: <a href="https://www.w3.org/TR/css-forms-1/#stylesheet-checkbox-radio">https://www.w3.org/TR/css-forms-1/#stylesheet-checkbox-radio</a>

* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html:
* Source/WebCore/css/html.css:
(input:is([type=&quot;radio&quot;], [type=&quot;checkbox&quot;])):
(input[type=&quot;radio&quot;]):
(input[type=checkbox]:not([switch]):checked::checkmark):
(input[type=radio]:checked::checkmark):
(input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark):

Canonical link: <a href="https://commits.webkit.org/306540@main">https://commits.webkit.org/306540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3269fe51a8e06fbff36753ab9edb7c63bf736d8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150222 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/329b2f50-e2a5-4c6e-84ad-fa8337e2d568) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108845 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33748bb2-e011-4a1c-b299-1b44fba2403d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89745 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10941 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8579 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152615 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116945 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13301 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2769 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13502 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->