### PR TITLE
[Smart Lists] Creating an ordered decimal list beginning with a large number causes the WebProcess to crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -342,6 +342,17 @@ TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)
     runTest(@"+42. Hello", expectedPlusPrefixedHTML.createNSString().get(), @"//body/text()", @"+42. Hello".length);
 }
 
+TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body>1000000000000000. hi</body>
+    )"""_s;
+
+    NSString *input = @"1000000000000000. hi";
+
+    runTest(input, expectedHTML.createNSString().get(), @"//body/text()", input.length);
+}
+
 // FIXME: rdar://163664100 ([ iOS26 iPhone ] 2X TestWebKitAPI.SmartLists (API-Tests) are constant failures (301651))
 #if PLATFORM(IOS)
 TEST(SmartLists, DISABLED_InsertingListMergesWithPreviousListIfPossible)


### PR DESCRIPTION
#### ea29af73c09a74960431c3dc304465e8dd34536a
<pre>
[Smart Lists] Creating an ordered decimal list beginning with a large number causes the WebProcess to crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=304229">https://bugs.webkit.org/show_bug.cgi?id=304229</a>
<a href="https://rdar.apple.com/166264813">rdar://166264813</a>

Reviewed by Richard Robinson.

`consumeNumber` in `TextListParser` now returns an optional int, and
checks if an overflow occurred during the calculation of its value. If
an overflow occurred, return `std::nullopt`. When `consumeNumber` is
called from `tryConsumeOrderedDecimalTextList`, check if a value exists
before continuing, otherwise skip to the end of the buffer and return
`std::nullopt`.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm

* Source/WebCore/editing/TextListParser.cpp:
(WebCore::consumeNumber):
(WebCore::tryConsumeOrderedDecimalTextList):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
((SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)):

Canonical link: <a href="https://commits.webkit.org/304531@main">https://commits.webkit.org/304531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a3710fa91bbd3cf53a96c286ce85d08362ff6b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87398 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103758 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2021886-cf4b-4e76-a612-01893a162d50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84636 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1b54316-a7cc-4fe7-ace2-742890765cd1) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3714 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4093 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146236 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112119 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5970 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7883 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36099 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->