### PR TITLE
[JSC] Handle `String.prototype.includes` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-includes-constant-folding.js
+++ b/JSTests/microbenchmarks/string-prototype-includes-constant-folding.js
@@ -1,0 +1,32 @@
+function testConstantFound() {
+    return "Hello World".includes("World");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".includes("xyz");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithIndex() {
+    return "Hello World".includes("World", 6);
+}
+noInline(testConstantWithIndex);
+
+function testConstantOneChar() {
+    return "Hello World".includes("W");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharWithIndex() {
+    return "Hello World".includes("W", 6);
+}
+noInline(testConstantOneCharWithIndex);
+
+for (var i = 0; i < 1e6; ++i) {
+    testConstantFound();
+    testConstantNotFound();
+    testConstantWithIndex();
+    testConstantOneChar();
+    testConstantOneCharWithIndex();
+}

--- a/JSTests/microbenchmarks/string-prototype-includes-with-index-with-one-char.js
+++ b/JSTests/microbenchmarks/string-prototype-includes-with-index-with-one-char.js
@@ -1,0 +1,22 @@
+function test(string, search, index) {
+    return string.includes(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var searchH = makeString("H");
+var searchX = makeString("X");
+var searchDot = makeString(".");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, searchH, 0);
+    test(string, searchH, 49);
+    test(string, searchH, 50);
+    test(string, searchX, 0);
+    test(string, searchDot, 57);
+}

--- a/JSTests/microbenchmarks/string-prototype-includes-with-index.js
+++ b/JSTests/microbenchmarks/string-prototype-includes-with-index.js
@@ -1,0 +1,21 @@
+function test(string, search, index) {
+    return string.includes(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okHellooko");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1, 0);
+    test(string, search1, 20);
+    test(string, search1, 50);
+    test(string, search2, 0);
+    test(string, search2, 47);
+}

--- a/JSTests/microbenchmarks/string-prototype-includes-with-one-char.js
+++ b/JSTests/microbenchmarks/string-prototype-includes-with-one-char.js
@@ -1,0 +1,20 @@
+function test(string, search) {
+    return string.includes(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var searchH = makeString("H");
+var searchX = makeString("X");
+var searchDot = makeString(".");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, searchH);
+    test(string, searchX);
+    test(string, searchDot);
+}

--- a/JSTests/microbenchmarks/string-prototype-includes.js
+++ b/JSTests/microbenchmarks/string-prototype-includes.js
@@ -1,0 +1,23 @@
+// Benchmark for operationStringIncludes (multi-char search, no index)
+
+function test(string, search) {
+    return string.includes(search);
+}
+noInline(test);
+
+// Create strings dynamically to avoid constant folding
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okHellooko");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1);
+    test(string, search2);
+    test(string, search3);
+}

--- a/JSTests/stress/string-prototype-includes-constant-folding.js
+++ b/JSTests/stress/string-prototype-includes-constant-folding.js
@@ -1,0 +1,55 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function testConstantFound() {
+    return "Hello World".includes("World");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".includes("xyz");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithIndex() {
+    return "Hello World".includes("World", 6);
+}
+noInline(testConstantWithIndex);
+
+function testConstantWithIndexNotFound() {
+    return "Hello World".includes("World", 7);
+}
+noInline(testConstantWithIndexNotFound);
+
+function testConstantOneChar() {
+    return "Hello World".includes("W");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharNotFound() {
+    return "Hello World".includes("X");
+}
+noInline(testConstantOneCharNotFound);
+
+function testConstantOneCharWithIndex() {
+    return "Hello World".includes("W", 6);
+}
+noInline(testConstantOneCharWithIndex);
+
+function testConstantOneCharWithIndexNotFound() {
+    return "Hello World".includes("W", 7);
+}
+noInline(testConstantOneCharWithIndexNotFound);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(testConstantFound(), true);
+    shouldBe(testConstantNotFound(), false);
+    shouldBe(testConstantWithIndex(), true);
+    shouldBe(testConstantWithIndexNotFound(), false);
+    shouldBe(testConstantOneChar(), true);
+    shouldBe(testConstantOneCharNotFound(), false);
+    shouldBe(testConstantOneCharWithIndex(), true);
+    shouldBe(testConstantOneCharWithIndexNotFound(), false);
+}

--- a/JSTests/stress/string-prototype-includes-with-index-with-one-char.js
+++ b/JSTests/stress/string-prototype-includes-with-index-with-one-char.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, index) {
+    return string.includes(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var searchH = makeString("H");
+var searchX = makeString("X");
+var searchDot = makeString(".");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, searchH, 0), true);
+    shouldBe(test(string, searchH, 20), true);
+    shouldBe(test(string, searchH, 49), true);
+    shouldBe(test(string, searchH, 50), false);
+    shouldBe(test(string, searchH, string.length), false);
+
+    shouldBe(test(string, searchX, 0), false);
+    shouldBe(test(string, searchX, 20), false);
+
+    shouldBe(test(string, searchDot, 0), true);
+    shouldBe(test(string, searchDot, 44), true);
+    shouldBe(test(string, searchDot, 57), true);  // After "okok"
+    shouldBe(test(string, searchDot, string.length - 1), true);
+    shouldBe(test(string, searchDot, string.length), false);
+
+    shouldBe(test(string, searchH, -10), true);
+    shouldBe(test(string, searchH, -1), true);
+}

--- a/JSTests/stress/string-prototype-includes-with-index.js
+++ b/JSTests/stress/string-prototype-includes-with-index.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, index) {
+    return string.includes(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okHellooko");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, search1, 0), true);
+    shouldBe(test(string, search1, 20), true);
+    shouldBe(test(string, search1, 47), true);
+    shouldBe(test(string, search1, 49), true);
+    shouldBe(test(string, search1, 50), false);
+    shouldBe(test(string, search1, string.length), false);
+
+    shouldBe(test(string, search2, 0), true);
+    shouldBe(test(string, search2, 20), true);
+    shouldBe(test(string, search2, 47), true);
+    shouldBe(test(string, search2, 48), false);
+    shouldBe(test(string, search2, string.length), false);
+
+    shouldBe(test(string, search3, 0), false);
+    shouldBe(test(string, search3, 20), false);
+
+    shouldBe(test(string, search1, -10), true);
+    shouldBe(test(string, search1, -1), true);
+}

--- a/JSTests/stress/string-prototype-includes-with-one-char.js
+++ b/JSTests/stress/string-prototype-includes-with-one-char.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.includes(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var searchH = makeString("H");
+var searchX = makeString("X");
+var searchDot = makeString(".");
+var searchO = makeString("o");
+var searchK = makeString("k");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, searchH), true);
+    shouldBe(test(string, searchX), false);
+    shouldBe(test(string, searchDot), true);
+    shouldBe(test(string, searchO), true);
+    shouldBe(test(string, searchK), true);
+
+    shouldBe(test(makeString(""), searchH), false);
+    shouldBe(test(makeString("H"), searchH), true);
+    shouldBe(test(makeString("h"), searchH), false);
+}

--- a/JSTests/stress/string-prototype-includes.js
+++ b/JSTests/stress/string-prototype-includes.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.includes(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okHellooko");
+var search3 = makeString("NotFound");
+var search4 = makeString("okok");
+var search5 = makeString("....");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, search1), true);
+    shouldBe(test(string, search2), true);
+    shouldBe(test(string, search3), false);
+    shouldBe(test(string, search4), true);
+    shouldBe(test(string, search5), true);
+
+    shouldBe(test(string, makeString("")), true);
+    shouldBe(test(makeString(""), search1), false);
+    shouldBe(test(makeString("Hello"), search1), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3055,7 +3055,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
-        case StringPrototypeIndexOfIntrinsic: {
+        case StringPrototypeIndexOfIntrinsic:
+        case StringPrototypeIncludesIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
 
@@ -3072,6 +3073,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 Node* index = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
                 result = addToGraph(StringIndexOf, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), thisValue, search, index);
             }
+
+            if (intrinsic == StringPrototypeIncludesIntrinsic)
+                result = addToGraph(LogicalNot, addToGraph(CompareStrictEq, result, jsConstant(jsNumber(-1))));
 
             setResult(result);
             return CallOptimizationResult::Inlined;

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -119,6 +119,7 @@ namespace JSC {
     macro(StringPrototypeAtIntrinsic) \
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \
+    macro(StringPrototypeIncludesIntrinsic) \
     macro(StringPrototypeLocaleCompareIntrinsic) \
     macro(StringPrototypeValueOfIntrinsic) \
     macro(StringPrototypeReplaceIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -154,7 +154,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("trim"_s, stringProtoFuncTrim, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().charCodeAtPrivateName(), stringProtoFuncCharCodeAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, CharCodeAtIntrinsic);
 


### PR DESCRIPTION
#### cc5da5a661a3dda8b8edd19f903fed3de7c35f4b
<pre>
[JSC] Handle `String.prototype.includes` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=304138">https://bugs.webkit.org/show_bug.cgi?id=304138</a>

Reviewed by Yusuke Suzuki.

This patch adds support for `String.prototype.includes` in DFG/FTL using C++
operations like `String.prototype.indexOf`.

This patch makes `String.prototype.includes` 1.2x to 1.4x faster in the following
microbenchmarks. Furthermore, it improves even more significantly when folding is
effective.

                                                  TipOfTree                  Patched

string-prototype-includes-with-index-with-one-char
                                               74.6933+-36.5188          65.5386+-26.0564         might be 1.1397x faster
string-prototype-includes                      70.8373+-31.3757          69.8322+-33.4859         might be 1.0144x faster
string-prototype-includes-with-index          113.6356+-70.8584          73.4337+-24.0293         might be 1.5475x faster
string-prototype-includes-constant-folding
                                               84.4210+-17.2479    ^      8.6475+-4.8715        ^ definitely 9.7625x faster
string-prototype-includes-with-one-char        52.5742+-20.4285          36.3516+-12.4097         might be 1.4463x faster

Tests: JSTests/stress/string-includes.js

* JSTests/microbenchmarks/string-prototype-includes-constant-folding.js: Added.
(testConstantFound):
(testConstantNotFound):
(testConstantWithIndex):
(testConstantOneChar):
(testConstantOneCharWithIndex):
* JSTests/microbenchmarks/string-prototype-includes-with-index-with-one-char.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-includes-with-index.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-includes-with-one-char.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-includes.js: Added.
(test):
(makeString):
* JSTests/stress/string-prototype-includes-constant-folding.js: Added.
(shouldBe):
(testConstantFound):
(testConstantNotFound):
(testConstantWithIndex):
(testConstantWithIndexNotFound):
(testConstantOneChar):
(testConstantOneCharNotFound):
(testConstantOneCharWithIndex):
(testConstantOneCharWithIndexNotFound):
* JSTests/stress/string-prototype-includes-with-index-with-one-char.js: Added.
(shouldBe):
(test):
(makeString):
* JSTests/stress/string-prototype-includes-with-index.js: Added.
(shouldBe):
(test):
(makeString):
* JSTests/stress/string-prototype-includes-with-one-char.js: Added.
(shouldBe):
(test):
(makeString):
* JSTests/stress/string-prototype-includes.js: Added.
(shouldBe):
(test):
(makeString):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/304852@main">https://commits.webkit.org/304852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daa18f4c8863f39fc893ada23adab41919bcddc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104510 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6747 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4437 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4987 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128628 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147151 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135153 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6672 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62829 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8758 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36803 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167932 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72324 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43817 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->