### PR TITLE
Import WPT tests for Resource Timing finalResponseHeadersStart and firstInterimResponseStart

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8191,3 +8191,7 @@ media/wireless-playback-media-player/ [ Skip ]
 webkit.org/b/295810 [ Debug ] fast/dynamic/disappearing-content-on-size-change-crash.html [ Timeout ]
 
 [ Debug ] fast/inline/continuation-with-anon-wrappers.html [ Slow ]
+# webkit.org/b/304239 Resource Timing interim response tests (waiting for implementation from webkit.org/b/304235)
+imported/w3c/web-platform-tests/loading/early-hints/early-hints-response-time.h2.html [ Failure ]
+imported/w3c/web-platform-tests/resource-timing/interim-response-times.html [ Failure ]
+imported/w3c/web-platform-tests/resource-timing/interim-response-times.h2.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/early-hints-response-time.h2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/early-hints-response-time.h2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<script src="/common/utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+  promise_test(async t => {
+    const iframe = document.createElement("iframe");
+    const params = new URLSearchParams();
+    const delays = [200, 100, 150];
+    params.set("delay1", delays[0]);
+    params.set("delay2", delays[1]);
+
+    iframe.src = `resources/early-hints-delay.h2.py?${params.toString()}`;
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => iframe.remove());
+    await new Promise(resolve => iframe.addEventListener("load", resolve));
+    const [entry] = iframe.contentWindow.performance.getEntriesByType("navigation");
+    assert_greater_than(entry.firstInterimResponseStart, entry.requestStart + delays[0]);
+    assert_greater_than(entry.finalResponseHeadersStart, entry.firstInterimResponseStart + delays[1]);
+    assert_equals(entry.responseStart, entry.firstInterimResponseStart);
+}, `Interim response times should correspond to delays (h2)`);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/early-hints-delay.h2.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/early-hints-delay.h2.py
@@ -1,0 +1,20 @@
+import time
+
+def handle_headers(frame, request, response):
+    early_hints = [
+        (b":status", b"103"),
+        (b"link", b"</empty.js>; rel=preload; as=script"),
+    ]
+
+    time.sleep(int(request.GET.first(b"delay1")) / 1000)
+    response.writer.write_raw_header_frame(headers=early_hints,
+                                           end_headers=True)
+
+    time.sleep(int(request.GET.first(b"delay2")) / 1000)
+    response.status = 200
+    response.headers[b"content-type"] = "text/html"
+    response.write_status_headers()
+
+
+def main(request, response):
+    response.writer.write_data(item="Hello", last=True)

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/empty.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/empty.js
@@ -1,0 +1,1 @@
+// Empty script

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.h2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.h2.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="timeout" content="long">
+<title>Resource Timing: PerformanceResourceTiming interim resource times</title>
+<link rel="author" title="Google" href="http://www.google.com/" />
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  const {REMOTE_HOST} = get_host_info();
+  function interim_response_time_test({origin, with100, with103}) {
+    promise_test(async t => {
+      const delay = 500;
+      const url = new URL('/resource-timing/resources/header-delay.h2.py',
+      origin == "same-origin" ?
+          location.href :
+          `${location.protocol}//${REMOTE_HOST}:${location.port}`);
+      url.searchParams.set("delay", delay);
+      if (origin === "cross-origin-with-TAO")
+        url.searchParams.set("tao", "*");
+      if (with100)
+        url.searchParams.set("with100", "true");
+      if (with103)
+        url.searchParams.set("with103", "true");
+      const response = await fetch(url.toString(), {mode: "cors"});
+      assert_equals(response.status, 200)
+      await response.text();
+      const [entry] = performance.getEntriesByName(url.toString());
+      if (origin === "cross-origin") {
+        assert_equals(entry.firstInterimResponseStart, 0);
+        return;
+      }
+      let total_delay = entry.requestStart;
+      if (with100) {
+        total_delay += delay;
+        assert_greater_than(entry.firstInterimResponseStart,
+        total_delay,
+                            "firstInterimResponseStart > 100 response");
+      }
+
+      if (with103) {
+        total_delay += delay;
+        if (with100) {
+          assert_less_than_equal(entry.firstInterimResponseStart,
+          total_delay,  "firstInterimResponseStart > 100 response");
+        } else {
+          assert_greater_than(entry.firstInterimResponseStart,
+          delay, "firstInterimResponseStart > 100 response");
+        }
+      }
+
+      total_delay += delay;
+      if (!with100 && !with103)
+        assert_equals(entry.firstInterimResponseStart, 0);
+
+      assert_greater_than(entry.finalResponseHeadersStart, total_delay, "responseStart");
+      assert_equals(entry.responseStart, entry.firstInterimResponseStart || entry.finalResponseHeadersStart);
+    }, `Fetch from ${origin} ${with103 ? "with" : "without"} early hints, ${
+        with100 ? "with" : "without"} 100 response`);
+  }
+
+  for (const with103 of [true, false]) {
+    for (const with100 of [true, false]) {
+      for (origin of ['same-origin', 'cross-origin', 'cross-origin-with-TAO']) {
+        interim_response_time_test({with100, with103, origin});
+      }
+    }
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="timeout" content="long">
+<title>Resource Timing: PerformanceResourceTiming interim resource times</title>
+<link rel="author" title="Google" href="http://www.google.com/" />
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  const {REMOTE_ORIGIN} = get_host_info();
+  function interim_response_time_test({origin, with100, with103}) {
+    promise_test(async t => {
+      const delay = 500;
+      const url = new URL('/resource-timing/resources/header-delay.py',
+        origin == "same-origin" ? location.href : REMOTE_ORIGIN);
+      url.searchParams.set("delay", delay);
+      if (origin === "cross-origin-with-TAO")
+        url.searchParams.set("tao", "*");
+      if (with100)
+        url.searchParams.set("with100", "true");
+      if (with103)
+        url.searchParams.set("with103", "true");
+      const response = await fetch(url.toString(), {mode: "cors"});
+      assert_equals(response.status, 200)
+      await response.text();
+      const [entry] = performance.getEntriesByName(url.toString());
+      if (origin === "cross-origin") {
+        assert_equals(entry.firstInterimResponseStart, 0);
+        return;
+      }
+      let total_delay = entry.requestStart;
+      if (with100) {
+        total_delay += delay;
+        assert_greater_than(entry.firstInterimResponseStart,
+        total_delay,
+                            "firstInterimResponseStart > 100 response");
+      }
+
+      if (with103) {
+        total_delay += delay;
+        if (with100) {
+          assert_less_than_equal(entry.firstInterimResponseStart,
+          total_delay,  "firstInterimResponseStart > 100 response");
+        } else {
+          assert_greater_than(entry.firstInterimResponseStart,
+          delay, "firstInterimResponseStart > 100 response");
+        }
+      }
+
+      total_delay += delay;
+      if (!with100 && !with103)
+        assert_equals(entry.firstInterimResponseStart, 0);
+
+      assert_greater_than(entry.finalResponseHeadersStart, total_delay,
+                        "responseStart");
+      assert_equals(entry.responseStart, entry.firstInterimResponseStart || entry.finalResponseHeadersStart);
+    }, `Fetch from ${origin} ${with103 ? "with" : "without"} early hints, ${
+        with100 ? "with" : "without"} 100 response`);
+  }
+
+  for (const with103 of [true, false]) {
+    for (const with100 of [true, false]) {
+      for (origin of ['same-origin', 'cross-origin', 'cross-origin-with-TAO']) {
+        interim_response_time_test({with100, with103, origin});
+      }
+    }
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.h2.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.h2.py
@@ -1,0 +1,25 @@
+from time import sleep
+
+def handle_headers(frame, request, response):
+    delay = int(request.GET.first(b"delay")) / 1000
+
+    if b"with100" in request.GET:
+        sleep(delay)
+        response.writer.write_raw_header_frame(headers=[(b":status", b"103")], end_headers=True)
+
+    if b"with103" in request.GET:
+        sleep(delay)
+        response.writer.write_raw_header_frame(headers=[(b":status", b"103")], end_headers=True)
+
+    sleep(delay)
+    response.status = 200
+
+    if b"tao" in request.GET:
+        response.headers[b"timing-allow-origin"] = "*"
+
+    response.headers[b"content-type"] = "text/plain"
+    response.headers[b"access-control-allow-origin"] = "*"
+    response.write_status_headers()
+
+def main(request, response):
+    response.writer.write_data(item="Hello World", last=True)

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.py
@@ -1,0 +1,29 @@
+from time import sleep
+
+def main(request, response):
+    delay = int(request.GET.first(b"delay")) / 1000
+
+    # TODO: make this exported from ResponseWriter
+    handler = response.writer._handler
+    if b"with100" in request.GET:
+        sleep(delay)
+        handler.send_response(100)
+        handler.end_headers()
+
+    if b"with103" in request.GET:
+        sleep(delay)
+        handler.send_response(103)
+        handler.send_header("Link", "<resources/empty.js>;rel=preload;as=script")
+        handler.end_headers()
+
+    sleep(delay)
+
+    handler.send_response(200)
+
+    if b"tao" in request.GET:
+        handler.send_header("timing-allow-origin", "*")
+
+    handler.send_header("content-type", "text/plain")
+    handler.send_header("access-control-allow-origin", "*")
+    handler.end_headers()
+    handler.wfile.write(bytes("Hello World", "utf8"))


### PR DESCRIPTION
Import WPT tests for finalResponseHeadersStart and firstInterimResponseStart
https://bugs.webkit.org/show_bug.cgi?id=304239

Reviewed by NOBODY (OOPS!).

Import Web Platform Tests for Resource Timing Level 3 interim response timing attributes.
Tests validate timing capture for HTTP 103 Early Hints and 100 Continue responses, cross-origin
security checks, and the updated responseStart behavior.

* LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/early-hints-response-time.h2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/early-hints-response-time.h2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/early-hints-delay.h2.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/loading/early-hints/resources/empty.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.h2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.h2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/interim-response-times.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.h2.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resources/header-delay.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any-expected.txt: Updated expectations.
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/idlharness.any.worker-expected.txt: Updated expectations.

---

**Note:** This PR depends on #55467 being merged first (adds the implementation that these tests validate).<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbae46e8b7f52f6233d22b527a13fd3cbea433c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143738 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89007 "Failed to checkout and rebase branch from PR 55469") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103963 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/89007 "Failed to checkout and rebase branch from PR 55469") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138985 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6579 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121907 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84838 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6264 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3906 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115533 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40100 "Exiting early after 10 failures. 10 tests run. 2 failures 1 missing results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8079 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40668 "5 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8095 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6785 "2 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112712 "Found 36 new API test failures: WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/iterator, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6171 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118207 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62049 "Failed to checkout and rebase branch from PR 55469") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8124 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36273 "Exiting early after 10 failures. 10 tests run. 1 missing results") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->