### PR TITLE
Re-enable wasm fast memory on Windows and stop

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -134,6 +134,10 @@ static RefPtr<BufferMemoryHandle> tryAllocateResizableMemory(VM* vm, size_t size
         return nullptr;
     }
 
+#if OS(WINDOWS)
+    if (initialBytes)
+        OSAllocator::commit(slowMemory, initialBytes, /* writable */ true, /* executable */ false);
+#endif
     constexpr bool readable = false;
     constexpr bool writable = false;
     OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable);

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -81,7 +81,12 @@ BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
         if (m_fastMemories.size() >= m_maxFastMemoryCount)
             return BufferMemoryResult(nullptr, BufferMemoryResult::Kind::SyncTryToReclaimMemory);
 
+#if OS(WINDOWS)
+        // Windows has no overcommit, so reserve the region and commit lazily.
+        void* result = OSAllocator::tryReserveUncommitted(BufferMemoryHandle::fastMappedBytes());
+#else
         void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
+#endif
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::Kind::SyncTryToReclaimMemory);
 
@@ -101,7 +106,11 @@ void BufferMemoryManager::freeFastMemory(void* basePtr)
 {
     {
         Locker locker { m_lock };
+#if OS(WINDOWS)
+        OSAllocator::releaseDecommitted(basePtr, BufferMemoryHandle::fastMappedBytes(), 0);
+#else
         Gigacage::freeVirtualPages(Gigacage::Primitive, basePtr, BufferMemoryHandle::fastMappedBytes());
+#endif
         m_fastMemories.removeFirst(basePtr);
     }
 
@@ -112,7 +121,11 @@ BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(
 {
     BufferMemoryResult result = [&] {
         Locker locker { m_lock };
+#if OS(WINDOWS)
+        void* result = OSAllocator::tryReserveUncommitted(mappedCapacity);
+#else
         void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, mappedCapacity);
+#endif
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::Kind::SyncTryToReclaimMemory);
 
@@ -130,7 +143,11 @@ void BufferMemoryManager::freeGrowableBoundsCheckingMemory(void* basePtr, size_t
 {
     {
         Locker locker { m_lock };
+#if OS(WINDOWS)
+        OSAllocator::releaseDecommitted(basePtr, mappedCapacity, 0);
+#else
         Gigacage::freeVirtualPages(Gigacage::Primitive, basePtr, mappedCapacity);
+#endif
         m_growableBoundsCheckingMemories.erase(std::make_pair(std::bit_cast<uintptr_t>(basePtr), mappedCapacity));
     }
 
@@ -249,10 +266,15 @@ BufferMemoryHandle::~BufferMemoryHandle()
         switch (m_mode) {
         case MemoryMode::Signaling: {
             // nullBasePointer's zero-sized memory is not used for MemoryMode::Signaling.
+#if OS(WINDOWS)
+            // The region was only reserved; releasing frees it without re-committing.
+            BufferMemoryManager::singleton().freeFastMemory(memory);
+#else
             constexpr bool readable = true;
             constexpr bool writable = true;
             OSAllocator::protect(memory, BufferMemoryHandle::fastMappedBytes(), readable, writable);
             BufferMemoryManager::singleton().freeFastMemory(memory);
+#endif
             break;
         }
         case MemoryMode::BoundsChecking: {
@@ -268,10 +290,14 @@ BufferMemoryHandle::~BufferMemoryHandle()
                     ASSERT(!m_size);
                     return;
                 }
+#if OS(WINDOWS)
+                BufferMemoryManager::singleton().freeGrowableBoundsCheckingMemory(memory, m_mappedCapacity);
+#else
                 constexpr bool readable = true;
                 constexpr bool writable = true;
                 OSAllocator::protect(memory, m_mappedCapacity, readable, writable);
                 BufferMemoryManager::singleton().freeGrowableBoundsCheckingMemory(memory, m_mappedCapacity);
+#endif
                 break;
             }
             }

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1009,7 +1009,7 @@ void Options::notifyOptionsChanged()
         // FIXME: Should support for OSR exit as well.
     }
 
-#if CPU(ADDRESS32) || PLATFORM(PLAYSTATION) || OS(WINDOWS)
+#if CPU(ADDRESS32) || PLATFORM(PLAYSTATION)
     Options::useWasmFastMemory() = false;
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -180,6 +180,11 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     }
     
     if (fastMemory) {
+#if OS(WINDOWS)
+        // The region is only reserved; commit the in-use bytes before the no-access guard below.
+        if (initialBytes)
+            OSAllocator::commit(fastMemory, initialBytes, /* writable */ true, /* executable */ false);
+#endif
         constexpr bool readable = false;
         constexpr bool writable = false;
         OSAllocator::protect(fastMemory + initialBytes, BufferMemoryHandle::fastMappedBytes() - initialBytes, readable, writable);
@@ -229,6 +234,10 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
             return nullptr;
         }
 
+#if OS(WINDOWS)
+        if (initialBytes)
+            OSAllocator::commit(slowMemory, initialBytes, /* writable */ true, /* executable */ false);
+#endif
         constexpr bool readable = false;
         constexpr bool writable = false;
         OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable);

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -135,15 +135,38 @@ bool OSAllocator::tryProtect(void* address, size_t bytes, bool readable, bool wr
 {
     if (!bytes)
         return true;
+    if (!readable && !writable) {
+        MEMORY_BASIC_INFORMATION pageInfo;
+        SIZE_T queried = VirtualQuery(address, &pageInfo, sizeof(pageInfo));
+        if (!queried)
+            return false;
+        // Assert that the region size is at least the size we're trying to protect.
+        ASSERT(pageInfo.RegionSize >= bytes);
+        if (pageInfo.RegionSize < bytes) {
+            // if the region size is less than the size we're trying to protect, return false.
+            return false;
+        }
+        if (pageInfo.State == MEM_FREE) {
+            // Memory is not reserved, so its reserved as noaccess.
+            return VirtualAlloc(address, bytes, MEM_RESERVE, PAGE_NOACCESS);
+        }
+        if (pageInfo.State == MEM_RESERVE) {
+            // Memory is reserved, so its already noaccess.
+            return true;
+        }
+        if (pageInfo.State == MEM_COMMIT) {
+            // Memory is committed, so its protection is flipped to noaccess.
+            DWORD oldProtection;
+            return VirtualProtect(address, bytes, PAGE_NOACCESS, &oldProtection);
+        }
+        return false;
+    }
     DWORD protection = 0;
     if (readable) {
         if (writable)
             protection = PAGE_READWRITE;
         else
             protection = PAGE_READONLY;
-    } else {
-        ASSERT(!readable && !writable);
-        protection = PAGE_NOACCESS;
     }
 
     // VirtualAlloc(MEM_COMMIT) cannot span multiple MEM_RESERVE regions, so walk


### PR DESCRIPTION
#### ba1efbac4841cd0c03a11216bd3affb082b92520
<pre>
Re-enable wasm fast memory on Windows and stop
committing the guard region
<a href="https://bugs.webkit.org/show_bug.cgi?id=304154">https://bugs.webkit.org/show_bug.cgi?id=304154</a>

We were committing the 4 GiB guard/redzone with
PAGE_NOACCESS on Windows, exhausting commit space
and forcing wasm fast memory off. Update
OSAllocator::tryProtect&apos;s guard path to actively
enforce no-access without committing: reserve if
free, accept already-reserved, and VirtualProtect
committed pages to PAGE_NOACCESS. Also assert the
queried region covers the requested span. This
keeps guard pages faulting while avoiding commit
bloat, so wasm fast memory can stay enabled on
Windows.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryProtect):
</pre>
----------------------------------------------------------------------
#### 3b89ff1c91b156a6f09fb57e05adfc27ffadc738
<pre>
Re-enable wasm fast memory on Windows and stop committing the guard region
<a href="https://bugs.webkit.org/show_bug.cgi?id=304154">https://bugs.webkit.org/show_bug.cgi?id=304154</a>

Reviewed by NOBODY (OOPS!).

This change ensures guard ranges actually fault
without consuming commit space, fixing the prior
behavior where a guard request could leave an
accessible range untouched. In
OSAllocator::tryProtect’s guard branch, we now
inspect the page state and enforce no-access:
reserve if free, noop if already reserved, and
VirtualProtect to PAGE_NOACCESS if committed.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryProtect):
</pre>
----------------------------------------------------------------------
#### 1e8d2aaec50d9db06fab5feb162245c9684907d6
<pre>
Re-enable wasm fast memory on Windows and stop
committing the guard region
<a href="https://bugs.webkit.org/show_bug.cgi?id=304154">https://bugs.webkit.org/show_bug.cgi?id=304154</a>

This change ensures guard ranges actually
fault without consuming commit space, fixing the
prior behavior where a guard request could leave
an accessible range untouched. In
OSAllocator::tryProtect’s guard branch, we now
inspect the page state and enforce no-access:
reserve if free, noop if already reserved, and
VirtualProtect to PAGE_NOACCESS if committed.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryProtect):
</pre>
----------------------------------------------------------------------
#### ea67b108bcbba35a32db00d905c1ca65527d3dab
<pre>
Re-enable wasm fast memory on Windows and stop
committing the guard region
<a href="https://bugs.webkit.org/show_bug.cgi?id=304154">https://bugs.webkit.org/show_bug.cgi?id=304154</a>

So the !readable &amp;&amp; !writable (guard) branch does
not commit. With this change we can keep
wasm fast memory enabled on Windows without
exhausting commit space while keeping the guard
reserved.

* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryProtect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cdb0082daa1f0cf6aaf7ab5db1f33f6c4185dfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152152 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146462 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101230 "1 flakes 37 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46756 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8625 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/15480 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46550 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/48712 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199820 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/186984 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61005 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156142 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61725 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155796 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50106 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133841 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/131434 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->