### PR TITLE
Elements should avoid floats even if they are as high as LayoutUnit::max()

### DIFF
--- a/LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max-expected.txt
+++ b/LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max-expected.txt
@@ -1,0 +1,3 @@
+Elements should avoid floats even if they are as high as LayoutUnit::max()
+a
+PASS

--- a/LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max.html
+++ b/LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style> #float { float:left; height: 33554431px; width: 83866px; }</style>
+<script src="../../../resources/check-layout.js"></script>
+<body onload="checkLayout('#table')">
+Elements should avoid floats even if they are as high as LayoutUnit::max()
+<div id="float"> </div>
+<table data-offset-y=33554431 id="table">
+<td>a</td>
+</table>
+</body>


### PR DESCRIPTION
#### 5b60e9ccada1598a1647fbd461bcb93793699883
<pre>
Elements should avoid floats even if they are as high as LayoutUnit::max()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265098">https://bugs.webkit.org/show_bug.cgi?id=265098</a>
<a href="https://rdar.apple.com/problem/118795348">rdar://problem/118795348</a>

Reviewed by Alan Baradlay.

Merge (Test): <a href="https://chromium.googlesource.com/chromium/blink/+/af76e7423374640fa2aa5e5c550709e9a7fd39c4">https://chromium.googlesource.com/chromium/blink/+/af76e7423374640fa2aa5e5c550709e9a7fd39c4</a>

This patch just syncs test because we use to fail it earlier and now passes,
in order to avoid future regression, it would be good to sync test.

* LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max-expected.txt:
* LayoutTests/fast/block/float/logical-bottom-exceeds-layoutunit-max.html:

Canonical link: <a href="https://commits.webkit.org/304586@main">https://commits.webkit.org/304586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933c14cae0d9d21282d02588c3b4c04204d3a374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87386 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9ca255e-4850-4316-8cac-e76f17d53e73) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103746 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a996910-7db1-4767-a022-c63ed8353ee9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84622 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c4d18d10-f0e1-4a22-8246-6bdd4da6502c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6085 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3702 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4074 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146217 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112105 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5956 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61752 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36085 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->