### PR TITLE
[text-wrap][pretty] Fix index type mismatch in layoutSingleLineForPretty().

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-long-span-crash-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-long-span-crash-expected.txt
@@ -1,0 +1,1 @@
+just some long long long long long long long long longlong long long long long long textAAAAAAAAAAAAAAAAAAAA This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-long-span-crash.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-long-span-crash.html
@@ -1,0 +1,19 @@
+<style>
+div {
+  letter-spacing: 1em;
+  text-wrap: pretty;
+}
+html, div {
+  margin-right: 10000px;
+  display: table-header-group;
+}
+*:last-child {
+  font-family: system-ui;
+}
+</style>
+<script>
+   if (window.testRunner)
+       testRunner.dumpAsText();
+</script>
+<div contenteditable="true"><span>just some long long long long long long long long longlong long long long long long text</span>AAAAAAAAAAAAAAAAAAAA</div>
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash-expected.txt
@@ -1,0 +1,1 @@
+#x13 { letter-spacing: 1em; text-wrap: pretty;direction: ltr;} *:first-child, style {margin-right: 999px; display: table-header-group;box-align: baseline;} *:last-child { font-family: system-ui;} A { Awebkit-align-self: AAAA;tab-size: 1em;-webkit-line-clamp: 16;-webkit-hyphenate-character: auto } AAAAAAAAAAAAAAAAAAAA This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash.html
@@ -1,0 +1,18 @@
+<style>
+   #x13 { letter-spacing: 1em; text-wrap: pretty;direction: ltr;}
+   *:first-child, style {margin-right: 999px; display: table-header-group;box-align: baseline;}
+   *:last-child { font-family: system-ui;}
+</style>
+<script>
+   function main() {
+   try { x21.appendChild(document.createTextNode("A { Awebkit-align-self: AAAA;tab-size: 1em;-webkit-line-clamp: 16;-webkit-hyphenate-character: auto }")); } catch (e) { }
+   }
+   if (window.testRunner)
+       testRunner.dumpAsText();
+</script>
+<body onload="main()">
+   <summary id="x13" contenteditable="true">
+   <style id="x21"></style>
+AAAAAAAAAAAAAAAAAAAA
+</body>
+This test passes if it doesn't crash.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -637,7 +637,7 @@ std::optional<Vector<LayoutUnit>> InlineContentConstrainer::prettifyRange(Inline
                 return { };
             }
 
-            auto newEntry = layoutSingleLineForPretty({ breakOpportunities[lastValidStateIndex.value()], range.endIndex() }, idealLineWidth, state[lastValidStateIndex.value()], lastValidStateIndex.value());
+            auto newEntry = layoutSingleLineForPretty({ breakOpportunities[state[lastValidStateIndex.value()].lineEnd.index], range.endIndex() }, idealLineWidth, state[lastValidStateIndex.value()], lastValidStateIndex.value());
             auto it = std::ranges::find(breakOpportunities, newEntry.lineEnd.index);
             // If hyphenation does not create a valid solution, we should return early.
             if (it == breakOpportunities.end())


### PR DESCRIPTION
#### e22d30daa17dd7f641022161136e3341a6560ca3
<pre>
[text-wrap][pretty] Fix index type mismatch in layoutSingleLineForPretty().

&lt;<a href="https://rdar.apple.com/162028337">rdar://162028337</a>&gt;

Reviewed by Alan Baradlay.

This PR fixes a crash caused by passing a break opportunity index instead of an inline item index to
layoutSingleLineForPretty(). This fix looks up the inline item index from the break opportunity index to
pass in the correct arguments to layoutSingleLineForPretty().

Combined changes:
Test: fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash.html
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash-expected.txt: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-style-element-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::prettifyRange):

Originally-landed-as: 301765.101@safari-7623-branch (86ed16e14826). <a href="https://rdar.apple.com/166338560">rdar://166338560</a>
Canonical link: <a href="https://commits.webkit.org/304506@main">https://commits.webkit.org/304506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26028fa2e799d181f1e288a23881dd5a25b7419c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7925acf3-6ae8-492e-93f4-e0ca19e4cf11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103749 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88e16166-12c9-4243-8039-b7df1a7d31b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dafc7e28-f7e2-44bd-91d4-81c5783845b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3704 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4079 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146222 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5957 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61755 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7870 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36088 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71419 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->