### PR TITLE
[appearance: base] Remove the duplication of the checkbox and radio button CSS rules in UA style sheet

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -790,12 +790,60 @@ input:-webkit-autofill, input:-webkit-autofill-strong-password, input:-webkit-au
 input:is([type="radio"], [type="checkbox"]) {
     margin: 3px 2px;
     box-sizing: border-box;
-#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border: initial;
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    width: 16px;
+    height: 16px;
+    padding: 0px;
+    /* We want to be as close to background:transparent as possible without actually being transparent */
+    background-color: rgba(255, 255, 255, 0.01);
 #else
     padding: initial;
     background-color: initial;
-    border: initial;
+#endif
+}
+
+input[type="checkbox"] {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    border-radius: 5px;
+#endif
+}
+
+input[type="radio"] {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    border-radius: 50%;
+#endif
+}
+
+input[type="checkbox"]:indeterminate {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    background: rgba(0, 0, 0, 0.8);
+#endif
+}
+
+input[type="checkbox"]:indeterminate:disabled {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    opacity: initial;
+    background: rgba(0, 0, 0, 0.8);
+#endif
+}
+
+input:is([type="checkbox"], [type="radio"]):checked {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    border-color: rgba(255, 255, 255, 0.0);
+#endif
+}
+
+input:is([type="checkbox"], [type="radio"]):disabled {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    opacity: initial;
+#endif
+}
+
+input:is([type="checkbox"], [type="radio"]):checked:disabled {
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+    opacity: initial;
+    background: rgba(0, 0, 0, 0.8);
 #endif
 }
 
@@ -935,49 +983,6 @@ select:disabled {
     opacity: initial;
 }
 
-#endif
-
-#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-input[type="checkbox"] {
-    border-radius: 5px;
-    width: 16px;
-    height: 16px;
-    padding: 0px;
-    /* We want to be as close to background:transparent as possible without actually being transparent */
-    background-color: rgba(255, 255, 255, 0.01);
-}
-
-input[type="radio"] {
-    appearance: auto;
-    border-radius: 50%;
-    width: 16px;
-    height: 16px;
-    padding: 0px;
-    /* We want to be as close to background:transparent as possible without actually being transparent */
-    background-color: rgba(255, 255, 255, 0.01);
-}
-
-input[type="checkbox"]:indeterminate {
-    background: rgba(0, 0, 0, 0.8);
-}
-
-input[type="checkbox"]:indeterminate:disabled {
-    opacity: initial;
-    background: rgba(0, 0, 0, 0.8);
-}
-
-input:is([type="checkbox"], [type="radio"]):checked {
-    border-color: rgba(255, 255, 255, 0.0);
-}
-
-input:is([type="checkbox"], [type="radio"]):disabled {
-    opacity: initial;
-}
-
-input:is([type="checkbox"], [type="radio"]):checked:disabled {
-    opacity: initial;
-    background: rgba(0, 0, 0, 0.8);
-}
 #endif
 
 input[type="color"] {


### PR DESCRIPTION
#### b8af2b4ded52b7aec889fc1d48736f8eb37c6ae9
<pre>
[appearance: base] Remove the duplication of the checkbox and radio button CSS rules in UA style sheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=304163">https://bugs.webkit.org/show_bug.cgi?id=304163</a>
<a href="https://rdar.apple.com/166514953">rdar://166514953</a>

Reviewed by Tim Nguyen.

Also mix the iOS checkbox and radio button CSS rules with the non iOS rules.

* Source/WebCore/css/html.css:
(input:is([type=&quot;radio&quot;], [type=&quot;checkbox&quot;])):
(input[type=&quot;checkbox&quot;]):
(input[type=&quot;radio&quot;]):
(input[type=&quot;checkbox&quot;]:indeterminate):
(input[type=&quot;checkbox&quot;]:indeterminate:disabled):
(input:is([type=&quot;checkbox&quot;], [type=&quot;radio&quot;]):checked):
(input:is([type=&quot;checkbox&quot;], [type=&quot;radio&quot;]):disabled):
(input:is([type=&quot;checkbox&quot;], [type=&quot;radio&quot;]):checked:disabled):
(#endif):

Canonical link: <a href="https://commits.webkit.org/304468@main">https://commits.webkit.org/304468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d62340a6feee9496ade27db2b87a07683be446f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143358 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/15b0a590-7c76-4d1c-b96d-bbc899ac32ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7860 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84527 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/750c2509-ed8e-4058-a419-0d706f91ce1d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3620 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3964 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146103 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7699 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40344 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28518 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5868 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61666 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7749 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71301 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/7718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->