### PR TITLE
RTCDataChannel close event does not fire if RTCPeerConnection closes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-local-close-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-local-close-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Close peerconnection causes close event on local channel
+PASS Close peerconnection causes close event on transfered channel
+PASS Close peerconnection causes close event on local being transfered channel
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-local-close.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-local-close.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="timeout" content="long">
+<title>RTCDataChannel.prototype.close</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+'use strict';
+
+promise_test(async t => {
+  const pc1 = new RTCPeerConnection();
+  t.add_cleanup(() => pc1.close());
+  const [channel1, channel2] = await createDataChannelPairWithLabel(t, 'local_close', [], pc1);
+
+  const haveClosed1 = new Promise((resolve, reject) => {
+    channel1.addEventListener('close', () => {
+      assert_true(isClosed);
+      resolve();
+    });
+    t.step_timeout(() => reject('test1 timed out'), 2000);
+  });
+  const haveClosed2 = new Promise((resolve, reject) => {
+    channel2.addEventListener('close', resolve);
+    t.step_timeout(() => reject('test2 timed out'), 2000);
+  });
+
+  let isClosed = false;
+  let isClosing1 = false;
+  let isClosing2 = false;
+  channel1.onclosing = () => {
+    isClosing1 = true;
+    assert_true(isClosed, "isClosed for channel1.onclosing");
+  }
+  channel2.onclosing = () => {
+    isClosing2 = true;
+    assert_true(isClosed, "isClosed for channel2.onclosing");
+  }
+ 
+  pc1.close();
+  isClosed = true;
+  await haveClosed1;
+  await haveClosed2;
+
+  assert_false(isClosing1, "isClosing1");
+  assert_true(isClosing2, "isClosing2");
+}, `Close peerconnection causes close event on local channel`);
+
+promise_test(async t => {
+  const pc1 = new RTCPeerConnection();
+  t.add_cleanup(() => pc1.close());
+  const channel1 = pc1.createDataChannel("test");
+
+  const worker = new Worker(`data:text/javascript,onmessage = e => { e.data.onclose = () => postMessage('CLOSED'); postMessage("OK"); };`);
+
+  worker.postMessage(channel1, [channel1]);
+  const transferResult = await new Promise(resolve => worker.addEventListener('message', e => resolve(e.data)));
+  assert_equals(transferResult, "OK");
+
+  const haveClosed1 = new Promise((resolve, reject) => {
+    worker.addEventListener('message', e => resolve(e.data));
+    t.step_timeout(() => reject("test timed out"), 1000);
+  });
+
+  pc1.close();
+  assert_equals(await haveClosed1, "CLOSED");
+}, `Close peerconnection causes close event on transfered channel`);
+
+promise_test(async t => {
+  const pc1 = new RTCPeerConnection();
+  t.add_cleanup(() => pc1.close());
+  const channel1 = pc1.createDataChannel("test");
+
+  const worker = new Worker(`data:text/javascript,onmessage = e => { if (e.data.readyState === 'closed') postMessage('CLOSED'); e.data.onclose = () => postMessage('CLOSED'); };`);
+  const haveClosed1 = new Promise((resolve, reject) => {
+    worker.onmessage = e => resolve(e.data);
+    t.step_timeout(() => reject("test timed out"), 1000);
+  });
+
+  worker.postMessage(channel1, [channel1]);
+  pc1.close();
+  assert_equals(await haveClosed1, "CLOSED");
+}, `Close peerconnection causes close event on local being transfered channel`);
+
+</script>

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
@@ -40,7 +40,7 @@ namespace WebCore {
 class RTCDataChannelRemoteSource : public RTCDataChannelHandlerClient, public RefCounted<RTCDataChannelRemoteSource> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RTCDataChannelRemoteSource, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT static Ref<RTCDataChannelRemoteSource> create(RTCDataChannelIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
+    WEBCORE_EXPORT static Ref<RTCDataChannelRemoteSource> create(RTCDataChannelIdentifier localIdentifier, RTCDataChannelIdentifier remoteIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
     ~RTCDataChannelRemoteSource();
 
     void ref() const final { RefCounted::ref(); }
@@ -51,17 +51,19 @@ public:
     void close() { m_handler->close(); }
 
 private:
-    WEBCORE_EXPORT RTCDataChannelRemoteSource(RTCDataChannelIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
+    WEBCORE_EXPORT RTCDataChannelRemoteSource(RTCDataChannelIdentifier localIdentifier, RTCDataChannelIdentifier remoteIdentifier, UniqueRef<RTCDataChannelHandler>&&, Ref<RTCDataChannelRemoteSourceConnection>&&);
 
     // RTCDataChannelHandlerClient
-    void didChangeReadyState(RTCDataChannelState state) final { m_connection->didChangeReadyState(m_identifier, state); }
-    void didReceiveStringData(const String& text) final { m_connection->didReceiveStringData(m_identifier, text); }
-    void didReceiveRawData(std::span<const uint8_t> data) final { m_connection->didReceiveRawData(m_identifier, data); }
-    void didDetectError(Ref<RTCError>&& error) final { m_connection->didDetectError(m_identifier, error->errorDetail(), error->message()); }
-    void bufferedAmountIsDecreasing(size_t amount) final { m_connection->bufferedAmountIsDecreasing(m_identifier, amount); }
-    size_t bufferedAmount() const final { return 0; }
+    void didChangeReadyState(RTCDataChannelState) final;
+    void didReceiveStringData(const String&) final;
+    void didReceiveRawData(std::span<const uint8_t>) final;
+    void didDetectError(Ref<RTCError>&&) final;
+    void bufferedAmountIsDecreasing(size_t) final;
+    size_t bufferedAmount() const final;
+    void peerConnectionIsClosing() final;
 
-    RTCDataChannelIdentifier m_identifier;
+    const RTCDataChannelIdentifier m_remoteIdentifier;
+    bool m_isClosed { false };
     const UniqueRef<RTCDataChannelHandler> m_handler;
     const Ref<RTCDataChannelRemoteSourceConnection> m_connection;
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -283,6 +283,7 @@ private:
     RTCConfiguration m_configuration;
     WeakPtr<RTCController> m_controller;
     Vector<RefPtr<RTCCertificate>> m_certificates;
+    Vector<RTCDataChannelIdentifier> m_channels;
     bool m_shouldDelayTasks { false };
     Deque<std::pair<Ref<DeferredPromise>, Function<void(Ref<DeferredPromise>&&)>>> m_operations;
     bool m_hasPendingOperation { false };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2717,6 +2717,7 @@ platform/mediastream/MediaEndpointConfiguration.cpp
 platform/mediastream/MediaStreamPrivate.cpp
 platform/mediastream/MediaStreamTrackDataHolder.cpp
 platform/mediastream/MediaStreamTrackPrivate.cpp
+platform/mediastream/RTCDataChannelHandlerClient.cpp
 platform/mediastream/RTCIceCandidateDescriptor.cpp
 platform/mediastream/RTCSessionDescriptionDescriptor.cpp
 platform/mediastream/RealtimeIncomingAudioSource.cpp

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.cpp
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RTCDataChannelHandlerClient.h"
+
+#if ENABLE(WEB_RTC)
+
+#include "RTCDataChannel.h"
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+static Lock s_rtcDataChannelHandlerClientsLock;
+static HashMap<RTCDataChannelLocalIdentifier, std::pair<std::optional<ScriptExecutionContextIdentifier>, WeakPtr<RTCDataChannelHandlerClient>>>& rtcDataChannelHandlerClients() WTF_REQUIRES_LOCK(s_rtcDataChannelHandlerClientsLock)
+{
+    static NeverDestroyed<HashMap<RTCDataChannelLocalIdentifier, std::pair<std::optional<ScriptExecutionContextIdentifier>, WeakPtr<RTCDataChannelHandlerClient>>>> map;
+    return map;
+}
+
+void RTCDataChannelHandlerClient::peerConnectionIsClosing(RTCDataChannelIdentifier identifier)
+{
+    ASSERT(isMainThread());
+    RefPtr<RTCDataChannelHandlerClient> mainThreadClient;
+    {
+        Locker locker { s_rtcDataChannelHandlerClientsLock };
+        auto iterator = rtcDataChannelHandlerClients().find(identifier.object());
+        if (iterator != rtcDataChannelHandlerClients().end()) {
+            if (iterator->value.first) {
+                ScriptExecutionContext::postTaskTo(*iterator->value.first, [weakClient = iterator->value.second](auto&) {
+                    if (RefPtr client = weakClient.get())
+                        client->peerConnectionIsClosing();
+                });
+                return;
+            }
+
+            mainThreadClient = iterator->value.second.get();
+        }
+    }
+    if (mainThreadClient) {
+        mainThreadClient->peerConnectionIsClosing();
+        return;
+    }
+
+    RTCDataChannel::removeDetachedRTCDataChannel(identifier);
+}
+
+RTCDataChannelHandlerClient::RTCDataChannelHandlerClient(std::optional<ScriptExecutionContextIdentifier> contextIdentifier, RTCDataChannelIdentifier identifier)
+    : m_identifier(identifier)
+{
+    Locker locker { s_rtcDataChannelHandlerClientsLock };
+    ASSERT(!rtcDataChannelHandlerClients().contains(m_identifier.object()));
+    rtcDataChannelHandlerClients().add(m_identifier.object(), std::make_pair(contextIdentifier, WeakPtr { *this }));
+}
+
+RTCDataChannelHandlerClient::~RTCDataChannelHandlerClient()
+{
+    unregister();
+}
+
+void RTCDataChannelHandlerClient::unregister()
+{
+    if (m_isUnregistered)
+        return;
+
+    m_isUnregistered = true;
+
+    Locker locker { s_rtcDataChannelHandlerClientsLock };
+    ASSERT(rtcDataChannelHandlerClients().contains(m_identifier.object()));
+    ASSERT(rtcDataChannelHandlerClients().get(m_identifier.object()).second.get() == this);
+    rtcDataChannelHandlerClients().remove(m_identifier.object());
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,9 @@
 
 #if ENABLE(WEB_RTC)
 
+#include <WebCore/RTCDataChannelIdentifier.h>
 #include <WebCore/RTCDataChannelState.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -38,7 +40,11 @@ class RTCError;
 
 class RTCDataChannelHandlerClient : public AbstractRefCountedAndCanMakeWeakPtr<RTCDataChannelHandlerClient, WeakPtrFactoryInitialization::Eager> {
 public:
-    virtual ~RTCDataChannelHandlerClient() = default;
+    static void peerConnectionIsClosing(RTCDataChannelIdentifier);
+    virtual ~RTCDataChannelHandlerClient();
+
+    RTCDataChannelIdentifier identifier() const { return m_identifier; }
+    void willDetach() { unregister(); }
 
     virtual void didChangeReadyState(RTCDataChannelState) = 0;
     virtual void didReceiveStringData(const String&) = 0;
@@ -46,6 +52,17 @@ public:
     virtual void didDetectError(Ref<RTCError>&&) = 0;
     virtual void bufferedAmountIsDecreasing(size_t) = 0;
     virtual size_t bufferedAmount() const { return 0; }
+
+    virtual void peerConnectionIsClosing() = 0;
+
+protected:
+    RTCDataChannelHandlerClient(std::optional<ScriptExecutionContextIdentifier>, RTCDataChannelIdentifier);
+
+private:
+    void unregister();
+
+    const RTCDataChannelIdentifier m_identifier;
+    bool m_isUnregistered { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -74,7 +74,7 @@ bool RTCDataChannelRemoteManager::connectToRemoteSource(WebCore::RTCDataChannelI
     if (!handler)
         return false;
 
-    auto iterator = m_sources.add(remoteIdentifier.object(), WebCore::RTCDataChannelRemoteSource::create(remoteIdentifier, makeUniqueRefFromNonNullUniquePtr(WTF::move(handler)), remoteSourceConnection()));
+    auto iterator = m_sources.add(remoteIdentifier.object(), WebCore::RTCDataChannelRemoteSource::create(localIdentifier, remoteIdentifier, makeUniqueRefFromNonNullUniquePtr(WTF::move(handler)), remoteSourceConnection()));
     return iterator.isNewEntry;
 }
 


### PR DESCRIPTION
#### e83716d173835cbf698bf91763d63a630776fa4e
<pre>
RTCDataChannel close event does not fire if RTCPeerConnection closes
<a href="https://rdar.apple.com/165617848">rdar://165617848</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303052">https://bugs.webkit.org/show_bug.cgi?id=303052</a>

Reviewed by Jean-Yves Avenard.

Since closing the peer connection backend is severing the state updates of the data channel backend, we add the logic to close the data channel from RTCPeerConnection::close.
For that reason, we keep a list of channel identifiers in RTCPeerConnection.

We then call RTCDataChannelHandlerClient::peerConnectionIsClosing for each of this identifier.
This will do the following:
- If the data channel lives in main thread, it will call RTCDataChannel::peerConnectionIsClosing() directly.
- If the data channel lives in another process, it will call RTCDataChannel::peerConnectionIsClosing() directly.
- If the data channel lives in a worker, it will call RTCDataChannel::peerConnectionIsClosing() after hopping to the service worker thread.
- If the data channel is being transferred, it will call RTCDataChannel::peerConnectionIsClosing() which will make the newly transferred data channel moving to closed state.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/304859@main">https://commits.webkit.org/304859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a09742a84436b806d9981fe316eb5c4c821fbdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/38349d02-727f-49ac-9a2c-faeba2e40c38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b7bc2ad-2753-4735-b28d-43b142fed1c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85364 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b0ad75d-2d44-446a-b18e-08fe2c0bcc44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4455 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5007 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8730 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112880 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6691 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62863 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8778 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8499 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->