### PR TITLE
RenderMathMLRoot does not reset radical operator when children change dynamically

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -14,7 +14,7 @@ PASS Appending and removing children to mroot
 PASS Appending and removing children to mrow
 PASS Appending and removing children to ms
 PASS Appending and removing children to mspace
-FAIL Appending and removing children to msqrt assert_approx_equals: inline size expected 12.703125 +/- 1 but got 16.640625
+PASS Appending and removing children to msqrt
 PASS Appending and removing children to mstyle
 PASS Appending and removing children to msub
 PASS Appending and removing children to msubsup
@@ -23,8 +23,7 @@ PASS Appending and removing children to mtable
 PASS Appending and removing children to mtext
 PASS Appending and removing children to munder
 PASS Appending and removing children to munderover
-FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -362.890625 +/- 1 but got -380.890625
+FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -112 +/- 1 but got -130
 maction:
-msqrt:
 semantics:
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
@@ -31,7 +31,7 @@ PASS Adding missing children to mroot
 PASS Removing child from valid mroot
 PASS Adding child to valid mroot
 PASS Removing extra child from mroot
-FAIL Removing children from msqrt assert_approx_equals: inline size expected 13 +/- 1 but got 16
+PASS Removing children from msqrt
 PASS Adding children to msqrt
 PASS Removing children from mpadded
 PASS Adding children to mpadded

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -14,7 +14,7 @@ PASS Appending and removing children to mroot
 PASS Appending and removing children to mrow
 PASS Appending and removing children to ms
 PASS Appending and removing children to mspace
-FAIL Appending and removing children to msqrt assert_approx_equals: inline size expected 13 +/- 1 but got 16
+PASS Appending and removing children to msqrt
 PASS Appending and removing children to mstyle
 PASS Appending and removing children to msub
 PASS Appending and removing children to msubsup
@@ -24,5 +24,4 @@ PASS Appending and removing children to mtext
 PASS Appending and removing children to munder
 PASS Appending and removing children to munderover
 PASS Appending and removing children to semantics
-msqrt:
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
@@ -31,7 +31,7 @@ PASS Adding missing children to mroot
 PASS Removing child from valid mroot
 PASS Adding child to valid mroot
 PASS Removing extra child from mroot
-FAIL Removing children from msqrt assert_approx_equals: inline size expected 12.703125 +/- 1 but got 18.828125
+PASS Removing children from msqrt
 PASS Adding children to msqrt
 PASS Removing children from mpadded
 PASS Adding children to mpadded

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -14,7 +14,7 @@ PASS Appending and removing children to mroot
 PASS Appending and removing children to mrow
 PASS Appending and removing children to ms
 PASS Appending and removing children to mspace
-FAIL Appending and removing children to msqrt assert_approx_equals: inline size expected 12.703125 +/- 1 but got 16.640625
+PASS Appending and removing children to msqrt
 PASS Appending and removing children to mstyle
 PASS Appending and removing children to msub
 PASS Appending and removing children to msubsup
@@ -23,8 +23,7 @@ PASS Appending and removing children to mtable
 PASS Appending and removing children to mtext
 PASS Appending and removing children to munder
 PASS Appending and removing children to munderover
-FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -377.890625 +/- 1 but got -397.890625
+FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -123 +/- 1 but got -143
 maction:
-msqrt:
 semantics:
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt
@@ -31,7 +31,7 @@ PASS Adding missing children to mroot
 PASS Removing child from valid mroot
 PASS Adding child to valid mroot
 PASS Removing extra child from mroot
-FAIL Removing children from msqrt assert_approx_equals: inline size expected 12.703125 +/- 1 but got 18.828125
+PASS Removing children from msqrt
 PASS Adding children to msqrt
 PASS Removing children from mpadded
 PASS Adding children to mpadded

--- a/Source/WebCore/mathml/MathMLRootElement.cpp
+++ b/Source/WebCore/mathml/MathMLRootElement.cpp
@@ -63,6 +63,16 @@ RenderPtr<RenderElement> MathMLRootElement::createElementRenderer(RenderStyle&& 
     return createRenderer<RenderMathMLRoot>(*this, WTF::move(style));
 }
 
+void MathMLRootElement::childrenChanged(const ChildChange& change)
+{
+    MathMLRowElement::childrenChanged(change);
+
+    if (CheckedPtr rootRenderer = dynamicDowncast<RenderMathMLRoot>(this->renderer())) {
+        rootRenderer->resetRadicalOperator();
+        rootRenderer->setNeedsLayoutAndPreferredWidthsUpdate();
+    }
+}
+
 }
 
 #endif // ENABLE(MATHML)

--- a/Source/WebCore/mathml/MathMLRootElement.h
+++ b/Source/WebCore/mathml/MathMLRootElement.h
@@ -44,6 +44,8 @@ private:
     MathMLRootElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
+    void childrenChanged(const ChildChange&) override;
+
     const RootType m_rootType;
 };
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -100,7 +100,7 @@ RenderBox& RenderMathMLRoot::getIndex() const
 void RenderMathMLRoot::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
 {
     RenderMathMLRow::styleDidChange(diff, oldStyle);
-    m_radicalOperator.reset(style());
+    resetRadicalOperator();
 }
 
 RenderMathMLRoot::HorizontalParameters RenderMathMLRoot::horizontalParameters(LayoutUnit indexWidth)

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -46,6 +46,7 @@ public:
     virtual ~RenderMathMLRoot();
 
     void updateStyle();
+    void resetRadicalOperator() { m_radicalOperator.reset(checkedStyle()); }
 
 private:
     bool isValid() const;


### PR DESCRIPTION
#### 498cdeb54915897996f55c8eb5cac655021a74ce
<pre>
RenderMathMLRoot does not reset radical operator when children change dynamically
<a href="https://bugs.webkit.org/show_bug.cgi?id=304194">https://bugs.webkit.org/show_bug.cgi?id=304194</a>
<a href="https://rdar.apple.com/166556627">rdar://166556627</a>

Reviewed by Frédéric Wang.

When children are dynamically removed from msqrt or mroot elements, the radical
operator retains its previously stretched width from the larger content,
causing the element to be wider than necessary for the remaining children.

The issue occurs because the renderer is not notified when the child list
changes. While styleDidChange() properly resets m_radicalOperator for style
changes, there was no corresponding mechanism to reset it when children are
added or removed from the DOM.

Fix by overriding childrenChanged() in MathMLRootElement to notify the
renderer when the child list changes. The renderer resets m_radicalOperator
and marks itself as needing layout and preferred width recalculation, ensuring
width calculations reflect the current children rather than stale cached state.

* Source/WebCore/mathml/MathMLRootElement.cpp:
(WebCore::MathMLRootElement::childrenChanged):
* Source/WebCore/mathml/MathMLRootElement.h:
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::styleDidChange):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h:

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-001-expected.txt:

Canonical link: <a href="https://commits.webkit.org/304822@main">https://commits.webkit.org/304822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5054a5a04ee2033685f031e6426158255d5f9a64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89549 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3a75bf2f-ba37-46bf-af0d-a38c4af14c0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104433 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9a70548-097e-427a-968d-464c943350bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fdb0eec8-7a19-45a9-9665-11e44647ddf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4346 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147058 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8619 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6600 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62652 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8667 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36721 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->