### PR TITLE
Remove suppression for NSApp

### DIFF
--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -825,13 +825,11 @@ void Pasteboard::setDragImage(DragImage image, const IntPoint& location)
     // This is the most innocuous event to use, per Kristin Forster.
     // This is only relevant in WK1. Do not execute in the WebContent process, since it is now using
     // NSRunLoop, and not the NSApplication run loop.
-    // This is a safer cpp false positive (rdar://161068288).
-    SUPPRESS_UNRETAINED_ARG if ([NSApp isRunning]) {
+    if ([NSApp isRunning]) {
         ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
         NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeMouseMoved location:NSZeroPoint
             modifierFlags:0 timestamp:0 windowNumber:0 context:nil eventNumber:0 clickCount:0 pressure:0];
-        // This is a safer cpp false positive (rdar://161068288).
-        SUPPRESS_UNRETAINED_ARG [NSApp postEvent:event atStart:YES];
+        [NSApp postEvent:event atStart:YES];
     }
 }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -491,14 +491,12 @@ void SOAuthorizationSession::dismissViewController()
         }
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://problem/161068288).
-    SUPPRESS_UNRETAINED_ARG if (!m_isInDestructor && NSApp.hidden) {
+    if (!m_isInDestructor && NSApp.hidden) {
         AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Application is hidden. Waiting to dismiss until active.");
         if (m_applicationDidUnhideObserver) {
             AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: [Hidden] Already has an Unhide observer (%p). Deminiaturized observer is %p", m_presentingWindowDidDeminiaturizeObserver.get(), m_applicationDidUnhideObserver.get());
             return;
         }
-        // FIXME: We should not need to protect NSApp here (rdar://problem/161068288).
         m_applicationDidUnhideObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidUnhideNotification object:NSApp queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
             AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Application is no longer hidden. Completing the dismissal.");
             dismissViewController();

--- a/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
+++ b/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
@@ -39,8 +39,7 @@ namespace WebKit {
 WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    // This is a safer cpp false positive (<rdar://problem/161068288>).
-    SUPPRESS_UNRETAINED_ARG RetainPtr responder = [[NSApp keyWindow] firstResponder];
+    RetainPtr responder = [[NSApp keyWindow] firstResponder];
 
     if (RetainPtr view = dynamic_objc_cast<WKWebView>(responder.get()))
         return view->_page.get();

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -455,8 +455,7 @@ void WebInspectorUIProxy::showSavePanel(NSWindow *frontendWindow, NSURL *platfor
         saveToURL(retainPtr([savePanel URL]).get());
     };
 
-    // This is a safer cpp false positive (rdar://161068288).
-    SUPPRESS_UNRETAINED_ARG if (RetainPtr window = frontendWindow ?: [NSApp keyWindow])
+    if (RetainPtr window = frontendWindow ?: [NSApp keyWindow])
         [savePanel beginSheetModalForWindow:window.get() completionHandler:makeBlockPtr(WTFMove(didShowModal)).get()];
     else
         didShowModal([savePanel runModal]);
@@ -669,10 +668,8 @@ void WebInspectorUIProxy::platformShowCertificate(const CertificateInfo& certifi
     else
         window = [[m_inspectorViewController webView] window];
 
-    if (!window) {
-        // This is a safer cpp false positive (rdar://161068288).
-        SUPPRESS_UNRETAINED_ARG window = [NSApp keyWindow];
-    }
+    if (!window)
+        window = [NSApp keyWindow];
 
     [certificatePanel beginSheetForWindow:window.get() modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust().get() showGroup:YES];
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -160,22 +160,19 @@ String WebPageProxy::standardUserAgent(const String& applicationNameForUserAgent
 void WebPageProxy::getIsSpeaking(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    // FIXME: This is a safer cpp false positive (rdar://problem/161068288).
-    SUPPRESS_UNRETAINED_ARG completionHandler([NSApp isSpeaking]);
+    completionHandler([NSApp isSpeaking]);
 }
 
 void WebPageProxy::speak(const String& string)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    // FIXME: This is a safer cpp false positive (rdar://problem/161068288).
-    SUPPRESS_UNRETAINED_ARG [NSApp speakString:string.createNSString().get()];
+    [NSApp speakString:string.createNSString().get()];
 }
 
 void WebPageProxy::stopSpeaking()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    // FIXME: This is a safer cpp false positive (rdar://problem/161068288).
-    SUPPRESS_UNRETAINED_ARG [NSApp stopSpeaking:nil];
+    [NSApp stopSpeaking:nil];
 }
 
 void WebPageProxy::searchTheWeb(const String& string)


### PR DESCRIPTION
#### 7e9901d99cf41fa368e926e131ea1083757abfe4
<pre>
Remove suppression for NSApp
<a href="https://bugs.webkit.org/show_bug.cgi?id=304197">https://bugs.webkit.org/show_bug.cgi?id=304197</a>

Reviewed by Geoffrey Garen.

Remove the safer C++ suppressions for NSApp now that the corresponding clang fix
has been merged &amp; deployed: <a href="https://github.com/llvm/llvm-project/pull/160990">https://github.com/llvm/llvm-project/pull/160990</a>

No new tests since there should be no behavioral changes.

* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::setDragImage):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::dismissViewController):
* Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::showSavePanel):
(WebKit::WebInspectorUIProxy::platformShowCertificate):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::getIsSpeaking):
(WebKit::WebPageProxy::speak):
(WebKit::WebPageProxy::stopSpeaking):

Canonical link: <a href="https://commits.webkit.org/304555@main">https://commits.webkit.org/304555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b1f3495623e22ea954169ff34dd2e0350e731fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26cba63b-a9e8-4d64-99e6-db9a13411efd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53541b08-ed8e-4f70-891f-81a52628542b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5bd4c208-1b48-46db-91f3-c20268d19052) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3639 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112037 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112411 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5884 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61684 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20935 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7772 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36022 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7737 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->