### PR TITLE
http tests: Add a json handler not to treat *.py.json files as CGI scripts

### DIFF
--- a/LayoutTests/http/conf/apache2.2-httpd.conf
+++ b/LayoutTests/http/conf/apache2.2-httpd.conf
@@ -109,6 +109,7 @@ ServerSignature On
     AddEncoding x-gzip .gz .tgz
 
     AddHandler cgi-script .cgi .pl .py
+    AddHandler default-handler json
 
     AddType text/html .shtml
     AddHandler server-parsed .shtml

--- a/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
+++ b/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
@@ -124,6 +124,7 @@ ServerSignature On
     AddEncoding x-gzip .gz .tgz
 
     AddHandler cgi-script .cgi .pl .py
+    AddHandler default-handler json
 
     AddType text/html .shtml
     AddHandler server-parsed .shtml

--- a/LayoutTests/http/conf/apache2.4-httpd.conf
+++ b/LayoutTests/http/conf/apache2.4-httpd.conf
@@ -116,6 +116,7 @@ ServerSignature On
     AddEncoding x-gzip .gz .tgz
 
     AddHandler cgi-script .cgi .pl .py
+    AddHandler default-handler json
 
     AddType text/html .shtml
     AddHandler server-parsed .shtml

--- a/LayoutTests/http/conf/archlinux-httpd.conf
+++ b/LayoutTests/http/conf/archlinux-httpd.conf
@@ -110,6 +110,7 @@ AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
 
 AddHandler cgi-script .cgi .pl .py
+AddHandler default-handler json
 
 AddType text/html .shtml
 AddOutputFilter INCLUDES .shtml

--- a/LayoutTests/http/conf/debian-httpd-2.4.conf
+++ b/LayoutTests/http/conf/debian-httpd-2.4.conf
@@ -106,6 +106,7 @@ AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
 
 AddHandler cgi-script .cgi .pl .py
+AddHandler default-handler json
 
 AddType text/html .shtml
 AddOutputFilter INCLUDES .shtml

--- a/LayoutTests/http/conf/fedora-httpd-2.2.conf
+++ b/LayoutTests/http/conf/fedora-httpd-2.2.conf
@@ -112,6 +112,7 @@ AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
 
 AddHandler cgi-script .cgi .pl .py
+AddHandler default-handler json
 
 AddType text/html .shtml
 AddOutputFilter INCLUDES .shtml

--- a/LayoutTests/http/conf/fedora-httpd-2.4.conf
+++ b/LayoutTests/http/conf/fedora-httpd-2.4.conf
@@ -110,6 +110,7 @@ AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
 
 AddHandler cgi-script .cgi .pl .py
+AddHandler default-handler json
 
 AddType text/html .shtml
 AddOutputFilter INCLUDES .shtml

--- a/LayoutTests/http/conf/win-httpd-2.4.conf
+++ b/LayoutTests/http/conf/win-httpd-2.4.conf
@@ -100,6 +100,7 @@ ServerSignature On
     AddEncoding x-gzip .gz .tgz
 
     AddHandler cgi-script .cgi .pl .py
+    AddHandler default-handler json
 
     AddType text/html .shtml
     AddHandler server-parsed .shtml

--- a/LayoutTests/http/tests/contentextensions/block-cookies-in-csp-report.py.json
+++ b/LayoutTests/http/tests/contentextensions/block-cookies-in-csp-report.py.json
@@ -1,10 +1,4 @@
-#!/usr/bin/env python3
-
-import sys
-
-sys.stdout.write('Content-Type: text/html\r\n\r\n')
-
-print('''[
+[
     {
         "trigger": {
             "url-filter": "save-ping.py"
@@ -13,4 +7,4 @@ print('''[
             "type": "block-cookies"
         }
     }
-]''')
+]

--- a/LayoutTests/http/tests/contentextensions/block-csp-report.py.json
+++ b/LayoutTests/http/tests/contentextensions/block-csp-report.py.json
@@ -1,10 +1,4 @@
-#!/usr/bin/env python3
-
-import sys
-
-sys.stdout.write('Content-Type: text/html\r\n\r\n')
-
-print('''[
+[
     {
         "trigger": {
             "url-filter": "save-ping.py"
@@ -13,4 +7,4 @@ print('''[
             "type": "block"
         }
     }
-]''')
+]

--- a/LayoutTests/http/tests/contentextensions/block-everything-unless-domain-redirect.py.json
+++ b/LayoutTests/http/tests/contentextensions/block-everything-unless-domain-redirect.py.json
@@ -1,10 +1,4 @@
-#!/usr/bin/env python3
-
-import sys
-
-sys.stdout.write('Content-Type: text/html\r\n\r\n')
-
-print('''[
+[
     {
         "action": {
             "type": "block"
@@ -14,4 +8,4 @@ print('''[
             "unless-domain": ["127.0.0.1"]
         }
     }
-]''')
+]

--- a/LayoutTests/http/tests/contentextensions/hide-on-csp-report.py.json
+++ b/LayoutTests/http/tests/contentextensions/hide-on-csp-report.py.json
@@ -1,10 +1,4 @@
-#!/usr/bin/env python3
-
-import sys
-
-sys.stdout.write('Content-Type: text/html\r\n\r\n')
-
-print('''[
+[
     {
         "trigger": {
             "url-filter": "save-ping.py"
@@ -14,4 +8,4 @@ print('''[
             "selector": ".foo"
         }
     }
-]''')
+]

--- a/LayoutTests/http/tests/contentextensions/main-resource-redirect-blocked.py.json
+++ b/LayoutTests/http/tests/contentextensions/main-resource-redirect-blocked.py.json
@@ -1,12 +1,4 @@
-#!/usr/bin/env python3
-
-import sys
-
-sys.stdout.write(
-    'Content-Type: text/html\r\n\r\n'
-)
-
-print('''[
+[
     {
         "action": {
             "type": "block"
@@ -15,4 +7,4 @@ print('''[
             "url-filter": ".*main-resource-redirect-blocked-target.html"
         }
     }
-]''')
+]

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3889,12 +3889,6 @@ webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/mediasource-seq
 webkit.org/b/197711 imported/w3c/web-platform-tests/media-source/mediasource-correct-frames.html [ Failure ]
 webkit.org/b/214349 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-negative.html [ Crash Failure Timeout Pass ]
 
-webkit.org/b/223965 http/tests/contentextensions/block-cookies-in-csp-report.py [ Crash ]
-webkit.org/b/223965 http/tests/contentextensions/block-csp-report.py [ Crash ]
-webkit.org/b/223965 http/tests/contentextensions/block-everything-unless-domain-redirect.py [ Crash ]
-webkit.org/b/223965 http/tests/contentextensions/hide-on-csp-report.py [ Crash ]
-webkit.org/b/223965 http/tests/contentextensions/main-resource-redirect-blocked.py [ Crash ]
-
 webkit.org/b/207978 imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing.sub.https.html [ Failure Pass ]
 
 webkit.org/b/127743 media/video-restricted-no-preload-auto.html [ Failure ]


### PR DESCRIPTION
#### ae76dacf89fa38b6fab82faae6c680cd70e7e2cf
<pre>
http tests: Add a json handler not to treat *.py.json files as CGI scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=223965">https://bugs.webkit.org/show_bug.cgi?id=223965</a>

Reviewed by Nikolas Zimmermann.

After 235901@main converted PHP scripts to Python,
http/tests/contentextensions/*.py tests were crashing in
TestController::configureContentExtensionForTest() for WPE and GTK ports
because it failed to parse content extension *.py.json files. The change
converted the content extension *.json files to Python scripts.

The Apache config file has the following line:
&gt; AddHandler cgi-script .cgi .pl .py

Thus, *.py.json files were treated as CGI. This change adds the following line:
&gt; AddHandler default-handler .json

Then, *.py.json files are handled by default-handler because the right-most
suffix is json.
&lt;<a href="https://httpd.apache.org/docs/current/en/mod/mod_mime.html#multipleext">https://httpd.apache.org/docs/current/en/mod/mod_mime.html#multipleext</a>&gt;

There are two TestController::configureContentExtensionForTest implementations,
Mac&apos;s and others. Mac&apos;s implementation fetch the content extension *.json files
by using NSURLSession. On the other hand, others implementation directly read
the files.

* LayoutTests/http/conf/apache2.2-httpd.conf:
* LayoutTests/http/conf/apache2.4-darwin-httpd.conf:
* LayoutTests/http/conf/apache2.4-httpd.conf:
* LayoutTests/http/conf/archlinux-httpd.conf:
* LayoutTests/http/conf/debian-httpd-2.4.conf:
* LayoutTests/http/conf/fedora-httpd-2.2.conf:
* LayoutTests/http/conf/fedora-httpd-2.4.conf:
* LayoutTests/http/conf/win-httpd-2.4.conf:
* LayoutTests/http/tests/contentextensions/block-cookies-in-csp-report.py.json:
* LayoutTests/http/tests/contentextensions/block-csp-report.py.json:
* LayoutTests/http/tests/contentextensions/block-everything-unless-domain-redirect.py.json:
* LayoutTests/http/tests/contentextensions/hide-on-csp-report.py.json:
* LayoutTests/http/tests/contentextensions/main-resource-redirect-blocked.py.json:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/304505@main">https://commits.webkit.org/304505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0452690ecd185da159e9d758f00a2b6d0c4c391

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103756 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3709 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7830 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112117 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112498 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5965 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61761 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7876 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36092 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7611 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->