### PR TITLE
Remove unnecessary suppression in DaemonConnectionCocoa.mm

### DIFF
--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -95,8 +95,7 @@ void ConnectionToMachService<Traits>::send(typename Traits::MessageType messageT
 {
     initializeConnectionIfNeeded();
     OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
-    // FIXME: This is a safer cpp false positive (rdar://161383542).
-    SUPPRESS_UNRETAINED_ARG Connection::send(dictionary.get());
+    Connection::send(dictionary.get());
 }
 
 template<typename Traits>
@@ -106,8 +105,7 @@ void ConnectionToMachService<Traits>::sendWithReply(typename Traits::MessageType
     initializeConnectionIfNeeded();
 
     OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
-    // FIXME: This is a safer cpp false positive (rdar://161383542).
-    SUPPRESS_UNRETAINED_ARG Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
             if (reply == XPC_ERROR_CONNECTION_INTERRUPTED)
                 LOG_ERROR("ConnectionToMachService::sendWithReply: connection is interrupted");


### PR DESCRIPTION
#### 4cd05829d85548eca52781799f5f49ef53195113
<pre>
Remove unnecessary suppression in DaemonConnectionCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=304200">https://bugs.webkit.org/show_bug.cgi?id=304200</a>

Reviewed by Geoffrey Garen.

Remove the unnecessary suppressions in DaemonConnectionCocoa.mm now that the corresponding clang
static analyzer fix has been merged and deployed: <a href="https://github.com/llvm/llvm-project/pull/161025">https://github.com/llvm/llvm-project/pull/161025</a>

No new tests since there should be no behavioral changes.

* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::send const):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::sendWithReply const):

Canonical link: <a href="https://commits.webkit.org/304561@main">https://commits.webkit.org/304561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d431907482b7c81d5964057e2b004ccf3a650cdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87327 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c1801d1-b663-4fe0-87fb-1b45db314af1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103679 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71645 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4e8ab24e-b7b1-43b9-888f-9619e0702e0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84551 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6025 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3642 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115250 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146132 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7723 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112415 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5888 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61688 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20939 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36021 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->