### PR TITLE
Address some safer cpp failures in DocumentThreadableLoader and WorkerThreadableLoader

### DIFF
--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -57,6 +57,13 @@ public:
     {
     }
 
+    void prepareForUseOnlyOnMainThread()
+    {
+#if ASSERT_ENABLED
+        m_wasConstructedOnMainThread = true;
+#endif
+    }
+
     void prepareForUseOnlyOnNonMainThread()
     {
 #if ASSERT_ENABLED

--- a/Source/WebCore/Modules/fetch/FetchLoader.h
+++ b/Source/WebCore/Modules/fetch/FetchLoader.h
@@ -46,7 +46,6 @@ class FragmentedSharedBuffer;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchLoader);
 class WEBCORE_EXPORT FetchLoader final : public RefCounted<FetchLoader>, public ThreadableLoaderClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FetchLoader, FetchLoader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchLoader);
 public:
     static Ref<FetchLoader> create(FetchLoaderClient&, FetchBodyConsumer*);
     ~FetchLoader();
@@ -59,6 +58,10 @@ public:
     void stop();
 
     bool isStarted() const { return m_isStarted; }
+
+    // ThreadableLoaderClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     FetchLoader(FetchLoaderClient&, FetchBodyConsumer*);

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -455,7 +455,7 @@ bool FetchResponse::Loader::start(ScriptExecutionContext& context, const FetchRe
 void FetchResponse::Loader::stop()
 {
     m_responseCallback = { };
-    if (CheckedPtr loader = m_loader.get())
+    if (RefPtr loader = m_loader.get())
         loader->stop();
 }
 
@@ -606,7 +606,7 @@ void FetchResponse::feedStream()
 
 RefPtr<FragmentedSharedBuffer> FetchResponse::Loader::startStreaming()
 {
-    if (CheckedPtr loader = m_loader.get())
+    if (RefPtr loader = m_loader.get())
         return loader->startStreaming();
 
     m_shouldStartStreaming = true;

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -26,8 +26,6 @@ layout/layouttree/LayoutChildIterator.h
 layout/layouttree/LayoutContainingBlockChainIterator.h
 layout/layouttree/LayoutDescendantIterator.h
 layout/layouttree/LayoutIterator.h
-loader/DocumentThreadableLoader.h
-loader/WorkerThreadableLoader.h
 page/FrameSnapshotting.cpp
 [ iOS ] page/ios/ContentChangeObserver.h
 platform/graphics/TextRunIterator.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -78,7 +78,6 @@ bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
 bindings/js/JSWorkerGlobalScopeBase.cpp
 bindings/js/JSWorkerNavigatorCustom.cpp
 bindings/js/JSWorkletGlobalScopeBase.cpp
-bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScheduledAction.cpp
 bindings/js/ScriptModuleLoader.cpp
 bridge/objc/WebScriptObject.mm
@@ -340,7 +339,6 @@ loader/ResourceMonitor.cpp
 loader/ResourceMonitorPersistence.cpp
 loader/SubframeLoader.cpp
 loader/SubresourceLoader.cpp
-loader/ThreadableLoaderClientWrapper.h
 loader/WorkerThreadableLoader.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 mathml/MathMLElement.cpp

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -37,6 +37,7 @@
 #include <WebCore/URLKeepingBlobAlive.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -56,7 +57,6 @@ class ThreadableLoader;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FileReaderLoader);
 class FileReaderLoader final : public ThreadableLoaderClient, public RefCounted<FileReaderLoader> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FileReaderLoader, FileReaderLoader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileReaderLoader);
 public:
     enum ReadType {
         ReadAsArrayBuffer,
@@ -69,17 +69,19 @@ public:
 
     // If client is given, do the loading asynchronously. Otherwise, load synchronously.
     WEBCORE_EXPORT static Ref<FileReaderLoader> create(ReadType, FileReaderLoaderClient*);
-    ~FileReaderLoader();
+    WEBCORE_EXPORT ~FileReaderLoader();
 
     WEBCORE_EXPORT void start(ScriptExecutionContext*, Blob&);
     void start(ScriptExecutionContext*, const URL&);
     WEBCORE_EXPORT void cancel();
 
-    // ThreadableLoaderClient
+    // ThreadableLoaderClient.
     void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) override;
     void didReceiveData(const SharedBuffer&) override;
     void didFinishLoading(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const NetworkLoadMetrics&) override;
     void didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError&) override;
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     String stringResult();
     WEBCORE_EXPORT RefPtr<JSC::ArrayBuffer> arrayBufferResult() const;

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
@@ -81,7 +81,10 @@ void InspectorThreadableLoaderClient::setLoader(RefPtr<ThreadableLoader>&& loade
 void InspectorThreadableLoaderClient::dispose()
 {
     m_loader = nullptr;
-    delete this;
+    if (!m_hasCalledDeref) {
+        m_hasCalledDeref = true;
+        deref();
+    }
 }
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -967,18 +967,16 @@ void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::Fra
     options.contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::DoNotEnforce;
 
     // InspectorThreadableLoaderClient deletes itself when the load completes or fails.
-    InspectorThreadableLoaderClient* inspectorThreadableLoaderClient = new InspectorThreadableLoaderClient(callback.copyRef());
-    auto loader = ThreadableLoader::create(*context, *inspectorThreadableLoaderClient, WTFMove(request), options);
+    Ref inspectorThreadableLoaderClient = InspectorThreadableLoaderClient::create(callback.copyRef());
+    RefPtr loader = ThreadableLoader::create(*context, inspectorThreadableLoaderClient, WTFMove(request), options);
     if (!loader) {
         callback->sendFailure("Could not load requested resource."_s);
         return;
     }
 
-    // If the load already completed, inspectorThreadableLoaderClient will have been deleted and we will have already called the callback.
-    if (!callback->isActive())
-        return;
-
-    inspectorThreadableLoaderClient->setLoader(WTFMove(loader));
+    // If the load already completed, no need the set the client.
+    if (callback->isActive())
+        inspectorThreadableLoaderClient->setLoader(WTFMove(loader));
 }
 
 Inspector::Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(const Inspector::Protocol::Network::RequestId& requestId)

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -137,7 +137,7 @@ class CachedRawResource;
         CachedResourceHandle<CachedRawResource> protectedResource() const;
 
         CachedResourceHandle<CachedRawResource> m_resource;
-        ThreadableLoaderClient* m_client; // FIXME: Use a smart pointer.
+        WeakPtr<ThreadableLoaderClient> m_client;
         WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
         ThreadableLoaderOptions m_options;
         bool m_responsesCanBeOpaque { true };

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -33,7 +33,7 @@
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -44,10 +44,9 @@ class ResourceResponse;
 class ResourceTiming;
 class SharedBuffer;
 
-class ThreadableLoaderClient : public CanMakeWeakPtr<ThreadableLoaderClient>, public CanMakeThreadSafeCheckedPtr<ThreadableLoaderClient> {
+class ThreadableLoaderClient : public AbstractRefCountedAndCanMakeWeakPtr<ThreadableLoaderClient> {
     WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ThreadableLoaderClient, Loader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadableLoaderClient);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }
 

--- a/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
+++ b/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
@@ -56,40 +56,40 @@ public:
 
     void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
     {
-        if (m_client)
-            m_client->didSendData(bytesSent, totalBytesToBeSent);
+        if (RefPtr client = m_client.get())
+            client->didSendData(bytesSent, totalBytesToBeSent);
     }
 
     void didReceiveResponse(ScriptExecutionContextIdentifier mainContext, std::optional<ResourceLoaderIdentifier> identifier, const ResourceResponse& response)
     {
-        if (m_client)
-            m_client->didReceiveResponse(mainContext, identifier, response);
+        if (RefPtr client = m_client.get())
+            client->didReceiveResponse(mainContext, identifier, response);
     }
 
     void didReceiveData(const SharedBuffer& buffer)
     {
-        if (m_client)
-            m_client->didReceiveData(buffer);
+        if (RefPtr client = m_client.get())
+            client->didReceiveData(buffer);
     }
 
     void didFinishLoading(ScriptExecutionContextIdentifier mainContext, std::optional<ResourceLoaderIdentifier> identifier, const NetworkLoadMetrics& metrics)
     {
         m_done = true;
-        if (m_client)
-            m_client->didFinishLoading(mainContext, identifier, metrics);
+        if (RefPtr client = m_client.get())
+            client->didFinishLoading(mainContext, identifier, metrics);
     }
 
     void notifyIsDone(bool isDone)
     {
-        if (m_client)
-            m_client->notifyIsDone(isDone);
+        if (RefPtr client = m_client.get())
+            client->notifyIsDone(isDone);
     }
 
     void didFail(std::optional<ScriptExecutionContextIdentifier> mainContext, const ResourceError& error)
     {
         m_done = true;
-        if (m_client)
-            m_client->didFail(mainContext, error);
+        if (RefPtr client = m_client.get())
+            client->didFail(mainContext, error);
     }
 
     const String& initiator() const { return m_initiator; }

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -50,16 +50,16 @@ template<typename> class ExceptionOr;
 
 class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(EventSource);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventSource);
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
     struct Init {
         bool withCredentials;
     };
     static ExceptionOr<Ref<EventSource>> create(ScriptExecutionContext&, const String& url, const Init&);
     virtual ~EventSource();
+
+    // EventTarget, ThreadableLoaderClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -44,13 +44,12 @@ struct FontCustomPlatformData;
 
 class WorkerFontLoadRequest final : public FontLoadRequest, public ThreadableLoaderClient, public RefCounted<WorkerFontLoadRequest> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerFontLoadRequest);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerFontLoadRequest);
 public:
     static Ref<WorkerFontLoadRequest> create(URL&&, LoadedFromOpaqueSource);
 
     void load(WorkerGlobalScope&);
 
-    // FontLoadRequest.
+    // FontLoadRequest, ThreadableLoaderClient.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -59,7 +59,6 @@ enum class CertificateInfoPolicy : uint8_t;
 
 class WorkerScriptLoader final : public RefCounted<WorkerScriptLoader>, public ThreadableLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(WorkerScriptLoader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerScriptLoader);
 public:
     enum class AlwaysUseUTF8 : bool { No, Yes };
     static Ref<WorkerScriptLoader> create(AlwaysUseUTF8 alwaysUseUTF8 = AlwaysUseUTF8::No)
@@ -73,6 +72,10 @@ public:
     void loadAsynchronously(ScriptExecutionContext&, ResourceRequest&&, Source, FetchOptions&&, ContentSecurityPolicyEnforcement, ServiceWorkersMode, WorkerScriptLoaderClient&, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier = std::nullopt);
 
     void notifyError(std::optional<ScriptExecutionContextIdentifier>);
+
+    // ThreadableLoaderClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const { return m_advancedPrivacyProtections; }
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -57,15 +57,15 @@ template<typename> class ExceptionOr;
 
 class XMLHttpRequest final : public ActiveDOMObject, public RefCounted<XMLHttpRequest>, private ThreadableLoaderClient, public XMLHttpRequestEventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(XMLHttpRequest, WEBCORE_EXPORT);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLHttpRequest);
 public:
+    static Ref<XMLHttpRequest> create(ScriptExecutionContext&);
+    WEBCORE_EXPORT ~XMLHttpRequest();
+
+    // ActiveDOMObject, ThreadableLoaderClient.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
     USING_CAN_MAKE_WEAKPTR(EventTarget);
-
-    static Ref<XMLHttpRequest> create(ScriptExecutionContext&);
-    WEBCORE_EXPORT ~XMLHttpRequest();
 
     // Keep it in 3bits.
     enum State : uint8_t {


### PR DESCRIPTION
#### a52d14e32d3bc9b6a06096aa04ce96a78ccaaf38
<pre>
Address some safer cpp failures in DocumentThreadableLoader and WorkerThreadableLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=304159">https://bugs.webkit.org/show_bug.cgi?id=304159</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::prepareForUseOnlyOnMainThread):
* Source/WebCore/Modules/fetch/FetchLoader.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::Loader::stop):
(WebCore::FetchResponse::Loader::startStreaming):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::start):
(WebCore::NotificationResourcesLoader::stop):
(WebCore::NotificationResourcesLoader::ResourceLoader::create):
(WebCore::NotificationResourcesLoader::ResourceLoader::ResourceLoader):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.h:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp:
(Inspector::InspectorThreadableLoaderClient::dispose):
* Source/WebCore/inspector/InspectorThreadableLoaderClient.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::loadResource):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::computeIsDone):
(WebCore::DocumentThreadableLoader::dataSent):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::didReceiveData):
(WebCore::DocumentThreadableLoader::finishedTimingForWorkerLoad):
(WebCore::DocumentThreadableLoader::didFinishLoading):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/ThreadableLoaderClient.h:
* Source/WebCore/loader/ThreadableLoaderClientWrapper.h:
(WebCore::ThreadableLoaderClientWrapper::didSendData):
(WebCore::ThreadableLoaderClientWrapper::didReceiveResponse):
(WebCore::ThreadableLoaderClientWrapper::didReceiveData):
(WebCore::ThreadableLoaderClientWrapper::didFinishLoading):
(WebCore::ThreadableLoaderClientWrapper::notifyIsDone):
(WebCore::ThreadableLoaderClientWrapper::didFail):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::WorkerThreadableLoader):
(WebCore::WorkerThreadableLoader::~WorkerThreadableLoader):
(WebCore::WorkerThreadableLoader::cancel):
(WebCore::WorkerThreadableLoader::computeIsDone):
(WebCore::WorkerThreadableLoader::MainThreadBridge::create):
(WebCore::m_contextIdentifier):
(WebCore::WorkerThreadableLoader::MainThreadBridge::~MainThreadBridge):
(WebCore::WorkerThreadableLoader::MainThreadBridge::detach):
(WebCore::WorkerThreadableLoader::MainThreadBridge::destroy): Deleted.
(WebCore::WorkerThreadableLoader::MainThreadBridge::clearClientWrapper): Deleted.
* Source/WebCore/loader/WorkerThreadableLoader.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/304576@main">https://commits.webkit.org/304576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f741b4c942f0275be129efb95acba563421e03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135987 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143689 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ce721adb-48b0-4b4c-8620-aab379e0942d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103923 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e844ea17-e495-44b0-8fe6-3a3143948e32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84800 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37192be2-2d58-4513-b212-e83b95daf3ef) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3866 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4291 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127947 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146440 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134470 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112281 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6129 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118168 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8075 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36235 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167258 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71632 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43648 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8017 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->