### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PlatformGamepad

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -83,7 +83,8 @@ void GamepadManager::platformGamepadConnected(PlatformGamepad& platformGamepad, 
         return;
 
     // Notify blind Navigators and Windows about all gamepads except for this one.
-    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
+    for (auto& weakGamepad : GamepadProvider::singleton().platformGamepads()) {
+        CheckedPtr gamepad = weakGamepad.get();
         if (!gamepad || gamepad == &platformGamepad)
             continue;
 
@@ -152,8 +153,8 @@ void GamepadManager::platformGamepadInputActivity(EventMakesGamepadsVisible even
     if (m_gamepadBlindNavigators.isEmptyIgnoringNullReferences() && m_gamepadBlindDOMWindows.isEmptyIgnoringNullReferences())
         return;
 
-    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
-        if (gamepad)
+    for (auto& weakGamepad : GamepadProvider::singleton().platformGamepads()) {
+        if (CheckedPtr gamepad = weakGamepad.get())
             makeGamepadVisible(*gamepad, m_gamepadBlindNavigators, m_gamepadBlindDOMWindows);
     }
 

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -133,12 +133,13 @@ const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
 
     auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
 
-    for (unsigned i = 0; i < platformGamepads.size(); ++i) {
-        if (!platformGamepads[i]) {
+    for (size_t i = 0; i < platformGamepads.size(); ++i) {
+        CheckedPtr gamepad = platformGamepads[i].get();
+        if (!gamepad) {
             ASSERT(!m_gamepads[i]);
             continue;
         }
-        Ref { *m_gamepads[i] }->updateFromPlatformGamepad(*platformGamepads[i]);
+        Ref { *m_gamepads[i] }->updateFromPlatformGamepad(*gamepad);
     }
 
     return m_gamepads;
@@ -149,11 +150,9 @@ void NavigatorGamepad::gamepadsBecameVisible()
     auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
     m_gamepads.resize(platformGamepads.size());
 
-    for (unsigned i = 0; i < platformGamepads.size(); ++i) {
-        if (!platformGamepads[i])
-            continue;
-
-        m_gamepads[i] = Gamepad::create(m_navigator->protectedDocument().get(), *platformGamepads[i]);
+    for (size_t i = 0; i < platformGamepads.size(); ++i) {
+        if (CheckedPtr gamepad = platformGamepads[i].get())
+            m_gamepads[i] = Gamepad::create(m_navigator->protectedDocument().get(), *gamepad);
     }
 }
 

--- a/Source/WebCore/Modules/webxr/WebXRGamepad.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRGamepad.cpp
@@ -31,8 +31,11 @@
 #include "Gamepad.h"
 #include "GamepadConstants.h"
 #include "XRTargetRayMode.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRGamepad);
 
 // https://immersive-web.github.io/webxr-gamepads-module/#gamepad-differences
 // Gamepad's index attribute must be -1.

--- a/Source/WebCore/Modules/webxr/WebXRGamepad.h
+++ b/Source/WebCore/Modules/webxr/WebXRGamepad.h
@@ -29,11 +29,14 @@
 
 #include "PlatformGamepad.h"
 #include "PlatformXR.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-class WebXRGamepad: public PlatformGamepad {
+class WebXRGamepad final : public PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(WebXRGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebXRGamepad);
 public:
     WebXRGamepad(double timestamp, double connectTime, const PlatformXR::FrameData::InputSource&);
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -52,7 +52,7 @@ WebXRInputSource::WebXRInputSource(Document& document, WebXRSession& session, do
     , m_targetRaySpace(WebXRInputSpace::create(document, session, source.pointerOrigin, source.handle))
     , m_connectTime(timestamp)
 #if ENABLE(GAMEPAD)
-    , m_gamepad(Gamepad::create(&document, WebXRGamepad(timestamp, timestamp, source)))
+    , m_gamepad(Gamepad::create(&document, makeUniqueRef<WebXRGamepad>(timestamp, timestamp, source)))
 #endif
 {
     update(timestamp, source);
@@ -84,7 +84,7 @@ void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::Inp
     } else
         m_gripSpace = nullptr;
 #if ENABLE(GAMEPAD)
-    m_gamepad->updateFromPlatformGamepad(WebXRGamepad(timestamp, m_connectTime, source));
+    m_gamepad->updateFromPlatformGamepad(makeUniqueRef<WebXRGamepad>(timestamp, m_connectTime, source));
 #endif
 
 #if ENABLE(WEBXR_HANDS)

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
@@ -39,20 +40,12 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class PlatformGamepad;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PlatformGamepad> : std::true_type { };
-}
-
-namespace WebCore {
 
 struct GamepadEffectParameters;
 
-class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad> {
+class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad>, public CanMakeCheckedPtr<PlatformGamepad> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformGamepad);
 public:
     virtual ~PlatformGamepad() = default;
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -30,6 +30,7 @@
 #include "GameControllerHapticEngines.h"
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS GCController;
 OBJC_CLASS GCControllerAxisInput;
@@ -40,8 +41,10 @@ namespace WebCore {
 
 class GameControllerHapticEngines;
 
-class GameControllerGamepad : public PlatformGamepad {
+class GameControllerGamepad final : public PlatformGamepad {
     WTF_MAKE_NONCOPYABLE(GameControllerGamepad);
+    WTF_MAKE_TZONE_ALLOCATED(GameControllerGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GameControllerGamepad);
 public:
     GameControllerGamepad(GCController *, unsigned index);
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -29,13 +29,17 @@
 #if ENABLE(GAMEPAD)
 #import "GameControllerGamepadProvider.h"
 #import "GameControllerHapticEngines.h"
-#import "GameControllerSoftLink.h"
 #import "GamepadConstants.h"
 #import <GameController/GCControllerElement.h>
 #import <GameController/GameController.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
 
+#import "GameControllerSoftLink.h"
+
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GameControllerGamepad);
 
 GameControllerGamepad::GameControllerGamepad(GCController *controller, unsigned index)
     : PlatformGamepad(index)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -32,8 +32,11 @@
 #if WPE_CHECK_VERSION(1, 13, 90)
 
 #include "GamepadProviderLibWPE.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GamepadLibWPE);
 
 GamepadLibWPE::GamepadLibWPE(struct wpe_gamepad_provider* provider, uintptr_t gamepadId, unsigned index)
     : PlatformGamepad(index)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
@@ -30,12 +30,15 @@
 
 #include "PlatformGamepad.h"
 #include <wpe/wpe.h>
+#include <wtf/TZoneMalloc.h>
 
 #if WPE_CHECK_VERSION(1, 13, 90)
 
 namespace WebCore {
 
 class GamepadLibWPE final : public PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(GamepadLibWPE);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GamepadLibWPE);
 public:
     GamepadLibWPE(struct wpe_gamepad_provider*, uintptr_t, unsigned);
     virtual ~GamepadLibWPE();

--- a/Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class Dualshock3HIDGamepad final : public HIDGamepad {
     WTF_MAKE_TZONE_ALLOCATED(Dualshock3HIDGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Dualshock3HIDGamepad);
 public:
     Dualshock3HIDGamepad(HIDDevice&&, unsigned index);
 };

--- a/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp
@@ -31,8 +31,11 @@
 #include "Logging.h"
 #include <IOKit/hid/IOHIDUsageTables.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GenericHIDGamepad);
 
 GenericHIDGamepad::GenericHIDGamepad(HIDDevice&& device, unsigned index)
     : HIDGamepad(WTFMove(device), index)

--- a/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.h
@@ -28,10 +28,13 @@
 #if ENABLE(GAMEPAD) && PLATFORM(MAC)
 
 #include "HIDGamepad.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class GenericHIDGamepad final : public HIDGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(GenericHIDGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GenericHIDGamepad);
 public:
     GenericHIDGamepad(HIDDevice&&, unsigned index);
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepad.cpp
@@ -38,11 +38,14 @@
 #include <IOKit/hid/IOHIDUsageTables.h>
 #include <IOKit/hid/IOHIDValue.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HIDGamepad);
 
 std::unique_ptr<HIDGamepad> HIDGamepad::create(IOHIDDeviceRef rawDevice, unsigned index)
 {

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
@@ -33,10 +33,13 @@
 #include <WebCore/HIDGamepadElement.h>
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class HIDGamepad : public PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(HIDGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HIDGamepad);
 public:
     static std::unique_ptr<HIDGamepad> create(IOHIDDeviceRef, unsigned index);
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -257,8 +257,9 @@ void HIDGamepadProvider::deviceAdded(IOHIDDeviceRef device)
     }
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
+    CheckedRef gamepadRef = *m_gamepadVector[index];
     for (Ref client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client->platformGamepadConnected(gamepadRef, eventVisibility);
 
     // If we are working together with the GameController provider, let it know
     // that gamepads should now be visible.
@@ -290,7 +291,7 @@ void HIDGamepadProvider::valuesChanged(IOHIDValueRef value)
     RetainPtr element = IOHIDValueGetElement(value);
     RetainPtr device = IOHIDElementGetDevice(element.get());
 
-    HIDGamepad* gamepad = m_gamepadMap.get(device.get());
+    CheckedPtr gamepad = m_gamepadMap.get(device.get());
 
     // When starting monitoring we might get a value changed callback before we even know the device is connected.
     if (!gamepad)

--- a/Source/WebCore/platform/gamepad/mac/LogitechGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/LogitechGamepad.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class LogitechGamepad final : public HIDGamepad {
     WTF_MAKE_TZONE_ALLOCATED(LogitechGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LogitechGamepad);
 public:
     LogitechGamepad(HIDDevice&&, unsigned index);
 };

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -32,6 +32,7 @@
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -73,7 +74,9 @@ private:
     // We create our own Gamepad type - to wrap both HID and GameController gamepads -
     // because MultiGamepadProvider needs to manage the indexes of its own gamepads
     // no matter what the HID or GameController index is.
-    class PlatformGamepadWrapper : public PlatformGamepad {
+    class PlatformGamepadWrapper final : public PlatformGamepad {
+        WTF_MAKE_TZONE_ALLOCATED(PlatformGamepadWrapper);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformGamepadWrapper);
     public:
         PlatformGamepadWrapper(unsigned index, PlatformGamepad* wrapped)
             : PlatformGamepad(index)
@@ -84,13 +87,15 @@ private:
             m_connectTime = wrapped->connectTime();
         }
 
-        MonotonicTime lastUpdateTime() const final { return m_platformGamepad->lastUpdateTime(); }
-        const Vector<SharedGamepadValue>& axisValues() const final { return m_platformGamepad->axisValues(); }
-        const Vector<SharedGamepadValue>& buttonValues() const final { return m_platformGamepad->buttonValues(); }
+        MonotonicTime lastUpdateTime() const final { return checkedPlatformGamepad()->lastUpdateTime(); }
+        const Vector<SharedGamepadValue>& axisValues() const final { return checkedPlatformGamepad()->axisValues(); }
+        const Vector<SharedGamepadValue>& buttonValues() const final { return checkedPlatformGamepad()->buttonValues(); }
 
-        ASCIILiteral source() const final { return m_platformGamepad->source(); }
+        ASCIILiteral source() const final { return checkedPlatformGamepad()->source(); }
 
     private:
+        CheckedRef<PlatformGamepad> checkedPlatformGamepad() const { return *m_platformGamepad; }
+
         WeakPtr<PlatformGamepad> m_platformGamepad;
     };
 

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -33,8 +33,11 @@
 #import "Logging.h"
 #import "PlatformGamepad.h"
 #import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MultiGamepadProvider::PlatformGamepadWrapper);
 
 static size_t numberOfGamepadProviders = 2;
 
@@ -114,8 +117,9 @@ void MultiGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Ev
     ASSERT(addResult.isNewEntry);
     m_gamepadVector[index] = addResult.iterator->value.get();
 
+    CheckedRef gamepadRef = *m_gamepadVector[index];
     for (Ref client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client->platformGamepadConnected(gamepadRef, eventVisibility);
 }
 
 void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)

--- a/Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class StadiaHIDGamepad final : public HIDGamepad {
     WTF_MAKE_TZONE_ALLOCATED(StadiaHIDGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StadiaHIDGamepad);
 public:
     StadiaHIDGamepad(HIDDevice&&, unsigned index);
 };

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -31,9 +31,12 @@
 #include "ManetteGamepadProvider.h"
 #include <linux/input-event-codes.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ManetteGamepad);
 
 static constexpr size_t standardGamepadAxisCount = static_cast<size_t>(ManetteGamepad::StandardGamepadAxis::RightStickY) + 1;
 static constexpr size_t standardGamepadButtonCount = static_cast<size_t>(ManetteGamepad::StandardGamepadButton::Mode) + 1;

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -31,11 +31,14 @@
 
 #include <libmanette.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 
 namespace WebCore {
 
 class ManetteGamepad final : public PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(ManetteGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ManetteGamepad);
 public:
     // Refer https://www.w3.org/TR/gamepad/#gamepadbutton-interface
     enum class StandardGamepadAxis : int8_t {

--- a/Source/WebCore/testing/MockGamepad.cpp
+++ b/Source/WebCore/testing/MockGamepad.cpp
@@ -27,8 +27,11 @@
 #include "MockGamepad.h"
 
 #if ENABLE(GAMEPAD)
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockGamepad);
 
 MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
     : PlatformGamepad(index)

--- a/Source/WebCore/testing/MockGamepad.h
+++ b/Source/WebCore/testing/MockGamepad.h
@@ -28,10 +28,13 @@
 #if ENABLE(GAMEPAD)
 
 #include <WebCore/PlatformGamepad.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-class MockGamepad : public PlatformGamepad {
+class MockGamepad final : public PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(MockGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MockGamepad);
 public:
     MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -152,10 +152,11 @@ void UIGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible e
 
     auto end = std::min(m_gamepads.size(), platformGamepads.size());
     for (size_t i = 0; i < end; ++i) {
-        if (!m_gamepads[i] || !platformGamepads[i])
+        CheckedPtr platformGamepad = platformGamepads[i].get();
+        if (!m_gamepads[i] || !platformGamepad)
             continue;
 
-        m_gamepads[i]->updateFromPlatformGamepad(*platformGamepads[i]);
+        m_gamepads[i]->updateFromPlatformGamepad(*platformGamepad);
     }
 
     if (eventVisibility == EventMakesGamepadsVisible::Yes)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -30,9 +30,12 @@
 
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <wpe/wpe-platform.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformGamepadWPE);
 
 PlatformGamepadWPE::PlatformGamepadWPE(WPEGamepad* gamepad, unsigned index)
     : PlatformGamepad(index)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <WebCore/PlatformGamepad.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _WPEGamepad WPEGamepad;
@@ -34,6 +35,8 @@ typedef struct _WPEGamepad WPEGamepad;
 namespace WebKit {
 
 class PlatformGamepadWPE final : public WebCore::PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(PlatformGamepadWPE);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformGamepadWPE);
 public:
     PlatformGamepadWPE(WPEGamepad*, unsigned index);
     virtual ~PlatformGamepadWPE();

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
@@ -30,10 +30,13 @@
 
 #include "GamepadData.h"
 #include "Logging.h"
+#include <wtf/TZoneMallocInlines.h>
 
 using WebCore::SharedGamepadValue;
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGamepad);
 
 WebGamepad::WebGamepad(const GamepadData& gamepadData)
     : PlatformGamepad(gamepadData.index())

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.h
@@ -28,12 +28,15 @@
 #if ENABLE(GAMEPAD)
 
 #include <WebCore/PlatformGamepad.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class GamepadData;
 
-class WebGamepad : public WebCore::PlatformGamepad {
+class WebGamepad final : public WebCore::PlatformGamepad {
+    WTF_MAKE_TZONE_ALLOCATED(WebGamepad);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebGamepad);
 public:
     WebGamepad(const GamepadData&);
 

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -86,8 +86,9 @@ void WebGamepadProvider::gamepadConnected(const GamepadData& gamepadData, EventM
     m_gamepads[gamepadData.index()] = makeUnique<WebGamepad>(gamepadData);
     m_rawGamepads[gamepadData.index()] = m_gamepads[gamepadData.index()].get();
 
+    CheckedRef gamepadRef = *m_gamepads[gamepadData.index()];
     for (Ref client : m_clients)
-        client->platformGamepadConnected(*m_gamepads[gamepadData.index()], eventVisibility);
+        client->platformGamepadConnected(gamepadRef, eventVisibility);
 }
 
 void WebGamepadProvider::gamepadDisconnected(unsigned index)
@@ -110,8 +111,8 @@ void WebGamepadProvider::gamepadActivity(const Vector<std::optional<GamepadData>
     ASSERT(m_gamepads.size() == gamepadDatas.size());
 
     for (size_t i = 0; i < m_gamepads.size(); ++i) {
-        if (m_gamepads[i] && gamepadDatas[i])
-            m_gamepads[i]->updateValues(*gamepadDatas[i]);
+        if (CheckedPtr gamepad = m_gamepads[i].get(); gamepad && gamepadDatas[i])
+            gamepad->updateValues(*gamepadDatas[i]);
     }
 
     for (Ref client : m_clients)


### PR DESCRIPTION
#### 37b3abb46e9257cb5c087723e7b435f272deb483
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PlatformGamepad
<a href="https://bugs.webkit.org/show_bug.cgi?id=304230">https://bugs.webkit.org/show_bug.cgi?id=304230</a>

Reviewed by Darin Adler and Adrian Perez de Castro.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadConnected):
(WebCore::GamepadManager::platformGamepadInputActivity):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::gamepads):
(WebCore::NavigatorGamepad::gamepadsBecameVisible):
* Source/WebCore/Modules/webxr/WebXRGamepad.cpp:
* Source/WebCore/Modules/webxr/WebXRGamepad.h:
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::WebXRInputSource):
(WebCore::WebXRInputSource::update):
* Source/WebCore/platform/gamepad/PlatformGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
(WebCore::GameControllerGamepad::ensureProtectedHapticEngines): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::controllerDidConnect):
(WebCore::GameControllerGamepadProvider::controllerDidDisconnect):
(WebCore::GameControllerGamepadProvider::makeInvisibleGamepadsVisible):
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp:
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h:
* Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.h:
* Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp:
* Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepad.cpp:
* Source/WebCore/platform/gamepad/mac/HIDGamepad.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::HIDGamepadProvider::deviceAdded):
(WebCore::HIDGamepadProvider::valuesChanged):
* Source/WebCore/platform/gamepad/mac/LogitechGamepad.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
(WebCore::MultiGamepadProvider::PlatformGamepadWrapper::PlatformGamepadWrapper): Deleted.
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::platformGamepadConnected):
* Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
* Source/WebCore/testing/MockGamepad.cpp:
* Source/WebCore/testing/MockGamepad.h:
(WebCore::MockGamepad::wasConnected): Deleted.
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::setMockGamepadDetails):
(WebCore::MockGamepadProvider::connectMockGamepad):
(WebCore::MockGamepadProvider::disconnectMockGamepad):
(WebCore::MockGamepadProvider::setMockGamepadAxisValue):
(WebCore::MockGamepadProvider::setMockGamepadButtonValue):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::platformGamepadInputActivity):
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h:
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
* Source/WebKit/WebProcess/Gamepad/WebGamepad.h:
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::gamepadConnected):
(WebKit::WebGamepadProvider::gamepadActivity):

Canonical link: <a href="https://commits.webkit.org/304574@main">https://commits.webkit.org/304574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8492ca11f09c56e9b4af5c743af39568bf886e96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9fbe508-1c6e-43c0-8742-0968eb79cbfb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138963 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4318 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8053 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40646 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8071 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112688 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28589 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/6144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118188 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8102 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7821 "Failed to checkout and rebase branch from PR 55461") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71659 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/8042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->