### PR TITLE
[Resource Timing] Add finalResponseHeadersStart and firstInterimResponseStart attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt
@@ -23,8 +23,8 @@ PASS PerformanceResourceTiming interface: attribute connectStart
 PASS PerformanceResourceTiming interface: attribute connectEnd
 PASS PerformanceResourceTiming interface: attribute secureConnectionStart
 PASS PerformanceResourceTiming interface: attribute requestStart
-FAIL PerformanceResourceTiming interface: attribute finalResponseHeadersStart assert_true: The prototype object must have a property "finalResponseHeadersStart" expected true got false
-FAIL PerformanceResourceTiming interface: attribute firstInterimResponseStart assert_true: The prototype object must have a property "firstInterimResponseStart" expected true got false
+PASS PerformanceResourceTiming interface: attribute finalResponseHeadersStart
+PASS PerformanceResourceTiming interface: attribute firstInterimResponseStart
 PASS PerformanceResourceTiming interface: attribute responseStart
 PASS PerformanceResourceTiming interface: attribute responseEnd
 PASS PerformanceResourceTiming interface: attribute transferSize
@@ -50,8 +50,8 @@ PASS PerformanceResourceTiming interface: resource must inherit property "connec
 PASS PerformanceResourceTiming interface: resource must inherit property "connectEnd" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "secureConnectionStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "requestStart" with the proper type
-FAIL PerformanceResourceTiming interface: resource must inherit property "finalResponseHeadersStart" with the proper type assert_inherits: property "finalResponseHeadersStart" not found in prototype chain
-FAIL PerformanceResourceTiming interface: resource must inherit property "firstInterimResponseStart" with the proper type assert_inherits: property "firstInterimResponseStart" not found in prototype chain
+PASS PerformanceResourceTiming interface: resource must inherit property "finalResponseHeadersStart" with the proper type
+PASS PerformanceResourceTiming interface: resource must inherit property "firstInterimResponseStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "responseStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "transferSize" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt
@@ -23,8 +23,8 @@ PASS PerformanceResourceTiming interface: attribute connectStart
 PASS PerformanceResourceTiming interface: attribute connectEnd
 PASS PerformanceResourceTiming interface: attribute secureConnectionStart
 PASS PerformanceResourceTiming interface: attribute requestStart
-FAIL PerformanceResourceTiming interface: attribute finalResponseHeadersStart assert_true: The prototype object must have a property "finalResponseHeadersStart" expected true got false
-FAIL PerformanceResourceTiming interface: attribute firstInterimResponseStart assert_true: The prototype object must have a property "firstInterimResponseStart" expected true got false
+PASS PerformanceResourceTiming interface: attribute finalResponseHeadersStart
+PASS PerformanceResourceTiming interface: attribute firstInterimResponseStart
 PASS PerformanceResourceTiming interface: attribute responseStart
 PASS PerformanceResourceTiming interface: attribute responseEnd
 PASS PerformanceResourceTiming interface: attribute transferSize
@@ -50,8 +50,8 @@ PASS PerformanceResourceTiming interface: resource must inherit property "connec
 PASS PerformanceResourceTiming interface: resource must inherit property "connectEnd" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "secureConnectionStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "requestStart" with the proper type
-FAIL PerformanceResourceTiming interface: resource must inherit property "finalResponseHeadersStart" with the proper type assert_inherits: property "finalResponseHeadersStart" not found in prototype chain
-FAIL PerformanceResourceTiming interface: resource must inherit property "firstInterimResponseStart" with the proper type assert_inherits: property "firstInterimResponseStart" not found in prototype chain
+PASS PerformanceResourceTiming interface: resource must inherit property "finalResponseHeadersStart" with the proper type
+PASS PerformanceResourceTiming interface: resource must inherit property "firstInterimResponseStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "responseStart" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type
 PASS PerformanceResourceTiming interface: resource must inherit property "transferSize" with the proper type

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -569,6 +569,11 @@ webkit.org/b/137096 svg/text/text-altglyph-01-b.svg [ Failure ]
 # Since r200320 resource-timing feature is a runtime flag.
 webkit.org/b/158617 fast/dom/Window/window-properties-performance-resource-timing.html [ Failure ]
 
+# Resource timing tests are flaky due to redirect timing variability
+webkit.org/b/197473 imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html [ Pass Failure ]
+webkit.org/b/197473 http/wpt/resource-timing/rt-cors.html [ Pass Failure ]
+webkit.org/b/197473 http/wpt/resource-timing/rt-cors.worker.html [ Pass Failure ]
+
 # No support for font-variant-* properties in @font-face declarations
 webkit.org/b/161586 css3/font-feature-settings-font-face-rendering.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
@@ -6,7 +6,7 @@ PASS Can use performance.getEntriesByName in workers
 PASS Can use performance.getEntriesByType in workers
 PASS Performance marks and measures seem to be working correctly in workers
 PASS Can use clearMarks and clearMeasures in workers
-FAIL Resource timing seems to work in workers assert_greater_than: Resource timing numbers reflect reality somewhat expected a number greater than 230 but got 0
+PASS Resource timing seems to work in workers
 PASS performance.clearResourceTimings in workers
 PASS performance.setResourceTimingBufferSize in workers
 PASS performance.timing is not available in workers

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
@@ -6,7 +6,7 @@ PASS Can use performance.getEntriesByName in workers
 PASS Can use performance.getEntriesByType in workers
 PASS Performance marks and measures seem to be working correctly in workers
 PASS Can use clearMarks and clearMeasures in workers
-FAIL Resource timing seems to work in workers assert_greater_than: Resource timing numbers reflect reality somewhat expected a number greater than 230 but got 0
+PASS Resource timing seems to work in workers
 PASS performance.clearResourceTimings in workers
 PASS performance.setResourceTimingBufferSize in workers
 PASS performance.timing is not available in workers

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -800,6 +800,12 @@ transitions/svg-text-shadow-transition.html [ DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/177871 http/wpt/resource-timing/rt-shared-resource-in-workers.html [ Failure ]
 
+# Resource timing tests are flaky due to redirect timing variability
+webkit.org/b/197473 imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html [ Pass Failure ]
+webkit.org/b/197473 http/wpt/resource-timing/rt-cors.html [ Pass Failure ]
+webkit.org/b/197473 http/wpt/resource-timing/rt-cors.worker.html [ Pass Failure ]
+webkit.org/b/197473 imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForRedirect [ Pass Failure ]
+
 webkit.org/b/178578 http/tests/images/hidpi-srcset-copy.html [ Failure ]
 
 Bug(WPE) svg/animations/animations-paused-in-background-page-iframe.html [ Skip ]

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
@@ -6,7 +6,7 @@ PASS Can use performance.getEntriesByName in workers
 PASS Can use performance.getEntriesByType in workers
 PASS Performance marks and measures seem to be working correctly in workers
 PASS Can use clearMarks and clearMeasures in workers
-FAIL Resource timing seems to work in workers assert_greater_than: Resource timing numbers reflect reality somewhat expected a number greater than 230 but got 0
+PASS Resource timing seems to work in workers
 PASS performance.clearResourceTimings in workers
 PASS performance.setResourceTimingBufferSize in workers
 PASS performance.timing is not available in workers

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -60,6 +60,8 @@ public:
     double connectEnd() const;
     double secureConnectionStart() const;
     double requestStart() const;
+    double finalResponseHeadersStart() const;
+    double firstInterimResponseStart() const;
     double responseStart() const;
     double responseEnd() const;
     uint64_t transferSize() const;

--- a/Source/WebCore/page/PerformanceResourceTiming.idl
+++ b/Source/WebCore/page/PerformanceResourceTiming.idl
@@ -48,6 +48,9 @@ typedef double DOMHighResTimeStamp;
     readonly attribute DOMHighResTimeStamp connectEnd;
     readonly attribute DOMHighResTimeStamp secureConnectionStart;
     readonly attribute DOMHighResTimeStamp requestStart;
+    // https://github.com/w3c/resource-timing/pull/408
+    readonly attribute DOMHighResTimeStamp finalResponseHeadersStart;
+    readonly attribute DOMHighResTimeStamp firstInterimResponseStart;
     readonly attribute DOMHighResTimeStamp responseStart;
     readonly attribute DOMHighResTimeStamp responseEnd;
     readonly attribute unsigned long long transferSize;

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 NetworkLoadMetrics::NetworkLoadMetrics() = default;
 
-NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
+NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, MonotonicTime&& finalResponseHeadersStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
     : redirectStart(WTF::move(redirectStart))
     , fetchStart(WTF::move(fetchStart))
     , domainLookupStart(WTF::move(domainLookupStart))
@@ -42,8 +42,10 @@ NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicT
     , connectEnd(WTF::move(connectEnd))
     , requestStart(WTF::move(requestStart))
     , responseStart(WTF::move(responseStart))
-    , responseEnd(responseEnd)
-    , workerStart(workerStart)
+    , responseEnd(WTF::move(responseEnd))
+    , workerStart(WTF::move(workerStart))
+    , firstInterimResponseStart(WTF::move(firstInterimResponseStart))
+    , finalResponseHeadersStart(WTF::move(finalResponseHeadersStart))
     , protocol(protocol)
     , redirectCount(redirectCount)
     , complete(complete)
@@ -76,6 +78,8 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
     MonotonicTime originalResponseStart = responseStart;
     MonotonicTime originalResponseEnd = responseEnd;
     MonotonicTime originalWorkerStart = workerStart;
+    MonotonicTime originalFirstInterimResponseStart = firstInterimResponseStart;
+    MonotonicTime originalFinalResponseHeadersStart = finalResponseHeadersStart;
     bool originalFromPrefetch = fromPrefetch;
     bool originalFromCache = fromCache;
 
@@ -103,6 +107,10 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
         responseEnd = originalResponseEnd;
     if (!workerStart)
         workerStart = originalWorkerStart;
+    if (!firstInterimResponseStart)
+        firstInterimResponseStart = originalFirstInterimResponseStart;
+    if (!finalResponseHeadersStart)
+        finalResponseHeadersStart = originalFinalResponseHeadersStart;
     if (!fromPrefetch)
         fromPrefetch = originalFromPrefetch;
     if (!fromCache)
@@ -150,6 +158,8 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
     copy.responseStart = responseStart.isolatedCopy();
     copy.responseEnd = responseEnd.isolatedCopy();
     copy.workerStart = workerStart.isolatedCopy();
+    copy.firstInterimResponseStart = firstInterimResponseStart.isolatedCopy();
+    copy.finalResponseHeadersStart = finalResponseHeadersStart.isolatedCopy();
 
     copy.protocol = protocol.isolatedCopy();
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -65,7 +65,7 @@ class NetworkLoadMetrics {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkLoadMetrics);
 public:
     WEBCORE_EXPORT NetworkLoadMetrics();
-    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
+    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, MonotonicTime&& finalResponseHeadersStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
 
     WEBCORE_EXPORT static const NetworkLoadMetrics& emptyMetrics();
 
@@ -95,6 +95,11 @@ public:
     MonotonicTime responseStart;
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
+
+    // https://github.com/w3c/resource-timing/pull/408
+    // Timing for interim (1xx) vs final (2xx/3xx/4xx/5xx) responses
+    MonotonicTime firstInterimResponseStart; // When first 1xx response arrived (if any)
+    MonotonicTime finalResponseHeadersStart; // When final response headers arrived
 
     // ALPN Protocol ID: https://w3c.github.io/resource-timing/#bib-RFC7301
     String protocol;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7457,6 +7457,8 @@ class WebCore::NetworkLoadMetrics {
     MonotonicTime responseStart;
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
+    MonotonicTime firstInterimResponseStart;
+    MonotonicTime finalResponseHeadersStart;
 
     String protocol;
 

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -3613,6 +3613,13 @@
    },
    {
       "emails" : [
+         "helmut@januschka.com"
+      ],
+      "github" : "hjanuschka",
+      "name" : "Helmut Januschka"
+   },
+   {
+      "emails" : [
          "hhjalmarsson@apple.com"
       ],
       "github" : "HerculesH",


### PR DESCRIPTION
#### 68d1bafc0c13201f68a6299fd06f228c95683154
<pre>
[Resource Timing] Add finalResponseHeadersStart and firstInterimResponseStart attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304235">https://bugs.webkit.org/show_bug.cgi?id=304235</a>

Reviewed by Alex Christensen.

Implement W3C Resource Timing Level 3 attributes for distinguishing interim (1xx) and final
response timing. This enables proper measurement of HTTP 103 Early Hints and other informational
responses. Timestamps are captured via NSURLSession delegate callbacks without requiring CFNetwork changes.

* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::PerformanceResourceTiming::finalResponseHeadersStart const): Added.
(WebCore::PerformanceResourceTiming::firstInterimResponseStart const): Added.
(WebCore::PerformanceResourceTiming::responseStart const): Updated to return interim if present.
* Source/WebCore/page/PerformanceResourceTiming.h:
* Source/WebCore/page/PerformanceResourceTiming.idl:
* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::updateFromFinalMetrics):
(WebCore::NetworkLoadMetrics::isolatedCopy const):
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:didReceiveInformationalResponse:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt: Updated expectations.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt: Updated expectations.

Add soup/glib support for interim response timing

Implement firstInterimResponseStart and finalResponseHeadersStart capture
for Linux/GTK/WPE platforms using libsoup&apos;s got-headers signal.

The got-headers callback is invoked for all HTTP responses including
informational (1xx) responses, allowing us to distinguish and capture
timing for both interim and final responses.

Add Helmut Januschka to contributors

Canonical link: <a href="https://commits.webkit.org/304905@main">https://commits.webkit.org/304905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55c8dfe63236ed538624a71cdb0e00da7430d5b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85454 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/136156 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6858 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4548 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41330 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112972 "Found 1 new test failure: imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForRedirect (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113302 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6778 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/63013 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21093 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8899 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72465 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->