### PR TITLE
Introduce MemoryDump printing utility for dataLog()

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		1CF18F3B26BB579E004B1722 /* LogChannels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CF18F3926BB579E004B1722 /* LogChannels.cpp */; };
 		1CFD5D3D2851AB3E00A0E30B /* EnumeratedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CFD5D3B2851AB3E00A0E30B /* EnumeratedArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1FA47C8A152502DA00568D1B /* WebCoreThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FA47C88152502DA00568D1B /* WebCoreThread.cpp */; };
+		231829062EF0B0D00078588C /* MemoryDump.h in Headers */ = {isa = PBXBuildFile; fileRef = 231829052EF0B0D00078588C /* MemoryDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27C793CF2C40909D000E1BE8 /* PlatformEnableWin.h in Headers */ = {isa = PBXBuildFile; fileRef = 27C793CE2C40909D000E1BE8 /* PlatformEnableWin.h */; };
 		2B70468D2C6BC5F600318C0A /* StdMultimap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B70468C2C6BC5F600318C0A /* StdMultimap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2CCD892A15C0390200285083 /* GregorianDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CCD892915C0390200285083 /* GregorianDateTime.cpp */; };
@@ -1265,6 +1266,7 @@
 		1CFD5D3B2851AB3E00A0E30B /* EnumeratedArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnumeratedArray.h; sourceTree = "<group>"; };
 		1FA47C88152502DA00568D1B /* WebCoreThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreThread.cpp; sourceTree = "<group>"; };
 		1FA47C89152502DA00568D1B /* WebCoreThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCoreThread.h; sourceTree = "<group>"; };
+		231829052EF0B0D00078588C /* MemoryDump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryDump.h; sourceTree = "<group>"; };
 		24F1B248619F412296D1C19C /* RandomDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RandomDevice.h; sourceTree = "<group>"; };
 		26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegerToStringConversion.h; sourceTree = "<group>"; };
 		26299B6D17A9E5B800ADEBE5 /* Ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ref.h; sourceTree = "<group>"; };
@@ -2552,6 +2554,7 @@
 				A8A472C9151A825B004123FF /* MathExtras.h */,
 				CD5497AA15857D0300B5BC30 /* MediaTime.cpp */,
 				CD5497AB15857D0300B5BC30 /* MediaTime.h */,
+				231829052EF0B0D00078588C /* MemoryDump.h */,
 				ADF2CE641E39F106006889DB /* MemoryFootprint.h */,
 				AD89B6B51E6415080090707F /* MemoryPressureHandler.cpp */,
 				AD89B6B61E6415080090707F /* MemoryPressureHandler.h */,
@@ -3704,6 +3707,7 @@
 				DD3DC89727A4BF8E007E5B61 /* Markable.h in Headers */,
 				DD3DC89427A4BF8E007E5B61 /* MathExtras.h in Headers */,
 				DD3DC96A27A4BF8E007E5B61 /* MediaTime.h in Headers */,
+				231829062EF0B0D00078588C /* MemoryDump.h in Headers */,
 				DD3DC8D227A4BF8E007E5B61 /* MemoryFootprint.h in Headers */,
 				DD3DC97727A4BF8E007E5B61 /* MemoryPressureHandler.h in Headers */,
 				DD3DC92427A4BF8E007E5B61 /* MessageQueue.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -184,6 +184,7 @@ set(WTF_PUBLIC_HEADERS
     Markable.h
     MathExtras.h
     MediaTime.h
+    MemoryDump.h
     MemoryFootprint.h
     MemoryPressureHandler.h
     MessageQueue.h

--- a/Source/WTF/wtf/MemoryDump.h
+++ b/Source/WTF/wtf/MemoryDump.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+
+namespace WTF {
+
+// For printing chunks of memory in the traditional hex dump form using dataLog or PrintStream.
+// Examples:
+//   dataLogLn("Memory dump: ", MemoryDump(startPtr, endPtr));
+//   dataLogLn("Memory dump: ", MemoryDump(std::span(data)));
+// By default, the output is truncated past the DefaultSizeLimit number of bytes (4K).
+// To change the limit, pass the desired limit value to HexDump() as an additional parameter.
+
+class MemoryDump {
+public:
+    static constexpr size_t DefaultSizeLimit = 4 * 1024;
+
+    template<typename T>
+    explicit MemoryDump(std::span<T> span, size_t sizeLimit = DefaultSizeLimit)
+        : m_data(std::as_bytes(span))
+        , m_sizeLimit(sizeLimit)
+    { }
+
+    explicit MemoryDump(const void* start, const void* end, size_t sizeLimit = DefaultSizeLimit);
+    MemoryDump() = default;
+
+    std::span<const std::byte> span() const { return m_data; }
+    size_t sizeLimit() const { return m_sizeLimit; }
+    const std::byte* invertedEnd() const { return m_invertedEnd; }
+
+private:
+    std::span<const std::byte> m_data { };
+    size_t m_sizeLimit { DefaultSizeLimit };
+    const std::byte* m_invertedEnd { nullptr }; // end pointer value, if it was below the start pointer
+    // TODO: enhance to support larger chunks than 1 bytes
+};
+
+inline MemoryDump::MemoryDump(const void* start, const void* end, size_t sizeLimit)
+    : m_sizeLimit(sizeLimit)
+{
+    auto* startByte = static_cast<const std::byte*>(start);
+    auto* endByte = static_cast<const std::byte*>(end);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    if (startByte <= endByte) [[likely]]
+        m_data = std::span<const std::byte>(startByte, endByte - startByte);
+    else {
+        m_data = std::span<const std::byte>(startByte, 0);
+        m_invertedEnd = endByte;
+    }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+} // namespace WTF
+
+using WTF::MemoryDump;

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -34,6 +34,7 @@
 #include <wtf/Forward.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/FixedWidthDouble.h>
+#include <wtf/MemoryDump.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RawHex.h>
 #include <wtf/RawPointer.h>
@@ -140,6 +141,7 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, float);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, double);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, RawHex);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, RawPointer);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, MemoryDump);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, FixedWidthDouble);
 
 template<typename... Values>

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TestWTF_SOURCES
     Tests/WTF/Markable.cpp
     Tests/WTF/MathExtras.cpp
     Tests/WTF/MediaTime.cpp
+    Tests/WTF/MemoryDump.cpp
     Tests/WTF/MetaAllocator.cpp
     Tests/WTF/MoveOnlyLifecycleLogger.cpp
     Tests/WTF/NakedPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		1D67BFDC2433E0A7006B5047 /* PreemptVideoFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1D67BFDB2433E0A7006B5047 /* PreemptVideoFullscreen.mm */; };
 		1FEF15102D7A2AA900D29B57 /* SkipAdInPictureInPicture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */; };
 		1FEF15112D7B69DB00D29B57 /* SkipAdInPictureInPicture.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */; };
+		231829092EF0E3140078588C /* MemoryDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 231829082EF0E3140078588C /* MemoryDump.cpp */; };
 		23CB493B2DFEAD81006E424B /* PreciseSum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */; };
 		272A691022F012DA000FDABB /* PageLoadState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 272A690F22F012C7000FDABB /* PageLoadState.cpp */; };
 		278E3E1923CD842F005A6B80 /* KeyedCoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */; };
@@ -2648,6 +2649,7 @@
 		1F83571A1D3FFB0E00E3967B /* WKBackForwardListTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKBackForwardListTests.mm; path = Tests/WebKit/WKBackForwardListTests.mm; sourceTree = SOURCE_ROOT; };
 		1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SkipAdInPictureInPicture.mm; sourceTree = "<group>"; };
 		1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = SkipAdInPictureInPicture.html; sourceTree = "<group>"; };
+		231829082EF0E3140078588C /* MemoryDump.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryDump.cpp; sourceTree = "<group>"; };
 		23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PreciseSum.cpp; sourceTree = "<group>"; };
 		260BA5781B1D2E7B004FA07C /* DFACombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DFACombiner.cpp; sourceTree = "<group>"; };
 		260BA57A1B1D2EE2004FA07C /* DFAHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DFAHelpers.h; sourceTree = "<group>"; };
@@ -6474,6 +6476,7 @@
 				EC79F168BE454E579E417B05 /* Markable.cpp */,
 				B4039F9C15E6D8B3007255D6 /* MathExtras.cpp */,
 				CD5497B315857F0C00B5BC30 /* MediaTime.cpp */,
+				231829082EF0E3140078588C /* MemoryDump.cpp */,
 				0FC6C4CE141034AD005B7F0C /* MetaAllocator.cpp */,
 				93A427AC180DA60F00CD24D7 /* MoveOnly.h */,
 				CE78705D2107AB8C0053AC67 /* MoveOnlyLifecycleLogger.cpp */,
@@ -7661,6 +7664,7 @@
 				4909EE3A2D09480C88982D56 /* Markable.cpp in Sources */,
 				7C83DEED1D0A590C00FEBCF3 /* MathExtras.cpp in Sources */,
 				7C83DEF11D0A590C00FEBCF3 /* MediaTime.cpp in Sources */,
+				231829092EF0E3140078588C /* MemoryDump.cpp in Sources */,
 				7C83DEF61D0A590C00FEBCF3 /* MetaAllocator.cpp in Sources */,
 				CE78705F2107AB980053AC67 /* MoveOnlyLifecycleLogger.cpp in Sources */,
 				7C83DEFE1D0A590C00FEBCF3 /* NakedPtr.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <wtf/HexNumber.h>
+#include <wtf/MemoryDump.h>
+#include <wtf/StringPrintStream.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF, MemoryDumpNullPointer)
+{
+    // Test null data pointer case
+    MemoryDump nullDump(std::span(static_cast<std::byte*>(nullptr), 42));
+
+    EXPECT_EQ(nullDump.span().data(), nullptr);
+    EXPECT_EQ(nullDump.span().size(), 42u);
+    EXPECT_EQ(nullDump.sizeLimit(), MemoryDump::DefaultSizeLimit);
+
+    StringPrintStream stream;
+    stream.print(nullDump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    EXPECT_EQ(output, "\n00000000: (not dumping 42 bytes)"_s);
+}
+
+TEST(WTF, MemoryDumpEmptySize)
+{
+    // Test zero size case
+    uint8_t data[] = { 0x41, 0x42, 0x43, 0x44 };
+    MemoryDump emptyDump(std::span<uint8_t>(data, 0));
+
+    EXPECT_EQ(emptyDump.span().data(), reinterpret_cast<const std::byte*>(data));
+    EXPECT_EQ(emptyDump.span().size(), 0u);
+
+    StringPrintStream stream;
+    stream.print(emptyDump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    EXPECT_TRUE(output.startsWith('\n'));
+    EXPECT_TRUE(output.contains(": (span is empty)"_s));
+}
+
+TEST(WTF, MemoryDumpSingleByte)
+{
+    uint8_t data[] = { 0x42 }; // 'B'
+    MemoryDump dump { std::span<uint8_t>(data) };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    EXPECT_TRUE(output.startsWith('\n'));
+
+    // Should contain the address, hex representation, and ASCII
+    EXPECT_TRUE(output.contains("42"_s));
+    EXPECT_TRUE(output.contains("B"_s));
+}
+
+TEST(WTF, MemoryDumpExactly16Bytes)
+{
+    uint8_t data[16];
+    for (int i = 0; i < 16; ++i)
+        data[i] = static_cast<uint8_t>(0x41 + i); // A, B, C, ...
+
+    MemoryDump dump { std::span<uint8_t>(data) };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    EXPECT_TRUE(output.startsWith('\n'));
+
+    // Verify hex formatting: should have space after 8th byte
+    Vector<String> parts = output.split("  "_s); // Split on double space before ASCII
+    EXPECT_EQ(parts.size(), 2u);
+
+    String hexPart = parts[0];
+    String asciiPart = parts[1];
+
+    // Verify ASCII part
+    EXPECT_EQ(asciiPart, "ABCDEFGHIJKLMNOP"_s);
+
+    // Verify hex part contains proper spacing
+    EXPECT_TRUE(hexPart.contains("41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50"_s));
+}
+
+TEST(WTF, MemoryDumpMultipleLines)
+{
+    uint8_t data[33]; // More than 2 lines
+    for (int i = 0; i < 33; ++i)
+        data[i] = static_cast<uint8_t>(i);
+
+    MemoryDump dump { std::span<uint8_t>(data) };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    auto lines = output.split('\n');
+    EXPECT_EQ(lines.size(), 3u);
+
+    // First line: 16 bytes (0x00-0x0f)
+    String line1 = lines[0];
+    EXPECT_TRUE(line1.contains("00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f"_s));
+
+    // Second line: 16 bytes (0x10-0x1f)
+    String line2 = lines[1];
+    EXPECT_TRUE(line2.contains("10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f"_s));
+
+    // Third line: 1 byte (0x20) - should be padded
+    String line3 = lines[2];
+    EXPECT_TRUE(line3.contains("20"_s));
+    EXPECT_TRUE(line3.contains(" "_s)); // Should have padding spaces
+}
+
+TEST(WTF, MemoryDumpASCIIRepresentation)
+{
+    // Test various ASCII ranges
+    uint8_t data[] = {
+        31, 32, 65, 90, 97, 122, 126, 127, // Control, space, A, Z, a, z, ~, DEL
+        0, 255, 128 // NUL, 0xFF, 0x80
+    };
+
+    MemoryDump dump { std::span<uint8_t>(data) };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    Vector<String> parts = output.split("  "_s);
+    EXPECT_EQ(parts.size(), 2u);
+
+    String asciiPart = parts[1];
+    // Verify ASCII conversion:
+    // 31->'.', 32->' ', 65->'A', 90->'Z', 97->'a', 122->'z', 126->'~', 127->'.', 0->'.', 255->'.', 128->'.'
+    EXPECT_TRUE(asciiPart.contains(". AZaz~...."_s));
+}
+
+TEST(WTF, MemoryDumpSizeLimitTruncation)
+{
+    constexpr size_t dataSize = 100;
+    constexpr size_t limitSize = 32; // Less than 2 full lines
+
+    uint8_t data[dataSize];
+    for (size_t i = 0; i < dataSize; ++i)
+        data[i] = static_cast<uint8_t>(i & 0xFF);
+
+    MemoryDump dump { std::span<uint8_t>(data), limitSize };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+
+    auto lines = output.split("\n"_s);
+    EXPECT_EQ(lines.size(), 3u); // two output lines and the truncation message
+
+    auto truncation = lines[2];
+
+    // Should contain truncation message
+    EXPECT_TRUE(truncation.contains("... (remaining 68 bytes not dumped)"_s));
+}
+
+TEST(WTF, MemoryDumpAddressFormatting)
+{
+    uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
+    MemoryDump dump { std::span<uint8_t>(data) };
+
+    StringPrintStream stream;
+    stream.print(dump);
+    auto result = stream.tryToString();
+    EXPECT_TRUE(result.has_value());
+
+    String output = result.value();
+    auto lines = output.split('\n');
+    EXPECT_EQ(lines.size(), 1u);
+    String dataLine = lines[0];
+
+    // Address should be 8 hex digits followed by ": "
+    auto colonPos = dataLine.find(':');
+    EXPECT_NE(colonPos, notFound);
+    String addressStr = dataLine.left(colonPos);
+
+    StringPrintStream expectedStream;
+    expectedStream.print(hex(reinterpret_cast<uintptr_t>(data), Lowercase));
+    auto expectedResult = expectedStream.tryToString();
+    EXPECT_TRUE(expectedResult.has_value());
+    String expected = expectedResult.value();
+
+    EXPECT_EQ(addressStr, expected);
+}
+
+TEST(WTF, MemoryDumpBasic)
+{
+    uint8_t data[] = { 0x41, 0x42, 0x43, 0x44 }; // "ABCD"
+
+    // Test span constructor
+    std::span<uint8_t> dataSpan(data);
+    MemoryDump dump(dataSpan);
+
+    // Test that we can create a MemoryDump object
+    EXPECT_EQ(dump.span().data(), reinterpret_cast<const std::byte*>(data));
+    EXPECT_EQ(dump.span().size(), 4u);
+
+    // Test StringBuilder integration via StringPrintStream
+    StringPrintStream stream;
+    stream.print(dump);
+    auto expectedResult = stream.tryToString();
+    EXPECT_TRUE(expectedResult.has_value());
+
+    StringBuilder builder;
+    builder.append(expectedResult.value());
+    String result = builder.toString();
+
+    // Should contain some output
+    EXPECT_FALSE(result.isEmpty());
+
+    // Test default size limit
+    EXPECT_EQ(dump.sizeLimit(), MemoryDump::DefaultSizeLimit);
+
+    // Test custom size limit with span constructor
+    constexpr size_t customLimit = 512;
+    MemoryDump spanDump(dataSpan, customLimit);
+    EXPECT_EQ(spanDump.span().data(), reinterpret_cast<const std::byte*>(data));
+    EXPECT_EQ(spanDump.span().size(), 4u);
+    EXPECT_EQ(spanDump.sizeLimit(), customLimit);
+
+    // Test output with custom limit (should still work for small data)
+    StringPrintStream limitedStream;
+    limitedStream.print(spanDump);
+    auto limitedResult = limitedStream.tryToString();
+    EXPECT_TRUE(limitedResult.has_value());
+    EXPECT_FALSE(limitedResult.value().isEmpty());
+}
+
+TEST(WTF, MemoryDumpRange)
+{
+    uint8_t data[] = { 0x41, 0x42, 0x43, 0x44, 0x45 }; // "ABCDE"
+
+    // Test range with pointers in correct order
+    MemoryDump dump1 = MemoryDump(data, data + 5);
+    EXPECT_EQ(dump1.span().data(), reinterpret_cast<const std::byte*>(data));
+    EXPECT_EQ(dump1.span().size(), 5u);
+    EXPECT_EQ(dump1.sizeLimit(), MemoryDump::DefaultSizeLimit);
+    EXPECT_EQ(dump1.invertedEnd(), nullptr);
+
+    // Test range with pointers in reverse order
+    MemoryDump dump2(data + 5, data);
+    EXPECT_EQ(dump2.span().data(), reinterpret_cast<const std::byte*>(data + 5));
+    EXPECT_EQ(dump2.span().size(), 0u);
+    EXPECT_EQ(dump2.invertedEnd(), reinterpret_cast<const std::byte*>(data));
+
+    // Test range with custom size limit
+    constexpr size_t customLimit = 256;
+    MemoryDump dump3(data, data + 3, customLimit);
+    EXPECT_EQ(dump3.span().data(), reinterpret_cast<const std::byte*>(data));
+    EXPECT_EQ(dump3.span().size(), 3u);
+    EXPECT_EQ(dump3.sizeLimit(), customLimit);
+
+    // Test outputs
+    StringPrintStream stream1;
+    stream1.print(dump1);
+    auto result1 = stream1.tryToString();
+    EXPECT_TRUE(result1.has_value());
+    EXPECT_TRUE(result1.value().contains("ABCDE"_s));
+
+    StringPrintStream stream2;
+    stream2.print(dump2);
+    auto result2 = stream2.tryToString();
+    EXPECT_TRUE(result2.has_value());
+    EXPECT_TRUE(result2.value().contains("span end is below the start"_s));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### fdc2659799c04e8f04466f8726c3a73b198b13e1
<pre>
Introduce MemoryDump printing utility for dataLog()
<a href="https://bugs.webkit.org/show_bug.cgi?id=304214">https://bugs.webkit.org/show_bug.cgi?id=304214</a>
<a href="https://rdar.apple.com/166570876">rdar://166570876</a>

Reviewed by Dan Hecht and Keith Miller.

It&apos;s sometimes helpful in trace output to print relatively large chunks of raw data such as
stack frames in the traditional hex dump form. This patch introduces a new printing
plug-in for dataLog() to do just that.

Examples:

    dataLogLn(&quot;Interesting data:&quot;, MemoryDump(startPtr, endPtr));
    dataLogLn(&quot;Interesting data:&quot;, MemoryDump(std::span(data)));

The style checker is unhappy with the usage of &apos;out.printf()&apos; in the code added to
PrintStream.cpp, however that is consistent with the rest of that file.

Tests: Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp
Canonical link: <a href="https://commits.webkit.org/304560@main">https://commits.webkit.org/304560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73a90b80e5241941e7ee9cc498545d35958fcf08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135891 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143604 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d37f1c2c-0e3a-4258-93c4-ca156caa49c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb40f8fa-acbe-4bcb-8f5d-66b76f604a92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84738 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6167 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3806 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4207 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127869 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146352 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134375 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7950 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112216 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112604 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28581 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6076 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61851 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7997 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36182 "Found 1 new test failure: fast/mediastream/granted-denied-request-management2.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167181 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71549 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43635 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->