### PR TITLE
[iOS] Safari sometimes crashes under -[UIPreviewTarget initWithContainer:center:transform:]

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -461,6 +461,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WebTextIndicatorLayer> _textIndicatorLayer;
 
 #if USE(UICONTEXTMENU)
+    BOOL _isPreparingToDisplayContextMenu;
     BOOL _isDisplayingContextMenuWithAnimation;
     RetainPtr<UITargetedPreview> _contextMenuInteractionTargetedPreview;
 #endif


### PR DESCRIPTION
#### 6269463a4c4fef31834c398cc93b9d7f08605fdb
<pre>
[iOS] Safari sometimes crashes under -[UIPreviewTarget initWithContainer:center:transform:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=304152">https://bugs.webkit.org/show_bug.cgi?id=304152</a>
<a href="https://rdar.apple.com/162978545">rdar://162978545</a>

Reviewed by Abrar Rahman Protyasha.

This is a speculative fix for an ObjC exception when presenting a context menu on iOS:

```
*** Terminating app due to uncaught exception &apos;NSInternalInconsistencyException&apos;, reason:
&apos;UIPreviewTarget requires that the container view is in a window, but it is not. (container:
&lt;WKTargetedPreviewContainer: 0x6b8f29f80; name=Context Menu Hint Preview Container&gt;)
```

From code inspection, it&apos;s theoretically possible for this context menu preview container to be
removed in the time between when:

• `-contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:` is called, and when
• `-contextMenuInteraction:willDisplayMenuForConfiguration:animator:` is called

...although I was unable to reproduce this locally to confirm. While we already have a mechanism to
avoid removing the context menu when `_isDisplayingContextMenuWithAnimation` is set (i.e. between
when `willDisplayMenuForConfiguration:` is called and when the animator completion block is called),
this doesn&apos;t extend to *before* `willDisplayMenuForConfiguration:` is called. To fix this, we add a
new flag and guard removing the context menu hint container on this flag being false.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView containerForContextMenuHintPreviews]):
(-[WKContentView _removeContainerForContextMenuHintPreviews]):

Also add release logging, so that we can gather more data about the context menu hint container
lifetime to diagnose further issues.

(-[WKContentView _removeContextMenuHintContainerIfPossible]):

Return early if `_isPreparingToDisplayContextMenu` is set; see above.

(-[WKContentView contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:]):
(-[WKContentView contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):

Canonical link: <a href="https://commits.webkit.org/304459@main">https://commits.webkit.org/304459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a8a5f44669387930b4428695f35783ecbee8e5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87225 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4d89213-8b13-4ab4-ae4e-7eb36ae8efff) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137411 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b5f0531-5093-4cda-b46e-ec664f35b6df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84452 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb0a4221-838c-4ea5-a517-094a92182a80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5927 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3539 "Found 1 new API test failure: TestWebKitAPI.WKUserContentController.DidAssociateFormControlsFromShadowTree (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115145 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145987 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7605 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111948 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28511 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5786 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117799 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7657 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35915 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7505 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->