### PR TITLE
Remove unnecessary suppressions from a variable declaration in "if"

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -636,9 +636,7 @@ AXCoreObject* AXCoreObject::nextUnignoredSibling(bool updateChildrenIfNeeded, AX
 
 AXCoreObject* AXCoreObject::nextSiblingIncludingIgnoredOrParent() const
 {
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* nextSibling = nextSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true))
+    if (auto* nextSibling = nextSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true))
         return nextSibling;
     return parentObject();
 }
@@ -1850,9 +1848,7 @@ void AXCoreObject::appendRadioButtonGroupMembers(AccessibilityChildrenVector& li
 AXCoreObject* AXCoreObject::parentObjectUnignored() const
 {
     if (role() == AccessibilityRole::Row) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* table = exposedTableAncestor())
+        if (auto* table = exposedTableAncestor())
             return table;
     }
 

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -71,18 +71,14 @@ inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
 
 inline AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isPartOfRelation)
 {
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* object = get(node))
+    if (auto* object = get(node))
         return object;
     return getOrCreateSlow(node, isPartOfRelation);
 }
 
 inline AccessibilityObject* AXObjectCache::getOrCreate(Element& element, IsPartOfRelation isPartOfRelation)
 {
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* object = get(element))
+    if (auto* object = get(element))
         return object;
     return getOrCreateSlow(element, isPartOfRelation);
 }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -530,9 +530,7 @@ RenderObject* AccessibilityRenderObject::renderParentObject() const
 
 AccessibilityObject* AccessibilityRenderObject::parentObject() const
 {
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* ownerParent = ownerParentObject()) [[unlikely]]
+    if (auto* ownerParent = ownerParentObject()) [[unlikely]]
         return ownerParent;
 
 #if USE(ATSPI)

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -79,9 +79,7 @@ inline Node* EventPath::eventTargetRespectingTargetRules(Node& referenceNode)
 
     // Events sent to elements inside an SVG use element's shadow tree go to the use element.
     if (auto* svgElement = dynamicDowncast<SVGElement>(referenceNode)) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* useElement = svgElement->correspondingUseElement())
+        if (auto* useElement = svgElement->correspondingUseElement())
             return useElement;
     }
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -357,9 +357,7 @@ static Node* firstNode(const BoundaryPoint& point)
 {
     if (point.container->isCharacterDataNode())
         return point.container.ptr();
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* child = point.container->traverseToChildAt(point.offset))
+    if (auto* child = point.container->traverseToChildAt(point.offset))
         return child;
     if (!point.offset)
         return point.container.ptr();

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
@@ -59,9 +59,7 @@ void ArchiveResourceCollection::addResource(Ref<ArchiveResource>&& resource)
 
 ArchiveResource* ArchiveResourceCollection::archiveResourceForURL(const URL& url)
 {
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* resource = m_subresources.get(url.string()))
+    if (auto* resource = m_subresources.get(url.string()))
         return resource;
     if (!url.protocolIs("https"_s))
         return nullptr;

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -110,9 +110,7 @@ PathImpl& Path::ensureImpl()
     if (auto segment = asSingle())
         return setImpl(PathStream::create(WTFMove(*segment)));
 
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* impl = asImpl())
+    if (auto* impl = asImpl())
         return *impl;
     ASSERT_NOT_REACHED(); // Impl is never empty.
     return setImpl(PathStream::create());

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -103,9 +103,7 @@ static RetainPtr<NSWindow> protectedWindow(Widget* widget)
 static NSScreen *screen(Widget* widget)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-    // as we merely return it right away (rdar://165602290).
-    SUPPRESS_UNRETAINED_LOCAL if (NSScreen *screenFromWindow = [protectedWindow(widget) screen])
+    if (NSScreen *screenFromWindow = [protectedWindow(widget) screen])
         return screenFromWindow;
 
     return screen(displayID(widget));

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1318,9 +1318,7 @@ void NetworkSessionCocoa::initializeNSURLSessionsInSet(SessionSet& sessionSet, N
 SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID)
 {
     if (webPageProxyID) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
+        if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
             return *sessionSet;
     }
     return m_defaultSessionSet.get();
@@ -1329,9 +1327,7 @@ SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIde
 const SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID) const
 {
     if (webPageProxyID) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
+        if (auto* sessionSet = m_perPageSessionSets.get(*webPageProxyID))
             return *sessionSet;
     }
     return m_defaultSessionSet.get();

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -370,9 +370,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);
 
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* axObject = axObjectCache->exportedGetOrCreate(*coreElement))
+        if (auto* axObject = axObjectCache->exportedGetOrCreate(*coreElement))
             return axObject;
     }
 
@@ -670,20 +668,14 @@ static WebCore::Element* containerElementForElement(WebCore::Element& element)
     if (is<WebCore::HTMLOptionElement>(element)) {
         if (auto* parentElement = WebCore::ancestorsOfType<WebCore::HTMLDataListElement>(element).first())
             return parentElement;
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* parentElement = downcast<WebCore::HTMLOptionElement>(element).ownerSelectElement())
+        if (auto* parentElement = downcast<WebCore::HTMLOptionElement>(element).ownerSelectElement())
             return parentElement;
-
         return nullptr;
     }
 
     if (RefPtr optgroup = dynamicDowncast<WebCore::HTMLOptGroupElement>(element)) {
-        // FIXME: This is a safer cpp false positive. We should not need to ref the variable here
-        // as we merely return it right away (rdar://165602290).
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* parentElement = optgroup->ownerSelectElement())
+        if (auto* parentElement = optgroup->ownerSelectElement())
             return parentElement;
-
         return nullptr;
     }
 


### PR DESCRIPTION
#### 0379aa1346bbb7eb8af1331f63efa03e8c5a1fca
<pre>
Remove unnecessary suppressions from a variable declaration in &quot;if&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=304203">https://bugs.webkit.org/show_bug.cgi?id=304203</a>

Reviewed by Tyler Wilcock.

Remove the unnecessary suppressions for a variable declaration within &quot;if&quot; statement
now that the corresponding clang static analyzer fix has been merged and deployed:
<a href="https://github.com/llvm/llvm-project/pull/171764">https://github.com/llvm/llvm-project/pull/171764</a>

No new tests since there should be no behavioral changes.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::nextSiblingIncludingIgnoredOrParent const):
(WebCore::AXCoreObject::parentObjectUnignored const):
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
* Source/WebCore/dom/EventPath.h:
(WebCore::EventPath::eventTargetRespectingTargetRules):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::firstNode):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::ensureImpl):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screen):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::sessionSetForPage):
(WebKit::NetworkSessionCocoa::sessionSetForPage const):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
(WebKit::containerElementForElement):

Canonical link: <a href="https://commits.webkit.org/304549@main">https://commits.webkit.org/304549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/094af209e9325201867566e20973f100ec7216f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87336 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103689 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fef4141c-b3c2-4df9-87ca-272a8e0228ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84562 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3c979b0-048d-43b4-a8dc-9bfdefae15bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3652 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4001 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146143 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7733 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7770 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6501 "Found 1 new test failure: inspector/unit-tests/iterableweakset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112425 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5900 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61697 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7786 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36036 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->