### PR TITLE
Remove ScriptDisallowedScope::InMainThreadOfWebProcess

### DIFF
--- a/Source/WebCore/dom/ScriptDisallowedScope.h
+++ b/Source/WebCore/dom/ScriptDisallowedScope.h
@@ -111,30 +111,6 @@ public:
         }
     };
 
-    class InMainThreadOfWebProcess {
-    public:
-        InMainThreadOfWebProcess()
-            : m_isInWebProcess(isInWebProcess())
-        {
-            ASSERT(isMainThread());
-            if (!m_isInWebProcess)
-                return;
-            ++s_count;
-        }
-
-        ~InMainThreadOfWebProcess()
-        {
-            ASSERT(isMainThread());
-            if (!m_isInWebProcess)
-                return;
-            ASSERT(s_count);
-            --s_count;
-        }
-
-    private:
-        bool m_isInWebProcess;
-    };
-
 #if ASSERT_ENABLED
     class EventAllowedScope {
     public:


### PR DESCRIPTION
#### 7a5823564e7d3465cfbdfb6b77fbb169363fa91b
<pre>
Remove ScriptDisallowedScope::InMainThreadOfWebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=304179">https://bugs.webkit.org/show_bug.cgi?id=304179</a>

Reviewed by Michael Catanzaro and Ryosuke Niwa.

This was initially introduced in
<a href="https://commits.webkit.org/253870@main">https://commits.webkit.org/253870@main</a> but this usage was later removed in
<a href="https://commits.webkit.org/263768@main">https://commits.webkit.org/263768@main</a> so it&apos;s no longer used.

* Source/WebCore/dom/ScriptDisallowedScope.h:
(WebCore::ScriptDisallowedScope::InMainThreadOfWebProcess::InMainThreadOfWebProcess): Deleted.
(WebCore::ScriptDisallowedScope::InMainThreadOfWebProcess::~InMainThreadOfWebProcess): Deleted.

Canonical link: <a href="https://commits.webkit.org/304501@main">https://commits.webkit.org/304501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0462f0118d998e8533445868c61a5e1980e429f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/5998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3606 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5855 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61650 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7733 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7481 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71284 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->