### PR TITLE
Adopt ImmersiveSpace with preferredSurroundingsEffect for 'preferredDarkness' and ImmersiveSpace for 'mrui_activeStage' due to deprecation

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.h
+++ b/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,34 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Add project-level Objective-C header files here to be able to access them from within Swift sources.
+#pragma once
 
+#import <Foundation/Foundation.h>
 #import <wtf/Platform.h>
 
-#import "ModelTypes.h" // NOLINT
-#import "UIWindowScene+Extras.h"
-#import "WKMaterialHostingSupport.h"
-#import "WKMouseDeviceObserver.h"
-#import "WKPreferencesInternal.h"
-#import "WKScrollGeometry.h"
-#import "WKSeparatedImageView.h"
-#import "WKSurroundingsEffect.h"
-#import "WKUIDelegateInternal.h"
-#import "WKWebViewConfigurationInternal.h"
-#import "WKWebViewInternal.h"
-#import "_WKTextExtractionInternal.h"
+#if PLATFORM(VISION)
+
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, WKSurroundingsEffectType) {
+    WKSurroundingsEffectTypeNone = 0,
+    WKSurroundingsEffectTypeSemiDark = 1,
+    WKSurroundingsEffectTypeDark = 2,
+    WKSurroundingsEffectTypeUltraDark = 3,
+};
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+NS_SWIFT_UI_ACTOR
+@interface WKSurroundingsEffectManager : NSObject
++ (WKSurroundingsEffectManager *)shared;
+@property (nonatomic) WKSurroundingsEffectType currentEffect;
+@end
+
+@interface WKSurroundingsEffectWindow : UIWindow
+- (instancetype)initWithWindowScene:(UIWindowScene *)windowScene;
+- (void)setupSurroundingsEffectIfNeeded;
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
+#endif

--- a/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.swift
+++ b/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.swift
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(visionOS)
+
+import Observation
+@_weakLinked internal import SwiftUI
+import UIKit
+internal import WebKit_Internal
+
+@MainActor
+@Observable
+final class WKSurroundingsEffectManagerWrapper {
+    var currentEffect: WKSurroundingsEffectType = .none
+
+    var surroundingsEffect: SurroundingsEffect? {
+        switch currentEffect {
+        case .none:
+            nil
+        case .semiDark:
+            .semiDark
+        case .dark:
+            .dark
+        case .ultraDark:
+            .ultraDark
+        @unknown default:
+            nil
+        }
+    }
+
+    nonisolated init() {}
+}
+
+private let sharedWrapper = WKSurroundingsEffectManagerWrapper()
+
+extension WKSurroundingsEffectManager {
+    @nonobjc
+    var wrapper: WKSurroundingsEffectManagerWrapper {
+        sharedWrapper
+    }
+}
+
+@objc
+@implementation
+extension WKSurroundingsEffectManager {
+    static let sharedInstance = WKSurroundingsEffectManager()
+
+    class func shared() -> WKSurroundingsEffectManager {
+        sharedInstance
+    }
+
+    var currentEffect: WKSurroundingsEffectType {
+        get { sharedWrapper.currentEffect }
+        set { sharedWrapper.currentEffect = newValue }
+    }
+
+    override init() {}
+}
+
+@objc
+@implementation
+extension WKSurroundingsEffectWindow {
+    private final var effectHostingController: UIViewController?
+
+    @MainActor
+    func setupSurroundingsEffectIfNeeded() {
+        guard effectHostingController == nil, let rootViewController else {
+            return
+        }
+
+        let wrapper = WKSurroundingsEffectManager.shared().wrapper
+
+        let effectView = WKSurroundingsEffectView()
+            .environment(wrapper)
+        let hostingController = UIHostingController(rootView: effectView)
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.isUserInteractionEnabled = false
+        hostingController.view.frame = rootViewController.view.bounds
+        hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        effectHostingController = hostingController
+        rootViewController.addChild(hostingController)
+        rootViewController.view.insertSubview(hostingController.view, at: 0)
+        hostingController.didMove(toParent: rootViewController)
+    }
+}
+#endif

--- a/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffectView.swift
+++ b/Source/WebKit/Platform/spi/visionos/WKSurroundingsEffectView.swift
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(visionOS)
+
+@_weakLinked internal import SwiftUI
+internal import WebKit_Internal
+
+struct WKSurroundingsEffectView: View {
+    @Environment(WKSurroundingsEffectManagerWrapper.self)
+    private var wrapper
+
+    var body: some View {
+        EmptyView()
+            .preferredSurroundingsEffect(wrapper.surroundingsEffect)
+    }
+}
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1870,7 +1870,10 @@
 		961A72D02E17270900DD2AF9 /* WebExtensionBookmarksParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 96CC7DBF2E15EC2800233E69 /* WebExtensionBookmarksParameters.h */; };
 		96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */; };
 		96EE6CE82DFA4980000F90BD /* WebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */; };
+		97311DE42F0DB61F00B23BE9 /* WKSurroundingsEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97311DE32F0DB1CF00B23BE9 /* WKSurroundingsEffectView.swift */; };
 		9732D19C2ECFD0B600AC856D /* _WKCaptionStyleMenuControllerAVKitMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 97AD28872ECFA49800039097 /* _WKCaptionStyleMenuControllerAVKitMac.mm */; };
+		976544262EF3514300BD8947 /* WKSurroundingsEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = 976544232EF34BDE00BD8947 /* WKSurroundingsEffect.h */; };
+		9788BFD92EF4A6940038405A /* WKSurroundingsEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9765441E2EF22B0B00BD8947 /* WKSurroundingsEffect.swift */; };
 		97AD28742ECE625300039097 /* _WKCaptionStyleMenuControllerAVKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 97F26D492EC67188006096CD /* _WKCaptionStyleMenuControllerAVKit.mm */; };
 		97C476282ECD33A6004D1492 /* _WKCaptionStyleMenuControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C476272ECD338A004D1492 /* _WKCaptionStyleMenuControllerInternal.h */; };
 		99036AE223A949CF0000B06A /* _WKInspectorDebuggableInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE123A949CE0000B06A /* _WKInspectorDebuggableInfoInternal.h */; };
@@ -7435,6 +7438,9 @@
 		96D1B84C2E01F06300D2D42E /* WebExtensionAPIBookmarksCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIBookmarksCocoa.mm; sourceTree = "<group>"; };
 		96E05A002DF7B58700285827 /* WebExtensionAPIBookmarks.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIBookmarks.idl; sourceTree = "<group>"; };
 		96EE6CE72DFA4975000F90BD /* WebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
+		97311DE32F0DB1CF00B23BE9 /* WKSurroundingsEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKSurroundingsEffectView.swift; sourceTree = "<group>"; };
+		9765441E2EF22B0B00BD8947 /* WKSurroundingsEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKSurroundingsEffect.swift; sourceTree = "<group>"; };
+		976544232EF34BDE00BD8947 /* WKSurroundingsEffect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKSurroundingsEffect.h; sourceTree = "<group>"; };
 		97AD28872ECFA49800039097 /* _WKCaptionStyleMenuControllerAVKitMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKCaptionStyleMenuControllerAVKitMac.mm; sourceTree = "<group>"; };
 		97AD28882ECFA4AE00039097 /* _WKCaptionStyleMenuControllerAVKitMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKCaptionStyleMenuControllerAVKitMac.h; sourceTree = "<group>"; };
 		97C476272ECD338A004D1492 /* _WKCaptionStyleMenuControllerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKCaptionStyleMenuControllerInternal.h; sourceTree = "<group>"; };
@@ -17407,6 +17413,9 @@
 				A1A207442D8A7A92003B1A13 /* QuickLook_SPI_Temp.swiftinterface */,
 				E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */,
 				DD6E58C42BE004DE0000C264 /* RealitySystemSupportSPI.h */,
+				976544232EF34BDE00BD8947 /* WKSurroundingsEffect.h */,
+				9765441E2EF22B0B00BD8947 /* WKSurroundingsEffect.swift */,
+				97311DE32F0DB1CF00B23BE9 /* WKSurroundingsEffectView.swift */,
 			);
 			path = visionos;
 			sourceTree = "<group>";
@@ -19320,6 +19329,7 @@
 				BC40761A124FF0370068F20A /* WKStringCF.h in Headers */,
 				BC9099801256A98200083756 /* WKStringPrivate.h in Headers */,
 				9593675F252E5E3100D3F0A0 /* WKStylusDeviceObserver.h in Headers */,
+				976544262EF3514300BD8947 /* WKSurroundingsEffect.h in Headers */,
 				CE5B4C8821B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.h in Headers */,
 				26F10BE819187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.h in Headers */,
 				F43548382AB7C41E00150894 /* WKTapHighlightView.h in Headers */,
@@ -22092,6 +22102,8 @@
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
 				07152D072F2F037D00B56C0E /* WKTextSelectionController.swift in Sources */,
+				9788BFD92EF4A6940038405A /* WKSurroundingsEffect.swift in Sources */,
+				97311DE42F0DB61F00B23BE9 /* WKSurroundingsEffectView.swift in Sources */,
 				076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */,
 				079A4DB02D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,


### PR DESCRIPTION
#### f97ba929583c3b390deae821fee3f3b53364103a
<pre>
Adopt ImmersiveSpace with preferredSurroundingsEffect for &apos;preferredDarkness&apos; and ImmersiveSpace for &apos;mrui_activeStage&apos; due to deprecation
<a href="https://rdar.apple.com/163514332">rdar://163514332</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304209">https://bugs.webkit.org/show_bug.cgi?id=304209</a>

Reviewed by Richard Robinson.

Created WKFullScreenImmersiveSpaceManager to coordinate effect state between Objective-C and
SwiftUI. Added WKSurroundingsEffectView that applies preferredSurroundingsEffect on a SwiftUI view based on the
manager&apos;s current effect value. Added WKSurroundingsEffectWindow that bridges the effect view into
the UIKit fullscreen window via UIHostingController.

No ImmersiveSpace required - preferredSurroundingsEffect works in shared space for the
dark/semiDark effects WebKit needs.

* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.h: Copied from Source/WebKit/Modules/Internal/WebKitInternal.h.
* Source/WebKit/Platform/spi/visionos/WKSurroundingsEffect.swift: Added.
(WKSurroundingsEffectManagerWrapper.currentEffect):
(WKSurroundingsEffectManagerWrapper.surroundingsEffect):
(WKSurroundingsEffectManager.wrapper):
(WKSurroundingsEffectManager.shared):
(WKSurroundingsEffectManager.currentEffect):
(WKSurroundingsEffectWindow.effectHostingController):
(WKSurroundingsEffectWindow.setupSurroundingsEffectIfNeeded):
* Source/WebKit/Platform/spi/visionos/WKSurroundingsEffectView.swift: Added.
(WKSurroundingsEffectView.body):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenParentWindowState initWithWindow:]):
(-[WKFullScreenWindowController didEnterVideoFullscreen]):
(-[WKFullScreenWindowController didExitVideoFullscreen]):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenWindowController toggleSceneDimming]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/307258@main">https://commits.webkit.org/307258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ad59c5553009d37ab874dda18cfc26ee748f90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152507 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110609 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91527 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10238 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2509 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121971 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154819 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16368 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14894 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15989 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5562 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->