### PR TITLE
[JavaScriptCore] os_script_config_storage is not available when back-deploying

### DIFF
--- a/Source/JavaScriptCore/Configurations/AllowedSPI.toml
+++ b/Source/JavaScriptCore/Configurations/AllowedSPI.toml
@@ -5,9 +5,3 @@
 request = "rdar://157890653"
 symbols = ["dyld_program_sdk_at_least"]
 requires = ["USE_APPLE_INTERNAL_SDK"]
-
-[[not-web-essential]]
-request = "rdar://163506174"
-symbols = ["os_script_config_storage"]
-requires = ["HAVE_OS_SCRIPT_CONFIG_SPI"]
-allow-unused = true

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -43,10 +43,6 @@ namespace JSC {
 
 class VM;
 
-#if USE(APPLE_INTERNAL_SDK) && defined(OS_SCRIPT_CONFIG_SPI_VERSION) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-#define HAVE_OS_SCRIPT_CONFIG_SPI 1
-#endif
-
 #if ENABLE(C_LOOP)
 typedef OpcodeID LLIntCode;
 #else
@@ -71,8 +67,15 @@ constexpr size_t OpcodeConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB
 
 #if HAVE(OS_SCRIPT_CONFIG_SPI)
 static_assert(OS_SCRIPT_CONFIG_STORAGE_SIZE == OpcodeConfigSizeToProtect);
+#elif PLATFORM(COCOA)
+// When targeting older versions of macOS that do not have
+// os_script_config_storage runtime support, this redeclaration clashes with
+// the declaration in the SDK that is marked as unavailable. Use a different
+// name to work around the availability diagnostic.
+extern "C" uint8_t os_script_config_storage_stub[] __asm__("_os_script_config_storage");
+#define os_script_config_storage os_script_config_storage_stub
 #else
-extern "C" WTF_EXPORT_PRIVATE uint8_t os_script_config_storage[];
+extern "C" uint8_t os_script_config_storage[];
 #endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN


### PR DESCRIPTION
#### 07f79c932d8fe2bc106eeae5482560190cf7b9a9
<pre>
[JavaScriptCore] os_script_config_storage is not available when back-deploying
<a href="https://bugs.webkit.org/show_bug.cgi?id=303933">https://bugs.webkit.org/show_bug.cgi?id=303933</a>
<a href="https://rdar.apple.com/166241210">rdar://166241210</a>

Unreviewed, reland of 304386@main with an AllowedSPI cleanup:

    Reviewed by Mark Lam.

    Fix two issues related to back-deploying from recent SDKs to Sonoma and
    Sequoia downlevels:

    1. We were using the presence of a macro in &lt;os/script_config_private.h&gt;
       to determine whether to compile with os_script_config_storage runtime
       support. When back deploying, that macro may exist even when the
       system being targeted does not have runtime support.

       Replace the HAVE_OS_SCRIPT_CONFIG_SPI check with one from
       WebKitAdditions based on deployment target version.

    2. When we are in the fallback configuration where we allocate our own
       buffer, JSC was redeclaring a `os_script_config_storage` using the
       same name as the declaration from the system header. This confused
       the compiler into thinking that we are attempting to use a
       declaration from the SDK that is marked unavailable.

       Work around this by giving the declaration a different name
       (os_script_config_storage_stub) and manually renaming its symbol so
       that LLInt can still bind to it.

    Also, do not export the stub symbol; it&apos;s only used within JSC.

Because the stub symbol is no longer exported, and because libSystem is
implicitly treated as API, audit-spi now flags the
os_script_config_storage entry, so remove it.

* Source/JavaScriptCore/Configurations/AllowedSPI.toml:
* Source/JavaScriptCore/llint/LLIntData.h:

Canonical link: <a href="https://commits.webkit.org/304431@main">https://commits.webkit.org/304431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde52c202fc61df78091abaf44e16497f75c0234

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87189 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138452 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/3810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127499 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133990 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7569 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/40218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/145951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7608 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/145951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/5752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61477 "Failed to checkout and rebase branch from PR 55369") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20894 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7621 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166829 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71167 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7587 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->