### PR TITLE
AX: The presence of a generic, insertion, or deletion prevents links from being exposed as atomic accessibility elements, causing unnecessary accessibility tree fragmentation

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion-expected.txt
@@ -1,0 +1,13 @@
+This test ensures we consider links to be leaf accessibility elements if they only contain text, generics, insertions, and deletions.
+
+Found accessibility element with role Link
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+10% OFF
+Foobar 9000
+Category Name
+$430.10
+$550.00
+

--- a/LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion.html
+++ b/LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<meta charset="utf-8"></meta>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<a href="#url">
+    <div>10% OFF</div>
+    <div>Foobar 9000</div>
+    <div>Category Name</div>
+    <div>
+        <div id="new-price-div"><span>$</span><span>430</span><span>.10</span></div>
+        <div>$550.00</div>
+    </div>
+</a>
+
+<script>
+var output = "This test ensures we consider links to be leaf accessibility elements if they only contain text, generics, insertions, and deletions.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var searchResult;
+    while (true) {
+        searchResult = webArea.uiElementForSearchPredicate(searchResult, /* directionIsNext */ true, "AXAnyTypeSearchKey", /* searchText */ "", /* visibleOnly */ true);
+        if (!searchResult)
+            break;
+        if (searchResult.isIgnored)
+            continue;
+        output += `Found accessibility element with role ${searchResult.role}\n`;
+    }
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1837,11 +1837,23 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return NO;
 
     for (unsigned i = 0; i < childrenSize; ++i) {
-        AccessibilityRole role = children[i]->role();
-        if (role != AccessibilityRole::StaticText && role != AccessibilityRole::Image && !children[i]->isGroup())
+        switch (children[i]->role()) {
+        case AccessibilityRole::StaticText:
+        case AccessibilityRole::Image:
+        case AccessibilityRole::Insertion:
+        case AccessibilityRole::Deletion:
+        case AccessibilityRole::Generic:
+            // It's okay to "stitch" insertion and deletion containers into their containing link
+            // because we expect ATs to read text within these containers in a different pitch
+            // indicating their presence.
+            continue;
+        default:
+            break;
+        }
+
+        if (!children[i]->isGroup())
             return NO;
     }
-
     return YES;
 }
 


### PR DESCRIPTION
#### 75585c26abb2e84a88a721b50f46fc6300763bfd
<pre>
AX: The presence of a generic, insertion, or deletion prevents links from being exposed as atomic accessibility elements, causing unnecessary accessibility tree fragmentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=304223">https://bugs.webkit.org/show_bug.cgi?id=304223</a>
<a href="https://rdar.apple.com/166578178">rdar://166578178</a>

Reviewed by Joshua Hoffman.

Whether a link is split into its descendants or treated as an atomic accessibility element is determined by
-[WebAccessibilityObjectWrapper containsUnnaturallySegmentedChildren]. This function returned true (indicating the link
should be split) whenever a generic was present, which are obviously extremely common and really shouldn&apos;t count as
a meaningful descendant. Links were also split when containing an insertion or deletion, which isn&apos;t ideal since the
content within these elements is almost always plain-text.

This commit makes this function more tolerant of generics, insertions, and deletions, motivated by markup from a real
page and distilled into layout test accessibility/ios-simulator/link-with-generics-and-insertion-deletion.html.

* LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/link-with-generics-and-insertion-deletion.html: Added.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper containsUnnaturallySegmentedChildren]):

Canonical link: <a href="https://commits.webkit.org/304507@main">https://commits.webkit.org/304507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9cb68162ffc92f0f7b52d0a2e5f06f0306d16b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87374 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84607 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6082 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3689 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4060 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146203 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5945 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61740 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7851 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36079 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->