### PR TITLE
WebView willStartRenderingUpdateDisplay crashes when _private->page is null

### DIFF
--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8794,12 +8794,11 @@ FORWARD(toggleUnderline)
 
 - (void)_willStartRenderingUpdateDisplay
 {
-    if (_private->page) {
 #if PLATFORM(IOS_FAMILY)
-        WebThreadLock();
+    WebThreadLock();
 #endif
-        _private->page->willStartRenderingUpdateDisplay();
-    }
+    if (RefPtr page = _private->page.get())
+        page->willStartRenderingUpdateDisplay();
 }
 
 - (void)_didCompleteRenderingUpdateDisplay


### PR DESCRIPTION
#### 41c6f81fa8535bc20d99a6e520683d1ae4961c8a
<pre>
WebView willStartRenderingUpdateDisplay crashes when _private-&gt;page is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=302069">https://bugs.webkit.org/show_bug.cgi?id=302069</a>
<a href="https://rdar.apple.com/164022564">rdar://164022564</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

In the function WebView::_willStartRenderingUpdateDisplay (in WebkitLegacy), the page can become null between when it is originally null-checked  if (_private-&gt;page)  and when willStartRenderingUpdateDisplay starts executing. This is due to an increased delay from WebThreadLock();

We should move WebThreadLock() before page-&gt;willStartRenderingUpdateDisplay starts executing so that the page cannot be manipulated by the WebThread before page-&gt;willStartRenderingUpdateDisplay runs.

* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _willStartRenderingUpdateDisplay]):

Originally-landed-as: cfc6df9eb93c. <a href="https://rdar.apple.com/166335789">rdar://166335789</a>
Canonical link: <a href="https://commits.webkit.org/304517@main">https://commits.webkit.org/304517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/264eddd83c47e7ef3e5123cd93c3304321c0b9cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc273c9e-fb98-43a5-99ad-a02546be7a39) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103748 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ad72580c-661d-4c0d-a102-923b0e02dbbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/36cf1efc-f68a-4206-9522-c39a4f6f19ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3703 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4078 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146221 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112108 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112489 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5959 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117980 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61754 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7869 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7699 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->