### PR TITLE
Simplify `requires` statements introduced in 304372@main

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -191,9 +191,9 @@ public:
     MappedTakeType takeFirst();
 
     // Useful when the key type is WeakPtr
-    template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) size_t computeSize() const;
-    template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) bool isEmptyIgnoringNullReferences() const;
-    template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) void removeWeakNullEntries();
+    size_t computeSize() const requires (KeyTraits::hasIsWeakNullValueFunction);
+    bool isEmptyIgnoringNullReferences() const requires (KeyTraits::hasIsWeakNullValueFunction);
+    void removeWeakNullEntries() requires (KeyTraits::hasIsWeakNullValueFunction);
 
     // Alternate versions of find() / contains() / get() / remove() that find the object
     // by hashing and comparing with some other type, to avoid the cost of type conversion.
@@ -608,22 +608,19 @@ auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::takeFirst() -> 
 }
 
 template<typename T, typename U, typename V, typename KeyTraits, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-inline size_t HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::computeSize() const
+inline size_t HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::computeSize() const requires (KeyTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.computeSize();
 }
 
 template<typename T, typename U, typename V, typename KeyTraits, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-inline bool HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::isEmptyIgnoringNullReferences() const
+inline bool HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::isEmptyIgnoringNullReferences() const requires (KeyTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.isEmptyIgnoringNullReferences();
 }
 
 template<typename T, typename U, typename V, typename KeyTraits, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-inline void HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::removeWeakNullEntries()
+inline void HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::removeWeakNullEntries() requires (KeyTraits::hasIsWeakNullValueFunction)
 {
     m_impl.removeWeakNullEntries();
 }

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -88,9 +88,9 @@ public:
     bool isEmpty() const;
 
     // Useful when the key type is WeakPtr
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) size_t computeSize() const;
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) bool isEmptyIgnoringNullReferences() const;
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) void removeWeakNullEntries();
+    size_t computeSize() const requires (ValueTraits::hasIsWeakNullValueFunction);
+    bool isEmptyIgnoringNullReferences() const requires (ValueTraits::hasIsWeakNullValueFunction);
+    void removeWeakNullEntries() requires (ValueTraits::hasIsWeakNullValueFunction);
 
     void reserveInitialCapacity(unsigned keyCount) { m_impl.reserveInitialCapacity(keyCount); }
 
@@ -293,22 +293,19 @@ inline bool HashSet<T, U, V, W, shouldValidateKey>::isEmpty() const
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename> requires (V::hasIsWeakNullValueFunction)
-inline size_t HashSet<T, U, V, W, shouldValidateKey>::computeSize() const
+inline size_t HashSet<T, U, V, W, shouldValidateKey>::computeSize() const requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.computeSize();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename> requires (V::hasIsWeakNullValueFunction)
-inline bool HashSet<T, U, V, W, shouldValidateKey>::isEmptyIgnoringNullReferences() const
+inline bool HashSet<T, U, V, W, shouldValidateKey>::isEmptyIgnoringNullReferences() const requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.isEmptyIgnoringNullReferences();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-template<typename> requires (V::hasIsWeakNullValueFunction)
-inline void HashSet<T, U, V, W, shouldValidateKey>::removeWeakNullEntries()
+inline void HashSet<T, U, V, W, shouldValidateKey>::removeWeakNullEntries() requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     m_impl.removeWeakNullEntries();
 }

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -509,9 +509,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         void clear();
 
         // Useful when the key type is WeakPtr
-        template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) size_t computeSize() const;
-        template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) bool isEmptyIgnoringNullReferences() const;
-        template<typename = void> requires (KeyTraits::hasIsWeakNullValueFunction) void removeWeakNullEntries() const;
+        size_t computeSize() const requires (KeyTraits::hasIsWeakNullValueFunction);
+        bool isEmptyIgnoringNullReferences() const requires (KeyTraits::hasIsWeakNullValueFunction);
+        void removeWeakNullEntries() const requires (KeyTraits::hasIsWeakNullValueFunction);
 
         template<size_t inlineCapacity>
         Vector<TakeType, inlineCapacity> takeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto&);
@@ -1107,24 +1107,21 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
-    template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-    inline size_t HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::computeSize() const
+    inline size_t HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::computeSize() const requires (KeyTraits::hasIsWeakNullValueFunction)
     {
         removeWeakNullEntries();
         return size();
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
-    template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-    inline bool HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::isEmptyIgnoringNullReferences() const
+    inline bool HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::isEmptyIgnoringNullReferences() const requires (KeyTraits::hasIsWeakNullValueFunction)
     {
         // FIXME: We should probably return isEmpty() || !computeSize() here to avoid pathological weak null iteration in an empty table.
         return isEmpty() || begin() == end(); // Iterators skip weak null
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
-    template<typename> requires (KeyTraits::hasIsWeakNullValueFunction)
-    inline void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::removeWeakNullEntries() const
+    inline void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::removeWeakNullEntries() const requires (KeyTraits::hasIsWeakNullValueFunction)
     {
         const_cast<HashTable&>(*this).removeIf([](ValueType&) {
             return false;

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -187,9 +187,9 @@ public:
     void clear();
 
     // Useful when the key type is WeakPtr
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) size_t computeSize() const;
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) bool isEmptyIgnoringNullReferences() const;
-    template<typename = void> requires (ValueTraits::hasIsWeakNullValueFunction) void removeWeakNullEntries();
+    size_t computeSize() const requires (ValueTraits::hasIsWeakNullValueFunction);
+    bool isEmptyIgnoringNullReferences() const requires (ValueTraits::hasIsWeakNullValueFunction);
+    void removeWeakNullEntries() requires (ValueTraits::hasIsWeakNullValueFunction);
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
     template<SmartPtr V = ValueType> iterator find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) LIFETIME_BOUND;
@@ -833,22 +833,19 @@ inline bool ListHashSet<T, U>::remove(const ValueType& value)
 }
 
 template<typename T, typename U>
-template<typename> requires(HashTraits<T>::hasIsWeakNullValueFunction)
-inline size_t ListHashSet<T, U>::computeSize() const
+inline size_t ListHashSet<T, U>::computeSize() const requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.computeSize();
 }
 
 template<typename T, typename U>
-template<typename> requires(HashTraits<T>::hasIsWeakNullValueFunction)
-inline bool ListHashSet<T, U>::isEmptyIgnoringNullReferences() const
+inline bool ListHashSet<T, U>::isEmptyIgnoringNullReferences() const requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     return m_impl.isEmptyIgnoringNullReferences();
 }
 
 template<typename T, typename U>
-template<typename> requires(HashTraits<T>::hasIsWeakNullValueFunction)
-inline void ListHashSet<T, U>::removeWeakNullEntries()
+inline void ListHashSet<T, U>::removeWeakNullEntries() requires (ValueTraits::hasIsWeakNullValueFunction)
 {
     m_impl.removeWeakNullEntries();
 }


### PR DESCRIPTION
#### 9ffb2a696a2c6e839d40a9caaab00a5b7f5f96d0
<pre>
Simplify `requires` statements introduced in 304372@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=304151">https://bugs.webkit.org/show_bug.cgi?id=304151</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/WTF/wtf/HashMap.h:
(WTF::requires):
(WTF::M&gt;::computeSize const): Deleted.
(WTF::M&gt;::isEmptyIgnoringNullReferences const): Deleted.
(WTF::M&gt;::removeWeakNullEntries): Deleted.
* Source/WTF/wtf/HashSet.h:
(WTF::requires):
(WTF::shouldValidateKey&gt;::computeSize const): Deleted.
(WTF::shouldValidateKey&gt;::isEmptyIgnoringNullReferences const): Deleted.
(WTF::shouldValidateKey&gt;::removeWeakNullEntries): Deleted.
* Source/WTF/wtf/HashTable.h:
(WTF::requires):
(WTF::Malloc&gt;::computeSize const): Deleted.
(WTF::Malloc&gt;::isEmptyIgnoringNullReferences const): Deleted.
(WTF::Malloc&gt;::removeWeakNullEntries const): Deleted.
* Source/WTF/wtf/ListHashSet.h:
(WTF::requires):
(WTF::U&gt;::computeSize const): Deleted.
(WTF::U&gt;::isEmptyIgnoringNullReferences const): Deleted.
(WTF::U&gt;::removeWeakNullEntries): Deleted.

Canonical link: <a href="https://commits.webkit.org/304442@main">https://commits.webkit.org/304442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/260867ee7851c906253014e87cef70da0ee8ab8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87243 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4ae1d460-a103-4de1-b4c5-59f0fe29cb33) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7786 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0139cb9e-9591-4b24-b328-008646d0ca66) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121521 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/206ee36c-0942-4084-8ea5-f2f21f403819) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3559 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3864 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127554 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115172 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146005 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134045 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40277 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28502 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5810 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7676 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35936 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166884 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71222 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43574 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7524 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->