### PR TITLE
SVGFEConvolveMatrixElement should reject invalid order attribute values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SVGAnimatedInteger interface - utilizing the targetX property of SVGFEConvolveMatrix assert_equals: expected 3 but got -1
+PASS SVGAnimatedInteger interface - utilizing the targetX property of SVGFEConvolveMatrix
 

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -71,15 +71,15 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         break;
     case AttributeNames::orderAttr: {
         auto result = parseNumberOptionalNumber(newValue);
-        if (!result) {
+        if (!result || result->first < 1 || result->second < 1) {
             m_orderX->setBaseValInternal(initialOrderValue);
             m_orderY->setBaseValInternal(initialOrderValue);
+            m_hasInvalidOrderAttribute = true;
+            protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         } else {
             m_orderX->setBaseValInternal(result->first);
             m_orderY->setBaseValInternal(result->second);
-
-            if (result->first < 1 || result->second < 1)
-                protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            m_hasInvalidOrderAttribute = false;
         }
         break;
     }
@@ -238,6 +238,8 @@ void SVGFEConvolveMatrixElement::svgAttributeChanged(const QualifiedName& attrNa
 RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
     auto filterOrder = [&] () {
+        if (m_hasInvalidOrderAttribute)
+            return IntSize();
         return IntSize(orderX(), orderY());
     };
 

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -113,6 +113,8 @@ private:
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
+
+    bool m_hasInvalidOrderAttribute { false };
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
     Ref<SVGAnimatedInteger> m_orderX { SVGAnimatedInteger::create(this, initialOrderValue) };

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -113,6 +113,8 @@ private:
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
+
+    bool m_hasInvalidOrderAttribute { false };
 
     const Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
     const Ref<SVGAnimatedInteger> m_orderX { SVGAnimatedInteger::create(this, initialOrderValue) };


### PR DESCRIPTION
#### c329236d6f8eb05d72d0aa0d262fbac2b4cb602d
<pre>
SVGFEConvolveMatrixElement should reject invalid order attribute values
<a href="https://bugs.webkit.org/show_bug.cgi?id=304107">https://bugs.webkit.org/show_bug.cgi?id=304107</a>
<a href="https://rdar.apple.com/166438611">rdar://166438611</a>

Reviewed by Taher Ali.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When the order attribute is set to an invalid value (e.g., negative numbers
or zero), the orderX and orderY SVG DOM getters return the initial value of 3
per WPT, rather than the invalid parsed value. But the filter must still fail
to render — otherwise an invalid order combined with a matching kernelMatrix
length would paint as if valid (e.g. order=&quot;-3&quot; with a 9-element kernelMatrix
would otherwise succeed as order=&quot;3&quot;).

To satisfy both requirements, track the invalid state via a new
m_hasInvalidOrderAttribute flag, set when parsing produces a value &lt; 1 and
cleared on a valid update. The DOM getters still report 3, while
createFilterEffect checks the flag and returns an empty IntSize so filter
creation fails.

Note: when a CSS filter reference fails, HTML elements still paint without
the filter (only SVG elements are suppressed via hasFailedFilterForSVG).
That discrepancy is pre-existing and out of scope for this patch.

* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
(WebCore::SVGFEConvolveMatrixElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/315133@main">https://commits.webkit.org/315133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98eebaf65d662e14f1330a129e16e6ccd1232474

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168149 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/41698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125850 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0aa181c-00e3-46dc-954b-902ca283cba7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab49c83c-d36d-4cb7-ab14-1c42000a688a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33318 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111356 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96121677-fa46-445c-8b9a-da5379209445) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31006 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26173 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142290 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180077 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32800 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41718 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37473 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42406 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105769 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34435 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114166 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40307 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5577 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40558 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->