### PR TITLE
AX: The line range for a given VisiblePosition should include the line break if one exists at the end of the line.

### DIFF
--- a/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt
+++ b/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt
@@ -2,6 +2,7 @@ First line
 
 second line
 Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+
 This tests that when list item has text of multiple lines we only speak the list marker for the first line.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
+++ b/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
@@ -5,7 +5,7 @@
 
 <ol>
 <li id="item1"><p>First line</p>second line</li>
-<li id="item2">Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long</p></li>
+<li id="item2"><p>Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long</p></li>
 </ol>
 
 
@@ -25,18 +25,18 @@
         // Get second line.
         var firstLineEnd = p1.endTextMarkerForTextMarkerRange(firstLineRange);
         var secondLineRange = p1.lineTextMarkerRangeForTextMarker(p1.nextTextMarker(firstLineEnd));
-        debug(p1.stringForTextMarkerRange(secondLineRange));
-        
+        debug(p1.stringForTextMarkerRange(secondLineRange).trim());
+
         // Soft lines.
         var listItem2 = accessibilityController.accessibleElementById("item2");
         var item2Range = listItem2.textMarkerRangeForElement(listItem2);
         var firstLineStart = listItem2.startTextMarkerForTextMarkerRange(item2Range);
         firstLineRange = listItem2.lineTextMarkerRangeForTextMarker(firstLineStart);
         debug(listItem2.stringForTextMarkerRange(firstLineRange));
-        
+
         firstLineEnd = listItem2.endTextMarkerForTextMarkerRange(firstLineRange);
         secondLineRange = listItem2.lineTextMarkerRangeForTextMarker(listItem2.nextTextMarker(firstLineEnd));
-        debug(listItem2.stringForTextMarkerRange(secondLineRange));
+        debug(listItem2.stringForTextMarkerRange(secondLineRange).trim());
     }
 
 </script>

--- a/LayoutTests/accessibility/mac/character-offset-from-upstream-position-expected.txt
+++ b/LayoutTests/accessibility/mac/character-offset-from-upstream-position-expected.txt
@@ -1,8 +1,8 @@
 This tests that CharacterOffset that comes from an upstream VisiblePosition is correct.
 
-First Line: Lorem ipsum vivamus nibh
-Second Line: urna mollis at aliquam taciti,
-[firstEnd, secondStart]: 'space'
+First Line: 'Lorem ipsum vivamus nibh '
+Second Line: 'urna mollis at aliquam taciti, '
+PASS: firstEnd.isEqual(secondStart) === true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/character-offset-from-upstream-position.html
+++ b/LayoutTests/accessibility/mac/character-offset-from-upstream-position.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test.js"></script>
 </head>
 <body>
@@ -18,19 +19,17 @@ if (window.accessibilityController) {
 
     let start = text.startTextMarkerForTextMarkerRange(textRange);
     let firstLine = text.lineTextMarkerRangeForTextMarker(start);
-    let firstEnd = text.endTextMarkerForTextMarkerRange(firstLine);
-    output += `First Line: ${text.stringForTextMarkerRange(firstLine)}\n`;
+    var firstEnd = text.endTextMarkerForTextMarkerRange(firstLine);
+    output += `First Line: '${text.stringForTextMarkerRange(firstLine)}'\n`;
 
-    let next = text.nextTextMarker(firstEnd);
-    let secondLine = text.lineTextMarkerRangeForTextMarker(next);
-    let secondStart = text.startTextMarkerForTextMarkerRange(secondLine);
-    output += `Second Line: ${text.stringForTextMarkerRange(secondLine)}\n`;
+    // Use the end of the firs line range to get the range for the second line,
+    // since the end of the first line should be the start of the second line.
+    let secondLine = text.lineTextMarkerRangeForTextMarker(firstEnd);
+    var secondStart = text.startTextMarkerForTextMarkerRange(secondLine);
+    output += `Second Line: '${text.stringForTextMarkerRange(secondLine)}'\n`;
 
-    // Here firstEnd should contain a upstream position.
-    // We need to make sure firstEnd does not equal to secondStart after
-    // converting to CharacterOffset.
-    let markerRange = text.textMarkerRangeForMarkers(firstEnd, secondStart);
-    output += `[firstEnd, secondStart]: ${text.stringForTextMarkerRange(markerRange).replace(' ', "'space'")}\n`;
+    // Re-confirm that the end marker of the first line is equal to the start marker of the second line.
+    output += expect("firstEnd.isEqual(secondStart)", "true");
 
     debug(output);
 }

--- a/LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt
+++ b/LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt
@@ -38,7 +38,7 @@ AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-
 First line.
 Some text click me more text.
 Another line."
-First line: "Attributes in range {0, 11}:
+Line 1: "Attributes in range {0, 12}:
 AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
@@ -46,8 +46,9 @@ AXFont: {
 }
 AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
 AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
-First line."
-Second line: "Attributes in range {0, 10}:
+First line.
+"
+Line 2: "Attributes in range {0, 10}:
 AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
@@ -65,7 +66,7 @@ AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-
 AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
 AXUnderline: YES
 AXUnderlineColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0.933333 1 )
-Attributes in range {18, 11}:
+Attributes in range {18, 12}:
 AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
@@ -73,8 +74,9 @@ AXFont: {
 }
 AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
 AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
-Some text click me more text."
-third line: "Attributes in range {0, 13}:
+Some text click me more text.
+"
+Line 3: "Attributes in range {0, 13}:
 AXFont: {
     AXFontFamily = Times;
     AXFontItalic = 1;

--- a/LayoutTests/accessibility/mac/content-editable-attributed-string.html
+++ b/LayoutTests/accessibility/mac/content-editable-attributed-string.html
@@ -17,27 +17,16 @@ if (accessibilityController) {
     let string = text.attributedStringForTextMarkerRange(range);
     output += `All text in the contenteditable: "${string}"\n`;
 
-    // Get the range for the first line.
+    // Get the line ranges for each of the three lines of text.
     let start = text.startTextMarkerForTextMarkerRange(range);
-    range = text.lineTextMarkerRangeForTextMarker(start);
-    string = text.attributedStringForTextMarkerRange(range);
-    output += `First line: "${string}"\n`;
+    for (i = 1; i <= 3; ++i) {
+        range = text.lineTextMarkerRangeForTextMarker(start);
+        string = text.attributedStringForTextMarkerRange(range);
+        output += `Line ${i}: "${string}"\n`;
 
-    // Get the range for the second line:
-    let end = text.nextLineEndTextMarkerForTextMarker(start);
-    end = text.nextTextMarker(end);
-    end = text.nextTextMarker(end);
-    range = text.lineTextMarkerRangeForTextMarker(end);
-    string = text.attributedStringForTextMarkerRange(range);
-    output += `Second line: "${string}"\n`;
-
-    // Get the range for the third line:
-    end = text.nextLineEndTextMarkerForTextMarker(end);
-    end = text.nextTextMarker(end);
-    end = text.nextTextMarker(end);
-    range = text.lineTextMarkerRangeForTextMarker(end);
-    string = text.attributedStringForTextMarkerRange(range);
-    output += `third line: "${string}"\n`;
+        // Get the range for the next line using the end of the current line:
+        start = text.endTextMarkerForTextMarkerRange(range);
+    }
 
     debug(output);
 }

--- a/LayoutTests/accessibility/mac/line-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-range-for-text-marker.html
@@ -28,9 +28,9 @@
         // Get the line text marker range for this text marker.
         var range = element.lineTextMarkerRangeForTextMarker(marker);
         // Return the text for this line text marker range.
-        return element.stringForTextMarkerRange(range);
+        return element.stringForTextMarkerRange(range).trim();
     }
-    
+
     if (window.accessibilityController) {
         var line = accessibilityController.accessibleElementById("line");
         // Line text from first text marker (add one to make sure we get the first marker for THIS line).

--- a/LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt
+++ b/LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt
@@ -1,7 +1,8 @@
 This tests the ability to search for accessible elements from an ignored element.
 
 PASS: element.stringForTextMarkerRange(range) === 'First line of text'
-PASS: element.stringForTextMarkerRange(range) === 'button'
+PASS: element.stringForTextMarkerRange(range) === `button
+`
 PASS: resultElement.stringValue === 'AXValue: Third line of text'
 PASS: resultElement.stringValue === 'AXValue: First line of text'
 

--- a/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
+++ b/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
@@ -26,7 +26,8 @@
         marker = element.nextTextMarker(marker);
         marker = element.nextTextMarker(marker);
         range = element.lineTextMarkerRangeForTextMarker(marker);
-        output += expect("element.stringForTextMarkerRange(range)", "'button'");
+        // The range for the line containing the button must include a '\n' since the <button> element is followed by <br>.
+        output += expect("element.stringForTextMarkerRange(range)", "`button\n`");
 
         marker = element.startTextMarkerForTextMarkerRange(range);
         var startElement = element.accessibilityElementForTextMarker(marker);


### PR DESCRIPTION
#### da7ff45293cafd8b692e5d13e84fd02927a87f07
<pre>
AX: The line range for a given VisiblePosition should include the line break if one exists at the end of the line.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304225">https://bugs.webkit.org/show_bug.cgi?id=304225</a>
<a href="https://rdar.apple.com/148920198">rdar://148920198</a>

Reviewed by Tyler Wilcock.

Both VisibleUnits endOfLine, AccessibilityObject::nextLineEndPosition, and the heuristics added to AccessibilityObject::lineRangeForPosition exclude a trailing line break (&apos;\n&apos; or equivalent) from the computed line range. This causes that VoiceOver does not properly display empty lines in Braille, as reported in <a href="https://rdar.apple.com/148920198">rdar://148920198</a>.

This patch fixes this problem by replacing the existing heuristics with a straightforward algorithm consisting in moving from the given visible position until either the new position is no longer in the same line or a line break is found, and includes the line break position in the returned range. This change applies only to AccessibilityObjects and not to AXIsolatedObjects.

Several tests listed below had to be modified to account for this behavior change. In some cases, it was necessary to trim the string returned by stringForTextMarkerRange in order for the test to pass in both ITM on and off modes. The differences in behavior between ITM on and off needs to be addressed in future patches.

Covered by existing tests.
* LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt:
* LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html:
* LayoutTests/accessibility/mac/character-offset-from-upstream-position-expected.txt:
* LayoutTests/accessibility/mac/character-offset-from-upstream-position.html:
* LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt:
* LayoutTests/accessibility/mac/content-editable-attributed-string.html:
* LayoutTests/accessibility/mac/line-range-for-text-marker.html:
* LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lineRangeForPosition const):

Canonical link: <a href="https://commits.webkit.org/304512@main">https://commits.webkit.org/304512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7207380ffde370d972a6210d4406d69dc763f2da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87379 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/79db1513-fd25-4109-9a01-c374fce11bd2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103736 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d266b4b5-8166-46e5-b3f7-43224a1ad10d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84612 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee9841c1-9d65-4a0d-aa31-acee351910c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3694 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146209 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112097 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112478 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5947 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7857 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->