### PR TITLE
[OpenXR] Raname m_pointerSpace of OpenXRInputSource to m_aimSpace

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -64,8 +64,8 @@ OpenXRInputSource::~OpenXRInputSource()
         xrDestroyActionSet(m_actionSet);
     if (m_gripSpace != XR_NULL_HANDLE)
         xrDestroySpace(m_gripSpace);
-    if (m_pointerSpace != XR_NULL_HANDLE)
-        xrDestroySpace(m_pointerSpace);
+    if (m_aimSpace != XR_NULL_HANDLE)
+        xrDestroySpace(m_aimSpace);
 }
 
 IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
@@ -85,8 +85,8 @@ XrResult OpenXRInputSource::initialize(OpenXRSystemProperties&& systemProperties
 
     RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_grip"_s), m_gripAction));
     RETURN_RESULT_IF_FAILED(createActionSpace(m_gripAction, m_gripSpace));
-    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_pointer"_s), m_pointerAction));
-    RETURN_RESULT_IF_FAILED(createActionSpace(m_pointerAction, m_pointerSpace));
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_aim"_s), m_aimAction));
+    RETURN_RESULT_IF_FAILED(createActionSpace(m_aimAction, m_aimSpace));
 
 #if defined(XR_EXT_hand_interaction)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span)) {
@@ -159,7 +159,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
             continue;
 
         CHECK_XRCMD(createBinding(profile.path, m_gripAction, makeString(m_subactionPathName, s_inputGripPath), bindings));
-        CHECK_XRCMD(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, s_inputAimPath), bindings));
+        CHECK_XRCMD(createBinding(profile.path, m_aimAction, makeString(m_subactionPathName, s_inputAimPath), bindings));
 
 #if defined(XR_EXT_hand_interaction)
         if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span)) {
@@ -251,7 +251,7 @@ std::optional<PlatformXR::FrameData::InputSource> OpenXRInputSource::collectInpu
     data.targetRayMode = PlatformXR::XRTargetRayMode::TrackedPointer;
     data.profiles = m_profiles;
 
-    getPose(m_pointerSpace, localSpace, frameState, data.pointerOrigin);
+    getPose(m_aimSpace, localSpace, frameState, data.pointerOrigin);
     PlatformXR::FrameData::InputSourcePose gripPose;
     if (XR_SUCCEEDED(getPose(m_gripSpace, localSpace, frameState, gripPose)))
         data.gripOrigin = gripPose;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
@@ -76,8 +76,8 @@ private:
     XrActionSet m_actionSet { XR_NULL_HANDLE };
     XrAction m_gripAction { XR_NULL_HANDLE };
     XrSpace m_gripSpace { XR_NULL_HANDLE };
-    XrAction m_pointerAction { XR_NULL_HANDLE };
-    XrSpace m_pointerSpace { XR_NULL_HANDLE };
+    XrAction m_aimAction { XR_NULL_HANDLE };
+    XrSpace m_aimSpace { XR_NULL_HANDLE };
     XrAction m_pinchPoseAction { XR_NULL_HANDLE };
     XrSpace m_pinchSpace { XR_NULL_HANDLE };
     XrAction m_pokePoseAction { XR_NULL_HANDLE };


### PR DESCRIPTION
#### 01a8e48ad2548c029e8efc552ce52d14da30714f
<pre>
[OpenXR] Raname m_pointerSpace of OpenXRInputSource to m_aimSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=304157">https://bugs.webkit.org/show_bug.cgi?id=304157</a>

Reviewed by Dan Glastonbury.

OpenXR spec is using terms &quot;grip&quot; and &quot;aim&quot;. To align the spec, renamed
&quot;pointer&quot; of m_pointerAction, m_pointerSpace, and _pointer action name suffix
to &quot;aim&quot;.

* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::~OpenXRInputSource):
(WebKit::OpenXRInputSource::initialize):
(WebKit::OpenXRInputSource::suggestBindings const):
(WebKit::OpenXRInputSource::collectInputSource const):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h:

Canonical link: <a href="https://commits.webkit.org/304445@main">https://commits.webkit.org/304445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e963bdda165900b6630ac4316738c6d1f912783

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3556 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115165 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146003 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112332 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5804 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61570 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20900 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7674 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35931 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71220 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->