### PR TITLE
ComputePassEncoder::setBindGroup is missing an early return

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-304220-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-304220-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Pass
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-304220.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-304220.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+<script type="text/javascript">
+
+var fuzzervars = {};
+
+function GetVariable(fuzzervars, var_type) { if(fuzzervars[var_type]) { return fuzzervars[var_type]
+; } else { return null; }}
+
+function SetVariable(fuzzervars, var_name, var_type) { fuzzervars[var_type] = var_name; }
+
+
+async function trigger() {
+try {var fuzzvar00040 = fuzzvar00014.createBindGroup() } catch(e) {}
+var fuzzvar00086 = await navigator.gpu.requestAdapter()
+var fuzzvar00085 = await fuzzvar00086.requestDevice()
+SetVariable(fuzzervars, fuzzvar00085, 'GPUDevice');
+var fuzzvar00123 = await fuzzvar00086.requestDevice()
+fuzzvar00123 = GetVariable(fuzzervars, 'GPUDevice');
+var fuzzvar00169 = fuzzvar00123.createCommandEncoder() 
+var fuzzvar00192 = fuzzvar00169.beginComputePass()
+fuzzvar00192.setBindGroup(1,fuzzvar00040)
+console.log('Pass')
+}
+</script>
+
+<body onload="trigger()"></body>
+</html>

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -463,6 +463,7 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup* grou
         m_bindGroupResources.remove(groupIndex);
         m_bindGroupDynamicOffsets.remove(groupIndex);
         m_maxDynamicOffsetAtIndex[groupIndex] = 0;
+        return;
     }
 
     auto& group = *groupPtr;


### PR DESCRIPTION
#### cdffdfba669efcb4fc6120196f60f4a440c57fcc
<pre>
ComputePassEncoder::setBindGroup is missing an early return
<a href="https://bugs.webkit.org/show_bug.cgi?id=304220">https://bugs.webkit.org/show_bug.cgi?id=304220</a>
<a href="https://rdar.apple.com/166494086">rdar://166494086</a>

Reviewed by Geoffrey Garen.

Clearing out bind groups was added to the WebGPU specification,
they are handled for RenderPassEncoders but the ComputePassEncoder
is missing a return statement leading to null-ptr crashes.

Test: fast/webgpu/nocrash/fuzz-304220.html

* LayoutTests/fast/webgpu/nocrash/fuzz-304220-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-304220.html: Added.
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/304593@main">https://commits.webkit.org/304593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d67da0defe9d3946c6a3ffcb7178fe49dd4a19f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87449 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103835 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e631c1ed-954e-4b51-8edd-bbd46030dde9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84712 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19cf38fd-a857-425a-9615-93e915b71b07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3790 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4188 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112193 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112579 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/28607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6059 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61837 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20951 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7980 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36161 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->