### PR TITLE
[GStreamer][WebRTC] Fill selected ICE candidates pair candidates only if they are known

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
@@ -296,11 +296,9 @@ bool webkitGstWebRTCIceTransportGetSelectedPair(WebKitGstIceTransport* transport
 #if GST_CHECK_VERSION(1, 27, 0)
 static GstWebRTCICECandidate* riceCandidateToGst(const RiceCandidate* candidate, const GRefPtr<RiceStream>& stream, bool isLocal)
 {
+    RELEASE_ASSERT(candidate);
     GstWebRTCICECandidate* gstCandidate = g_new0(GstWebRTCICECandidate, 1);
     gstCandidate->stats = g_new0(GstWebRTCICECandidateStats, 1);
-
-    if (!candidate)
-        return gstCandidate;
 
     // FIXME: Fill those fields.
     gstCandidate->sdp_mid = nullptr;
@@ -323,8 +321,11 @@ static GstWebRTCICECandidatePair* webkitGstWebRTCIceTransportGetSelectedCandidat
 
     auto riceStream = webkitGstWebRTCIceStreamGetRiceStream(iceStream.get());
     GstWebRTCICECandidatePair* candidatesPair = g_new0(GstWebRTCICECandidatePair, 1);
-    candidatesPair->local = riceCandidateToGst(transport->priv->selectedPair.first.get(), riceStream, true);
-    candidatesPair->remote = riceCandidateToGst(transport->priv->selectedPair.second.get(), riceStream, false);
+    auto& [localCandidate, remoteCandidate] = transport->priv->selectedPair;
+    if (localCandidate)
+        candidatesPair->local = riceCandidateToGst(localCandidate.get(), riceStream, true);
+    if (remoteCandidate)
+        candidatesPair->remote = riceCandidateToGst(remoteCandidate.get(), riceStream, false);
     return candidatesPair;
 }
 #endif


### PR DESCRIPTION
#### a47a9e1dcf46d3e4e2a3ea5aafdf10e4a7134051
<pre>
[GStreamer][WebRTC] Fill selected ICE candidates pair candidates only if they are known
<a href="https://bugs.webkit.org/show_bug.cgi?id=304165">https://bugs.webkit.org/show_bug.cgi?id=304165</a>

Reviewed by Xabier Rodriguez-Calvar.

The selected pair isn&apos;t always fully determined so allocate the corresponding GstWebRTCICECandidate
only when it is known. This prevents critical warnings in GStreamer&apos;s webrtcstats module.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp:
(riceCandidateToGst):
(webkitGstWebRTCIceTransportGetSelectedCandidatePair):

Canonical link: <a href="https://commits.webkit.org/304522@main">https://commits.webkit.org/304522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8122ce8cf08c676b548ddecab5f8999245683359

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103613 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/70998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3577 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7646 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40294 "Found 60 new test failures: compositing/masks/compositing-clip-path.html compositing/masks/mask-and-drop-shadow.html compositing/overflow/image-load-overflow-scrollbars.html compositing/tiling/huge-layer-img-resize.html editing/async-clipboard/clipboard-read-write-images.html editing/pasteboard/data-transfer-get-data-on-paste-as-plain-text-when-custom-pasteboard-data-disabled.html fast/attachment/cocoa/wide-attachment-class.html fast/attachment/cocoa/wide-attachment-default-icon.html fast/attachment/cocoa/wide-attachment-folder-icon.html fast/attachment/cocoa/wide-attachment-icon-from-file-extension.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111977 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5824 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71244 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->