### PR TITLE
Move CoreIPCNSURLRequest off of using PlistDictionary for IPC serialization

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -383,10 +383,6 @@
     [Legacy] StructureParam WTF::CString.span()
 }
 
-[UnsafeWrapper] std::optional<WebKit::CoreIPCPlistDictionary> {
-    [Legacy] StructureParam WebKit::CoreIPCNSURLRequestData.protocolProperties
-}
-
 # Shared Memory
 [SafeWrapper] StructureParam WebCore::ShareableBitmapHandle.m_handle WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam IPC::StreamServerConnectionHandle.buffer WebCore::SharedMemoryHandle

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -97,12 +97,23 @@ enum class NSURLRequestFlags : int16_t {
     ShouldStartSynchronously = (1 << 12)
 };
 
+struct ProtocolProperties {
+    RetainPtr<CFBooleanRef> isTopLevelNavigation;
+    RetainPtr<CFBooleanRef> allowAllPOSTCaching;
+    String siteForCookies;
+    String cachePartitionKey;
+    RetainPtr<CFBooleanRef> wkVeryLowLoadPriority;
+    RetainPtr<CFNumberRef> fileProtocolExpectedDevice;
+    RetainPtr<CFBooleanRef> shouldSniff;
+    RetainPtr<CFBooleanRef> contentDecoderSkipURLCheck;
+};
+
 struct CoreIPCNSURLRequestData {
 
     using BodyParts = Variant<CoreIPCString, CoreIPCData>;
     using HeaderField = std::pair<String, Variant<String, Vector<String>>>;
 
-    std::optional<CoreIPCPlistDictionary> protocolProperties;
+    std::optional<ProtocolProperties> protocolProperties;
     bool isMutable { false };
     CoreIPCURL url;
     double timeout { 0 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -69,13 +69,32 @@ namespace WebKit {
 #define SET_DICT_FROM_PRIMITIVE(KEY, CLASS, PRIMITIVE) \
     [dict setObject:[NSNumber numberWith##PRIMITIVE:m_data.KEY] forKey:@#KEY]
 
+#define EXTRACT_TYPED_VALUE(dictionary, key, type, target) { \
+    id extractedValue = [(NSDictionary *)dictionary objectForKey:key]; \
+    if (extractedValue) \
+        target = (__bridge type##Ref)extractedValue; \
+    }
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCNSURLRequest);
 
 CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
 {
     RetainPtr dict = [request _webKitPropertyListData];
 
-    SET_NSURLREQUESTDATA(protocolProperties, NSDictionary, CoreIPCPlistDictionary);
+    if (auto *protocolPropertiesDict = dynamic_objc_cast<NSDictionary>(dict.get()[@"protocolProperties"])) {
+        ProtocolProperties props;
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation", CFBoolean, props.isTopLevelNavigation);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"kCFURLRequestAllowAllPOSTCaching", CFBoolean, props.allowAllPOSTCaching);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertySiteForCookies", CFString, props.siteForCookies);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"_kCFURLCachePartitionKey", CFString, props.cachePartitionKey);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"WKVeryLowLoadPriority", CFBoolean, props.wkVeryLowLoadPriority);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"NSURLRequestFileProtocolExpectedDevice", CFNumber, props.fileProtocolExpectedDevice);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"_kCFURLConnectionPropertyShouldSniff", CFBoolean, props.shouldSniff);
+        EXTRACT_TYPED_VALUE(protocolPropertiesDict, @"kCFURLRequestContentDecoderSkipURLCheck", CFBoolean, props.contentDecoderSkipURLCheck);
+
+        m_data.protocolProperties = WTF::move(props);
+    }
+
     SET_NSURLREQUESTDATA_PRIMITIVE(isMutable, NSNumber, bool);
 
     RetainPtr<id> url = dict.get()[@"URL"];
@@ -223,11 +242,28 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(const RetainPtr<NSURLRequest>& request)
     : CoreIPCNSURLRequest(request.get()) { }
 
 
+#define INJECT_TYPED_VALUE(dictionary, key, value) \
+    if (value) \
+        [dictionary.get() setObject:bridge_cast(value.get()) forKey:key]
+
 RetainPtr<id> CoreIPCNSURLRequest::toID() const
 {
     RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:CoreIPCNSURLRequestData::numberOfFields]);
 
-    SET_DICT_FROM_OPTIONAL_MEMBER(protocolProperties);
+    if (m_data.protocolProperties) {
+        RetainPtr protocolPropertiesDict = adoptNS([[NSMutableDictionary alloc] init]);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation", m_data.protocolProperties->isTopLevelNavigation);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"kCFURLRequestAllowAllPOSTCaching", m_data.protocolProperties->allowAllPOSTCaching);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertySiteForCookies", m_data.protocolProperties->siteForCookies.createCFString());
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"_kCFURLCachePartitionKey", m_data.protocolProperties->cachePartitionKey.createCFString());
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"WKVeryLowLoadPriority", m_data.protocolProperties->wkVeryLowLoadPriority);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"NSURLRequestFileProtocolExpectedDevice", m_data.protocolProperties->fileProtocolExpectedDevice);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"_kCFURLConnectionPropertyShouldSniff", m_data.protocolProperties->shouldSniff);
+        INJECT_TYPED_VALUE(protocolPropertiesDict, @"kCFURLRequestContentDecoderSkipURLCheck", m_data.protocolProperties->contentDecoderSkipURLCheck);
+
+        [dict setObject:protocolPropertiesDict.get() forKey:@"protocolProperties"];
+    }
+
     SET_DICT_FROM_PRIMITIVE(isMutable, NSNumber, Bool);
 
     if (auto nsURL = m_data.url.toID())
@@ -344,5 +380,7 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
 #undef SET_DICT_FROM_OPTIONAL_MEMBER
 #undef SET_DICT_FROM_PRIMITIVE
 #undef SET_DICT_FROM_OPTIONAL_PRIMITIVE
+#undef EXTRACT_TYPED_VALUE
+#undef INJECT_TYPED_VALUE
 
 #endif // PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -96,9 +96,20 @@ header: "CoreIPCNSURLRequest.h"
 using WebKit::CoreIPCNSURLRequestData::BodyParts = Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>;
 using WebKit::CoreIPCNSURLRequestData::HeaderField = std::pair<String, Variant<String, Vector<String>>>;
 
+[CustomHeader, WebKitPlatform] struct WebKit::ProtocolProperties {
+    RetainPtr<CFBooleanRef> isTopLevelNavigation;
+    RetainPtr<CFBooleanRef> allowAllPOSTCaching;
+    String siteForCookies;
+    String cachePartitionKey;
+    RetainPtr<CFBooleanRef> wkVeryLowLoadPriority;
+    RetainPtr<CFNumberRef> fileProtocolExpectedDevice;
+    RetainPtr<CFBooleanRef> shouldSniff;
+    RetainPtr<CFBooleanRef> contentDecoderSkipURLCheck;
+}
+
 header: "CoreIPCNSURLRequest.h"
 [CustomHeader, WebKitPlatform] struct WebKit::CoreIPCNSURLRequestData {
-    std::optional<WebKit::CoreIPCPlistDictionary> protocolProperties;
+    std::optional<WebKit::ProtocolProperties> protocolProperties;
     bool isMutable;
     WebKit::CoreIPCURL url;
     double timeout;


### PR DESCRIPTION
#### 6ce83e4758bc48c2fbe059dfb4f6467b94ebd46a
<pre>
Move CoreIPCNSURLRequest off of using PlistDictionary for IPC serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=304245">https://bugs.webkit.org/show_bug.cgi?id=304245</a>
<a href="https://rdar.apple.com/166612102">rdar://166612102</a>

Reviewed by NOBODY (OOPS!).

Replaces the opaque PlistDictionary in CoreIPCNSURLRequest with an
explicit breakdown of it&apos;s internal data for protocol properties.

* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce83e4758bc48c2fbe059dfb4f6467b94ebd46a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93958 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db0374b5-4945-4a4a-8f80-6492750fb9b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108100 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78408 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c8991b7-d510-4cf8-becd-c3d0d8488ef2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143821 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10798 "Found 2 new test failures: http/tests/cookies/cookie-store-set-secure.https.html http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89001 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/645edd8c-19c6-4b4d-8275-f05fda527e2d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140215 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10384 "Found 3 new test failures: imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html imported/w3c/web-platform-tests/cookiestore/cookieListItem_attributes.https.window.html imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7956 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119633 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151833 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116323 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116662 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12712 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68097 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2184 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->