### PR TITLE
[JSC] Fix `USE(BIGINT32)` build

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -2344,11 +2344,11 @@ void SpeculativeJIT::emitUntypedBranch(Edge nodeUse, BasicBlock* taken, BasicBlo
         bool isDefinitelyBigInt32 = !needsTypeCheck(nodeUse, SpecCell | SpecBoolean | SpecInt32Only | SpecFullDouble | SpecBigInt32);
         Jump skipBigInt32Case;
         if (!isDefinitelyBigInt32)
-            skipBigInt32Case = branchIfNotBigInt32(valueGPR, tempGPR);
+            skipBigInt32Case = branchIfNotBigInt32(valueGPR, temp1GPR);
 
-        move(valueGPR, tempGPR);
-        urshift64(TrustedImm32(16), tempGPR);
-        branchTest32(NonZero, tempGPR, taken);
+        move(valueGPR, temp1GPR);
+        urshift64(TrustedImm32(16), temp1GPR);
+        branchTest32(NonZero, temp1GPR, taken);
         // Here we fallthrough to the jump(notTaken) below and outside this branch.
 
         if (!isDefinitelyBigInt32)

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -1423,7 +1423,7 @@ IntlMathematicalValue IntlMathematicalValue::parseString(JSGlobalObject* globalO
 
 #if USE(BIGINT32)
             if (bigInt.isBigInt32())
-                return IntlMathematicalValue { value.bigInt32AsInt32() };
+                return IntlMathematicalValue { static_cast<double>(bigInt.bigInt32AsInt32()) };
 #endif
 
             auto* heapBigInt = bigInt.asHeapBigInt();

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -2052,6 +2052,13 @@ JSBigInt::ComparisonResult JSBigInt::compare(JSBigInt* x, int32_t y)
     return compareImpl(HeapBigIntImpl { x }, Int32BigIntImpl { y });
 }
 
+JSBigInt::ComparisonResult JSBigInt::compare(int32_t x, int32_t y)
+{
+    if (x == y)
+        return ComparisonResult::Equal;
+    return x > y ? ComparisonResult::GreaterThan : ComparisonResult::LessThan;
+}
+
 JSBigInt::ComparisonResult JSBigInt::compare(JSBigInt* x, int64_t y)
 {
     return compareImpl(HeapBigIntImpl { x }, Int64BigIntImpl { y });
@@ -2087,8 +2094,8 @@ JSBigInt::ComparisonResult JSBigInt::compare(JSValue x, JSValue y)
     ASSERT(x.isBigInt() && y.isBigInt());
 #if USE(BIGINT32)
     if (x.isBigInt32() && y.isBigInt32()) {
-        int32_t x1 = x.asBigInt32();
-        int32_t y1 = y.asBigInt32();
+        int32_t x1 = x.bigInt32AsInt32();
+        int32_t y1 = y.bigInt32AsInt32();
         if (x1 == y1)
             return JSBigInt::ComparisonResult::Equal;
         if (x1 < y1)

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -107,6 +107,16 @@ public:
 
     unsigned length() const { return m_length; }
 
+    ALWAYS_INLINE static JSValue makeHeapBigIntOrBigInt32(JSGlobalObject* globalObject, int32_t value)
+    {
+#if USE(BIGINT32)
+        UNUSED_PARAM(globalObject);
+        return jsBigInt32(value);
+#else
+        return JSBigInt::createFrom(globalObject, static_cast<int64_t>(value));
+#endif
+    }
+
     ALWAYS_INLINE static JSValue makeHeapBigIntOrBigInt32(JSGlobalObject* globalObject, int64_t value)
     {
 #if USE(BIGINT32)
@@ -167,6 +177,7 @@ public:
     static ComparisonResult compare(JSBigInt* x, JSBigInt* y);
     static ComparisonResult compare(int32_t x, JSBigInt* y);
     static ComparisonResult compare(JSBigInt* x, int32_t y);
+    static ComparisonResult compare(int32_t x, int32_t y);
     static ComparisonResult compare(JSBigInt* x, int64_t y);
     static ComparisonResult compare(JSValue x, int64_t y);
     static ComparisonResult compare(JSBigInt* x, uint64_t y);


### PR DESCRIPTION
#### a295251fd1fe5ba21a1b48e6449fa2a7b32190b8
<pre>
[JSC] Fix `USE(BIGINT32)` build
<a href="https://bugs.webkit.org/show_bug.cgi?id=304222">https://bugs.webkit.org/show_bug.cgi?id=304222</a>

Reviewed by NOBODY (OOPS!).

This patch changes to fix `USE(BIGINT32)` build.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitUntypedBranch):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlMathematicalValue::parseString):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::compare):
* Source/JavaScriptCore/runtime/JSBigInt.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a295251fd1fe5ba21a1b48e6449fa2a7b32190b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103738 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3688 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4057 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127720 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146200 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134220 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7803 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112475 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5950 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36078 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167042 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71398 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43608 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->