### PR TITLE
REGRESSION(287399@main): [Skia] Broke rendering of various PDFs

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1668,9 +1668,6 @@ private:
         Ref imageBitmap = jsCast<JSImageBitmap*>(obj)->wrapped();
         auto index = m_transferredImageBitmaps.find(obj);
         if (index != m_transferredImageBitmaps.end()) {
-#if USE(SKIA)
-            imageBitmap->prepareForCrossThreadTransfer();
-#endif
             write(ImageBitmapTransferTag);
             write(index->value);
             return;
@@ -4559,9 +4556,6 @@ private:
             m_imageBitmaps[index] = ImageBitmap::create(*protectedExecutionContext(m_lexicalGlobalObject).get(), WTFMove(*m_detachedImageBitmaps.at(index)));
 
         RefPtr bitmap = m_imageBitmaps[index];
-#if USE(SKIA)
-        bitmap->finalizeCrossThreadTransfer();
-#endif
         return getJSValue(bitmap.get());
     }
 

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -66,11 +66,6 @@
 #include "OffscreenCanvas.h"
 #endif
 
-#if USE(SKIA)
-#include "GLFence.h"
-#include "GraphicsContextSkia.h"
-#endif
-
 namespace WebCore {
 
 
@@ -195,19 +190,6 @@ void ImageBitmap::close()
 {
     takeImageBuffer();
 }
-
-#if USE(SKIA)
-void ImageBitmap::prepareForCrossThreadTransfer()
-{
-    m_bitmap = ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(WTFMove(m_bitmap));
-    m_fence = m_bitmap->renderingMode() == RenderingMode::Accelerated ? GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded(m_bitmap->surface()) : nullptr;
-}
-
-void ImageBitmap::finalizeCrossThreadTransfer()
-{
-    m_bitmap = ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(WTFMove(m_bitmap), WTFMove(m_fence));
-}
-#endif
 
 void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, ImageBitmap::Source&& source, ImageBitmapOptions&& options, int sx, int sy, int sw, int sh, ImageBitmap::Promise&& promise)
 {

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -45,7 +45,6 @@ class CanvasBase;
 class CSSStyleImageValue;
 class DestinationColorSpace;
 class FloatSize;
-class GLFence;
 class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
@@ -141,11 +140,6 @@ public:
     bool isDetached() const { return !m_bitmap; }
     void close();
 
-#if USE(SKIA)
-    void prepareForCrossThreadTransfer();
-    void finalizeCrossThreadTransfer();
-#endif
-
     size_t memoryCost() const;
 private:
     friend class ImageBitmapImageObserver;
@@ -178,9 +172,6 @@ private:
     const bool m_originClean : 1 { false };
     const bool m_premultiplyAlpha : 1 { false };
     const bool m_forciblyPremultiplyAlpha : 1 { false };
-#if USE(SKIA)
-    std::unique_ptr<GLFence> m_fence;
-#endif
 };
 
 }

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -139,6 +139,11 @@ RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
     // by buffer(), to avoid resetting the context state, we have to make a copy and
     // clear the original buffer rather than returning the original buffer.
     RefPtr result = buffer->clone();
+#if USE(SKIA)
+    // Ensure GPU commands are flushed before the ImageBuffer may be transferred cross-thread.
+    if (result)
+        result->flushDrawingContext();
+#endif
     clearCanvas();
     return result;
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -218,10 +218,6 @@ public:
     //     buffer = nullptr;
     WEBCORE_EXPORT static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
-#if USE(SKIA)
-    static RefPtr<ImageBuffer> sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImageBuffer>);
-    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>, std::unique_ptr<GLFence>&&);
-#endif
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
     WEBCORE_EXPORT static RefPtr<SharedBuffer> sinkIntoPDFDocument(RefPtr<ImageBuffer>);
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -116,8 +116,8 @@ public:
 
     void drawSkiaText(const sk_sp<SkTextBlob>&, SkScalar, SkScalar, bool, bool);
 
-    static std::unique_ptr<GLFence> createAcceleratedRenderingFenceIfNeeded(SkSurface*);
-    static std::unique_ptr<GLFence> createAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>&);
+    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(SkSurface*);
+    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(const sk_sp<SkImage>&);
 
 private:
     enum class ContextMode : bool {

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -125,6 +125,15 @@ ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const Param
 
 ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend() = default;
 
+void ImageBufferSkiaAcceleratedBackend::flushContext()
+{
+    if (!m_surface)
+        return;
+
+    if (auto fence = GraphicsContextSkia::createAcceleratedRenderingFence(m_surface.get()))
+        fence->serverWait();
+}
+
 void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
 {
 #if USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -46,6 +46,7 @@ public:
 private:
     ImageBufferSkiaAcceleratedBackend(const Parameters&, sk_sp<SkSurface>&&);
 
+    void flushContext() final;
     void prepareForDisplay() final;
 
     RefPtr<NativeImage> copyNativeImage() final;


### PR DESCRIPTION
#### 48db7480703cf267922ad0b91f1ef965d8fa64a4
<pre>
REGRESSION(287399@main): [Skia] Broke rendering of various PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=295538">https://bugs.webkit.org/show_bug.cgi?id=295538</a>

Reviewed by Carlos Garcia Campos.

Fix PDF rendering regression caused by cross-thread transfer of accelerated
ImageBitmap. When a texture-backed image is transferred across threads, the
GPU texture may not be valid for the current Skia context.

The fix has two parts:

1. Flush GPU commands before cross-thread transfer by calling
   flushDrawingContext() in OffscreenCanvasRenderingContext2D::transferToImageBuffer().
   This is implemented via ImageBufferSkiaAcceleratedBackend::flushContext()
   which creates a GL fence and performs a server wait.

2. Rewrap textures at draw time in GraphicsContextSkia::drawNativeImage().
   When drawing a texture-backed image, check if it&apos;s valid for the current
   GrContext using isValid(). If not (because it was created in a different
   thread/context), use SkImages::BorrowTextureFrom() to create a new SkImage
   wrapper around the existing backend texture. Before rewrapping, create
   a GL fence and server wait to ensure pending GPU operations on the source
   image are complete.

This approach simplifies cross-thread transfer by removing the explicit
prepare/finalize pattern from ImageBitmap (prepareForCrossThreadTransfer,
finalizeCrossThreadTransfer, m_fence member), ImageBuffer
(sinkIntoImageBufferForCrossThreadTransfer,
sinkIntoImageBufferAfterCrossThreadTransfer), and SerializedScriptValue.

Also refactor the fence creation API: rename the implementation to
createAcceleratedRenderingFenceInternal, add public static
createAcceleratedRenderingFence() methods for both SkSurface* and
sk_sp&lt;SkImage&gt;, and remove the private createAcceleratedRenderingFenceIfNeeded
methods by inlining the null/texture-backed checks into callers.

Covered by existing tests.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneDeserializer::readTransferredImageBitmap):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::prepareForCrossThreadTransfer): Deleted.
(WebCore::ImageBitmap::finalizeCrossThreadTransfer): Deleted.
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::transferToImageBuffer):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::DefaultSerializedImageBuffer::DefaultSerializedImageBuffer):
(WebCore::ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer): Deleted.
(WebCore::ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::createAcceleratedRenderingFenceInternal):
(WebCore::GraphicsContextSkia::createAcceleratedRenderingFence):
(WebCore::GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded):
(WebCore::createAcceleratedRenderingFence): Deleted.
(WebCore::GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::flushContext):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:

Canonical link: <a href="https://commits.webkit.org/304687@main">https://commits.webkit.org/304687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887da01fb8ac1ff52c7a54a399aecfc27d140f6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143991 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6778 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122119 "Found 1 new API test failure: TestWebKitAPI.WKUserContentController.DidAssociateFormControlsFromShadowTree (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4095 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146735 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8319 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40888 "Found 1 new test failure: fast/images/mac/play-all-pause-all-animations-context-menu-items.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112544 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6364 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118424 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36481 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71926 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->