### PR TITLE
[libpas] fix lock-free reads of the medium directory tuple table

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2285,7 +2285,7 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
     {
         ConcurrentJSLocker locker(m_lock);
         forEachStructureStubInfo([&](StructureStubInfo& stubInfo) {
-            stubInfo.reset(locker, this);
+            stubInfo.deref();
             return IterationStatus::Continue;
         });
     }

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1225,6 +1225,10 @@ void MediaSource::detachFromElement()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    if (!m_isAttached) {
+        ASSERT(isClosed());
+        return;
+    }
     // 2.4.2 Detaching from a media element
     // https://rawgit.com/w3c/media-source/45627646344eea0170dd1cbc5a3d508ca751abb8/media-source-respec.html#mediasource-detach
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -810,6 +810,8 @@ HTMLMediaElement::~HTMLMediaElement()
     }
 
 #if ENABLE(MEDIA_SOURCE)
+    if (auto mediaProvider = std::exchange(m_mediaProvider, { }); mediaProvider && std::holds_alternative<RefPtr<MediaSource>>(*mediaProvider))
+        std::get<RefPtr<MediaSource>>(*mediaProvider)->elementIsShuttingDown();
     if (RefPtr mediaSource = std::exchange(m_mediaSource, { }))
         mediaSource->elementIsShuttingDown();
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1833,6 +1833,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
     pas_allocation_result result;
 
     PAS_TESTING_ASSERT(!allocator->scavenger_data.is_in_use);
+    PAS_TESTING_ASSERT(size <= allocator->object_size || !allocator->object_size);
 
     if (verbose) {
         pas_log("Allocator %p (%s) allocating size = %zu, alignment = %zu.\n",
@@ -1854,6 +1855,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
                     (void*)result.begin);
         }
     
+        PAS_TESTING_ASSERT(size <= allocator->object_size);
         return result_filter(
             pas_allocation_result_create_success_with_zero_mode(result.begin, result.zero_mode));
     }
@@ -1875,6 +1877,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
             allocator, allocation_mode, counts, result_filter);
         if (verbose)
             pas_log("in small segregated slow return - result.begin = %p\n", (void*)result.begin);
+        PAS_TESTING_ASSERT(size <= allocator->object_size);
         return result;
     }
 
@@ -1882,6 +1885,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
         allocator, size, alignment, allocation_mode, counts, result_filter);
     if (verbose)
         pas_log("in generic return - result.begin = %p\n", (void*)result.begin);
+    PAS_TESTING_ASSERT(size <= allocator->object_size);
     return result;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -344,7 +344,7 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
 }
 
 typedef struct {
-    pas_segregated_heap_medium_directory_tuple* tuple;
+    pas_segregated_heap_medium_directory_result value;
     uintptr_t dependency;
 } medium_directory_tuple_for_index_impl_result;
 
@@ -360,7 +360,7 @@ medium_directory_tuple_for_index_impl(
 
     unsigned begin;
     unsigned end;
-    pas_segregated_heap_medium_directory_tuple* best;
+    pas_segregated_heap_medium_directory_result best;
     medium_directory_tuple_for_index_impl_result result;
 
     PAS_ASSERT(rare_data);
@@ -370,7 +370,7 @@ medium_directory_tuple_for_index_impl(
 
     begin = 0;
     end = num_medium_directories;
-    best = NULL;
+    best = pas_segregated_heap_medium_directory_result_create_empty();
 
     result.dependency = (uintptr_t)medium_directories;
 
@@ -379,6 +379,7 @@ medium_directory_tuple_for_index_impl(
         pas_segregated_heap_medium_directory_tuple* directory;
         unsigned begin_index;
         unsigned end_index;
+        pas_segregated_heap_medium_directory_result result_for_current;
 
         middle = (begin + end) >> 1;
 
@@ -395,7 +396,7 @@ medium_directory_tuple_for_index_impl(
            or the tuple straddling page boundary, leading to the begin index being zero and the end_index
            having its original value. */
         if (!begin_index) {
-            result.tuple = NULL;
+            result.value = pas_segregated_heap_medium_directory_result_create_empty();
             return result;
         }
 
@@ -403,9 +404,18 @@ medium_directory_tuple_for_index_impl(
 
         result.dependency += begin_index + end_index;
 
+        result_for_current.tuple_unsafe_without_lock = directory;
+        result_for_current.directory =
+            pas_compact_atomic_segregated_size_directory_ptr_load(&directory->directory);
+        result_for_current.allocator_index = directory->allocator_index;
+
+        /* Don't include the tuple in the dependency since you should only be using it if you're
+           holding the lock. */
+        result.dependency +=
+            (uintptr_t)result_for_current.directory + result_for_current.allocator_index;
         if (index < begin_index) {
             end = middle;
-            best = directory;
+            best = result_for_current;
             continue;
         }
 
@@ -414,33 +424,33 @@ medium_directory_tuple_for_index_impl(
             continue;
         }
 
-        result.tuple = directory;
+        result.value = result_for_current;
         return result;
     }
 
     switch (search_mode) {
     case pas_segregated_heap_medium_size_directory_search_within_size_class_progression:
-        result.tuple = NULL;
+        result.value = pas_segregated_heap_medium_directory_result_create_empty();
         return result;
 
     case pas_segregated_heap_medium_size_directory_search_least_greater_equal:
-        result.tuple = best;
+        result.value = best;
         return result;
     }
 
     PAS_ASSERT_NOT_REACHED();
-    result.tuple = NULL;
+    result.value = pas_segregated_heap_medium_directory_result_create_empty();
     return result;
 }
 
-static pas_segregated_heap_medium_directory_tuple*
+static pas_segregated_heap_medium_directory_result
 medium_directory_tuple_for_index_with_lock(
     pas_segregated_heap* heap,
     size_t index,
     pas_segregated_heap_medium_size_directory_search_mode search_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    pas_segregated_heap_medium_directory_tuple* result;
+    pas_segregated_heap_medium_directory_result result;
     pas_segregated_heap_rare_data* rare_data;
     pas_segregated_heap_medium_directory_tuple* medium_directories;
 
@@ -455,14 +465,14 @@ medium_directory_tuple_for_index_with_lock(
         medium_directories,
         rare_data->num_medium_directories,
         index,
-        search_mode).tuple;
+        search_mode).value;
 
     pas_heap_lock_unlock_conditionally(heap_lock_hold_mode);
 
     return result;
 }
 
-pas_segregated_heap_medium_directory_tuple*
+pas_segregated_heap_medium_directory_result
 pas_segregated_heap_medium_directory_tuple_for_index(
     pas_segregated_heap* heap,
     size_t index,
@@ -479,7 +489,7 @@ pas_segregated_heap_medium_directory_tuple_for_index(
 
     rare_data = pas_segregated_heap_rare_data_ptr_load(&heap->rare_data);
     if (!rare_data)
-        return NULL;
+        return pas_segregated_heap_medium_directory_result_create_empty();
 
     if (heap_lock_hold_mode == pas_lock_is_held) {
         return medium_directory_tuple_for_index_with_lock(
@@ -502,9 +512,9 @@ pas_segregated_heap_medium_directory_tuple_for_index(
 
     if (pas_mutation_count_matches_with_dependency(
             &rare_data->mutation_count, saved_count, result.dependency)) {
-        if (verbose && !result.tuple)
+        if (verbose && !result.value.directory)
             pas_log("did not find tuple\n");
-        return result.tuple;
+        return result.value;
     }
 
     return medium_directory_tuple_for_index_with_lock(
@@ -519,20 +529,16 @@ unsigned pas_segregated_heap_medium_allocator_index_for_index(
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
-    pas_segregated_heap_medium_directory_tuple* medium_directory;
+    pas_segregated_heap_medium_directory_result medium_directory;
+    unsigned result;
 
     medium_directory = pas_segregated_heap_medium_directory_tuple_for_index(
         heap, index, search_mode, heap_lock_hold_mode);
 
-    if (medium_directory) {
-        unsigned result;
-        result = medium_directory->allocator_index;
-        if (verbose && !result)
-            pas_log("found null allocator index\n");
-        return result;
-    }
-
-    return 0;
+    result = medium_directory.allocator_index;
+    if (verbose && !result)
+        pas_log("found null allocator index\n");
+    return result;
 }
 
 pas_segregated_size_directory* pas_segregated_heap_medium_size_directory_for_index(
@@ -541,15 +547,12 @@ pas_segregated_size_directory* pas_segregated_heap_medium_size_directory_for_ind
     pas_segregated_heap_medium_size_directory_search_mode search_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    pas_segregated_heap_medium_directory_tuple* medium_directory;
+    pas_segregated_heap_medium_directory_result medium_directory;
 
     medium_directory = pas_segregated_heap_medium_directory_tuple_for_index(
         heap, index, search_mode, heap_lock_hold_mode);
 
-    if (medium_directory)
-        return pas_compact_atomic_segregated_size_directory_ptr_load(&medium_directory->directory);
-
-    return NULL;
+    return medium_directory.directory;
 }
 
 static size_t compute_small_index_upper_bound(pas_segregated_heap* heap,
@@ -920,7 +923,7 @@ pas_segregated_heap_ensure_allocator_index(
             pas_segregated_heap_medium_directory_tuple_for_index(
                 heap, index,
                 pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
-                pas_lock_is_held);
+                pas_lock_is_held).tuple_unsafe_without_lock;
         PAS_ASSERT(medium_directory, medium_directory);
         PAS_ASSERT(
             pas_compact_atomic_segregated_size_directory_ptr_load(&medium_directory->directory)
@@ -1594,7 +1597,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
         medium_tuple = pas_segregated_heap_medium_directory_tuple_for_index(
             heap, index,
             pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
-            pas_lock_is_held);
+            pas_lock_is_held).tuple_unsafe_without_lock;
         if (medium_tuple) {
             pas_segregated_heap_rare_data* rare_data;
 
@@ -1715,7 +1718,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
         medium_tuple = pas_segregated_heap_medium_directory_tuple_for_index(
             heap, index,
             pas_segregated_heap_medium_size_directory_search_least_greater_equal,
-            pas_lock_is_held);
+            pas_lock_is_held).tuple_unsafe_without_lock;
         if (medium_tuple) {
             pas_segregated_size_directory* directory;
             directory = pas_compact_atomic_segregated_size_directory_ptr_load(
@@ -2072,7 +2075,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
             next_tuple = pas_segregated_heap_medium_directory_tuple_for_index(
                 heap, index,
                 pas_segregated_heap_medium_size_directory_search_least_greater_equal,
-                pas_lock_is_held);
+                pas_lock_is_held).tuple_unsafe_without_lock;
 
             if (next_tuple &&
                 pas_compact_atomic_segregated_size_directory_ptr_load(

--- a/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
@@ -274,36 +274,34 @@ void testRematerializeAfterSearchOfDecommitted()
         reinterpret_cast<uintptr_t>(ptr), &bmalloc_heap_config);
     pas_segregated_size_directory* directory = pas_segregated_view_get_size_directory(view);
 
-    pas_segregated_heap_medium_directory_tuple* tuple =
+    pas_segregated_heap_medium_directory_result result =
         pas_segregated_heap_medium_directory_tuple_for_index(
             &heap->segregated_heap,
             pas_segregated_heap_index_for_size(size, BMALLOC_HEAP_CONFIG),
             pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
             pas_lock_is_not_held);
 
-    CHECK(tuple);
-    CHECK_EQUAL(pas_compact_atomic_segregated_size_directory_ptr_load(&tuple->directory),
-                directory);
+    CHECK_EQUAL(result.directory, directory);
 
     pas_scavenger_fake_decommit_expendable_memory();
 
-    tuple->begin_index = 0;
+    result.tuple_unsafe_without_lock->begin_index = 0;
 
-    pas_segregated_heap_medium_directory_tuple* someOtherTuple =
+    pas_segregated_heap_medium_directory_result someOtherResult =
         pas_segregated_heap_medium_directory_tuple_for_index(
             &heap->segregated_heap,
             pas_segregated_heap_index_for_size(someOtherSize, BMALLOC_HEAP_CONFIG),
             pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
             pas_lock_is_not_held);
 
-    if (someOtherTuple) {
-        cout << "Unexpectedly found a tuple: " << someOtherTuple << "\n";
+    if (someOtherResult.tuple_unsafe_without_lock) {
+        cout << "Unexpectedly found a tuple: " << someOtherResult.tuple_unsafe_without_lock << "\n";
         cout << "It points at directory = "
-             << pas_compact_atomic_segregated_size_directory_ptr_load(&someOtherTuple->directory) << "\n";
+             << someOtherResult.directory << "\n";
         cout << "Our original directory is = " << directory << "\n";
     }
     
-    CHECK(!someOtherTuple);
+    CHECK(!someOtherResult.tuple_unsafe_without_lock);
 }
 
 void testBasicSizeClass(unsigned firstSize, unsigned secondSize)


### PR DESCRIPTION
#### 39a5ac27139893e6369b2b491c0ec29e816eac5d
<pre>
[libpas] fix lock-free reads of the medium directory tuple table
<a href="https://bugs.webkit.org/show_bug.cgi?id=301940">https://bugs.webkit.org/show_bug.cgi?id=301940</a>
<a href="https://rdar.apple.com/163964480">rdar://163964480</a>

Reviewed by Yusuke Suzuki and Keith Miller.

Some paths read the medium directory tuple table using a lock-free
algorithm. However, they return a pointer into this table and
load from the pointer after checking for mutations to the table,
potentially reading the wrong entry.

Fix this by performing the read in the lock free critical section
(unless the heap lock is held along the path, in which case the pointer
is still used).

Thanks to Phil Pizlo for finding the issue and proposing the fix.

Testing: added asserts to verify this race condition

* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(medium_directory_tuple_for_index_impl):
(medium_directory_tuple_for_index_with_lock):
(pas_segregated_heap_medium_directory_tuple_for_index):
(pas_segregated_heap_medium_allocator_index_for_index):
(pas_segregated_heap_medium_size_directory_for_index):
(pas_segregated_heap_ensure_allocator_index):
(pas_segregated_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h:
(pas_segregated_heap_medium_directory_result_create_empty):

Originally-landed-as: 301765.261@safari-7623-branch (1164239a5354). <a href="https://rdar.apple.com/166336234">rdar://166336234</a>
Canonical link: <a href="https://commits.webkit.org/304406@main">https://commits.webkit.org/304406@main</a>
</pre>
----------------------------------------------------------------------
#### 05aaac31df25b1abf015b35c0fd0900904b2b264
<pre>
ARQuickLook HTML banner fails to render
<a href="https://bugs.webkit.org/show_bug.cgi?id=301865">https://bugs.webkit.org/show_bug.cgi?id=301865</a>
<a href="https://rdar.apple.com/163899118">rdar://163899118</a>

Reviewed by Sihui Liu.

If the sandbox in the UI process is blocking network access, the Networking process sandbox inherits this property.
This change prevents ARQuickLook from rendering HTML banners. This issue can be resolved by making an exemption for
platform binaries.

* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):

Originally-landed-as: 301765.248@safari-7623-branch (5eb90b01bff3). <a href="https://rdar.apple.com/166336525">rdar://166336525</a>
Canonical link: <a href="https://commits.webkit.org/304405@main">https://commits.webkit.org/304405@main</a>
</pre>
----------------------------------------------------------------------
#### 7c0f5e8d5531e0729dee99d81743b9864c1d6f44
<pre>
com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::ResourceUsageThread::platformCollectCPUData
<a href="https://bugs.webkit.org/show_bug.cgi?id=301716">https://bugs.webkit.org/show_bug.cgi?id=301716</a>
<a href="https://rdar.apple.com/140592689">rdar://140592689</a>

Reviewed by Abrar Rahman Protyasha.

In <a href="https://commits.webkit.org/209170@main">https://commits.webkit.org/209170@main</a>, we improved the
categorization of the threads shown in the CPU profiler. To identify
a thread as used by WebKit, we rely on a set of heuristics, one of them
being the thread&apos;s current dispatch queue&apos;s name. This required first
dereferencing a dispatch_queue_t*, which is unsafe given the queue may
be destroyed concurrently.

Given there appears to be no safe alternative way of getting the queue&apos;s
name, remove the retrieval and therefore the check using it. This means
a good portion of WebKit-related threads will still be discovered and
categorized, except for those temporarily-borrowed with the Grand
Central Dispatch, which will start to be labeled as unknown/other
threads. Given the severity and frequency of the crash due to the unsafe
dereferencing, I believe it&apos;s worth it to prevent it at the expense of
the reduced functionality, and find a way to safely implement it later
(<a href="https://webkit.org/b/301777).">https://webkit.org/b/301777).</a>

No new tests. The special behavior that this patch removed was not
not covered by tests, so no tests should be broken. The basic thread
identification is covered by existing tests inspector/cpu-profiler/{threads,tracking}.html,
which should continue to pass.

* Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm:
(WebCore::threadInfos):
(WebCore::ResourceUsageThread::platformCollectCPUData):

Originally-landed-as: 301765.247@safari-7623-branch (97d718c3ff9a). <a href="https://rdar.apple.com/166336640">rdar://166336640</a>
Canonical link: <a href="https://commits.webkit.org/304404@main">https://commits.webkit.org/304404@main</a>
</pre>
----------------------------------------------------------------------
#### 1025bd18c9c7bd3d5b35f88f5926ae7e8feb8796
<pre>
CodeBlock jettison should deref, rather than reset, StructureStubInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=301726">https://bugs.webkit.org/show_bug.cgi?id=301726</a>
<a href="https://rdar.apple.com/162487754">rdar://162487754</a>

Reviewed by Yusuke Suzuki and Mark Lam.

Other CodeBlocks may still be referring to that StructureStubInfo, thus
we cannot just blindly reset it. Instead, we&apos;ll deref it, which updates
the reference count to indicate we&apos;re no longer using it.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::jettison):

Originally-landed-as: 301765.223@safari-7623-branch (178c4858a787). <a href="https://rdar.apple.com/166336835">rdar://166336835</a>
Canonical link: <a href="https://commits.webkit.org/304403@main">https://commits.webkit.org/304403@main</a>
</pre>
----------------------------------------------------------------------
#### 3cb52d84eeb3e3f1d64b4aa963ec2da521a9bfdb
<pre>
WebCore::MediaSource::~MediaSource; WebCore::MediaSource::~MediaSource; mpark::detail::destructor::~destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=301674">https://bugs.webkit.org/show_bug.cgi?id=301674</a>
<a href="https://rdar.apple.com/163479310">rdar://163479310</a>

Reviewed by Jer Noble.

In 285110@main, we handled the case where the MediaSource object would be
destructed and the attempt to ref itself, causing an assertion. 285110@main
handled the case where the resource selection algorithm had already run
and HTMLMediaElement::m_mediaSource would have already been set.
It is apparently possible however, for the HTMLMediaElement to be GCed before the
resource selection algorithm got to run, in which case the MediaSource reference
is hold in HTMLMediaElement::m_mediaProvider hold the MediaSource.
For this to occur, the HTMLMediaElement to which we just set the srcObj attribute
must be GCed within that same runloop.
We now handle such case.
Additionally we exit early in MediaSource::detachFromElement if the MediaSource
is no yet or no longer attached to any element, which allows to call this
method multiple times on the same MediaSource object.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::detachFromElement):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):

Originally-landed-as: 301765.208@safari-7623-branch (4c366859c744). <a href="https://rdar.apple.com/166337132">rdar://166337132</a>
Canonical link: <a href="https://commits.webkit.org/304402@main">https://commits.webkit.org/304402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f978505b2c8e06f7f4c5d9485ef7209f97c57c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135450 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87145 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80b51c74-c2d7-417b-b544-05241c0f33ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8df55c84-cbcd-48c2-813f-1436381799a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84381 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8260d7a4-40e5-403a-a3e5-90328389ea22) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3458 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127445 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145898 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133934 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7511 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111885 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112257 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5706 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61406 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7565 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35824 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71112 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7414 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->