### PR TITLE
AudioVideoRendererRemote should only serialise TrackInfo if it changes

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2689,6 +2689,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/MediaPlayerPrivate.h
     platform/graphics/MediaReorderQueue.h
     platform/graphics/MediaResourceSniffer.h
+    platform/graphics/MediaSampleConverter.h
     platform/graphics/MediaSourceConfiguration.h
     platform/graphics/MediaSourcePrivate.h
     platform/graphics/MediaSourcePrivateClient.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2573,6 +2573,7 @@ platform/graphics/MediaPlayer.cpp
 platform/graphics/MediaPlayerPrivate.cpp
 platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
 platform/graphics/MediaResourceSniffer.cpp
+platform/graphics/MediaSampleConverter.cpp
 platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/ModelContext.cpp

--- a/Source/WebCore/platform/MediaSamplesBlock.cpp
+++ b/Source/WebCore/platform/MediaSamplesBlock.cpp
@@ -29,17 +29,23 @@
 #if USE(AVFOUNDATION)
 #include "CMUtilities.h"
 #include "MediaSampleAVFObjC.h"
+#include <CoreMedia/CMFormatDescription.h>
+
+#include <pal/cf/CoreMediaSoftLink.h>
 #endif
 
 namespace WebCore {
 
-RefPtr<MediaSample> MediaSamplesBlock::toMediaSample() const
+RefPtr<MediaSample> MediaSamplesBlock::toMediaSample(const MediaSample* referenceSample) const
 {
 #if USE(AVFOUNDATION)
-    auto result = toCMSampleBuffer(*this);
+    RetainPtr cmSample = referenceSample ? referenceSample->platformSample().cmSampleBuffer() : nullptr;
+    RetainPtr description = cmSample ? PAL::CMSampleBufferGetFormatDescription(cmSample.get()) : nullptr;
+    auto result = toCMSampleBuffer(*this, description.get());
     ASSERT(!!result);
     return result ? RefPtr { MediaSampleAVFObjC::create(result->get(), trackID()) } : nullptr;
 #else
+    UNUSED_PARAM(referenceSample);
     ASSERT_NOT_REACHED();
     return nullptr;
 #endif

--- a/Source/WebCore/platform/MediaSamplesBlock.h
+++ b/Source/WebCore/platform/MediaSamplesBlock.h
@@ -103,7 +103,7 @@ public:
     SamplesVector::const_iterator begin() const LIFETIME_BOUND { return m_samples.begin(); }
     SamplesVector::const_iterator end() const LIFETIME_BOUND { return m_samples.end(); }
 
-    WEBCORE_EXPORT RefPtr<MediaSample> toMediaSample() const;
+    WEBCORE_EXPORT RefPtr<MediaSample> toMediaSample(const MediaSample* = nullptr) const;
     WEBCORE_EXPORT static UniqueRef<MediaSamplesBlock> fromMediaSample(const MediaSample&, const TrackInfo* = nullptr);
 
 private:

--- a/Source/WebCore/platform/graphics/MediaSampleConverter.cpp
+++ b/Source/WebCore/platform/graphics/MediaSampleConverter.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaSampleConverter.h"
+
+#include <WebCore/MediaSample.h>
+#include <WebCore/MediaSamplesBlock.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if PLATFORM(COCOA)
+#include <CoreMedia/CMFormatDescription.h>
+
+#include <pal/cf/CoreMediaSoftLink.h>
+#endif
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSampleConverter);
+
+MediaSampleConverter::MediaSampleConverter() = default;
+MediaSampleConverter::~MediaSampleConverter() = default;
+
+static bool hasSameInitSegment(const MediaSample& sampleA, const MediaSample& sampleB)
+{
+#if PLATFORM(COCOA)
+    RetainPtr cmSampleA = sampleA.platformSample().cmSampleBuffer();
+    RetainPtr cmSampleB = sampleB.platformSample().cmSampleBuffer();
+    RetainPtr descriptionA = PAL::CMSampleBufferGetFormatDescription(cmSampleA.get());
+    RetainPtr descriptionB = PAL::CMSampleBufferGetFormatDescription(cmSampleB.get());
+    return descriptionA == descriptionB;
+#else
+    UNUSED_PARAM(sampleA);
+    UNUSED_PARAM(sampleB);
+    return false;
+#endif
+}
+
+UniqueRef<MediaSamplesBlock> MediaSampleConverter::convert(const MediaSample& sample, SetTrackInfo setTrackInfo)
+{
+    bool canReuseLastTrackInfo = m_lastSample && hasSameInitSegment(sample, Ref { *m_lastSample });
+    auto block = MediaSamplesBlock::fromMediaSample(sample, canReuseLastTrackInfo ? m_lastTrackInfo.get() : nullptr);
+    if (!canReuseLastTrackInfo) {
+        m_lastTrackInfo = block->info();
+        m_lastSample = &sample;
+    }
+    if (setTrackInfo == SetTrackInfo::No)
+        block->setInfo(nullptr);
+    return block;
+}
+
+RefPtr<MediaSample> MediaSampleConverter::convert(MediaSamplesBlock&& block)
+{
+    ASSERT(m_lastTrackInfo || block.info());
+    if (!block.info())
+        block.setInfo(m_lastTrackInfo.get());
+    RefPtr sample = block.toMediaSample(m_lastSample.get());
+    if (!m_lastSample)
+        m_lastSample = sample;
+    return sample;
+}
+
+bool MediaSampleConverter::hasFormatChanged(const MediaSample& sample)
+{
+    if (RefPtr lastSample = m_lastSample)
+        return !hasSameInitSegment(*lastSample, sample);
+    return true;
+}
+
+RefPtr<const TrackInfo> MediaSampleConverter::currentTrackInfo() const
+{
+    return m_lastTrackInfo;
+}
+
+void MediaSampleConverter::setTrackInfo(Ref<const TrackInfo>&& trackInfo)
+{
+    if (m_lastTrackInfo && trackInfo.get() != *m_lastTrackInfo)
+        m_lastSample = nullptr;
+    m_lastTrackInfo = WTFMove(trackInfo);
+}
+
+}

--- a/Source/WebCore/platform/graphics/MediaSampleConverter.h
+++ b/Source/WebCore/platform/graphics/MediaSampleConverter.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class MediaSample;
+class MediaSamplesBlock;
+struct TrackInfo;
+
+class MediaSampleConverter final {
+    WTF_MAKE_TZONE_ALLOCATED(MediaSampleConverter);
+public:
+    WEBCORE_EXPORT MediaSampleConverter();
+    WEBCORE_EXPORT ~MediaSampleConverter();
+
+    enum class SetTrackInfo : bool {
+        No,
+        Yes
+    };
+    WEBCORE_EXPORT UniqueRef<MediaSamplesBlock> convert(const MediaSample&, SetTrackInfo = SetTrackInfo::Yes);
+    WEBCORE_EXPORT RefPtr<const TrackInfo> currentTrackInfo() const;
+    WEBCORE_EXPORT void setTrackInfo(Ref<const TrackInfo>&&);
+
+    WEBCORE_EXPORT RefPtr<MediaSample> convert(MediaSamplesBlock&&);
+
+    WEBCORE_EXPORT bool hasFormatChanged(const MediaSample&);
+
+private:
+    RefPtr<const MediaSample> m_lastSample;
+    RefPtr<const TrackInfo> m_lastTrackInfo;
+};
+
+}

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -560,7 +560,6 @@ UniqueRef<MediaSamplesBlock> samplesBlockFromCMSampleBuffer(CMSampleBufferRef cm
     ASSERT(cmSample);
     RefPtr info = trackInfo;
     if (!trackInfo) {
-        // While this path is currently unused; we only support creating a TrackInfo from an Audio CMFormatDescription
         if (RetainPtr description = PAL::CMSampleBufferGetFormatDescription(cmSample)) {
             if (PAL::CMFormatDescriptionGetMediaType(description.get()) == kCMMediaType_Audio)
                 info = createAudioInfoFromFormatDescription(description.get());

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -41,6 +41,7 @@
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/MediaPromiseTypes.h>
+#include <WebCore/MediaSampleConverter.h>
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
@@ -94,6 +95,7 @@ private:
     void addTrack(RemoteAudioVideoRendererIdentifier, WebCore::TrackInfo::TrackType, CompletionHandler<void(Expected<TrackIdentifier, WebCore::PlatformMediaError>)>&&);
     void removeTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
+    void newTrackInfoForTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier, Ref<WebCore::TrackInfo>&&);
     void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>, CompletionHandler<void(bool)>&&);
     void requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
@@ -163,6 +165,7 @@ private:
 #if PLATFORM(COCOA)
         LayerHostingContextManager layerHostingContextManager;
 #endif
+        HashMap<TrackIdentifier, WebCore::MediaSampleConverter> converters { };
         WebCore::VideoRendererPreferences preferences { };
     };
     RefPtr<WebCore::AudioVideoRenderer> createRenderer();
@@ -172,6 +175,7 @@ private:
     void rendereringModeChanged(RemoteAudioVideoRendererIdentifier);
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);
+    WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);
 
 #if PLATFORM(COCOA)
     void setVideoLayerSizeFenced(RemoteAudioVideoRendererIdentifier, const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -40,6 +40,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     AddTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, enum:uint8_t WebCore::TrackInfoTrackType type) -> (Expected<WebCore::SamplesRendererTrackIdentifier, WebCore::PlatformMediaError> result) Synchronous
     RemoveTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 
+    NewTrackInfoForTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, Ref<WebCore::TrackInfo> info);
     EnqueueSample(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock block, std::optional<MediaTime> upcomingMinimumTime) -> (bool readyForMoreData);
     RequestMediaDataWhenReady(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -36,6 +36,7 @@
 #include <WebCore/AudioVideoRenderer.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/MediaSampleConverter.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
@@ -258,6 +259,7 @@ private:
     HashMap<TrackIdentifier, ReadyForMoreDataState> m_readyForMoreDataStates WTF_GUARDED_BY_LOCK(m_lock);
     HashMap<TrackIdentifier, std::unique_ptr<RequestPromise::AutoRejectProducer>> m_requestMediaDataWhenReadyDataPromises WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    HashMap<TrackIdentifier, WebCore::MediaSampleConverter> m_mediaSampleConverters WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
     Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     WebCore::HostingContext m_layerHostingContext WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### 7f582bce96ed45d1a34d2061696482b8bcf2fd8d
<pre>
AudioVideoRendererRemote should only serialise TrackInfo if it changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=303433">https://bugs.webkit.org/show_bug.cgi?id=303433</a>
<a href="https://rdar.apple.com/165725525">rdar://165725525</a>

Reviewed by Youenn Fablet.

The MediaSamplesBlock&apos;s TrackInfo object was fully serialised/deserialised
when sent over IPC, even when it didn&apos;t change.
This conversion was one of the top CPU&apos;s ms/cpu usage in the web content process
and caused unnecessary elevated power usage.

We add a new MediaSampleConverter utility class that will track if the metadata (init segment)
of a MediaSample has changed, and if not will re-use the previously converted TrackInfo instead.
A new IPC newTrackInfoForTrack to RemoteAudioVideoRendererProxyManager is added so that we can
send separately the TrackInfo object when it has changed.
MediaSamplesBlock will have their TrackInfo set to null before being set to
the GPU process so that upon receiving we can re-use the existing, previously received,
 TrackInfo.

No change in observable behaviour, covered by existing tests.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/MediaSamplesBlock.cpp:
(WebCore::MediaSamplesBlock::toMediaSample const):
* Source/WebCore/platform/MediaSamplesBlock.h:
* Source/WebCore/platform/graphics/MediaSampleConverter.cpp: Added.
(WebCore::hasSameInitSegment):
(WebCore::MediaSampleConverter::convert):
(WebCore::MediaSampleConverter::hasFormatChanged):
(WebCore::MediaSampleConverter::currentTrackInfo const):
* Source/WebCore/platform/graphics/MediaSampleConverter.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::samplesBlockFromCMSampleBuffer):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::converterContextFor):
(WebKit::RemoteAudioVideoRendererProxyManager::newTrackInfoForTrack):
(WebKit::RemoteAudioVideoRendererProxyManager::enqueueSample):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::enqueueSample):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/304579@main">https://commits.webkit.org/304579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13b91a678841324e349ec3a488ced5111c3b5c81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143730 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d936e52-cfe9-4893-ab6b-b4a5ef64e52f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103952 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eeef3444-144b-44e6-87a5-dce121a8c49b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121898 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84831 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8933bae-7ac4-42a9-a697-2f0f38a1bd80) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4331 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146483 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40660 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8082 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6769 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6157 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118202 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8116 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8053 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->