### PR TITLE
Cache API is broken in nested workers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cache API in nested worker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker.https.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Cache Storage: Verify nested worker functionality</title>
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+promise_test(async function(t) {
+   const worker = new Worker("cache-api-nested-worker1.js");
+   const result = await new Promise((resolve, reject) => {
+       worker.onmessage = e => resolve(e.data);
+       t.step_timeout(() => reject("test timed out"), 2000);
+   });
+   assert_equals(result, "PASS");
+}, "Cache API in nested worker");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker1.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker1.js
@@ -1,0 +1,3 @@
+const worker2 = new Worker("cache-api-nested-worker2.js");
+worker2.onmessage = e => self.postMessage(e.data);
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker2.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-api-nested-worker2.js
@@ -1,0 +1,1 @@
+self.caches.keys().then(() => postMessage('PASS'), () => postMessage('FAIL'));

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -35,6 +35,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DedicatedWorkerGlobalScope.h"
 #include "DedicatedWorkerThread.h"
+#include "Document.h"
 #include "ErrorEvent.h"
 #include "EventNames.h"
 #include "FetchRequestCredentials.h"
@@ -311,6 +312,9 @@ RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnectio
         return nullptr;
 
     RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    if (!document)
+        document = Document::allDocumentsMap().get(m_loaderContextIdentifier);
+
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;
@@ -321,6 +325,9 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDat
 {
     ASSERT(isMainThread());
     RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    if (!document)
+        document = Document::allDocumentsMap().get(m_loaderContextIdentifier);
+
     ASSERT(document);
     if (!document || !document->page())
         return nullptr;


### PR DESCRIPTION
#### 944251868a312f044ee8c202c5484df5d32c1862
<pre>
Cache API is broken in nested workers
<a href="https://rdar.apple.com/166525017">rdar://166525017</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304170">https://bugs.webkit.org/show_bug.cgi?id=304170</a>

Reviewed by Alex Christensen.

In case of nested workers, we get the connection from the loading document.
This aligns WebKit with other browsers.
Covered by added WPT test.

Canonical link: <a href="https://commits.webkit.org/304500@main">https://commits.webkit.org/304500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5090a59abbaccf108b4dfa0388c9c77c966ab58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87271 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/65bb1028-7b91-4dc7-a312-1d275a0630d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103622 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe3a1dda-3f38-46c9-af86-930bffdb75fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/923024d5-e9b4-4a4e-aa8b-6195151ddd81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3586 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146035 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7655 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/111985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112357 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5834 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7707 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35958 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7456 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->