### PR TITLE
[JSC] StoreBarrierInsertionPhase's escape should mark all transitively incoming values to phi

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -204,7 +204,17 @@ private:
         bool result = true;
 
         UncheckedKeyHashMap<AbstractHeap, Node*> potentialStackEscapes;
-        
+        auto escape = [&](Node* node) {
+            if (mode == PhaseMode::Global) {
+                m_interpreter->phiChildren()->forAllTransitiveIncomingValues(
+                    node,
+                    [&](Node* incoming) {
+                        incoming->setEpoch(Epoch());
+                    });
+            } else
+                node->setEpoch(Epoch());
+        };
+
         for (m_nodeIndex = 0; m_nodeIndex < block->size(); ++m_nodeIndex) {
             m_node = block->at(m_nodeIndex);
             
@@ -460,7 +470,7 @@ private:
                         return;
                     potentialStackEscapes.removeIf([&] (const auto& entry) {
                         if (entry.key.overlaps(heap)) {
-                            entry.value->setEpoch(Epoch());
+                            escape(entry.value);
                             return true;
                         }
                         return false;
@@ -480,10 +490,6 @@ private:
                 clobberize(m_graph, m_node, readFunc, writeFunc, NoOpClobberize());
 
                 if (wroteHeapOrStack) {
-                    auto escape = [&] (Node* node) {
-                        node->setEpoch(Epoch());
-                    };
-
                     auto escapeToTheStack = [&] (Node* node) {
                         if (node->epoch() == m_currentEpoch) {
                             RELEASE_ASSERT(!!preciseStackWrite);
@@ -549,7 +555,7 @@ private:
 
         {
             for (auto* node : potentialStackEscapes.values())
-                node->setEpoch(Epoch());
+                escape(node);
             potentialStackEscapes.clear();
         }
         


### PR DESCRIPTION
#### b21a503b579a8ab14c839f82cc77176e507352e5
<pre>
[JSC] StoreBarrierInsertionPhase&apos;s escape should mark all transitively incoming values to phi
<a href="https://bugs.webkit.org/show_bug.cgi?id=302502">https://bugs.webkit.org/show_bug.cgi?id=302502</a>
<a href="https://rdar.apple.com/164593392">rdar://164593392</a>

Reviewed by Keith Miller and Mark Lam.

Let&apos;s have the following code.

    BB#1
    a: NewObject
    b: NewObject
    ...
    c: Upsilon(@b, ^f)
       Branch(BB#2, BB#3)

    BB#2
    ...
    d: Something
    e: Upsilon(@d, ^f)
       Jump(BB#3)

    BB#3
    f: Phi(@c, @e)
    ...
    g: PutByOffset(@a, @f)
    ...
    h: PutByOffset(@b, ...)
    ...

Since @b can cause GC, epoch is bumped and @a can be in the old region.
As a result, in @g, we should insert a StoreBarrier after that. And
because this old @a can leak @f to the world scanned by concurrent GC,
we need to escape @f and subsequent code must insert a StoreBarrier when
@f&apos;s properties are modified. However we are marking @f, but not marking
all incoming values @b and @d propagated through Upsilon. As a result,
@h can use @b directly (since BB#3 is dominated by BB#1, it is fine),
and we failed to insert a StoreBarrier after @h since @b is not marked!

This patch fixes it by marking all transitively incoming values for the
escaped one. The code will mark the node itself, and then mark all
incoming nodes when the node is Phi.

* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:

Originally-landed-as: 0cfb4a033f7e. <a href="https://rdar.apple.com/166335758">rdar://166335758</a>
Canonical link: <a href="https://commits.webkit.org/304602@main">https://commits.webkit.org/304602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62cf78109e379bfbfbe1d134de5b6bda8bb50efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143679 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f37738a-1e91-4bf4-9ff4-201232760306) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103906 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5860c20-d81e-4c90-82b9-918c18dfc696) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84783 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6207 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3855 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4281 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127936 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146430 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134456 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8017 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112259 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112652 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6122 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118155 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20957 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8065 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36224 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71622 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43647 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7867 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->