### PR TITLE
AX: Adjust Atspi::Role to match the enum defined in at-spi2-core

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -23,6 +23,11 @@
 namespace WebCore {
 namespace Atspi {
 
+// These enum values are passed over DBus as integers and must correspond
+// to the definitions in at-spi2-core
+// (https://gitlab.gnome.org/GNOME/at-spi2-core). Do not modify them without
+// a corresponding change in at-spi2-core.
+
 enum class Role {
     InvalidRole,
     AcceleratorLabel,
@@ -96,6 +101,7 @@ enum class Role {
     Window,
     Extended,
     Header,
+    Footer,
     Paragraph,
     Ruler,
     Application,
@@ -139,8 +145,6 @@ enum class Role {
     Math,
     Rating,
     Timer,
-    SectionFooter,
-    SectionHeader,
     Static,
     MathFraction,
     MathRoot,
@@ -154,7 +158,13 @@ enum class Role {
     ContentInsertion,
     Mark,
     Suggestion,
+    PushButtonMenu,
+    Switch,
 };
+
+static_assert((int)Atspi::Role::Paragraph == 73);
+static_assert((int)Atspi::Role::Section == 85);
+static_assert((int)Atspi::Role::Switch == 130);
 
 enum class State : uint64_t {
     InvalidState            = 1LLU << 0,

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -323,9 +323,9 @@ static Atspi::Role atspiRole(AccessibilityRole role)
     case AccessibilityRole::LandmarkSearch:
         return Atspi::Role::Landmark;
     case AccessibilityRole::SectionFooter:
-        return Atspi::Role::SectionFooter;
+        return Atspi::Role::Footer;
     case AccessibilityRole::SectionHeader:
-        return Atspi::Role::SectionHeader;
+        return Atspi::Role::Header;
     case AccessibilityRole::DescriptionList:
         return Atspi::Role::DescriptionList;
     case AccessibilityRole::Term:

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -745,6 +745,8 @@ static String roleValueToString(WebCore::Atspi::Role roleValue)
         return "AXEmbedded"_s;
     case WebCore::Atspi::Role::Entry:
         return "AXTextField"_s;
+    case WebCore::Atspi::Role::Footer:
+        return "AXFooter"_s;
     case WebCore::Atspi::Role::Footnote:
         return "AXFootnote"_s;
     case WebCore::Atspi::Role::Form:
@@ -811,10 +813,6 @@ static String roleValueToString(WebCore::Atspi::Role roleValue)
         return "AXRowHeader"_s;
     case WebCore::Atspi::Role::Ruler:
         return "AXRuler"_s;
-    case WebCore::Atspi::Role::SectionFooter:
-        return "AXSectionFooter"_s;
-    case WebCore::Atspi::Role::SectionHeader:
-        return "AXSectionHeader"_s;
     case WebCore::Atspi::Role::ScrollBar:
         return "AXScrollBar"_s;
     case WebCore::Atspi::Role::ScrollPane:


### PR DESCRIPTION
#### 7a4fc4e0025af69f35143b029256d7a8a8f3b13b
<pre>
AX: Adjust Atspi::Role to match the enum defined in at-spi2-core
<a href="https://bugs.webkit.org/show_bug.cgi?id=300090">https://bugs.webkit.org/show_bug.cgi?id=300090</a>

Reviewed by Adrian Perez de Castro.

R296017 removed the Footer member from Atspi::Role and also added
SectionHeader and SectionFooter, which do not currently exist in AT-SPI,
leading to the wrong Role values being reported. This commit adjusts the
enum to correspond with the current AT-SPI specification and also adds a
couple of newer AT-SPI roles.

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::atspiRole):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::roleValueToString):

Canonical link: <a href="https://commits.webkit.org/304783@main">https://commits.webkit.org/304783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b7fb5a46dc849e92104fd162926c6c074a93536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121941 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84871 "Found 3 new API test failures: WPE/TestWebKitWebView:/webkit/WebKitWebView/title-change, WPE/TestWebKitWebView:/webkit/WebKitWebView/save, WPE/TestAuthentication:/webkit/Authentication/authentication-success (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6286 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3937 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6817 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112738 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6196 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118241 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62098 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8162 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71721 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->