### PR TITLE
Teed byte streams can be GCed even though their parent stream can still fulfil read requests

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1923,7 +1923,6 @@ imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disal
 webkit.org/b/245092 webaudio/offlineaudiocontext-gc.html [ Pass Failure ]
 
 webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-streams/construct-byob-request.any.worker.html [ Pass Failure ]
-webkit.org/b/304202 imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.html [ Skip ]
 
 # SVG tests that are broken in the legacy SVG engine, but pass using LBSE.
 svg/transforms/layout-tiny-elements-in-scaled-group.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -48,6 +48,7 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
 [
     ExportMacro=WEBCORE_EXPORT,
     Exposed=*,
+    GenerateIsReachable=Impl,
     JSCustomMarkFunction,
     PrivateIdentifier,
     PublicIdentifier

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -57,7 +57,12 @@ ReadableStreamBYOBReader::ReadableStreamBYOBReader(Ref<DOMPromise>&& promise, Re
 {
 }
 
-ReadableStreamBYOBReader::~ReadableStreamBYOBReader() = default;
+ReadableStreamBYOBReader::~ReadableStreamBYOBReader()
+{
+    RefPtr stream = m_stream;
+    if (stream && stream->byobReader() == this)
+        stream->setByobReader(nullptr);
+}
 
 DOMPromise& ReadableStreamBYOBReader::closedPromise()
 {

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -73,7 +73,12 @@ ReadableStreamDefaultReader::ReadableStreamDefaultReader(Ref<ReadableStream>&& s
     ASSERT(m_stream->hasByteStreamController() == !m_internalDefaultReader);
 }
 
-ReadableStreamDefaultReader::~ReadableStreamDefaultReader() = default;
+ReadableStreamDefaultReader::~ReadableStreamDefaultReader()
+{
+    RefPtr stream = m_stream;
+    if (stream && stream->defaultReader() == this)
+        stream->setDefaultReader(nullptr);
+}
 
 // https://streams.spec.whatwg.org/#generic-reader-closed
 DOMPromise& ReadableStreamDefaultReader::closedPromise() const

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -298,6 +298,7 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
     state->setBranch1(branch0);
     state->setBranch2(branch1);
 
+    stream.setTeedBranches(branch0, branch1);
     branches.append(WTF::move(branch0));
     branches.append(WTF::move(branch1));
 


### PR DESCRIPTION
#### 898e897b19bfe645292b81d50d62996ab4d9dff5
<pre>
Teed byte streams can be GCed even though their parent stream can still fulfil read requests
<a href="https://rdar.apple.com/166562238">rdar://166562238</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304253">https://bugs.webkit.org/show_bug.cgi?id=304253</a>

Reviewed by Chris Dumez.

We have an issue that leads to GC of streams in case of byteStreamTee.
If the stream gets GCed, the readable stream reader will also be GCed and the read promises will not get fulfilled.
A reader of a teed stream should not be GCed if the source stream is active.
To fix that issue, whenever a source stream is visited by GC, we are marking its teed streams as reachable from opaque roots if the source stream is readable.
We make sure to use a lock for the weak pointers and nullify the weak pointer before the corresponding stream gets destroyed.

Covered by reenabled tests.

Canonical link: <a href="https://commits.webkit.org/304858@main">https://commits.webkit.org/304858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a00ff60d9809d4b20e8f34cc5c2dc7fdacb0d45a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70d8a02a-f517-44a6-9b8c-62a2a4488aad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b76ceb71-1c42-4444-8c68-3b6e6c882d44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5997a991-fc5b-48ef-844d-5056c89e0b5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4454 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5006 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8729 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112879 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6690 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62862 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8777 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36823 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72343 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->