### PR TITLE
Drop unnecessary IsDeprecatedWeakRefSmartPointerException for TableGridCell

### DIFF
--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -37,23 +37,13 @@
 
 namespace WebCore {
 namespace Layout {
-class TableGridCell;
-}
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::Layout::TableGridCell> : std::true_type { };
-}
-
-namespace WebCore {
-namespace Layout {
 class Box;
 class ElementBox;
 
 // Cell represents a <td> or <th>. It can span multiple slots in the grid.
-class TableGridCell : public CanMakeWeakPtr<TableGridCell> {
+class TableGridCell final : public CanMakeWeakPtr<TableGridCell>, public CanMakeCheckedPtr<TableGridCell> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TableGridCell);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TableGridCell);
 public:
     TableGridCell(const ElementBox&, SlotPosition, CellSpan);
 


### PR DESCRIPTION
#### 53a061b06da58523fe3f1be5368450e549315f24
<pre>
Drop unnecessary IsDeprecatedWeakRefSmartPointerException for TableGridCell
<a href="https://bugs.webkit.org/show_bug.cgi?id=304169">https://bugs.webkit.org/show_bug.cgi?id=304169</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
(WebCore::Layout::TableGridCell::startColumn const): Deleted.
(WebCore::Layout::TableGridCell::endColumn const): Deleted.
(WebCore::Layout::TableGridCell::startRow const): Deleted.
(WebCore::Layout::TableGridCell::endRow const): Deleted.
(WebCore::Layout::TableGridCell::columnSpan const): Deleted.
(WebCore::Layout::TableGridCell::rowSpan const): Deleted.
(WebCore::Layout::TableGridCell::position const): Deleted.
(WebCore::Layout::TableGridCell::span const): Deleted.
(WebCore::Layout::TableGridCell::setBaseline): Deleted.
(WebCore::Layout::TableGridCell::baseline const): Deleted.
(WebCore::Layout::TableGridCell::box const): Deleted.

Canonical link: <a href="https://commits.webkit.org/304498@main">https://commits.webkit.org/304498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62d8902981fe023958d34bad3356c23a29665853

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87267 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b73ea1a2-0449-469c-9f80-69e517272627) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/367c47eb-243c-46e7-9dab-1019000bb162) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6193 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121547 "Found 1 new API test failure: TestWebKitAPI.InWindowFullscreen.IFrameDocument (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84486 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a6a544d-f978-4fab-9ae0-0c2512935940) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3580 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3889 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146030 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112351 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5827 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7702 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35957 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7668 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->