### PR TITLE
Speculation Rules - ensure eagerness properly falls back to "conservative"

### DIFF
--- a/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Document rule with immediate eagerness prefetches immediately
+PASS Document rule with eager eagerness falls back to conservative
+PASS Document rule with moderate eagerness falls back to conservative
+PASS Document rule with conservative eagerness does not prefetch immediately
+PASS Document rule with eager eagerness prefetches on pointerdown
+PASS Document rule with moderate eagerness prefetches on pointerdown
+PASS Document rule with conservative eagerness prefetches on pointerdown
+

--- a/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpeculationRulesPrefetchEnabled=true ] -->
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>Speculation Rules Eagerness Fallback to Conservative</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<body>
+<script>
+
+setup(() => {
+  assert_implements(
+      'supports' in HTMLScriptElement,
+      'HTMLScriptElement.supports must be supported');
+  assert_implements(
+      HTMLScriptElement.supports('speculationrules'),
+      '<script type="speculationrules"> must be supported');
+});
+
+const PREFETCH_RESOURCE_URL = new URL('/speculation-rules/prefetch/resources/prefetch.py', location.href);
+
+function getPrefetchUrl(extra_params = {}) {
+  let params = new URLSearchParams({ uuid: token(), ...extra_params });
+  return new URL(`${PREFETCH_RESOURCE_URL}?${params}`);
+}
+
+async function isUrlPrefetched(url) {
+  let response = await fetch(url, { redirect: 'follow' });
+  return response.json();
+}
+
+function insertSpeculationRules(body) {
+  let script = document.createElement('script');
+  script.type = 'speculationrules';
+  script.textContent = JSON.stringify(body);
+  document.head.appendChild(script);
+  return script;
+}
+
+function addLink(href, parent = document.body) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.textContent = 'link';
+  parent.appendChild(a);
+  return a;
+}
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'immediate' });
+  const link = addLink(url);
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'immediate',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  assert_equals(await isUrlPrefetched(url), 1, 'immediate eagerness should prefetch immediately');
+}, 'Document rule with immediate eagerness prefetches immediately');
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'eager' });
+  const link = addLink(url);
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'eager',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  assert_equals(await isUrlPrefetched(url), 0, 'eager eagerness should fall back to conservative (no immediate prefetch)');
+}, 'Document rule with eager eagerness falls back to conservative');
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate' });
+  const link = addLink(url);
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  assert_equals(await isUrlPrefetched(url), 0, 'moderate eagerness should fall back to conservative (no immediate prefetch)');
+}, 'Document rule with moderate eagerness falls back to conservative');
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'conservative' });
+  const link = addLink(url);
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  await new Promise(resolve => t.step_timeout(resolve, 2000));
+  assert_equals(await isUrlPrefetched(url), 0, 'conservative eagerness should not prefetch immediately');
+}, 'Document rule with conservative eagerness does not prefetch immediately');
+
+function triggerPointerDown(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  const pointerdownEvent = new PointerEvent('pointerdown', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    clientX: x,
+    clientY: y,
+    button: 0,
+    pointerType: 'mouse'
+  });
+  element.dispatchEvent(pointerdownEvent);
+
+  const mousedownEvent = new MouseEvent('mousedown', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    clientX: x,
+    clientY: y,
+    button: 0
+  });
+  element.dispatchEvent(mousedownEvent);
+}
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'eager-click' });
+  const link = addLink(url);
+  link.id = 'eager-click-link';
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'eager',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched before interaction');
+
+  triggerPointerDown(link);
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+
+  assert_equals(await isUrlPrefetched(url), 1, 'eager eagerness should prefetch on pointerdown');
+}, 'Document rule with eager eagerness prefetches on pointerdown');
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate-click' });
+  const link = addLink(url);
+  link.id = 'moderate-click-link';
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched before interaction');
+
+  triggerPointerDown(link);
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+
+  assert_equals(await isUrlPrefetched(url), 1, 'moderate eagerness should prefetch on pointerdown');
+}, 'Document rule with moderate eagerness prefetches on pointerdown');
+
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'conservative-click' });
+  const link = addLink(url);
+  link.id = 'conservative-click-link';
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { href_matches: url.href }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched before interaction');
+
+  triggerPointerDown(link);
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+
+  assert_equals(await isUrlPrefetched(url), 1, 'conservative eagerness should prefetch on pointerdown');
+}, 'Document rule with conservative eagerness prefetches on pointerdown');
+
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4887,7 +4887,7 @@ void Document::processSpeculationRules()
     for (RefPtr element = iterator.next(); element; element = iterator.next()) {
         if (RefPtr anchorElement = dynamicDowncast<HTMLAnchorElement>(element.get())) {
             if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(*this, *anchorElement))
-                anchorElement->setShouldBePrefetched(prefetchRule->conservative, WTFMove(prefetchRule->tags), WTFMove(prefetchRule->referrerPolicy));
+                anchorElement->setShouldBePrefetched(prefetchRule->eagerness, WTFMove(prefetchRule->tags), WTFMove(prefetchRule->referrerPolicy));
         }
     }
     // Prefetch all the URL lists that need to be prefetched immediately

--- a/Source/WebCore/dom/SpeculationRulesMatcher.cpp
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.cpp
@@ -116,7 +116,7 @@ std::optional<PrefetchRule> SpeculationRulesMatcher::hasMatchingRule(Document& d
         for (const auto& rule : rules) {
             for (const auto& href : rule.urls) {
                 if (href == url)
-                    return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness == SpeculationRules::Eagerness::Conservative };
+                    return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness };
             }
 
             if (rule.predicate && matches(rule.predicate.value(), document, anchor)) {
@@ -128,7 +128,7 @@ std::optional<PrefetchRule> SpeculationRulesMatcher::hasMatchingRule(Document& d
                     if (linkReferrerPolicy != ReferrerPolicy::EmptyString)
                         referrerPolicy = linkReferrerPolicy;
                 }
-                return PrefetchRule { rule.tags, referrerPolicy, rule.eagerness == SpeculationRules::Eagerness::Conservative || rule.eagerness == SpeculationRules::Eagerness::Moderate };
+                return PrefetchRule { rule.tags, referrerPolicy, rule.eagerness };
             }
         }
     }

--- a/Source/WebCore/dom/SpeculationRulesMatcher.h
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/SpeculationRules.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -37,7 +38,7 @@ enum class ReferrerPolicy : uint8_t;
 struct PrefetchRule {
     Vector<String> tags;
     std::optional<ReferrerPolicy> referrerPolicy;
-    bool conservative;
+    SpeculationRules::Eagerness eagerness;
 };
 
 class SpeculationRulesMatcher {

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -28,6 +28,7 @@
 #include <WebCore/HTMLNames.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/SharedStringHash.h>
+#include <WebCore/SpeculationRules.h>
 #include <WebCore/URLDecomposition.h>
 #include <wtf/OptionSet.h>
 
@@ -85,7 +86,7 @@ public:
 
     AtomString target() const override;
 
-    void setShouldBePrefetched(bool conservative, Vector<String>&& tags, std::optional<ReferrerPolicy>&&);
+    void setShouldBePrefetched(SpeculationRules::Eagerness, Vector<String>&& tags, std::optional<ReferrerPolicy>&&);
 
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);


### PR DESCRIPTION
#### 568012af0888ada190de7cf46dfac45cce2e6509
<pre>
Speculation Rules - ensure eagerness properly falls back to &quot;conservative&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=304177">https://bugs.webkit.org/show_bug.cgi?id=304177</a>

Reviewed by Alex Christensen.

Our current implementation doesn&apos;t handle graceful fallbacks of eagerness values we don&apos;t yet support.
This PR changes that by piping the eagerness values to the relevant logic, and then considering everything that&apos;s not &quot;immediate&quot; to be &quot;conservative&quot;.

Test: http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html

* LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt: Added.
* LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processSpeculationRules): Pipe the eagerness value.
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::SpeculationRulesMatcher::hasMatchingRule): Pipe the eagerness value.
* Source/WebCore/dom/SpeculationRulesMatcher.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::setShouldBePrefetched): Implement the fallback.
(WebCore::HTMLAnchorElement::checkForSpeculationRules): Pipe the eagerness value.
* Source/WebCore/html/HTMLAnchorElement.h:

Canonical link: <a href="https://commits.webkit.org/304466@main">https://commits.webkit.org/304466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29effd671098183f67c019d0267d236abaeadc7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103638 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84509 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3600 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5846 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61640 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7725 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35980 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71276 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->