### PR TITLE
Adopt Safer CPP in GenericMediaQuerySerialization.cpp, ImageBufferUtilitiesCG.cpp & LibWebRTCVPXVideoEncoder.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -269,7 +269,6 @@ css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
-css/query/GenericMediaQuerySerialization.cpp
 css/query/MediaQueryFeatures.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
 css/typedom/CSSStyleValue.cpp
@@ -675,7 +674,6 @@ platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
 [ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
 [ iOS ] platform/ios/wak/WAKWindow.mm
-platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -77,7 +77,6 @@ platform/graphics/cg/GraphicsContextGLCG.cpp
 platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
 platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
 platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
-platform/graphics/cg/ImageBufferUtilitiesCG.cpp
 [ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cocoa/CMUtilities.mm
@@ -122,7 +121,6 @@ platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/ios/wak/WKView.mm
 [ iOS ] platform/ios/wak/WebCoreThread.mm
 [ iOS ] platform/ios/wak/WebCoreThreadRun.cpp
-platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 [ iOS ] platform/mediastream/ios/ReplayKitCaptureSource.mm
 platform/mediastream/mac/AVVideoCaptureSource.mm

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -109,12 +109,12 @@ void serialize(StringBuilder& builder, const Feature& feature)
         }
         serializeIdentifier(feature.name, builder);
 
-        builder.append(": "_s, feature.rightComparison->value->cssText(CSS::defaultSerializationContext()));
+        builder.append(": "_s, feature.rightComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
         break;
 
     case Syntax::Range:
         if (feature.leftComparison) {
-            builder.append(feature.leftComparison->value->cssText(CSS::defaultSerializationContext()));
+            builder.append(feature.leftComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
             serializeRangeComparisonOperator(feature.leftComparison->op);
         }
 
@@ -122,7 +122,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
 
         if (feature.rightComparison) {
             serializeRangeComparisonOperator(feature.rightComparison->op);
-            builder.append(feature.rightComparison->value->cssText(CSS::defaultSerializationContext()));
+            builder.append(feature.rightComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
         }
         break;
     }

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -47,6 +47,8 @@ struct FeatureSchema;
 struct Comparison {
     ComparisonOperator op;
     RefPtr<CSSValue> value;
+
+    RefPtr<CSSValue> protectedValue() const { return value; }
 };
 
 struct Feature {

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -181,7 +181,7 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
         return false;
 
     auto imageSize = source.size();
-    auto image = adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), source.format().colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(dataAlphaInfo), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
+    auto image = adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), source.format().colorSpace.protectedPlatformColorSpace().get(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(dataAlphaInfo), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
 
     return encode(image.get(), mimeType, quality, function);
 }


### PR DESCRIPTION
#### 768116774033d9d5384f97631a2e398b6a467978
<pre>
Adopt Safer CPP in GenericMediaQuerySerialization.cpp, ImageBufferUtilitiesCG.cpp &amp; LibWebRTCVPXVideoEncoder.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=304095">https://bugs.webkit.org/show_bug.cgi?id=304095</a>
<a href="https://rdar.apple.com/166419146">rdar://166419146</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

No new tests needed.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
(WebCore::MQ::Comparison::protectedValue const):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::vpxEncoderQueueSingleton):
(WebCore::LibWebRTCVPXVideoEncoder::encode):
(WebCore::LibWebRTCVPXVideoEncoder::flush):
(WebCore::LibWebRTCVPXVideoEncoder::setRates):
(WebCore::LibWebRTCVPXInternalVideoEncoder::encode):
(WebCore::vpxEncoderQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/304626@main">https://commits.webkit.org/304626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad50ecc781c8f23de15133b04f9598bf47a08c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143694 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6313fcc2-3623-41fb-8dbe-4060247a623d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c0b4797-1d0a-47a9-aedb-5bedac01b748) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc09d4a1-4c5f-4db2-a2e4-f26c5ba25693) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3869 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146445 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112671 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6132 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118169 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8080 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36236 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 16 flakes 1 failures; Uploaded test results; 12 flakes") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->