### PR TITLE
[audit-spi] SDKDB cache contains multiples of each API declaration when switching between Xcodes

### DIFF
--- a/Source/WTF/Scripts/audit-spi-if-needed.sh
+++ b/Source/WTF/Scripts/audit-spi-if-needed.sh
@@ -29,10 +29,14 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
         fi
     done
 
+    # Use a different cache file for different SDKs (either different
+    # platforms, or reusing the same build directory between different Xcodes).
+    sdk_name_unique="${SDK_NAME}_$(printf %s ${SDKROOT} | sha1)"
+
     for arch in ${ARCHS}; do
         (set -x && "${program}" \
          --sdkdb-dir "${versioned_sdkdb_dir}" \
-         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${SDK_NAME}.sqlite3" \
+         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${sdk_name_unique}.sqlite3" \
          --sdk-dir "${SDKROOT}" --arch-name "${arch}" \
          --depfile "${depfile}" \
          -F "${BUILT_PRODUCTS_DIR}" \

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -421,7 +421,7 @@ class SDKDB:
                     'SELECT i.arch, i.kind, i.input_file, i.name, '
                     '       a.kind, group_concat(aw.input_file), a.name, '
                     '           min(a.allow_unused), '
-                    '       ew.input_file, '
+                    '       group_concat(ew.input_file), '
                     '       sum(e.name IS NOT NULL AND '
                     '           ew.input_file IS NOT NULL) as export_found, '
                     '       sum(a.name IS NOT NULL AND '
@@ -453,7 +453,7 @@ class SDKDB:
                     'ORDER BY i.input_file, i.kind, a.kind, i.name, a.name')
         for (arch, import_kind, input_path, import_name,
              allowed_kind, allowlist_paths, allowed_name, allow_unused,
-             export_path, export_found, allow_found) in cur.fetchall():
+             export_paths, export_found, allow_found) in cur.fetchall():
             if import_name and not export_found and not allow_found:
                 # Imported but neither exported nor allowed => possible SPI.
                 yield MissingName(name=import_name, file=Path(input_path),
@@ -470,6 +470,10 @@ class SDKDB:
                 # Allowed but also exported => unnecessary allowlist entry to
                 # remove.
                 for path in sorted(set(allowlist_paths.split(','))):
+                    # Normally, a declaration would only be exported from one
+                    # library in the SDK. If the cache sees multiple sources,
+                    # just pick one.
+                    export_path = min(export_paths.split(','))
                     yield UnnecessaryAllowedName(name=allowed_name,
                                                  file=Path(path),
                                                  kind=allowed_kind,


### PR DESCRIPTION
#### 560b5b74032815b7d0019dddd9b34a8dada437c6
<pre>
[audit-spi] SDKDB cache contains multiples of each API declaration when switching between Xcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304224">https://bugs.webkit.org/show_bug.cgi?id=304224</a>
<a href="https://rdar.apple.com/166578115">rdar://166578115</a>

Reviewed by Alexey Proskuryakov.

We cache the SDKDB at a path like
`WebKitBuild/WebKitSDKDBs/iphoneos26.0.sqlite3`. When switching between
different Xcode bundles with the same SDK, the cache will be updated
with API declarations from each SDK, for libraries that we treat
as implicitly API and load from the SDK.

This wastes space and reveals a bug in the main query: when diagnosing
an UnnecessaryAllowedName, it may be exported from multiple entries in
the SDKDB cache; one for the loaded SDK, and others for the other copies
of the SDK seeded in the cache. The query assumes that the `input_file`
of the declaration will always be nonnull, because any matched
declaration comes from a file in the window. But because the field was
not aggregated, its value could come from one of the un-loaded entries
and be NULL.

Fix this, and change how Xcode invokes audit-spi to isolate different
copies of the same SDK.

* Source/WTF/Scripts/audit-spi-if-needed.sh:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.audit):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.add_library):
(TestSDKDB.test_audit_unused_allow_multiple_allowlists):
(TestSDKDB):
(TestSDKDB.test_exported_in_nonnull):

Canonical link: <a href="https://commits.webkit.org/305233@main">https://commits.webkit.org/305233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6de27208da2c12d1d92cd9da48b06a791d482cc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49213 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10365 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13e64fae-cd8b-4a15-9ade-bc3f29623ba4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140807 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8141 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Skipped layout-tests; 2 new passes 2 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123594 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3711524f-eee8-4ab7-9063-eb26955460df) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137210 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5507 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6208 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129826 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148638 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136402 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9909 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28994 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7701 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64629 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9955 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169134 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9685 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44109 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->