### PR TITLE
Incorrect handling of invalid UTF-8 in streaming decoder

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js
@@ -13,14 +13,14 @@ test(() => {
 
 test(() => {
   const decoder = new TextDecoder();
-  decoder.decode(new Uint8Array([0xF0]), { stream: true });
+  assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
   assert_equals(decoder.decode(), "\uFFFD");
 
-  decoder.decode(new Uint8Array([0xF0]), { stream: true });
-  decoder.decode(new Uint8Array([0x9F]), { stream: true });
+  assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
+  assert_equals(decoder.decode(new Uint8Array([0x9F]), { stream: true }), "");
   assert_equals(decoder.decode(), "\uFFFD");
 
-  decoder.decode(new Uint8Array([0xF0, 0x9F]), { stream: true });
+  assert_equals(decoder.decode(new Uint8Array([0xF0, 0x9F]), { stream: true }), "");
   assert_equals(decoder.decode(new Uint8Array([0x92])), "\uFFFD");
 
   assert_equals(decoder.decode(new Uint8Array([0xF0, 0x9F]), { stream: true }), "");
@@ -36,5 +36,23 @@ test(() => {
   assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
   assert_equals(decoder.decode(new Uint8Array([0x8F]), { stream: true }), "\uFFFD\uFFFD");
   assert_equals(decoder.decode(new Uint8Array([0x92]), { stream: true }), "\uFFFD");
+  assert_equals(decoder.decode(), "");
+
+  assert_equals(decoder.decode(new Uint8Array([0xF0, 0xC2, 0x80, 0x2A]), { stream: true }), "\uFFFD\x80*");
+  assert_equals(decoder.decode(), "");
+
+  assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
+  assert_equals(decoder.decode(new Uint8Array([0xC2]), { stream: true }), "\uFFFD");
+  assert_equals(decoder.decode(new Uint8Array([0x80]), { stream: true }), "\x80");
+  assert_equals(decoder.decode(new Uint8Array([0x2A]), { stream: true }), "*");
+  assert_equals(decoder.decode(), "");
+
+  assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
+  assert_equals(decoder.decode(new Uint8Array([0xC2]), { stream: true }), "\uFFFD");
+  assert_equals(decoder.decode(new Uint8Array([0x80, 0x2A]), { stream: true }), "\x80*");
+  assert_equals(decoder.decode(), "");
+
+  assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
+  assert_equals(decoder.decode(new Uint8Array([0xC2, 0x80, 0x2A]), { stream: true }), "\uFFFD\x80*");
   assert_equals(decoder.decode(), "");
 }, "TextDecoder end-of-queue handling using stream: true");

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -294,6 +294,7 @@ void TextCodecUTF8::handlePartialSequence(std::span<char16_t>& destination, std:
         }
 
         m_partialSequenceSize -= count;
+        memmoveSpan(std::span { m_partialSequence }, std::span { m_partialSequence }.subspan(count, m_partialSequenceSize));
         if (std::exchange(m_shouldStripByteOrderMark, false) && character == byteOrderMark)
             continue;
         destination = appendCharacter(destination, character);


### PR DESCRIPTION
#### ab37a057cd386226d8abfd2f33640ecd6e694ca8
<pre>
Incorrect handling of invalid UTF-8 in streaming decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=304181">https://bugs.webkit.org/show_bug.cgi?id=304181</a>
<a href="https://rdar.apple.com/166583808">rdar://166583808</a>

Reviewed by Alex Christensen.

* LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js:
Tightened the tests a little and added a test case that runs into this bug,
basically the one in the report.

* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::handlePartialSequence):
Added missing code to move the characters left in the partial sequence buffer
after handling a valid sequence from the buffer.

Canonical link: <a href="https://commits.webkit.org/304496@main">https://commits.webkit.org/304496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6249550702e681fe21845c409e38fee9e62a1563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143465 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ed6615b-fb87-4bad-b995-b396ef96af4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8dcf5e95-0171-4624-93ac-0f31d20a5b33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84618 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2cffedf7-317c-4271-8845-9832bd575818) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4071 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146214 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5953 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117968 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7862 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7694 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->