### PR TITLE
Add CPP IPC layout test

### DIFF
--- a/LayoutTests/ipc/cpp-receiver.html
+++ b/LayoutTests/ipc/cpp-receiver.html
@@ -1,0 +1,34 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that a Swift receiver handles a message.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+    const testerID = 447;
+    const processTarget = 'UI'; // Currently only UI is supported for addTesterReceiver.
+    IPC.addTesterReceiver(processTarget);
+    try {
+        let messages = [];
+        // Sync messages don't currently work with the IPCTester arrangement, so we
+        // send an async message. We add a listener to wait for it to be delivered
+        // before we proceed.
+        IPC.addIncomingMessageListener(processTarget, (message) => {
+            if (message.name != IPC.messages.IPCTesterReceiver_AsyncMessage.name)
+                return;
+            messages.push(message);
+        });
+        IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_SendAsyncMessageToReceiver.name, [
+            { type: 'uint32_t', value: 78 },
+        ]);
+        await t.step_wait(() => { return messages.length > 0 }, "Waiting until async message is intercepted");
+        assert_equals(messages.length, 1, `for ${ processTarget }`);
+    } finally {
+        IPC.removeTesterReceiver(processTarget);
+    }
+}, "IPC message handling in Swift");
+</script>
+</body>

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -191,8 +191,10 @@ void IPCTester::sendAsyncMessageToSwiftReceiver(IPC::Connection& connection, uin
 {
 #if ENABLE(IPC_TESTING_SWIFT)
     connection.sendWithAsyncReply(Messages::IPCTesterReceiverSwift::AsyncMessage(arg0 + 1), [arg0](uint32_t newArg0) {
-        ASSERT_UNUSED(arg0, newArg0 == arg0 + 2);
+        ASSERT_UNUSED(arg0, newArg0 == arg0 + 3);
     }, 0);
+#else
+    sendAsyncMessageToReceiver(connection, arg0);
 #endif
 }
 

--- a/Source/WebKit/Shared/IPCTesterReceiverSwift.swift
+++ b/Source/WebKit/Shared/IPCTesterReceiverSwift.swift
@@ -43,7 +43,7 @@ final class IPCTesterReceiverSwift {
     }
 
     func asyncMessage(data: UInt32, completionHandler: AsyncMessageCompletionHandler) {
-        completionHandler.pointee(data + 1)
+        completionHandler.pointee(data + 2)
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2761,6 +2761,9 @@ JSValueRef JSIPC::removeTesterReceiver(JSContextRef context, JSObjectRef, JSObje
     }
 
     WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName());
+#if ENABLE(IPC_TESTING_SWIFT)
+    WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiverSwift::messageReceiverName());
+#endif
     return JSValueMakeUndefined(context);
 }
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=303989
rdar://166293273

This is a test PR to find if a C++ receiver test fails with the same problems we've been seeing on EWS with a Swift receiver. Do not merge.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8cb4fbfe7d3707efd99bf4dce1aa353f3fa24a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87260 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2042573-beb3-4773-8fd9-0f7af57fe90a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7804 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103609 "Found 2 new test failures: imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html ipc/cpp-receiver.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f40b1281-ba4f-48cc-9179-d07dcb069c1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138525 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6189 "Found 1 new test failure: ipc/cpp-receiver.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84479 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d33c961-3e48-4589-a3b8-346f5d328aa8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5965 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3573 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3881 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146022 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7642 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40285 "Found 1 new test failure: ipc/cpp-receiver.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111973 "Found 1 new test failure: ipc/cpp-receiver.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7680 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6420 "Found 1 new test failure: ipc/cpp-receiver.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112345 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5819 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117829 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61599 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7694 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35944 "Found 2 new test failures: fast/mediastream/granted-denied-request-management1.html ipc/cpp-receiver.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->