### PR TITLE
[WebXR Hit Test][OpenXR] Support XR_TRACKABLE_TYPE_DEPTH_ANDROID

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
@@ -97,12 +97,15 @@ bool OpenXRExtensions::loadMethods(XrInstance instance)
 #if defined(XR_ANDROID_trackables)
     if (isExtensionSupported(XR_ANDROID_TRACKABLES_EXTENSION_NAME ""_span)) {
         xrGetInstanceProcAddr(instance, "xrCreateTrackableTrackerANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrCreateTrackableTrackerANDROID));
+        xrGetInstanceProcAddr(instance, "xrDestroyTrackableTrackerANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrDestroyTrackableTrackerANDROID));
         RELEASE_ASSERT(m_methods->xrCreateTrackableTrackerANDROID);
+        RELEASE_ASSERT(m_methods->xrDestroyTrackableTrackerANDROID);
     }
 #endif
 #if defined(XR_ANDROID_raycast)
     if (isExtensionSupported(XR_ANDROID_RAYCAST_EXTENSION_NAME ""_span)) {
         xrGetInstanceProcAddr(instance, "xrRaycastANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrRaycastANDROID));
+        xrGetInstanceProcAddr(instance, "xrEnumerateRaycastSupportedTrackableTypesANDROID", reinterpret_cast<PFN_xrVoidFunction*>(&m_methods->xrEnumerateRaycastSupportedTrackableTypesANDROID));
         RELEASE_ASSERT(m_methods->xrRaycastANDROID);
     }
 #endif

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -59,9 +59,11 @@ public:
 #endif
 #if defined(XR_ANDROID_trackables)
     PFN_xrCreateTrackableTrackerANDROID xrCreateTrackableTrackerANDROID { nullptr };
+    PFN_xrDestroyTrackableTrackerANDROID xrDestroyTrackableTrackerANDROID { nullptr };
 #endif
 #if defined(XR_ANDROID_raycast)
     PFN_xrRaycastANDROID xrRaycastANDROID { nullptr };
+    PFN_xrEnumerateRaycastSupportedTrackableTypesANDROID xrEnumerateRaycastSupportedTrackableTypesANDROID { nullptr };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
@@ -32,14 +32,15 @@ class OpenXRHitTestManager {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRHitTestManager);
     WTF_MAKE_NONCOPYABLE(OpenXRHitTestManager);
 public:
-    static std::unique_ptr<OpenXRHitTestManager> create(XrSession);
-    OpenXRHitTestManager(XrSession);
+    static std::unique_ptr<OpenXRHitTestManager> create(XrInstance, XrSystemId, XrSession);
+    OpenXRHitTestManager(XrInstance, XrSystemId, XrSession);
+    ~OpenXRHitTestManager();
     Vector<PlatformXR::FrameData::HitTestResult> requestHitTest(const PlatformXR::Ray&, XrSpace, XrTime);
 
 private:
     XrSession m_session { XR_NULL_HANDLE };
 #if defined(XR_ANDROID_trackables)
-    XrTrackableTrackerANDROID m_trackableTracker { XR_NULL_HANDLE };
+    Vector<XrTrackableTrackerANDROID> m_trackableTrackers;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -400,7 +400,7 @@ void OpenXRCoordinator::requestHitTestSource(WebPageProxy& page, const PlatformX
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTFMove(copiedOptions), completionHandler = WTFMove(completionHandler)]() mutable {
 #if ENABLE(WEBXR_HIT_TEST)
                 if (!renderState->hitTestManager)
-                    renderState->hitTestManager = OpenXRHitTestManager::create(m_session);
+                    renderState->hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
 #endif
                 auto addResult = renderState->hitTestSources.add(renderState->nextHitTestSource, WTFMove(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
@@ -459,7 +459,7 @@ void OpenXRCoordinator::requestTransientInputHitTestSource(WebPageProxy& page, c
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTFMove(copiedOptions), completionHandler = WTFMove(completionHandler)]() mutable {
 #if ENABLE(WEBXR_HIT_TEST)
                 if (!renderState->hitTestManager)
-                    renderState->hitTestManager = OpenXRHitTestManager::create(m_session);
+                    renderState->hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
 #endif
                 auto addResult = renderState->transientInputHitTestSources.add(renderState->nextTransientInputHitTestSource, WTFMove(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);


### PR DESCRIPTION
#### 6ebd87afdc61d6f470541a2eb4f66feabab879ec
<pre>
[WebXR Hit Test][OpenXR] Support XR_TRACKABLE_TYPE_DEPTH_ANDROID
<a href="https://bugs.webkit.org/show_bug.cgi?id=304233">https://bugs.webkit.org/show_bug.cgi?id=304233</a>

Reviewed by Sergio Villar Senin.

It supported only XR_TRACKABLE_TYPE_PLANE_ANDROID. Support
XR_TRACKABLE_TYPE_DEPTH_ANDROID too. Use
xrEnumerateRaycastSupportedTrackableTypesANDROID to enumerate supported types.

Additionally, use xrDestroyTrackableTrackerANDROID to destroy tracker trakers.

* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp:
(WebKit::OpenXRExtensions::loadMethods):
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
(WebKit::OpenXRHitTestManager::create):
(WebKit::OpenXRHitTestManager::OpenXRHitTestManager):
(WebKit::OpenXRHitTestManager::~OpenXRHitTestManager):
(WebKit::OpenXRHitTestManager::requestHitTest):
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):

Canonical link: <a href="https://commits.webkit.org/304631@main">https://commits.webkit.org/304631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/683c1096945c3e74199f0eb0fe7b231504619df6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143769 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121932 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84862 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3928 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115557 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112360 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6809 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112731 "Found 36 new API test failures: WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/iterator, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6194 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118232 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8152 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36295 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71711 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->