### PR TITLE
REGRESSION( iOS 26): 2X TestWebKitAPI.ProcessSwap gesture controller API Tests are constant failures

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -113,6 +113,8 @@ void ViewGestureController::disconnectFromProcess()
     if (!m_isConnectedToProcess)
         return;
 
+    platformDisconnectFromProcess();
+
     if (RefPtr mainFrameProcess = std::exchange(m_mainFrameProcess, nullptr).get())
         mainFrameProcess->removeMessageReceiver(Messages::ViewGestureController::messageReceiverName(), *m_webPageIDInMainFrameProcess);
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -115,6 +115,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     void platformTeardown();
+    void platformDisconnectFromProcess();
 
     void disconnectFromProcess();
     void connectToProcess();

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -79,6 +79,10 @@ void ViewGestureController::platformTeardown()
     cancelSwipe();
 }
 
+void ViewGestureController::platformDisconnectFromProcess()
+{
+}
+
 bool ViewGestureController::PendingSwipeTracker::scrollEventCanStartSwipe(PlatformGtkScrollData*)
 {
     return true;

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -88,6 +88,13 @@ static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
 
 - (void)invalidate
 {
+    if (_gestureRecognizerView) {
+        if (RetainPtr backRecognizer = [_backTransitionController gestureRecognizer])
+            [_gestureRecognizerView.get() removeGestureRecognizer:backRecognizer.get()];
+        if (RetainPtr forwardRecognizer = [_forwardTransitionController gestureRecognizer])
+            [_gestureRecognizerView.get() removeGestureRecognizer:forwardRecognizer.get()];
+    }
+
     _gestureController = nullptr;
 }
 
@@ -174,6 +181,11 @@ void ViewGestureController::platformTeardown()
     [m_swipeTransitionContext _setTransitionIsInFlight:NO];
     [m_swipeTransitionContext _setInteractor:nil];
     [m_swipeTransitionContext _setAnimator:nil];
+    [m_swipeInteractiveTransitionDelegate invalidate];
+}
+
+void ViewGestureController::platformDisconnectFromProcess()
+{
     [m_swipeInteractiveTransitionDelegate invalidate];
 }
 

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -86,6 +86,10 @@ void ViewGestureController::platformTeardown()
         removeSwipeSnapshot();
 }
 
+void ViewGestureController::platformDisconnectFromProcess()
+{
+}
+
 double ViewGestureController::resistanceForDelta(double deltaScale, double currentScale, double minMagnification, double maxMagnification)
 {
     // Zoom out with slight acceleration, until we reach minimum scale.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -6253,12 +6253,7 @@ static bool viewHasSwipeGestures(UIView *view)
 }
 #endif
 
-// rdar://163517689 (REGRESSION( iOS 26): 2X TestWebKitAPI.ProcessSwap (API-Tests) are constant failures (301536))
-#if PLATFORM(IOS)
-TEST(ProcessSwap, DISABLED_SwapWithGestureController)
-#else
 TEST(ProcessSwap, SwapWithGestureController)
-#endif
 {
     @autoreleasepool {
         auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -6298,12 +6293,7 @@ TEST(ProcessSwap, SwapWithGestureController)
     }
 }
 
-// rdar://163517689 (REGRESSION( iOS 26): 2X TestWebKitAPI.ProcessSwap (API-Tests) are constant failures (301536))
-#if PLATFORM(IOS)
-TEST(ProcessSwap, DISABLED_CrashWithGestureController)
-#else
 TEST(ProcessSwap, CrashWithGestureController)
-#endif
 {
     @autoreleasepool {
         auto processPoolConfiguration = psonProcessPoolConfiguration();


### PR DESCRIPTION
#### 49c4b8c1c84e37bc1a11d4c53f6a144c07f76475
<pre>
REGRESSION( iOS 26): 2X TestWebKitAPI.ProcessSwap gesture controller API Tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=301536">https://bugs.webkit.org/show_bug.cgi?id=301536</a>
<a href="https://rdar.apple.com/163517689">rdar://163517689</a>

Reviewed by Aditya Keerthi and Rupin Mittal.

The gesture recognizers were not being properly removed on process swaps. I added a
new method platformDisconnectFromProcess to remove the stale gesture recognizers.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::disconnectFromProcess):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::platformDisconnectFromProcess):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(-[WKSwipeTransitionController invalidate]):
(WebKit::ViewGestureController::platformDisconnectFromProcess):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::platformDisconnectFromProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, SwapWithGestureController)):
((ProcessSwap, CrashWithGestureController)(ProcessSwap, CrashWithGestureController)):
((ProcessSwap, DISABLED_SwapWithGestureController)(ProcessSwap, SwapWithGestureController)): Deleted.
((ProcessSwap, DISABLED_CrashWithGestureController)(ProcessSwap, CrashWithGestureController)): Deleted.

Canonical link: <a href="https://commits.webkit.org/304570@main">https://commits.webkit.org/304570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34be213b80332a7ec11da9ccaa3162d5793af1c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87474 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/850eb649-b898-461f-ba0f-0c1b8929b21f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1711873-d55d-44a3-b37d-6fd3c71d4f3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae464459-bbc1-4261-8e03-28d948d312bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3818 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7969 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112225 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28587 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6082 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8016 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36191 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7965 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7827 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->