### PR TITLE
[Site Isolation] Make BrowsingContextGroup aware of opaque origins

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -83,7 +83,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
 
         Ref process = pageConfiguration->protectedProcessPool()->processForSite(websiteDataStore.get(), WebProcessPool::IsSharedProcess::Yes, site, mainFrameSite, domainsWithUserInteraction, lockdownMode, enhancedSecurity, pageConfiguration.get(), ProcessSwapDisposition::Other);
         ASSERT(!process->isInProcessCache());
-        Ref frameProcess = FrameProcess::create(process, protectedThis, std::nullopt, mainFrameSite, preferences, LoadedWebArchive::No, InjectBrowsingContextIntoProcess::Yes);
+        Ref frameProcess = FrameProcess::create(process, protectedThis, std::nullopt, mainFrameSite, preferences, LoadedWebArchive::No, InjectBrowsingContextIntoProcess::Yes, std::nullopt);
         ASSERT(frameProcess->isSharedProcess());
         ASSERT(frameProcess->process().isSharedProcess());
         frameProcess->process().addSharedProcessDomain(site.domain());
@@ -92,12 +92,25 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
     });
 }
 
-Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, const Site& mainFrameSite, WebProcessProxy& process, const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
+Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, const Site& mainFrameSite, WebProcessProxy& process, const WebPreferences& preferences, const std::optional<WebCore::SecurityOriginData>& effectiveOrigin, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess, ShouldReuseProcessFromOpaqueOrigin shouldReuseProcessFromOpaqueOrigin)
 {
     if (preferences.siteIsolationEnabled()) {
         if ((m_sharedProcess && m_sharedProcessSites.contains(site)) || process.isSharedProcess()) {
             ASSERT(&m_sharedProcess->process() == &process);
             return *m_sharedProcess;
+        }
+        if (shouldReuseProcessFromOpaqueOrigin == ShouldReuseProcessFromOpaqueOrigin::Yes) {
+            if (RefPtr opaqueOriginProcess = processForOpaqueOrigin(process.coreProcessIdentifier())) {
+                if (!site.isEmpty())
+                    m_processMap.set(site, opaqueOriginProcess);
+                return opaqueOriginProcess.releaseNonNull();
+            }
+        }
+        if (site.isEmpty() && effectiveOrigin) {
+            if (RefPtr existingProcess = processForSite(Site { *effectiveOrigin })) {
+                if (existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier())
+                    return existingProcess.releaseNonNull();
+            }
         }
         if (RefPtr existingProcess = processForSite(site)) {
             if (existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier())
@@ -105,7 +118,7 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
         }
     }
 
-    return FrameProcess::create(process, *this, site, mainFrameSite, preferences, loadedWebArchive, injectBrowsingContextIntoProcess);
+    return FrameProcess::create(process, *this, site, mainFrameSite, preferences, loadedWebArchive, injectBrowsingContextIntoProcess, effectiveOrigin);
 }
 
 RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site)
@@ -113,6 +126,16 @@ RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site)
     if (m_sharedProcessSites.contains(site))
         return m_sharedProcess.get();
     RefPtr process = m_processMap.get(site);
+    if (!process)
+        return nullptr;
+    if (process->process().state() == WebProcessProxy::State::Terminated)
+        return nullptr;
+    return process;
+}
+
+RefPtr<FrameProcess> BrowsingContextGroup::processForOpaqueOrigin(const WebCore::ProcessIdentifier& processID)
+{
+    RefPtr process = m_opaqueOriginProcessMap.get(processID);
     if (!process)
         return nullptr;
     if (process->process().state() == WebProcessProxy::State::Terminated)
@@ -166,8 +189,16 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     auto& site = *process.site();
     if (m_processMap.get(site) == &process)
         return;
-    ASSERT(!m_processMap.get(site) || m_processMap.get(site)->process().state() == WebProcessProxy::State::Terminated);
-    m_processMap.set(site, process);
+    if (site.isEmpty() && !process.effectiveOrigin()) {
+        WebCore::ProcessIdentifier opaqueProcessID = process.process().coreProcessIdentifier();
+        ASSERT(!m_opaqueOriginProcessMap.get(opaqueProcessID) || m_opaqueOriginProcessMap.get(opaqueProcessID)->process().state() == WebProcessProxy::State::Terminated);
+        m_opaqueOriginProcessMap.set(opaqueProcessID, process);
+    } else {
+        auto& effectiveSite = process.effectiveOrigin() ? Site { *process.effectiveOrigin() } : site;
+        ASSERT(!m_processMap.get(effectiveSite) || m_processMap.get(effectiveSite)->process().state() == WebProcessProxy::State::Terminated);
+        ASSERT(!effectiveSite.isEmpty());
+        m_processMap.set(effectiveSite, process);
+    }
     for (Ref page : m_pages) {
         if (site == Site(URL(page->currentURL())))
             continue;

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -56,14 +56,17 @@ enum class IsMainFrame : bool;
 
 enum class InjectBrowsingContextIntoProcess : bool { No, Yes };
 
+enum class ShouldReuseProcessFromOpaqueOrigin : bool { No, Yes };
+
 class BrowsingContextGroup : public RefCountedAndCanMakeWeakPtr<BrowsingContextGroup> {
 public:
     static Ref<BrowsingContextGroup> create() { return adoptRef(*new BrowsingContextGroup()); }
     ~BrowsingContextGroup();
 
     void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
-    Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, InjectBrowsingContextIntoProcess = InjectBrowsingContextIntoProcess::Yes);
+    Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, const std::optional<WebCore::SecurityOriginData>&, LoadedWebArchive = LoadedWebArchive::No, InjectBrowsingContextIntoProcess = InjectBrowsingContextIntoProcess::Yes, ShouldReuseProcessFromOpaqueOrigin = ShouldReuseProcessFromOpaqueOrigin::No);
     RefPtr<FrameProcess> processForSite(const WebCore::Site&);
+    RefPtr<FrameProcess> processForOpaqueOrigin(const WebCore::ProcessIdentifier&);
     void addFrameProcess(FrameProcess&);
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);
     void removeFrameProcess(FrameProcess&);
@@ -91,6 +94,7 @@ private:
     WeakHashSet<WebPageProxy> m_pagesInSharedProcess;
 
     HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
+    HashMap<WebCore::ProcessIdentifier, WeakPtr<FrameProcess>> m_opaqueOriginProcessMap;
     WeakListHashSet<WebPageProxy> m_pages;
     WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_remotePages;
 };

--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -36,12 +36,14 @@
 namespace WebKit {
 
 FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebCore::Site& mainFrameSite,
-    const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
+    const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess,
+    const std::optional<WebCore::SecurityOriginData>& effectiveOrigin)
     : m_process(process)
     , m_browsingContextGroup(group)
     , m_site(site)
     , m_mainFrameSite(mainFrameSite)
     , m_isArchiveProcess(loadedWebArchive == LoadedWebArchive::Yes)
+        , m_effectiveOrigin(effectiveOrigin)
 {
     if (!preferences.siteIsolationEnabled()) {
         m_browsingContextGroup = nullptr;

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -49,21 +49,24 @@ public:
     bool isSharedProcess() const { return !m_site; }
     const WebCore::Site& sharedProcessMainFrameSite() const { ASSERT(!m_site); return m_mainFrameSite; }
     bool isArchiveProcess() const { return m_isArchiveProcess; }
+    const std::optional<WebCore::SecurityOriginData>& effectiveOrigin() const { return m_effectiveOrigin; }
 
 private:
     friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.
     static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebCore::Site& mainFrameSite,
-        const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess)
+        const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, InjectBrowsingContextIntoProcess injectBrowsingContextIntoProcess,
+        const std::optional<WebCore::SecurityOriginData>& effectiveOrigin)
     {
-        return adoptRef(*new FrameProcess(process, group, site, mainFrameSite, preferences, loadedWebArchive, injectBrowsingContextIntoProcess));
+        return adoptRef(*new FrameProcess(process, group, site, mainFrameSite, preferences, loadedWebArchive, injectBrowsingContextIntoProcess, effectiveOrigin));
     }
-    FrameProcess(WebProcessProxy&, BrowsingContextGroup&, const std::optional<WebCore::Site>&, const WebCore::Site& mainFrameSite, const WebPreferences&, LoadedWebArchive, InjectBrowsingContextIntoProcess);
+    FrameProcess(WebProcessProxy&, BrowsingContextGroup&, const std::optional<WebCore::Site>&, const WebCore::Site& mainFrameSite, const WebPreferences&, LoadedWebArchive, InjectBrowsingContextIntoProcess, const std::optional<WebCore::SecurityOriginData>&);
 
     const Ref<WebProcessProxy> m_process;
     WeakPtr<BrowsingContextGroup> m_browsingContextGroup;
     const std::optional<WebCore::Site> m_site;
     const WebCore::Site m_mainFrameSite;
     bool m_isArchiveProcess;
+    const std::optional<WebCore::SecurityOriginData> m_effectiveOrigin;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -530,7 +530,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     auto mainFrameDomain = mainFrameSite.domain();
 
     m_provisionalFrame = nullptr;
-    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(navigationSite, mainFrameSite, process, page->protectedPreferences())));
+    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(navigationSite, mainFrameSite, process, page->protectedPreferences(), std::nullopt)));
     page->protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
         completionHandler(pageID);
     });

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1798,12 +1798,11 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     Ref browsingContextGroup = m_browsingContextGroup;
     Ref preferences = m_preferences;
 
-
     // If an empty site openes a new page, this new page should be in the same process
     // as the opener. To do so, we can pass the opener's origin to BrowsingContextGroup::ensureProcessForSite.
     Site effectiveSite = site.isEmpty() && internals().openerOrigin ? Site { *internals().openerOrigin } : site;
 
-    m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
+    m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences, std::nullopt, LoadedWebArchive::No, InjectBrowsingContextIntoProcess::Yes, ShouldReuseProcessFromOpaqueOrigin::Yes), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protectedDrawingArea(), m_mainFrame->frameID(), std::nullopt)), 0);
@@ -5529,7 +5528,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
     // FIXME: Assert the equality of data stores regardless of whether site isolation is enabled or not.
     ASSERT(!protectedPreferences()->siteIsolationEnabled() || newProcess->websiteDataStore() == &websiteDataStore());
-    Ref frameProcess = browsingContextGroup.ensureProcessForSite(navigationSite, Site { mainFrame()->url() }, newProcess, preferences, loadedWebArchive, InjectBrowsingContextIntoProcess::No);
+    Ref frameProcess = browsingContextGroup.ensureProcessForSite(navigationSite, Site { mainFrame()->url() }, newProcess, preferences, std::nullopt, loadedWebArchive, InjectBrowsingContextIntoProcess::No);
     // Make sure we destroy any existing ProvisionalPageProxy object *before* we construct a new one.
     // It is important from the previous provisional page to unregister itself before we register a
     // new one to avoid confusion.
@@ -7624,7 +7623,7 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (auto frameProcessSite = frame->frameProcess().site(); frameProcessSite && !frame->frameProcess().isArchiveProcess()) {
         auto frameSite = Site { frame->url() };
         if (frameProcessSite->isEmpty() && !frameSite.isEmpty())
-            frame->setProcess(protectedBrowsingContextGroup()->ensureProcessForSite(frameSite, Site { protectedMainFrame()->url() }, frame->frameProcess().process(), preferences));
+            frame->setProcess(protectedBrowsingContextGroup()->ensureProcessForSite(frameSite, Site { protectedMainFrame()->url() }, frame->frameProcess().process(), preferences, std::nullopt, LoadedWebArchive::No, InjectBrowsingContextIntoProcess::Yes, ShouldReuseProcessFromOpaqueOrigin::Yes));
     }
 
     if (frame->isMainFrame()) {

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2354,13 +2354,13 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     if (!m_configuration->processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol() && !sourceURL.protocolIsInHTTPFamily() && sourceURL.protocol() == targetURL.protocol() && !siteIsolationEnabled)
         return { WTF::move(sourceProcess), nullptr, "Navigation within the same non-HTTP(s) protocol"_s };
 
-    if (!sourceURL.isValid()
+    if ((!siteIsolationEnabled && !sourceURL.isValid())
         || !targetURL.isValid()
-        || sourceURL.isEmpty()
+        || (!siteIsolationEnabled && sourceURL.isEmpty())
         || (siteIsolationEnabled ? targetSite.matches(sourceURL) : targetSite.domain().matches(sourceURL)))
         return { WTF::move(sourceProcess), nullptr, "Navigation is same-site"_s };
 
-    if (sourceURL.protocolIsAbout()) {
+    if (sourceURL.protocolIsAbout() || sourceURL.isEmpty()) {
         if (auto sourceSite = sourceProcess->site()) {
             if (!siteIsolationEnabled && sourceSite->domain().matches(targetURL))
                 return { WTF::move(sourceProcess), nullptr, "Navigation is treated as same-site (matched domain)"_s };
@@ -2368,10 +2368,17 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
                 return { WTF::move(sourceProcess), nullptr, "Navigation is treated as same-site (matched site)"_s };
         }
 
-        const bool treatAsSameSiteForAboutNavigation = [&sourceProcess, &siteIsolationEnabled] {
+        const bool treatAsSameSiteWhenNavigatingFromAbout = [&] {
             if (sourceProcess->hasCommittedAnyMeaningfulProvisionalLoads())
                 return false;
             if (siteIsolationEnabled) {
+                // navigation is either happening in a separate window or iframe
+                if ((sourceURL.isAboutBlank() || sourceURL.isEmpty())
+                    && !sourceProcess->hasCommittedAnyMeaningfulProvisionalLoads()
+                    && ((page.mainFrame() && page.mainFrame()->opener()) || frameInfo.parentFrameID)
+                    && !(targetURL.isAboutBlank() || targetURL.isEmpty())) {
+                    return false;
+                }
                 auto sourceSite = sourceProcess->site();
                 if (sourceSite)
                     return sourceSite->isEmpty();
@@ -2381,7 +2388,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
             return true;
         }();
 
-        if (treatAsSameSiteForAboutNavigation)
+        if (treatAsSameSiteWhenNavigatingFromAbout)
             return { WTF::move(sourceProcess), nullptr, "Navigation is treated as same-site"_s };
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -810,12 +810,7 @@ TEST(SiteIsolation, NavigationAfterWindowOpen)
         Util::spinRunLoop();
 }
 
-// FIXME: Re-enable this test once https://bugs.webkit.org/show_bug.cgi?id=300844 is resolved
-#if !defined(NDEBUG)
-TEST(SiteIsolation, DISABLED_OpenBeforeInitialLoad)
-#else
 TEST(SiteIsolation, OpenBeforeInitialLoad)
-#endif
 {
     HTTPServer server({
         { "/webkit"_s, { "<script>alert('loaded')</script>"_s } }
@@ -7743,5 +7738,250 @@ TEST(SiteIsolation, CrossSiteIFrameCanReceiveDeviceMotionEvents)
 }
 
 #endif // ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
+
+TEST(SiteIsolation, OpenFromAboutBlankOpenerWithOpaqueOrigin)
+{
+    HTTPServer server({
+        { "/webkit"_s, { "<script>alert('loaded')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebView> opened;
+    uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.get().navigationDelegate = navigationDelegate.get();
+        opened.get().UIDelegate = uiDelegate.get();
+        return opened.get();
+    };
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@"window.open('https://webkit.org/webkit')" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            // this represents an empty, opaque origin which can come from
+            // a page has newly been opened to about:blank without being
+            // previously navigated to a non-about:blank site
+            "://"_s,
+        },
+        { RemoteFrame },
+    });
+    checkFrameTreesInProcesses(opened.get(), {
+        { RemoteFrame },
+        { "https://webkit.org"_s },
+    });
+}
+
+TEST(SiteIsolation, NavigateFrameFromAboutBlankParentWithOpaqueOrigin)
+{
+    HTTPServer server({
+        { "/iframe1"_s, { "<script>alert('loaded iframe1')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:
+        @"var iframe1 = document.createElement('iframe');"
+        "document.body.appendChild(iframe1);"
+        "iframe1.src = 'https://apple.com/iframe1';"
+    completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded iframe1");
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            // this represents an empty, opaque origin which can come from
+            // a page has newly been opened to about:blank without being
+            // previously navigated to a non-about:blank site
+            { "://"_s, { { RemoteFrame } } },
+            { RemoteFrame, { { "https://apple.com"_s } } },
+        },
+    });
+}
+
+// These two test are almost the same as
+// SiteIsolation.OpenFromAboutBlankOpenerWithOpaqueOrigin and
+// SiteIsolation.NavigateFrameFromEmptyParentWithOpaqueOrigin, respectively,
+// with the subtle difference being that here, we don't explictly navigate the main
+// page to "about:blank" before calling window.open().
+// This means the opener has an empty url, as opposed to an explicit "about:blank" url.
+// While these seem logically equivalent, they are handled different in navigation logic.
+// For example, some navigation logic looks at URL::isEmpty() vs. URL::isAboutBlank().
+//      "about:blank" - isEmpty: false, isAboutBlank: true
+//      "" - isEmpty: true, isAboutBlank: false
+TEST(SiteIsolation, OpenFromEmptyOpenerWithOpaqueOrigin)
+{
+    HTTPServer server({
+        { "/webkit"_s, { "<script>alert('loaded')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebView> opened;
+    uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.get().navigationDelegate = navigationDelegate.get();
+        opened.get().UIDelegate = uiDelegate.get();
+        return opened.get();
+    };
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView evaluateJavaScript:@"window.open('https://webkit.org/webkit')" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            // this represents an empty, opaque origin which can come from
+            // a page has newly been opened to about:blank without being
+            // previously navigated to a non-about:blank site
+            "://"_s,
+        },
+        { RemoteFrame },
+    });
+    checkFrameTreesInProcesses(opened.get(), {
+        { RemoteFrame },
+        { "https://webkit.org"_s },
+    });
+}
+
+TEST(SiteIsolation, NavigateFrameFromEmptyParentWithOpaqueOrigin)
+{
+    HTTPServer server({
+        { "/iframe1"_s, { "<script>alert('loaded iframe1')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView evaluateJavaScript:
+        @"var iframe1 = document.createElement('iframe');"
+        "document.body.appendChild(iframe1);"
+        "iframe1.src = 'https://apple.com/iframe1';"
+    completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded iframe1");
+
+    checkFrameTreesInProcesses(webView.get(), {
+        {
+            // this represents an empty, opaque origin which can come from
+            // a page has newly been opened to about:blank without being
+            // previously navigated to a non-about:blank site
+            { "://"_s, { { RemoteFrame } } },
+            { RemoteFrame, { { "https://apple.com"_s } } },
+        },
+    });
+}
+
+TEST(SiteIsolation, OpenWindowAndNavigateIframeFromAboutBlankWithOpaqueOrigin)
+{
+    HTTPServer server({
+        { "/webkit"_s, { "<script>alert('loaded')</script>"_s } },
+        { "/iframe1"_s, { "<script>alert('loaded iframe1')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // Taken from openerAndOpenedViews but without waiting for the load at the end since it was
+    // originally hanging when navigating the opener to about:blank.
+    __block WebViewAndDelegates opener;
+    __block WebViewAndDelegates opened;
+    opener.navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [opener.navigationDelegate allowAnyTLSCertificate];
+    auto configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration);
+    opener.webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    opener.webView.get().navigationDelegate = opener.navigationDelegate.get();
+    opener.uiDelegate = adoptNS([TestUIDelegate new]);
+    opener.uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        enableSiteIsolation(configuration);
+        opened.webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [opened.navigationDelegate allowAnyTLSCertificate];
+        opened.uiDelegate = adoptNS([TestUIDelegate new]);
+        opened.webView.get().navigationDelegate = opened.navigationDelegate.get();
+        opened.webView.get().UIDelegate = opened.uiDelegate.get();
+        return opened.webView.get();
+    };
+    [opener.webView setUIDelegate:opener.uiDelegate.get()];
+    opener.webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    [opener.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [opener.navigationDelegate waitForDidFinishNavigation];
+
+    [opener.webView evaluateJavaScript:@"window.open('https://webkit.org/webkit')" completionHandler:nil];
+    [opened.navigationDelegate waitForDidFinishNavigation];
+
+    [opener.webView evaluateJavaScript:
+        @"var iframe1 = document.createElement('iframe');"
+        "document.body.appendChild(iframe1);"
+        "iframe1.src = 'https://apple.com/iframe1';"
+    completionHandler:nil];
+    EXPECT_WK_STREQ([opener.uiDelegate waitForAlert], "loaded iframe1");
+
+    checkFrameTreesInProcesses(opener.webView.get(), {
+        {
+            { RemoteFrame, { { "https://apple.com"_s } } },
+            // this represents an empty, opaque origin which can come from
+            // a page has newly been opened to about:blank without being
+            // previously navigated to a non-about:blank site
+            { "://"_s, { { RemoteFrame } } },
+            { RemoteFrame, { { RemoteFrame } } },
+        },
+    });
+    checkFrameTreesInProcesses(opened.webView.get(), {
+        {
+            { "https://webkit.org"_s },
+            { RemoteFrame },
+            { RemoteFrame },
+        },
+    });
+}
+
+TEST(SiteIsolation, SameSiteAboutBlankOpenerAndChildIframe)
+{
+    HTTPServer server({
+        { "/webkit"_s, { "This is webkit.org/webkit"_s } },
+        { "/iframe1"_s, { "<script>alert('loaded iframe1')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebView> opened;
+    RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.get().navigationDelegate = openedNavigationDelegate.get();
+        opened.get().UIDelegate = uiDelegate.get();
+        return opened.get();
+    };
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@"window.open('about:blank');" completionHandler:nil];
+    [openedNavigationDelegate waitForDidFinishNavigation];
+
+    [opened evaluateJavaScript:
+        @"var iframe1 = document.createElement('iframe');"
+        "document.body.appendChild(iframe1);"
+        "iframe1.src = 'https://webkit.org/iframe1';"
+    completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded iframe1");
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://webkit.org"_s },
+    });
+    checkFrameTreesInProcesses(opened.get(), {
+        {
+            "https://webkit.org"_s,
+            { { "https://webkit.org"_s } }
+        },
+    });
+}
 
 }


### PR DESCRIPTION
#### 2689aae698be7cc1aa1ad9d6b6566dfbcf38719f
<pre>
[Site Isolation] Make BrowsingContextGroup aware of opaque origins
<a href="https://bugs.webkit.org/show_bug.cgi?id=300844">https://bugs.webkit.org/show_bug.cgi?id=300844</a>
<a href="https://rdar.apple.com/162728352">rdar://162728352</a>

Reviewed by NOBODY (OOPS!).

Previously, BrowsingContextGroup maintained a HashMap (m_processMap) which
mapped `WebCore::Site`s to `FrameProcess`s. The current implentation of
BrowsingContextGroup::ensureProcessForSite doesn&apos;t capture two
scenarios that can arise with empty sites:
1. An empty/about:blank site inherits an origin from a non-empty/about:blank site.
2. An empty/about:blank has it&apos;s own unique, opaque origin which is not tied
   to any specific site.

This patch has two main changes:
1. Updates BrowsingContextGroup to be aware of empty sites
   (i.e. about:blank). BrowsingContextGroup keeps track of
   mappings between sites and processes. However, not all empty sites
   should be mapped to the same process. An about:blank page might inherit an
   origin from whoever initated navigation to about:blank while another
   about:blank might have a unique, opaque origin (i.e. when they have no
   opener or parent).
   After this patch, BrowsingContextGroup will keep track of empty sites:
       a. For empty sites which inherit their origin, BrowsingContextGroup
          will take another argument to represent the effective origin of the
          frame. Then, it will map this effective origin to the frame of the
          empty site.
       b. For empty sites with opaque origins, there is another HashMap in
          BrowsingContextGroup to keep track of the FrameProcesses with opaque
          origins. The key of this HashMap isn&apos;t WebCore::Site since these
          frames don&apos;t have a site or an inherited origin.
2. Updates the navigation logic in WebProcessPool::processForNavigationInternal
   for cases when navigating away from about:blank. Here are the cases:
       a. When navigating from about:blank to a non-about:blank page
          AND the about:blank page has never loaded a non-about:blank page
          AND the navigation takes place in an iframe or different window,
          THEN perform a process swap. This scenario is tested by API Tests:
          SiteIsolation.OpenBeforeInitialLoad,
          SiteIsolation.OpenFromAboutBlankOpenerWithOpaqueOrigin,
          and SiteIsolation.NavigateFrameFromAboutBlankParentWithOpaqueOrigin.
       b. When navigating from about:blank to a non-about:blank page
          AND the about:blank page has never loaded a non-about:blank page
          AND the navigation will replace the original about:blank page,
          THEN reuse the about:blank page&apos;s process. This scenario is tested by
          ProcessSwap.ReuseProcessAfterNavigatingFromAboutPage.

As a result of the BrowsingContextGroup changes, this patch fixes the
SiteIsolation.OpenBeforeInitialLoad test which was previously failing since
the site -&gt; process map had conflicting entries for an empty site and
&quot;<a href="https://webkit.org&quot">https://webkit.org&quot</a>; which both belonged to the same process.

The following tests trigger the scenario where a process swap is needed after
an about:blank with an opaque origin navigates an iframe or separate window:
SiteIsolation.OpenFromAboutBlankOpenerWithOpaqueOrigin and
SiteIsolation.NavigateFrameFromAboutBlankParentWithOpaqueOrigin.

The following tests are the same as the previous ones, except they use an
empty site instead of an explicit &quot;about:blank&quot; to hit different code paths:
SiteIsolation.OpenFromEmptyOpenerWithOpaqueOrigin and
SiteIsolation.NavigateFrameFromEmptyParentWithOpaqueOrigin.

The test SiteIsolation.SameSiteAboutBlankOpenerAndChildIframe tests that an
about:blank page with an opener will have it&apos;s process reused when navigating
an iframe to the same site as the about:blank page&apos;s opener.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::ensureProcessForSite):
(WebKit::BrowsingContextGroup::processForOpaqueOrigin):
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/FrameProcess.cpp:
(WebKit::FrameProcess::FrameProcess):
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::effectiveOrigin const):
(WebKit::FrameProcess::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, OpenBeforeInitialLoad)):
(TestWebKitAPI::(SiteIsolation, OpenFromAboutBlankOpenerWithOpaqueOrigin)):
(TestWebKitAPI::(SiteIsolation, NavigateFrameFromAboutBlankParentWithOpaqueOrigin)):
(TestWebKitAPI::(SiteIsolation, OpenFromEmptyOpenerWithOpaqueOrigin)):
(TestWebKitAPI::(SiteIsolation, NavigateFrameFromEmptyParentWithOpaqueOrigin)):
(TestWebKitAPI::(SiteIsolation, OpenWindowAndNavigateIframeFromAboutBlankWithOpaqueOrigin)):
(TestWebKitAPI::(SiteIsolation, SameSiteAboutBlankOpenerAndChildIframe)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2689aae698be7cc1aa1ad9d6b6566dfbcf38719f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90684 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80267bf8-e26f-4bc0-ba30-7ab4dde77c05) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105337 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86197 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b8a5e21-5bdb-4d77-8acb-9fb937a03121) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5372 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148244 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113730 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9772 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8229 "Found 60 new test failures: fast/events/onunload-not-on-body.html http/tests/contentextensions/cross-origin-content-rules.html http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html http/tests/site-isolation/accessibility/remote-element-returned.html http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/compositing/iframes/iframe-content-flipping.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114070 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7577 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119656 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64446 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9803 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->