### PR TITLE
[WPE] Add public API for context menu handling

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -60,6 +60,11 @@ struct _WebKitContextMenuPrivate {
     GList* items;
     WebKitContextMenuItem* parentItem;
     GRefPtr<GVariant> userData;
+#if PLATFORM(WPE)
+    gint positionX;
+    gint positionY;
+    gboolean hasPosition;
+#endif
 #if PLATFORM(GTK)
 #if USE(GTK4)
     GRefPtr<GdkEvent> event;
@@ -432,5 +437,45 @@ GdkEvent* webkit_context_menu_get_event(WebKitContextMenu* menu)
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU(menu), nullptr);
 
     return menu->priv->event.get();
+}
+#endif
+
+#if PLATFORM(WPE) && ENABLE(CONTEXT_MENUS)
+void webkitContextMenuSetPosition(WebKitContextMenu* menu, gint x, gint y)
+{
+    menu->priv->positionX = x;
+    menu->priv->positionY = y;
+    menu->priv->hasPosition = TRUE;
+}
+
+/**
+ * webkit_context_menu_get_position:
+ * @menu: a #WebKitContextMenu
+ * @x: (out) (optional): return location for the X coordinate
+ * @y: (out) (optional): return location for the Y coordinate
+ *
+ * Gets the position of the context menu.
+ *
+ * Gets the position where the context menu was triggered. This function
+ * only returns valid coordinates when called for a #WebKitContextMenu
+ * passed to #WebKitWebView::context-menu signal; in all other cases,
+ * %FALSE is returned and @x and @y are not modified.
+ *
+ * Returns: %TRUE if the position was set, or %FALSE otherwise.
+ *
+ */
+gboolean webkit_context_menu_get_position(WebKitContextMenu* menu, gint* x, gint* y)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU(menu), FALSE);
+
+    if (!menu->priv->hasPosition)
+        return FALSE;
+
+    if (x)
+        *x = menu->priv->positionX;
+    if (y)
+        *y = menu->priv->positionY;
+
+    return TRUE;
 }
 #endif

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
@@ -61,6 +61,9 @@ struct _WebKitContextMenuItemPrivate {
 
     std::unique_ptr<WebContextMenuItemGlib> menuItem;
     GRefPtr<WebKitContextMenu> subMenu;
+#if PLATFORM(WPE)
+    CString titleUTF8;
+#endif
 #endif // ENABLE(CONTEXT_MENUS)
 };
 
@@ -356,6 +359,32 @@ WebKitContextMenuAction webkit_context_menu_item_get_stock_action(WebKitContextM
     g_assert_not_reached();
 #endif // ENABLE(CONTEXT_MENUS)
 }
+
+#if PLATFORM(WPE)
+/**
+ * webkit_context_menu_item_get_title:
+ * @item: a #WebKitContextMenuItem
+ *
+ * Gets the title of @item.
+ *
+ * Returns: the title of @item, or %NULL if @item is a separator.
+ *
+ */
+const gchar* webkit_context_menu_item_get_title(WebKitContextMenuItem* item)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), nullptr);
+
+#if ENABLE(CONTEXT_MENUS)
+    if (item->priv->menuItem->type() == WebCore::ContextMenuItemType::Separator)
+        return nullptr;
+    if (item->priv->titleUTF8.isNull())
+        item->priv->titleUTF8 = item->priv->menuItem->title().utf8();
+    return item->priv->titleUTF8.data();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
+}
+#endif
 
 /**
  * webkit_context_menu_item_is_separator:

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -33,6 +33,9 @@ void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenu
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemData>&);
 void webkitContextMenuSetParentItem(WebKitContextMenu*, WebKitContextMenuItem*);
 WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu*);
+#if PLATFORM(WPE)
+void webkitContextMenuSetPosition(WebKitContextMenu*, gint x, gint y);
+#endif
 #if PLATFORM(GTK)
 #if USE(GTK4)
 void webkitContextMenuSetEvent(WebKitContextMenu*, GRefPtr<GdkEvent>&&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
@@ -111,6 +111,13 @@ WEBKIT_API GdkEvent *
 webkit_context_menu_get_event            (WebKitContextMenu     *menu);
 #endif
 
+#if PLATFORM(WPE)
+WEBKIT_API gboolean
+webkit_context_menu_get_position         (WebKitContextMenu     *menu,
+                                          gint                  *x,
+                                          gint                  *y);
+#endif
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
@@ -89,6 +89,11 @@ webkit_context_menu_item_get_gaction                      (WebKitContextMenuItem
 WEBKIT_API WebKitContextMenuAction
 webkit_context_menu_item_get_stock_action                 (WebKitContextMenuItem  *item);
 
+#if PLATFORM(WPE)
+WEBKIT_API const gchar *
+webkit_context_menu_item_get_title                        (WebKitContextMenuItem  *item);
+#endif
+
 WEBKIT_API gboolean
 webkit_context_menu_item_is_separator                     (WebKitContextMenuItem  *item);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -39,6 +39,9 @@
 #include "SystemSettingsManagerProxy.h"
 #include "WebContextMenuItem.h"
 #include "WebContextMenuItemData.h"
+#if PLATFORM(WPE)
+#include "WebContextMenuProxyWPE.h"
+#endif
 #include "WebFrameProxy.h"
 #include "WebKitAuthenticationRequestPrivate.h"
 #include "WebKitBackForwardListPrivate.h"
@@ -3023,6 +3026,12 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
     GRefPtr<WebKitContextMenu> contextMenu = adoptGRef(webkitContextMenuCreate(proposedMenu));
     if (userData)
         webkit_context_menu_set_user_data(WEBKIT_CONTEXT_MENU(contextMenu.get()), userData);
+
+    // Set the menu position from the active context menu data.
+    auto& page = webkitWebViewGetPage(webView);
+    auto menuLocation = page.activeContextMenuLocation();
+    webkitContextMenuSetPosition(contextMenu.get(), menuLocation.x(), menuLocation.y());
+
     GRefPtr<WebKitHitTestResult> hitTestResult = adoptGRef(webkitHitTestResultCreate(hitTestResultData));
     gboolean returnValue;
     g_signal_emit(webView, signals[CONTEXT_MENU], 0, contextMenu.get(),
@@ -3030,6 +3039,39 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
         nullptr,
 #endif
         hitTestResult.get(), &returnValue);
+}
+
+/**
+ * webkit_web_view_select_context_menu_item:
+ * @web_view: a #WebKitWebView
+ * @item: a #WebKitContextMenuItem
+ *
+ * Selects a context menu item.
+ *
+ * This function should be called by WPE applications that render their own
+ * context menu UI. When the user selects a menu item, call this function to
+ * tell WebKit which item was selected. WebKit will then execute the
+ * corresponding action (e.g., copy, paste, open link, etc.).
+ *
+ * This function must be called while the context menu is still active (i.e.,
+ * after the #WebKitWebView::context-menu signal was emitted and before the
+ * #WebKitWebView::context-menu-dismissed signal is emitted).
+ *
+ */
+void webkit_web_view_select_context_menu_item(WebKitWebView* webView, WebKitContextMenuItem* item)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    g_return_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item));
+
+    auto& page = webkitWebViewGetPage(webView);
+    auto* contextMenuProxy = static_cast<WebContextMenuProxyWPE*>(page.activeContextMenu());
+    if (!contextMenuProxy) {
+        g_warning("webkit_web_view_select_context_menu_item: No active context menu");
+        return;
+    }
+
+    auto itemData = webkitContextMenuItemToWebContextMenuItemData(item);
+    page.contextMenuItemSelected(itemData, contextMenuProxy->frameInfo());
 }
 #endif
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -29,6 +29,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitAuthenticationRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardList.h>
 #include <@API_INCLUDE_PREFIX@/WebKitContextMenu.h>
+#include <@API_INCLUDE_PREFIX@/WebKitContextMenuItem.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 #include <@API_INCLUDE_PREFIX@/WebKitEditorState.h>
 #include <@API_INCLUDE_PREFIX@/WebKitFileChooserRequest.h>
@@ -1072,6 +1073,12 @@ webkit_web_view_leave_immersive_mode                 (WebKitWebView             
  *
  * Deprecated: 2.40: Use webkit_web_view_call_async_javascript_function() instead.
  */
+#endif
+
+#if PLATFORM(WPE)
+WEBKIT_API void
+webkit_web_view_select_context_menu_item          (WebKitWebView             *web_view,
+                                                   WebKitContextMenuItem     *item);
 #endif
 
 G_END_DECLS

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -303,9 +303,9 @@ RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy& pag
 }
 
 #if ENABLE(CONTEXT_MENUS)
-Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& page, FrameInfoData&&, ContextMenuContextData&& context, const UserData& userData)
+Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
 {
-    return WebContextMenuProxyWPE::create(page, WTFMove(context), userData);
+    return WebContextMenuProxyWPE::create(page, WTFMove(frameInfo), WTFMove(context), userData);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10975,6 +10975,11 @@ void WebPageProxy::handleContextMenuKeyEvent()
     send(Messages::WebPage::ContextMenuForKeyEvent());
 }
 
+const WebCore::IntPoint& WebPageProxy::activeContextMenuLocation() const
+{
+    return internals().activeContextMenuContextData.menuLocation();
+}
+
 #endif // ENABLE(CONTEXT_MENUS)
 
 #if ENABLE(CONTEXT_MENU_EVENT)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1822,6 +1822,7 @@ public:
     void didDismissContextMenu();
     void contextMenuItemSelected(const WebContextMenuItemData&, const FrameInfoData&);
     void handleContextMenuKeyEvent();
+    const WebCore::IntPoint& activeContextMenuLocation() const;
 #endif
 
 #if USE(UICONTEXTMENU)
@@ -2426,7 +2427,7 @@ public:
     void setHasExecutedAppBoundBehaviorBeforeNavigation() { m_hasExecutedAppBoundBehaviorBeforeNavigation = true; }
 
     WebPopupMenuProxy* activePopupMenu() const { return m_activePopupMenu.get(); }
-#if ENABLE(CONTEXT_MENUS) && PLATFORM(WIN)
+#if ENABLE(CONTEXT_MENUS) && (PLATFORM(WIN) || PLATFORM(WPE))
     WebContextMenuProxy* activeContextMenu() const { return m_activeContextMenu.get(); }
 #endif
 

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
@@ -31,8 +31,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
     : WebContextMenuProxy(page, WTFMove(context), userData)
+    , m_frameInfo(WTFMove(frameInfo))
 {
 }
 

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameInfoData.h"
 #include "WebContextMenuProxy.h"
 
 #if ENABLE(CONTEXT_MENUS)
@@ -33,14 +34,18 @@ namespace WebKit {
 
 class WebContextMenuProxyWPE final : public WebContextMenuProxy {
 public:
-    static auto create(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+    static auto create(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
     {
-        return adoptRef(*new WebContextMenuProxyWPE(page, WTFMove(context), userData));
+        return adoptRef(*new WebContextMenuProxyWPE(page, WTFMove(frameInfo), WTFMove(context), userData));
     }
 
+    const FrameInfoData& frameInfo() const { return m_frameInfo; }
+
 private:
-    WebContextMenuProxyWPE(WebPageProxy&, ContextMenuContextData&&, const UserData&);
+    WebContextMenuProxyWPE(WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
+
+    const FrameInfoData m_frameInfo;
 };
 
 } // namespace WebKit

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -61,6 +61,7 @@ static char* timeZone;
 static const char* featureList = nullptr;
 static gboolean enableITP;
 static gboolean printVersion;
+static gboolean testContextMenu;
 static guint windowWidth = 0;
 static guint windowHeight = 0;
 static guint defaultWindowWidthLegacyAPI = 1280;
@@ -130,6 +131,7 @@ static const GOptionEntry commandLineOptions[] =
 #endif
     { "size", 's', 0, G_OPTION_ARG_CALLBACK, reinterpret_cast<gpointer>(parseWindowSize), "Specify the window size to use, e.g. --size=\"800x600\"", nullptr },
     { "version", 'v', 0, G_OPTION_ARG_NONE, &printVersion, "Print the WPE version", nullptr },
+    { "test-context-menu", 0, 0, G_OPTION_ARG_NONE, &testContextMenu, "Enable context menu API testing. Use G_MESSAGES_DEBUG=all to see debug logs", nullptr },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uriArguments, nullptr, "[URL]" },
     { nullptr, 0, 0, G_OPTION_ARG_NONE, nullptr, nullptr, nullptr }
 };
@@ -324,6 +326,104 @@ static void webViewClose(WebKitWebView* webView, gpointer user_data)
         g_application_quit(G_APPLICATION(user_data));
 }
 
+struct ContextMenuTestData {
+    WebKitWebView* webView;
+    WebKitContextMenuItem* item;
+};
+
+static gboolean selectContextMenuItemAfterDelay(gpointer userData)
+{
+    auto* data = static_cast<ContextMenuTestData*>(userData);
+
+    g_debug("Timer fired! Selecting context menu item...");
+    const char* title = webkit_context_menu_item_get_title(data->item);
+    g_debug("Selecting: \"%s\"", title ? title : "(null)");
+
+    webkit_web_view_select_context_menu_item(data->webView, data->item);
+
+    g_object_unref(data->item);
+    delete data;
+
+    return G_SOURCE_REMOVE;
+}
+
+#if ENABLE_2022_GLIB_API
+static gboolean contextMenuCallback(WebKitWebView* webView, WebKitContextMenu* contextMenu, WebKitHitTestResult* hitTestResult, gpointer)
+#else
+static gboolean contextMenuCallback(WebKitWebView* webView, WebKitContextMenu* contextMenu, gpointer /*event*/, WebKitHitTestResult* hitTestResult, gpointer)
+#endif
+{
+    g_debug("context-menu signal emitted for webView %p", static_cast<void*>(webView));
+    g_debug("contextMenu: %p, hitTestResult: %p", static_cast<void*>(contextMenu), static_cast<void*>(hitTestResult));
+
+    gint x = 0, y = 0;
+    if (webkit_context_menu_get_position(contextMenu, &x, &y))
+        g_debug("click position: (%d, %d)", x, y);
+    else
+        g_debug("click position: (not available)");
+
+    if (hitTestResult) {
+        guint context = webkit_hit_test_result_get_context(hitTestResult);
+        g_debug("context flags: 0x%x", context);
+        g_debug("is_link: %s", webkit_hit_test_result_context_is_link(hitTestResult) ? "true" : "false");
+        g_debug("is_image: %s", webkit_hit_test_result_context_is_image(hitTestResult) ? "true" : "false");
+        g_debug("is_media: %s", webkit_hit_test_result_context_is_media(hitTestResult) ? "true" : "false");
+        g_debug("is_editable: %s", webkit_hit_test_result_context_is_editable(hitTestResult) ? "true" : "false");
+        g_debug("is_selection: %s", webkit_hit_test_result_context_is_selection(hitTestResult) ? "true" : "false");
+        g_debug("is_scrollbar: %s", webkit_hit_test_result_context_is_scrollbar(hitTestResult) ? "true" : "false");
+
+        const char* linkUri = webkit_hit_test_result_get_link_uri(hitTestResult);
+        const char* linkTitle = webkit_hit_test_result_get_link_title(hitTestResult);
+        const char* linkLabel = webkit_hit_test_result_get_link_label(hitTestResult);
+        const char* imageUri = webkit_hit_test_result_get_image_uri(hitTestResult);
+        const char* mediaUri = webkit_hit_test_result_get_media_uri(hitTestResult);
+
+        g_debug("link_uri: %s", linkUri ? linkUri : "(null)");
+        g_debug("link_title: %s", linkTitle ? linkTitle : "(null)");
+        g_debug("link_label: %s", linkLabel ? linkLabel : "(null)");
+        g_debug("image_uri: %s", imageUri ? imageUri : "(null)");
+        g_debug("media_uri: %s", mediaUri ? mediaUri : "(null)");
+    }
+
+    // Print context menu items
+    GList* items = webkit_context_menu_get_items(contextMenu);
+    g_debug("menu items (%u):", g_list_length(items));
+    for (GList* iter = items; iter; iter = iter->next) {
+        auto* item = WEBKIT_CONTEXT_MENU_ITEM(iter->data);
+        if (webkit_context_menu_item_is_separator(item))
+            g_debug("- (separator)");
+        else {
+            const char* title = webkit_context_menu_item_get_title(item);
+            WebKitContextMenuAction action = webkit_context_menu_item_get_stock_action(item);
+            g_debug("- \"%s\" (action=%d)", title ? title : "(null)", action);
+        }
+    }
+
+    // Test: Select the second non-separator item after 5 seconds delay
+    int itemIndex = 0;
+    for (GList* iter = items; iter; iter = iter->next) {
+        auto* item = WEBKIT_CONTEXT_MENU_ITEM(iter->data);
+        if (!webkit_context_menu_item_is_separator(item)) {
+            itemIndex++;
+            if (itemIndex == 2) {
+                const char* title = webkit_context_menu_item_get_title(item);
+                g_debug("Will select item #%d (\"%s\") after 5 seconds...",
+                    itemIndex, title ? title : "(null)");
+
+                auto* testData = new ContextMenuTestData;
+                testData->webView = webView;
+                testData->item = item;
+                g_object_ref(item);
+
+                g_timeout_add_seconds(5, selectContextMenuItemAfterDelay, testData);
+                break;
+            }
+        }
+    }
+
+    return FALSE; // FALSE: show menu, TRUE: suppress menu
+}
+
 static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationAction*, gpointer user_data)
 {
     auto backend = createViewBackend(defaultWindowWidthLegacyAPI, defaultWindowHeightLegacyAPI);
@@ -356,6 +456,8 @@ static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationActi
 
     g_signal_connect(newWebView, "create", G_CALLBACK(createWebView), user_data);
     g_signal_connect(newWebView, "close", G_CALLBACK(webViewClose), user_data);
+    if (testContextMenu)
+        g_signal_connect(newWebView, "context-menu", G_CALLBACK(contextMenuCallback), nullptr);
 
     g_hash_table_add(openViews, newWebView);
 
@@ -648,6 +750,8 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
     g_signal_connect(webView, "permission-request", G_CALLBACK(decidePermissionRequest), nullptr);
     g_signal_connect(webView, "create", G_CALLBACK(createWebView), application);
     g_signal_connect(webView, "close", G_CALLBACK(webViewClose), application);
+    if (testContextMenu)
+        g_signal_connect(webView, "context-menu", G_CALLBACK(contextMenuCallback), nullptr);
     g_hash_table_add(openViews, webView);
 
     WebKitColor color;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestContextMenuWPE.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestContextMenuWPE.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "WebViewTest.h"
+#include <wtf/glib/GRefPtr.h>
+
+class ContextMenuTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(ContextMenuTest);
+
+    ~ContextMenuTest()
+    {
+        if (m_contextMenu)
+            g_object_unref(m_contextMenu);
+        if (m_hitTestResult)
+            g_object_unref(m_hitTestResult);
+    }
+
+#if ENABLE(2022_GLIB_API)
+    static gboolean contextMenuCallback(WebKitWebView* webView, WebKitContextMenu* contextMenu, WebKitHitTestResult* hitTestResult, ContextMenuTest* test)
+#else
+    static gboolean contextMenuCallback(WebKitWebView* webView, WebKitContextMenu* contextMenu, gpointer /*event*/, WebKitHitTestResult* hitTestResult, ContextMenuTest* test)
+#endif
+    {
+        g_assert_nonnull(contextMenu);
+        g_assert_nonnull(hitTestResult);
+        // Reference the objects to keep them alive after the callback returns
+        test->m_contextMenu = WEBKIT_CONTEXT_MENU(g_object_ref(contextMenu));
+        test->m_hitTestResult = WEBKIT_HIT_TEST_RESULT(g_object_ref(hitTestResult));
+        test->quitMainLoop();
+        return FALSE;
+    }
+
+    static gboolean contextMenuTimeoutCallback(ContextMenuTest* test)
+    {
+        test->m_contextMenuTimedOut = true;
+        test->quitMainLoop();
+        return G_SOURCE_REMOVE;
+    }
+
+    WebKitContextMenu* showContextMenuAtPosition(int x, int y)
+    {
+        // Release any previously held references
+        if (m_contextMenu) {
+            g_object_unref(m_contextMenu);
+            m_contextMenu = nullptr;
+        }
+        if (m_hitTestResult) {
+            g_object_unref(m_hitTestResult);
+            m_hitTestResult = nullptr;
+        }
+        m_contextMenuTimedOut = false;
+
+        auto contextMenuId = g_signal_connect(m_webView.get(), "context-menu", G_CALLBACK(contextMenuCallback), this);
+
+        // Add a timeout to prevent hanging forever if context menu doesn't appear
+        auto timeoutId = g_timeout_add(5000, reinterpret_cast<GSourceFunc>(contextMenuTimeoutCallback), this);
+
+        clickMouseButton(x, y, MouseButton::Secondary);
+        g_main_loop_run(m_mainLoop);
+
+        g_source_remove(timeoutId);
+        g_signal_handler_disconnect(m_webView.get(), contextMenuId);
+
+        if (m_contextMenuTimedOut)
+            g_test_message("Context menu did not appear within timeout");
+
+        return m_contextMenu;
+    }
+
+    WebKitContextMenu* m_contextMenu { nullptr };
+    WebKitHitTestResult* m_hitTestResult { nullptr };
+    bool m_contextMenuTimedOut { false };
+};
+
+static void testContextMenuGetPosition(ContextMenuTest* test, gconstpointer)
+{
+    test->showInWindow(800, 600);
+    test->loadHtml("<html><body style='margin:0;padding:0;'><p>Context menu position test</p></body></html>", nullptr);
+    test->waitUntilLoadFinished();
+
+    const int clickX = 100;
+    const int clickY = 50;
+
+    auto* menu = test->showContextMenuAtPosition(clickX, clickY);
+    if (!menu) {
+        g_test_skip("Context menu did not appear - context menu testing may not be supported in this environment");
+        return;
+    }
+
+    gint x = 0, y = 0;
+    gboolean hasPosition = webkit_context_menu_get_position(menu, &x, &y);
+    g_assert_true(hasPosition);
+    g_assert_cmpint(x, ==, clickX);
+    g_assert_cmpint(y, ==, clickY);
+
+    // Test with nullptr parameters - should still return TRUE
+    g_assert_true(webkit_context_menu_get_position(menu, nullptr, nullptr));
+    g_assert_true(webkit_context_menu_get_position(menu, &x, nullptr));
+    g_assert_true(webkit_context_menu_get_position(menu, nullptr, &y));
+}
+
+static void testContextMenuItemGetTitle(ContextMenuTest* test, gconstpointer)
+{
+    test->showInWindow(800, 600);
+    test->loadHtml("<html><body style='margin:0;padding:0;'><p>Context menu item title test</p></body></html>", nullptr);
+    test->waitUntilLoadFinished();
+
+    auto* menu = test->showContextMenuAtPosition(100, 50);
+    if (!menu) {
+        g_test_skip("Context menu did not appear");
+        return;
+    }
+
+    GList* items = webkit_context_menu_get_items(menu);
+    g_assert_nonnull(items);
+    g_assert_cmpuint(g_list_length(items), >, 0);
+
+    // Test that non-separator items return a valid string pointer
+    // Note: Some items may have empty titles depending on localization
+    int itemsWithTitle = 0;
+    for (GList* l = items; l; l = g_list_next(l)) {
+        auto* item = WEBKIT_CONTEXT_MENU_ITEM(l->data);
+        g_assert_true(WEBKIT_IS_CONTEXT_MENU_ITEM(item));
+
+        if (webkit_context_menu_item_is_separator(item)) {
+            // Separator items should return nullptr for title
+            g_assert_null(webkit_context_menu_item_get_title(item));
+        } else {
+            // Non-separator items should return a valid pointer (not nullptr)
+            const char* title = webkit_context_menu_item_get_title(item);
+            g_assert_nonnull(title);
+            if (strlen(title) > 0)
+                itemsWithTitle++;
+        }
+    }
+    // At least some items should have non-empty titles
+    g_assert_cmpint(itemsWithTitle, >, 0);
+}
+
+static void testContextMenuItemGetTitleStability(ContextMenuTest* test, gconstpointer)
+{
+    test->showInWindow(800, 600);
+    test->loadHtml("<html><body style='margin:0;padding:0;'><p>Title stability test</p></body></html>", nullptr);
+    test->waitUntilLoadFinished();
+
+    auto* menu = test->showContextMenuAtPosition(100, 50);
+    if (!menu) {
+        g_test_skip("Context menu did not appear");
+        return;
+    }
+
+    GList* items = webkit_context_menu_get_items(menu);
+    g_assert_nonnull(items);
+
+    // Find a non-separator item with a non-empty title
+    WebKitContextMenuItem* itemWithTitle = nullptr;
+    for (GList* l = items; l; l = g_list_next(l)) {
+        auto* item = WEBKIT_CONTEXT_MENU_ITEM(l->data);
+        if (!webkit_context_menu_item_is_separator(item)) {
+            const char* title = webkit_context_menu_item_get_title(item);
+            if (title && strlen(title) > 0) {
+                itemWithTitle = item;
+                break;
+            }
+        }
+    }
+
+    if (!itemWithTitle) {
+        g_test_skip("No menu item with non-empty title found");
+        return;
+    }
+
+    // Call get_title multiple times and verify the pointer is stable (cached)
+    const char* title1 = webkit_context_menu_item_get_title(itemWithTitle);
+    const char* title2 = webkit_context_menu_item_get_title(itemWithTitle);
+    const char* title3 = webkit_context_menu_item_get_title(itemWithTitle);
+
+    g_assert_nonnull(title1);
+    g_assert_true(title1 == title2);
+    g_assert_true(title2 == title3);
+}
+
+// TODO: Add the following tests:
+//
+// 1. testSelectContextMenuItem
+//    - Test webkit_web_view_select_context_menu_item() API
+//    - Verify that selecting a "Copy" menu item on selected text works correctly
+//
+// 2. testSelectContextMenuItemOnLink
+//    - Test webkit_web_view_select_context_menu_item() on a link element
+//    - Verify that "Copy Link Address" action works correctly
+//
+// These tests work correctly in MiniBrowser but block in the test environment
+//
+// Note: "context-menu-dismissed" signal testing is not applicable for WPE
+// since the application draws the context menu (not WebKit), so WebKit
+// cannot know when the menu is dismissed.
+
+void beforeAll()
+{
+    ContextMenuTest::add("ContextMenu", "get-position", testContextMenuGetPosition);
+    ContextMenuTest::add("ContextMenu", "item-get-title", testContextMenuItemGetTitle);
+    ContextMenuTest::add("ContextMenu", "item-get-title-stability", testContextMenuItemGetTitleStability);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -163,6 +163,10 @@ ADD_WK2_TEST(TestDOMElement ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDOME
 ADD_WK2_TEST(TestGeolocationManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp)
 ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp)
 
+if (PORT STREQUAL "WPE")
+    ADD_WK2_TEST(TestContextMenuWPE ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestContextMenuWPE.cpp)
+endif ()
+
 if (ENABLE_WEBXR AND USE_OPENXR)
     ADD_WK2_TEST(TestWebKitWebXR ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp)
 endif ()


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=272354

Reviewed by NOBODY (OOPS!).

## Summary
Add WPE-specific public APIs to allow applications to handle context menus:

- `webkit_context_menu_get_position()`: Get the position where the context menu was triggered
- `webkit_context_menu_item_get_title()`: Get the title of a context menu item
- `webkit_web_view_select_context_menu_item()`: Select a context menu item to execute its action

These APIs are necessary for WPE applications that render their own context menu UI, as WPE does not provide a native context menu implementation.

## Changes
- Added new public APIs for WPE context menu handling
- Added MiniBrowser test code with `--test-context-menu` option
- Added API tests in `TestContextMenuWPE.cpp`

## Test Plan
- [x] Build WPE port successfully
- [x] Run `TestContextMenuWPE` tests (3/3 pass)
- [x] Manual testing with MiniBrowser using `--test-context-menu` option


</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e14a4d4310940cd5556640adc5e8e599c3aecabe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103591 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/70976 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3551 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5798 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117811 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61563 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7669 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71215 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->