### PR TITLE
[inspector] WorkerInspectorController needs thread-safe CheckedPointer variant

### DIFF
--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -47,7 +47,7 @@ class WebInjectedScriptManager;
 class WorkerDebugger;
 struct WorkerAgentContext;
 
-class WorkerInspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<WorkerInspectorController> {
+class WorkerInspectorController final : public Inspector::InspectorEnvironment, public CanMakeThreadSafeCheckedPtr<WorkerInspectorController> {
     WTF_MAKE_NONCOPYABLE(WorkerInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerInspectorController);
@@ -56,11 +56,11 @@ public:
     ~WorkerInspectorController() override;
 
     // AbstractCanMakeCheckedPtr overrides
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     void workerTerminating();
 


### PR DESCRIPTION
#### 7fc78f4d62854242a2cf1f135678e9896e433643
<pre>
[inspector] WorkerInspectorController needs thread-safe CheckedPointer variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=304178">https://bugs.webkit.org/show_bug.cgi?id=304178</a>

Reviewed by Darin Adler.

Seen occassionally in post-commit Debug bots (mac and linux):

Thread 1 (Thread 0x7f5f627fd6c0 (LWP 609672)):
0  WTFCrash () at ../../../Source/WTF/wtf/Assertions.cpp:380
1  0x00007f714089ebf0 in WTFCrashWithInfo () at WTF/Headers/wtf/Assertions.h:985
2  0x00007f714144fc98 in WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;::assertThread (this=0x7f711a5dc378) at WTF/Headers/wtf/SingleThreadIntegralWrapper.h:54
3  0x00007f7141a86ef2 in WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;::operator++ (this=0x7f711a5dc378) at WTF/Headers/wtf/SingleThreadIntegralWrapper.h:98
4  0x00007f7141a7cd14 in WTF::CanMakeCheckedPtrBase&lt;WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;, unsigned int, bool, (WTF::CheckedPtrDeleteCheckException)0&gt;::incrementCheckedPtrCount (this=0x7f711a5dc378) at WTF/Headers/wtf/CheckedRef.h:296
5  0x00007f7148e5edd0 in WebCore::WorkerInspectorController::incrementCheckedPtrCount (this=0x7f711a5dc360) at ../../../Source/WebCore/inspector/WorkerInspectorController.h:61
6  0x00007f712f7bff7c in WTF::CheckedRef&lt;Inspector::InspectorEnvironment, WTF::RawPtrTraits&lt;Inspector::InspectorEnvironment&gt; &gt;::CheckedRef (this=0x7f5f627fc3c0, object=...) at WTF/Headers/wtf/CheckedRef.h:62
7  0x00007f712f8eb44c in Inspector::InspectorHeapAgent::checkedEnvironment (this=0x7f711a810720) at ../../../Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:80
8  0x00007f712f8fb96a in Inspector::InspectorHeapAgent::willGarbageCollect (this=0x7f711a810720) at ../../../Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:275Thread 1 (Thread 0x7f5f627fd6c0 (LWP 609672)):

* Source/WebCore/inspector/WorkerInspectorController.h:

Canonical link: <a href="https://commits.webkit.org/304519@main">https://commits.webkit.org/304519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a38bed5b4bfbdb02d57507bd1ac3790b3de64895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3603 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146082 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7677 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5848 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7728 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35983 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71279 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->