### PR TITLE
(StabilityTracer: CloudTelemetryLocalBackendService at JavaScriptCore:  WTF::ParkingLot::parkConditionallyImpl)

### DIFF
--- a/Source/WTF/wtf/ParkingLot.h
+++ b/Source/WTF/wtf/ParkingLot.h
@@ -143,6 +143,8 @@ public:
     // Unparks every thread from the queue associated with the given address, which cannot be null.
     WTF_EXPORT_PRIVATE static void unparkAll(const void* address);
 
+    static uintptr_t currentThreadID();
+
     // Locks the parking lot and walks all of the parked threads and the addresses they are waiting
     // on. Threads that are on the same queue are guaranteed to be walked from first to last, but the
     // queues may be randomly interleaved. For example, if the queue for address A1 has T1 and T2 and
@@ -159,7 +161,7 @@ public:
     template<typename Func>
     static void forEach(const Func& func)
     {
-        forEachImpl(scopedLambdaRef<void(Thread&, const void*)>(func));
+        forEachImpl(scopedLambdaRef<void(uintptr_t, const void*)>(func));
     }
 
 private:
@@ -172,7 +174,7 @@ private:
     WTF_EXPORT_PRIVATE static void unparkOneImpl(
         const void* address, const ScopedLambda<intptr_t(UnparkResult)>& callback);
 
-    WTF_EXPORT_PRIVATE static void forEachImpl(const ScopedLambda<void(Thread&, const void*)>&);
+    WTF_EXPORT_PRIVATE static void forEachImpl(const ScopedLambda<void(uintptr_t, const void*)>&);
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### a523c7bf08138ebba37af0adeea5ea042dc6592d
<pre>
(StabilityTracer: CloudTelemetryLocalBackendService at JavaScriptCore:  WTF::ParkingLot::parkConditionallyImpl)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304215">https://bugs.webkit.org/show_bug.cgi?id=304215</a>
<a href="https://rdar.apple.com/165745990">rdar://165745990</a>

Reviewed by Chris Dumez.

We have a circular dependency: Lock =&gt; ThreadData =&gt; Thread =&gt;
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr =&gt; Lock.

There are a lot of different ways we can fix this, but ultimately the dependency
only serves exactly one unit test, so let&apos;s just remove it and rework the test.

* Source/WTF/wtf/ParkingLot.cpp:
(WTF::ParkingLot::forEachImpl):
(WTF::ParkingLot::currentThreadID): Pass clients an unretained opaque identifier
for testing. This removes the dependency on Thread.

* Source/WTF/wtf/ParkingLot.h:
(WTF::ParkingLot::forEach):
* Tools/TestWebKitAPI/Tests/WTF/ParkingLot.cpp: Track an unretained opaque
identifier instead of a Thread* when testing.

Canonical link: <a href="https://commits.webkit.org/304494@main">https://commits.webkit.org/304494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c39e38e57ec629ea420b3a5c6b8b09fc2f31e83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143437 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01e60569-f788-477f-8148-226ed14ea423) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7945 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/843be392-b756-4d8b-81f2-71ab569c33c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121652 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3dfef6e-5aa2-406e-b951-a75ea1f52c2f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3679 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4043 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127707 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146186 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134205 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112079 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112459 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5932 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61725 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20918 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7834 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36060 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71385 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43605 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7670 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->