### PR TITLE
[GStreamer] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-promises.https.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2400,8 +2400,6 @@ webkit.org/b/226807 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-a
 webkit.org/b/218010 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-output-channel-count.https.html [ Failure Pass ]
 webkit.org/b/218010 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/suspended-context-messageport.https.html [ Failure Pass ]
 
-webkit.org/b/304132 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-promises.https.html [ Pass Crash ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAudio-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -132,8 +132,6 @@ AudioDestinationGStreamer::~AudioDestinationGStreamer()
         return;
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "Disposing");
-    if (m_src) [[likely]]
-        g_object_set(m_src.get(), "destination", nullptr, nullptr);
     unregisterPipeline(m_pipeline);
     disconnectSimpleBusMessageCallback(m_pipeline.get());
     gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
@@ -151,10 +149,8 @@ void AudioDestinationGStreamer::initializePipeline()
         this->handleMessage(message);
     });
 
-    m_src = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_WEB_AUDIO_SRC, "rate", sampleRate(),
-        "destination", this, "frames", AudioUtilities::renderQuantumSize, nullptr));
-
-    webkitWebAudioSourceSetBus(WEBKIT_WEB_AUDIO_SRC(m_src.get()), m_renderBus);
+    m_src = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_WEB_AUDIO_SRC, nullptr));
+    webkitWebAudioSourceSetDestination(WEBKIT_WEB_AUDIO_SRC(m_src.get()), this);
 
     auto& quirksManager = GStreamerQuirksManager::singleton();
     GRefPtr<GstElement> audioSink = quirksManager.createWebAudioSink();

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -22,16 +22,17 @@
 #include "AudioDestination.h"
 #include "GRefPtrGStreamer.h"
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class AudioDestinationGStreamer : public AudioDestination, public RefCounted<AudioDestinationGStreamer> {
+class AudioDestinationGStreamer : public AudioDestination, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioDestinationGStreamer, WTF::DestructionThread::Main> {
 public:
     AudioDestinationGStreamer(const CreationOptions&);
     virtual ~AudioDestinationGStreamer();
 
-    void ref() const final { return RefCounted<AudioDestinationGStreamer>::ref(); }
-    void deref() const final { return RefCounted<AudioDestinationGStreamer>::deref(); }
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     WEBCORE_EXPORT void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;
     WEBCORE_EXPORT void stop(CompletionHandler<void(bool)>&&) final;
@@ -41,6 +42,8 @@ public:
 
     bool handleMessage(GstMessage*);
     void notifyIsPlaying(bool);
+
+    const RefPtr<AudioBus>& renderBus() const { return m_renderBus; }
 
 protected:
     virtual void startRendering(CompletionHandler<void(bool)>&&);

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h
@@ -20,7 +20,7 @@
 
 #if USE(GSTREAMER)
 
-#include "AudioBus.h"
+#include "AudioDestinationGStreamer.h"
 #include <gst/gst.h>
 #include <wtf/Forward.h>
 
@@ -31,7 +31,7 @@ typedef struct _WebKitWebAudioSrc WebKitWebAudioSrc;
 
 GType webkit_web_audio_src_get_type();
 
-void webkitWebAudioSourceSetBus(WebKitWebAudioSrc*, RefPtr<WebCore::AudioBus>);
+void webkitWebAudioSourceSetDestination(WebKitWebAudioSrc*, const RefPtr<WebCore::AudioDestinationGStreamer>&);
 void webkitWebAudioSourceSetDispatchToRenderThreadFunction(WebKitWebAudioSrc*, Function<void(Function<void()>&&)>&&);
 
 #endif // USE(GSTREAMER)


### PR DESCRIPTION
#### cfa781ae8897182fb3ef4cb14fc2a61ea9e4d578
<pre>
[GStreamer] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-promises.https.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=304132">https://bugs.webkit.org/show_bug.cgi?id=304132</a>

Reviewed by Xabier Rodriguez-Calvar.

The webaudiosrc now uses a weak reference to the AudioDestination instead of a raw pointer. I used
the opportunity to refactor some code and get rid of superfluous GObject properties.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::~AudioDestinationGStreamer):
(WebCore::AudioDestinationGStreamer::initializePipeline):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h:
(WebCore::AudioDestinationGStreamer::renderBus const):
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webkit_web_audio_src_class_init):
(webKitWebAudioSrcConstructed):
(webKitWebAudioSrcAllocateBuffer):
(webKitWebAudioSrcRenderAndPushFrames):
(webKitWebAudioSrcChangeState):
(webkitWebAudioSourceSetDestination):
(webKitWebAudioSrcSetProperty): Deleted.
(webKitWebAudioSrcGetProperty): Deleted.
(webkitWebAudioSourceSetBus): Deleted.
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/304449@main">https://commits.webkit.org/304449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3213a579f1d24aa2779645436bdd3a96228160b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3575 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3883 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7644 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111976 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5822 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61601 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7696 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71242 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->