### PR TITLE
[git-webkit] Support finding commits on remotes

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -132,15 +132,28 @@ class Git(Scm):
             log = None
             try:
                 self._last_populated[branch] = time.time()
+                ref_to_use = '{}/{}'.format(remote, branch) if remote else branch
                 log = subprocess.Popen(
-                    [self.repo.executable(), 'log', '{}/{}'.format(remote, branch) if remote else branch, '--no-decorate', '--date=unix', '--'],
+                    [self.repo.executable(), 'log', ref_to_use, '--no-decorate', '--date=unix', '--'],
                     cwd=self.repo.root_path,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     encoding='utf-8',
                 )
                 if log.poll():
-                    raise self.repo.Exception("Failed to construct branch history for '{}'".format(branch))
+                    # If the local ref doesn't exist and no remote was specified, try to find the branch in canonical remotes
+                    if not remote:
+                        candidate_remotes = []
+                        for candidate_remote in self.repo.source_remotes(personal=False):
+                            if branch in self.repo.branches_for(remote=candidate_remote):
+                                candidate_remotes.append(candidate_remote)
+
+                        for candidate_remote in candidate_remotes:
+                            try:
+                                return self.populate(branch=branch, remote=candidate_remote)
+                            except self.repo.Exception:
+                                continue
+                    raise self.repo.Exception("Failed to construct branch history for '{}'".format(ref_to_use))
 
                 hash = None
                 revision = None
@@ -248,7 +261,19 @@ class Git(Scm):
                 return self._ordered_commits[branch][b_count]
             if populate:
                 self.populate(branch=branch)
-                return self.to_hash(identifier=identifier, populate=False)
+                if branch in self._ordered_commits and len(self._ordered_commits[branch]) > b_count:
+                    return self._ordered_commits[branch][b_count]
+
+                # If we still don't have enough commits, try other remotes
+                for remote in self.repo.source_remotes(personal=False):
+                    if branch in self.repo.branches_for(remote=remote):
+                        try:
+                            self.populate(branch=branch, remote=remote)
+                            if branch in self._ordered_commits and len(self._ordered_commits[branch]) > b_count:
+                                return self._ordered_commits[branch][b_count]
+                        except self.repo.Exception:
+                            continue
+                return None
             return None
 
         def to_revision(self, hash=None, identifier=None, populate=True, branch=None):
@@ -269,7 +294,19 @@ class Git(Scm):
                 return self._ordered_revisions[branch][b_count]
             if populate:
                 self.populate(branch=branch)
-                return self.to_revision(identifier=identifier, populate=False)
+                if branch in self._ordered_revisions and len(self._ordered_revisions[branch]) > b_count:
+                    return self._ordered_revisions[branch][b_count]
+
+                # If we still don't have enough commits, try other remotes
+                for remote in self.repo.source_remotes(personal=False):
+                    if branch in self.repo.branches_for(remote=remote):
+                        try:
+                            self.populate(branch=branch, remote=remote)
+                            if branch in self._ordered_revisions and len(self._ordered_revisions[branch]) > b_count:
+                                return self._ordered_revisions[branch][b_count]
+                        except self.repo.Exception:
+                            continue
+                return None
             return None
 
         def to_identifier(self, hash=None, revision=None, populate=True, branch=None):
@@ -283,7 +320,18 @@ class Git(Scm):
                     return self._revisions_to_identifiers[revision]
                 if populate:
                     self.populate(branch=branch)
-                    return self.to_identifier(revision=revision, populate=False)
+                    if revision in self._revisions_to_identifiers:
+                        return self._revisions_to_identifiers[revision]
+
+                    # If we still don't have the revision, try other remotes
+                    for remote in self.repo.source_remotes(personal=False):
+                        if branch and branch in self.repo.branches_for(remote=remote):
+                            try:
+                                self.populate(branch=branch, remote=remote)
+                                if revision in self._revisions_to_identifiers:
+                                    return self._revisions_to_identifiers[revision]
+                            except self.repo.Exception:
+                                continue
                 return None
 
             hash = Commit._parse_hash(hash, do_assert=False)
@@ -301,7 +349,26 @@ class Git(Scm):
                     return candidate
                 if populate:
                     self.populate(branch=branch)
-                    return self.to_identifier(hash=hash, populate=False)
+                    try:
+                        candidate = self._hash_to_identifiers.get(hash)
+                    except KeyError:
+                        return None
+                    if candidate:
+                        return candidate
+
+                    # If we still don't have the hash, try other remotes
+                    for remote in self.repo.source_remotes(personal=False):
+                        if branch and branch in self.repo.branches_for(remote=remote):
+                            try:
+                                self.populate(branch=branch, remote=remote)
+                                try:
+                                    candidate = self._hash_to_identifiers.get(hash)
+                                except KeyError:
+                                    continue
+                                if candidate:
+                                    return candidate
+                            except self.repo.Exception:
+                                continue
             return None
 
 
@@ -801,21 +868,51 @@ class Git(Scm):
                 if is_default:
                     base_count = self._commit_count(baseline)
                 else:
-                    base_count = min(
-                        self._commit_count('{}..{}'.format(default_branch, baseline)),
-                        self._commit_count('{}/{}..{}'.format(self.default_remote, default_branch, baseline)),
-                    )
+                    # Try to compute the commit count, first trying the local ref, then remote refs if that fails
+                    base_count = None
+                    try:
+                        base_count = min(
+                            self._commit_count('{}..{}'.format(default_branch, baseline)),
+                            self._commit_count('{}/{}..{}'.format(self.default_remote, default_branch, baseline)),
+                        )
+                    except self.Exception:
+                        pass
+
+                    # If local ref failed or doesn't have enough commits, try remote refs
+                    if base_count is None or identifier > base_count:
+                        best_remote_ref = None
+                        best_base_count = base_count
+                        for remote in self.source_remotes(personal=False):
+                            if branch in self.branches_for(remote=remote):
+                                try:
+                                    remote_ref = '{}/{}'.format(remote, branch)
+                                    remote_base_count = min(
+                                        self._commit_count('{}..{}'.format(default_branch, remote_ref)),
+                                        self._commit_count('{}/{}..{}'.format(self.default_remote, default_branch, remote_ref)),
+                                    )
+                                    if best_base_count is None or remote_base_count > best_base_count:
+                                        best_base_count = remote_base_count
+                                        best_remote_ref = remote_ref
+                                except self.Exception:
+                                    continue
+
+                        if best_remote_ref is not None:
+                            baseline = best_remote_ref
+                            base_count = best_base_count
+
+                    if base_count is None:
+                        raise self.Exception("Failed to compute identifier count for branch '{}'".format(branch))
 
                 if identifier > base_count:
                     raise self.Exception('Identifier {} cannot be found on the specified branch in the current checkout. Latest identifier on this branch is {}'.format(identifier, base_count))
                 log = run(
-                    [self.executable(), 'log', '{}~{}'.format(branch or 'HEAD', base_count - identifier)] + log_format + ['--'],
+                    [self.executable(), 'log', '{}~{}'.format(baseline, base_count - identifier)] + log_format + ['--'],
                     cwd=self.root_path,
                     capture_output=True,
                     encoding='utf-8',
                 )
                 if log.returncode:
-                    raise self.Exception("Failed to retrieve commit information for 'i{}@{}'".format(identifier, branch or 'HEAD'))
+                    raise self.Exception("Failed to retrieve commit information for 'i{}@{}'".format(identifier, baseline))
 
                 # Negative identifiers are actually commits on the default branch, we will need to re-compute the identifier
                 if identifier < 0 and is_default:


### PR DESCRIPTION
#### 64e615db8c639ddf6cf3036f8a781d8bbb9a289d
<pre>
[git-webkit] Support finding commits on remotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304188">https://bugs.webkit.org/show_bug.cgi?id=304188</a>
<a href="https://rdar.apple.com/166545118">rdar://166545118</a>

Reviewed by NOBODY (OOPS!).

Modify webkitscmpy so that `git-webkit` can find commits which are not tracked in local branch refs.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.Cache.populate): Fallback to canonical remotes to populate our branch cache.
(Git.Cache.to_revision): Attempt to populate cache from alternative remotes if we
can&apos;t find the provided reference.
(Git.Cache.to_identifier): Ditto.
(Git.commit): Fallback to canonical remotes if we cannot assign an identifier to a commit.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e615db8c639ddf6cf3036f8a781d8bbb9a289d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1556f05f-ffeb-46bf-80de-4cc12a73c854) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103649 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71637 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c178f775-8fdd-4ccc-bba3-b057f5239d20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138579 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6233 "Found 1 new test failure: fast/forms/datalist/datalist-crash-when-dynamic.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84520 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c49135a8-d4fd-4548-bef2-d7da19057ab6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/134981 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3613 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3957 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146096 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7692 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112011 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/135060 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112385 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5862 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61660 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/35993 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7489 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->