### PR TITLE
Web Inspector: remove trailing ".0" for timestamps

### DIFF
--- a/LayoutTests/inspector/unit-tests/number-utilities.html
+++ b/LayoutTests/inspector/unit-tests/number-utilities.html
@@ -42,7 +42,7 @@ function test()
             InspectorTest.expectEqual(Number.secondsToString(0.123456, false), "123ms", "normal resolution of greater than 100ms but sub 1s should be ms");
             InspectorTest.expectEqual(Number.secondsToString(1.123456, false), "1.12s", "normal resolution of greater than 1s but sub 1min should be seconds");
             InspectorTest.expectEqual(Number.secondsToString(30.123456, false), "30.12s", "normal resolution of greater than 1s but sub 1min should be seconds");
-            InspectorTest.expectEqual(Number.secondsToString(60.123456, false), "1.0min", "normal resolution of greater than 1min but sub 1hr should be minutes");
+            InspectorTest.expectEqual(Number.secondsToString(60.123456, false), "1min", "normal resolution of greater than 1min but sub 1hr should be minutes");
             InspectorTest.expectEqual(Number.secondsToString(100.123456, false), "1.7min", "normal resolution of greater than 1min but sub 1hr should be minutes");
             InspectorTest.expectEqual(Number.secondsToString(12345, false), "3.4hrs", "normal resolution of greater than 1hr but sub 1 day should be hrs");
             InspectorTest.expectEqual(Number.secondsToString(123456, false), "1.4 days", "normal resolution of greater than 1 day should be days");

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -1158,7 +1158,8 @@ Object.defineProperty(String, "standardFormatters",
             let options = {
                 minimumFractionDigits: token.precision,
                 maximumFractionDigits: token.precision,
-                useGrouping: false
+                useGrouping: false,
+                trailingZeroDisplay: "stripIfInteger",
             };
             return value.toLocaleString(undefined, options);
         },
@@ -1321,7 +1322,7 @@ Object.defineProperty(Number, "percentageString",
 {
     value(fraction, precision = 1)
     {
-        return fraction.toLocaleString(undefined, {minimumFractionDigits: precision, style: "percent"});
+        return fraction.toLocaleString(undefined, {minimumFractionDigits: precision, style: "percent", trailingZeroDisplay: "stripIfInteger"});
     }
 });
 

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
@@ -297,7 +297,8 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
             minimumFractionDigits: 0,
             maximumFractionDigits: 2,
             useGrouping: false,
-        }
+            trailingZeroDisplay: "stripIfInteger",
+        };
         return value.toLocaleString(undefined, options);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
@@ -141,7 +141,8 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
             minimumFractionDigits: 0,
             maximumFractionDigits: 2,
             useGrouping: false,
-        }
+            trailingZeroDisplay: "stripIfInteger",
+        };
         return value.toLocaleString(undefined, options);
     }
 


### PR DESCRIPTION
#### b4456ac914a1a17444a6a1b58cecdcbdbb24b05b
<pre>
Web Inspector: remove trailing &quot;.0&quot; for timestamps
<a href="https://bugs.webkit.org/show_bug.cgi?id=191122">https://bugs.webkit.org/show_bug.cgi?id=191122</a>
<a href="https://rdar.apple.com/problem/166500013">rdar://problem/166500013</a>

Reviewed by Devin Rousso.

Strip trailing zeros from integer duration values to improve readability.
For example, &quot;1.00ms&quot; now displays as &quot;1ms&quot;.

This is achieved by adding `trailingZeroDisplay: &quot;stripIfInteger&quot;` to the
`toLocaleString` options in `String.standardFormatters`, which handles
this in a locale-aware manner.

* LayoutTests/inspector/unit-tests/number-utilities.html:
* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(value.f):
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype._formatAxisValueAsString):
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js:
(WI.FontVariationDetailsSectionRow.prototype._formatAxisValueAsString):

Canonical link: <a href="https://commits.webkit.org/304851@main">https://commits.webkit.org/304851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/123bd5857931c4967b2fe2c0437dcf3dde19e935

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89646 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c9bfd30-149a-4682-8cb7-f7d999980231) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e130a5f1-a9ef-4ba9-adbd-4904ab02a006) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85354 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df327882-35e0-4c18-9aa4-4760ce31bdec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6755 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4441 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147157 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6678 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8764 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36809 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8556 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->