### PR TITLE
Web Inspector: Performance issue with search tab and single character

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -219,6 +219,7 @@
     <link rel="stylesheet" href="Views/ScriptTimelineOverviewGraph.css">
     <link rel="stylesheet" href="Views/ScrubberNavigationItem.css">
     <link rel="stylesheet" href="Views/SearchIcons.css">
+    <link rel="stylesheet" href="Views/SearchResultsPlaceholderTreeElement.css">
     <link rel="stylesheet" href="Views/SearchSidebarPanel.css">
     <link rel="stylesheet" href="Views/SettingEditor.css">
     <link rel="stylesheet" href="Views/SettingsPopover.css">
@@ -861,6 +862,7 @@
     <script src="Views/ScriptTimelineDataGridNode.js"></script>
     <script src="Views/ScriptTimelineOverviewGraph.js"></script>
     <script src="Views/ScrubberNavigationItem.js"></script>
+    <script src="Views/SearchResultsPlaceholderTreeElement.js"></script>
     <script src="Views/SearchResultTreeElement.js"></script>
     <script src="Views/SearchSidebarPanel.js"></script>
     <script src="Views/ShaderProgramContentView.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.css
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.tree-outline .item.search-results-placeholder > button {
+    border: none;
+    background: none;
+    text-decoration: underline;
+    padding-inline: 0;
+
+    & + button {
+        padding-inline-start: 5px;
+    }
+
+    &:first-of-type {
+        margin-inline-start: var(--tree-outline-icon-margin-start);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.SearchResultsPlaceholderTreeElement = class SearchResultsPlaceholderTreeElement extends WI.TreeElement
+{
+    constructor(delegate, incrementCount, remainingCount)
+    {
+        const title = "";
+        super(title);
+
+        console.assert(delegate?.searchResultsPlaceholderLoadMoreResults, delegate);
+        console.assert(incrementCount > 0, incrementCount);
+        console.assert(remainingCount > 0, remainingCount);
+
+        this._delegate = delegate;
+        this._incrementCount = Math.min(incrementCount, remainingCount);
+        this._remainingCount = remainingCount > incrementCount ? remainingCount : 0;
+    }
+
+    // Protected
+
+    onattach()
+    {
+        if (this._incrementCount) {
+            this._showMoreButtonElement = this._listItemNode.appendChild(document.createElement("button"));
+            this._showMoreButtonElement.textContent = WI.UIString("Show %d More").format(this._incrementCount);
+            this._showMoreButtonElement.addEventListener("click", this._handleShowMoreButtonClicked.bind(this));
+        }
+
+        if (this._remainingCount) {
+            this._showAllButtonElement = this._listItemNode.appendChild(document.createElement("button"));
+            this._showAllButtonElement.textContent = WI.UIString("Show All (%d More)").format(this._remainingCount);
+            this._showAllButtonElement.addEventListener("click", this._handleShowAllButtonClicked.bind(this));
+        }
+
+        this._listItemNode.classList.add("item", "search-results-placeholder");
+    }
+
+    // Private
+
+    _handleShowMoreButtonClicked(event)
+    {
+        this._delegate.searchResultsPlaceholderLoadMoreResults?.(this, this._incrementCount);
+    }
+
+    _handleShowAllButtonClicked(event)
+    {
+        this._delegate.searchResultsPlaceholderLoadMoreResults?.(this, this._remainingCount);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
@@ -108,18 +108,6 @@ WI.TreeElement = class TreeElement extends WI.Object
         this.didChange();
     }
 
-    get titleHTML()
-    {
-        return this._titleHTML;
-    }
-
-    set titleHTML(x)
-    {
-        this._titleHTML = x;
-        this._setListItemNodeContent();
-        this.didChange();
-    }
-
     get tooltip()
     {
         return this._tooltip;
@@ -241,11 +229,7 @@ WI.TreeElement = class TreeElement extends WI.Object
         if (!this._listItemNode)
             return;
 
-        if (!this._titleHTML && !this._title)
-            this._listItemNode.removeChildren();
-        else if (typeof this._titleHTML === "string")
-            this._listItemNode.innerHTML = this._titleHTML;
-        else if (typeof this._title === "string")
+        if (typeof this._title === "string")
             this._listItemNode.textContent = this._title;
         else {
             this._listItemNode.removeChildren();


### PR DESCRIPTION
#### a2e3ab02b806f1bb8532d598b96ff123daaf03f0
<pre>
Web Inspector: Performance issue with search tab and single character
<a href="https://rdar.apple.com/49234522">rdar://49234522</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=262158">https://bugs.webkit.org/show_bug.cgi?id=262158</a>

Reviewed by Devin Rousso.

Web Inspector search works by first requesting a list of all resources
that have matches for a query. Then, iterating through each resource,
it gets lines of text where matches are found. Finally the same search
query regex is applied to each line to get individual search result matches.

Before this patch, a `WI.SearchResultTreeElement` was created and attached
for each match, regardless of how many. This was expensive for a few reasons:

- for each result, a few substring operations are run on the line of text
to provide context around the individual match. On minified files,
this means working on almost the entire contents of the file.

- attaching the tree element to the tree outline creates a DOM structure for each element,
without necessarily attaching it to the DOM (tree outline virtualization handles that),
adds event handlers, creates relationships with sibling tree elements, etc.
All this work is done regardless if the tree element will ever be seen.

For queries with a very large number of results (tens or hundreds of thousands),
there&apos;s a lot unnecessary work done before even showing the first few results.
This work occurs on the UI thread and blocks interaction within Web Inspector.

From a UX perspective, a user overwhelmed with a large volume of search results
is more likely to want to refine their query than see all of the results.

This patch reduces the amount of work done:
- for each resource, show only the first 100 results by default.

- provide UI controls per resource to load more results or all results.
This allows a user to intentionally request to show a known large number of results
with the implied acknowledgement that the action might cause a slowdown.
This follows a pattern used elsewhere in Web Inspector: showing contents of Arrays,
Sets, Maps, or DataGrids with many entries.

- other piecemeal optimizations:
-- event delegation for handling double-click on individual search result tree elements

* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.css: Added.
(.tree-outline .item.search-results-placeholder &gt; button):
(&amp;:first-of-type):
* Source/WebInspectorUI/UserInterface/Views/SearchResultsPlaceholderTreeElement.js: Added.
(WI.SearchResultsPlaceholderTreeElement):
(WI.SearchResultsPlaceholderTreeElement.prototype.onattach):
(WI.SearchResultsPlaceholderTreeElement.prototype._handleShowMoreButtonClicked):
(WI.SearchResultsPlaceholderTreeElement.prototype._handleShowAllButtonClicked):
* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js:
(WI.SearchSidebarPanel):
(WI.SearchSidebarPanel.prototype.performSearch):
(WI.SearchSidebarPanel.prototype.attached):
(WI.SearchSidebarPanel.prototype.detached):
(WI.SearchSidebarPanel.prototype.matchTreeElementAgainstCustomFilters):
(WI.SearchSidebarPanel.prototype.searchResultsPlaceholderLoadMoreResults):
(WI.SearchSidebarPanel.prototype._renderResultsForSourceCodeTreeElement):
(WI.SearchSidebarPanel.prototype._createSearchResultsPlaceholderTreeElementIfNeeded):
(WI.SearchSidebarPanel.prototype.performSearch.createTreeElementForMatchObject): Deleted.
(WI.SearchSidebarPanel.prototype._treeElementDoubleClick): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TreeElement.js:
(WI.TreeElement.prototype._setListItemNodeContent):
(WI.TreeElement.prototype.get titleHTML): Deleted.
(WI.TreeElement.prototype.set titleHTML): Deleted.
Drive-by clean-up of unused `titleHTML`

Canonical link: <a href="https://commits.webkit.org/306429@main">https://commits.webkit.org/306429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8c1513663a29766e9ed01e00fa1284c76cde64f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149920 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13881 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11145 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89501 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8337 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119985 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152310 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2148 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13417 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116701 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/117034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13083 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13459 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13196 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->