### PR TITLE
IPInt should push PL as a frame-relative value

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10200,7 +10200,9 @@ end
     # t3 is not used after this
     subp cfr, t3
     push t3, PC
-    push PL, wasmInstance
+    # ditto for PL, t3 is okay to use as scratch
+    subp PL, cfr, t3
+    push t3, wasmInstance
 
     # set up the call frame
     move sp, t2
@@ -10214,7 +10216,7 @@ end
     # reserved
     # reserved
     # (first_non_arg_addr - cfr), PC
-    # PL, wasmInstance <- t2 = native argument stack (pushed by mINT)
+    # (PL - cfr), wasmInstance <- t2 = native argument stack (pushed by mINT)
     # call frame
     # call frame
     # call frame
@@ -10578,7 +10580,7 @@ _wasm_ipint_call_return_location_wide32:
     # reserved
     # reserved
     # (first_non_arg_addr - cfr), PC
-    # PL, wasmInstance  <- sc3
+    # (PL - cfr), wasmInstance  <- sc3
     # call frame return
     # call frame return
     # call frame
@@ -10744,7 +10746,7 @@ mintAlign(_end)
     # return result
     # return result     <- mintRetDst => new SP
     # (first_non_arg_addr - cfr), PC
-    # PL, wasmInstance  <- sc3
+    # (PL - cfr), wasmInstance  <- sc3
     # call frame return <- mintRetSrc
     # call frame return
     # call frame
@@ -10754,7 +10756,8 @@ mintAlign(_end)
 
     # note: we don't care about t3 anymore
 if ARM64 or ARM64E
-    loadpairq [sc3], PL, wasmInstance
+    loadpairq [sc3], t3, wasmInstance
+    addp t3, cfr, PL
 else
     loadq [sc3], wasmInstance
 end
@@ -10770,7 +10773,8 @@ end
     storep ws0, UnboxedWasmCalleeStackSlot[cfr]
 if X86_64
     move sc2, wasmInstance
-    loadq 8[sc3], PL
+    loadq 8[sc3], t3
+    addp t3, cfr, PL
     loadp (2 * SlotSize)[sc3], PC
 end
 


### PR DESCRIPTION
#### e9cd29d47bef97e456c04ad2c2afc00c21e5b4db
<pre>
IPInt should push PL as a frame-relative value
<a href="https://bugs.webkit.org/show_bug.cgi?id=304100">https://bugs.webkit.org/show_bug.cgi?id=304100</a>
<a href="https://rdar.apple.com/166433411">rdar://166433411</a>

Reviewed by Dan Hecht and Yusuke Suzuki.

As part of function call sequence before loading argument registers, IPInt pushes onto the
stack the value of the PL register. (PL is mapped to x6 on arm64, so it overlaps with
argument registers). PL is a pointer to the locals on the stack. To make stack frames
easily relocatable for JSPI, we need to push and pop PL as an offset from the frame
pointer rather than an absolute value.

Tests: covered by existing ones.
Canonical link: <a href="https://commits.webkit.org/304460@main">https://commits.webkit.org/304460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3867e570c9377d799df087ba08655ab5413562a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87158 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5249e35e-29a9-4d7f-8924-5bd4f8403938) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61f94cf1-f93b-4de7-9422-e0203c16acb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84391 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3476 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3777 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127466 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145919 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133957 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7536 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5723 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61430 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7588 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35846 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166796 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7335 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71134 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 49617 issues") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43565 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->