### PR TITLE
Remove unnecessary protectedThis in VTTCue.cpp

### DIFF
--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -156,9 +156,9 @@ void VTTCueBox::applyCSSPropertiesWithRegion()
         return;
 
     // the 'left' property must be set to left
-    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
+    WTF::visit(WTF::makeVisitor([&] (double left) {
         setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_PERCENTAGE);
-    }, [this, protectedThis = Ref { *this }] (auto) {
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyLeft, CSSValueAuto);
     }), cue->left());
     setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
@@ -206,16 +206,16 @@ void VTTCueBox::applyCSSProperties()
     setInlineStyleProperty(CSSPropertyWritingMode, cue->getCSSWritingMode());
 
     // the 'top' property must be set to top
-    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double top) {
+    WTF::visit(WTF::makeVisitor([&] (double top) {
         setInlineStyleProperty(CSSPropertyTop, top, CSSUnitType::CSS_CQH);
-    }, [this, protectedThis = Ref { *this }] (auto) {
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyTop, CSSValueAuto);
     }), cue->top());
 
     // the 'left' property must be set to left
-    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
+    WTF::visit(WTF::makeVisitor([&] (double left) {
         setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_CQW);
-    }, [this, protectedThis = Ref { *this }] (auto) {
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyLeft, CSSValueAuto);
     }), cue->left());
 
@@ -226,16 +226,16 @@ void VTTCueBox::applyCSSProperties()
     // is not a true viewport, but it is a container, so they serve the same purpose.
 
     // the 'width' property must be set to width
-    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double width) {
+    WTF::visit(WTF::makeVisitor([&] (double width) {
         setInlineStyleProperty(CSSPropertyWidth, width, CSSUnitType::CSS_CQW);
-    }, [this, protectedThis = Ref { *this }] (auto) {
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyWidth, CSSValueAuto);
     }), cue->width());
 
     // the 'height' property must be set to height
-    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double height) {
+    WTF::visit(WTF::makeVisitor([&] (double height) {
         setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_CQH);
-    }, [this, protectedThis = Ref { *this }] (auto) {
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
     }), cue->height());
 


### PR DESCRIPTION
#### 76163e7606bf639bf57a563e97ec372e3bf94c58
<pre>
Remove unnecessary protectedThis in VTTCue.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=304195">https://bugs.webkit.org/show_bug.cgi?id=304195</a>

Reviewed by NOBODY (OOPS!).

Removed unnecessary protectedThis in VTTCue.cpp now that the corresponding clang fix has been merged:
<a href="https://github.com/llvm/llvm-project/pull/161926">https://github.com/llvm/llvm-project/pull/161926</a>

No new tests since there should be no change in behavior.

* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSPropertiesWithRegion):
(WebCore::VTTCueBox::applyCSSProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76163e7606bf639bf57a563e97ec372e3bf94c58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87319 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/704e3ae4-31d7-4354-a867-684eb3d088e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71640 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6df7b796-d3b5-422a-b806-0f342325604c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d2a4586a-5395-468f-9c74-00bdc71f6151) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3635 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3984 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146124 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112033 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112408 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5883 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61680 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7768 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36012 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7512 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71321 "Found 9 new failures in html/track/VTTCue.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->