### PR TITLE
AX: Update several layout tests to accessibility current standards.

### DIFF
--- a/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt
+++ b/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt
@@ -1,18 +1,14 @@
-First line
-
-second line
-Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
-
 This tests that when list item has text of multiple lines we only speak the list marker for the first line.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 1. First line
 second line
 2. Long long long long long long long long long long long long long long long long long long long long long long
 long long long long long long long long long long long long long
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
+First line
 
+second line
+Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long

--- a/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
+++ b/LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html
@@ -1,48 +1,42 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script src="../../resources/js-test-pre.js"></script>
-<body id="body" tabindex="0">
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
 
 <ol>
 <li id="item1"><p>First line</p>second line</li>
 <li id="item2"><p>Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long</p></li>
 </ol>
 
-
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+let output = "This tests that when list item has text of multiple lines we only speak the list marker for the first line.\n\n";
 
-    description("This tests that when list item has text of multiple lines we only speak the list marker for the first line.");
+if (window.accessibilityController) {
+    var listItem1 = accessibilityController.accessibleElementById("item1");
+    var p1 = listItem1.childAtIndex(1);
+    var firstLineRange = p1.textMarkerRangeForElement(p1);
+    output += `${p1.stringForTextMarkerRange(firstLineRange)}\n`;
 
-    if (window.accessibilityController) {
-        var listItem1 = accessibilityController.accessibleElementById("item1");
-        var p1 = listItem1.childAtIndex(1);
-        var firstLineRange = p1.textMarkerRangeForElement(p1);
-        debug(p1.stringForTextMarkerRange(firstLineRange));
-        
-        // Get second line.
-        var firstLineEnd = p1.endTextMarkerForTextMarkerRange(firstLineRange);
-        var secondLineRange = p1.lineTextMarkerRangeForTextMarker(p1.nextTextMarker(firstLineEnd));
-        debug(p1.stringForTextMarkerRange(secondLineRange).trim());
+    // Get second line.
+    var firstLineEnd = p1.endTextMarkerForTextMarkerRange(firstLineRange);
+    var secondLineRange = p1.lineTextMarkerRangeForTextMarker(p1.nextTextMarker(firstLineEnd));
+    output += `${p1.stringForTextMarkerRange(secondLineRange).trim()}\n`;
 
-        // Soft lines.
-        var listItem2 = accessibilityController.accessibleElementById("item2");
-        var item2Range = listItem2.textMarkerRangeForElement(listItem2);
-        var firstLineStart = listItem2.startTextMarkerForTextMarkerRange(item2Range);
-        firstLineRange = listItem2.lineTextMarkerRangeForTextMarker(firstLineStart);
-        debug(listItem2.stringForTextMarkerRange(firstLineRange));
+    // Soft line break.
+    var listItem2 = accessibilityController.accessibleElementById("item2");
+    var item2Range = listItem2.textMarkerRangeForElement(listItem2);
+    var firstLineStart = listItem2.startTextMarkerForTextMarkerRange(item2Range);
+    firstLineRange = listItem2.lineTextMarkerRangeForTextMarker(firstLineStart);
+    output += `${listItem2.stringForTextMarkerRange(firstLineRange)}\n`;
 
-        firstLineEnd = listItem2.endTextMarkerForTextMarkerRange(firstLineRange);
-        secondLineRange = listItem2.lineTextMarkerRangeForTextMarker(listItem2.nextTextMarker(firstLineEnd));
-        debug(listItem2.stringForTextMarkerRange(secondLineRange).trim());
-    }
+    firstLineEnd = listItem2.endTextMarkerForTextMarkerRange(firstLineRange);
+    secondLineRange = listItem2.lineTextMarkerRangeForTextMarker(listItem2.nextTextMarker(firstLineEnd));
+    output += `${listItem2.stringForTextMarkerRange(secondLineRange).trim()}\n`;
 
+    debug(output);
+}
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
-
 </body>
 </html>
-

--- a/LayoutTests/accessibility/mac/line-range-continuity-expected.txt
+++ b/LayoutTests/accessibility/mac/line-range-continuity-expected.txt
@@ -1,4 +1,4 @@
-This tests that CharacterOffset that comes from an upstream VisiblePosition is correct.
+Tests continuity of line ranges in soft line breaks, i.e., the end of the current line range is the start of the next line range.
 
 First Line: 'Lorem ipsum vivamus nibh '
 Second Line: 'urna mollis at aliquam taciti, '

--- a/LayoutTests/accessibility/mac/line-range-continuity.html
+++ b/LayoutTests/accessibility/mac/line-range-continuity.html
@@ -7,11 +7,11 @@
 <body>
 
 <div id="container">
-<div id="text"  style="width:200px;" contenteditable="true">Lorem ipsum vivamus nibh urna mollis at aliquam taciti, etiam arcu mi semper nostra taciti nulla dolor</div>
+<div id="text" style="width:200px;" contenteditable="true">Lorem ipsum vivamus nibh urna mollis at aliquam taciti, etiam arcu mi semper nostra taciti nulla dolor</div>
 </div>
 
 <script>
-let output = "This tests that CharacterOffset that comes from an upstream VisiblePosition is correct.\n\n";
+let output = "Tests continuity of line ranges in soft line breaks, i.e., the end of the current line range is the start of the next line range.\n\n";
 
 if (window.accessibilityController) {
     let text = accessibilityController.accessibleElementById("text").childAtIndex(0);

--- a/LayoutTests/accessibility/mac/line-range-for-text-marker-expected.txt
+++ b/LayoutTests/accessibility/mac/line-range-for-text-marker-expected.txt
@@ -1,11 +1,9 @@
 This tests that line range is returned correctly for a given text marker.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: lineText === expectedText
+PASS: lineText === expectedText
+PASS: lineText === expectedText
 
-
-PASS lineText is 'Line of text.'
-PASS lineText is 'Line of text.'
-PASS lineText is 'Line of text.'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/line-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-range-for-text-marker.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<title>Line Range for Text Marker</title>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 
@@ -12,42 +12,41 @@
 <p>After.</p>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This tests that line range is returned correctly for a given text marker.");
-    
-    var lineText = 0;
-    
-    function lineTextForPoint(x, y) {
-        // Get the element for this point.
-        var element = accessibilityController.elementAtPoint(x, y);
-        // Get the text marker for this point.
-        var marker = element.textMarkerForPoint(x, y);
-        // Get the line text marker range for this text marker.
-        var range = element.lineTextMarkerRangeForTextMarker(marker);
-        // Return the text for this line text marker range.
-        return element.stringForTextMarkerRange(range).trim();
-    }
+let output = "This tests that line range is returned correctly for a given text marker.\n\n";
 
-    if (window.accessibilityController) {
-        var line = accessibilityController.accessibleElementById("line");
-        // Line text from first text marker (add one to make sure we get the first marker for THIS line).
-        lineText = lineTextForPoint(line.x + 1, line.y + 1);
-        shouldBe("lineText", "'Line of text.'");
-        // Line text from center text marker.
-        lineText = lineTextForPoint(line.x + line.width / 2, line.y + line.height / 2);
-        shouldBe("lineText", "'Line of text.'");
-        // Line text from last text marker (subtract one to make sure we get the last marker for THIS line).
-        lineText = lineTextForPoint(line.x + line.width - 1, line.y + line.height - 1);
-        shouldBe("lineText", "'Line of text.'");
-        
-        // Hide superfluous text.
-        document.getElementById("container").style.display = "none";
-    }
+var lineText = "";
+var expectedText = "Line of text.";
+
+function lineTextForPoint(x, y) {
+    // Get the element for this point.
+    var element = accessibilityController.elementAtPoint(x, y);
+    // Get the text marker for this point.
+    var marker = element.textMarkerForPoint(x, y);
+    // Get the line text marker range for this text marker.
+    var range = element.lineTextMarkerRangeForTextMarker(marker);
+    // Return the text for this line text marker range.
+    return element.stringForTextMarkerRange(range).trim();
+}
+
+if (window.accessibilityController) {
+    var line = accessibilityController.accessibleElementById("line");
+    // Line text from first text marker (add one to make sure we get the first marker for THIS line).
+    lineText = lineTextForPoint(line.x + 1, line.y + 1);
+    output += expect("lineText", "expectedText");
+
+    // Line text from center text marker.
+    lineText = lineTextForPoint(line.x + line.width / 2, line.y + line.height / 2);
+    output += expect("lineText", "expectedText");
+
+    // Line text from last text marker (subtract one to make sure we get the last marker for THIS line).
+    lineText = lineTextForPoint(line.x + line.width - 1, line.y + line.height - 1);
+    output += expect("lineText", "expectedText");
+
+    // Hide superfluous text.
+    document.getElementById("container").style.display = "none";
+    debug(output);
+}
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
+++ b/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
@@ -13,36 +13,36 @@
 </div>
 
 <script>
-    if (window.accessibilityController) {
-        let output = "This tests the ability to search for accessible elements from an ignored element.\n\n";
+let output = "This tests the ability to search for accessible elements from an ignored element.\n\n";
 
-        var container = accessibilityController.accessibleElementById("container");
-        var element = accessibilityController.accessibleElementById("test").childAtIndex(0);
-        var range = element.textMarkerRangeForElement(element);
-        output += expect("element.stringForTextMarkerRange(range)", "'First line of text'");
+if (window.accessibilityController) {
+    var container = accessibilityController.accessibleElementById("container");
+    var element = accessibilityController.accessibleElementById("test").childAtIndex(0);
+    var range = element.textMarkerRangeForElement(element);
+    output += expect("element.stringForTextMarkerRange(range)", "'First line of text'");
 
-        // Try to get the ignored element using line text marker calls.
-        var marker = element.endTextMarkerForTextMarkerRange(range);
-        marker = element.nextTextMarker(marker);
-        marker = element.nextTextMarker(marker);
-        range = element.lineTextMarkerRangeForTextMarker(marker);
-        // The range for the line containing the button must include a '\n' since the <button> element is followed by <br>.
-        output += expect("element.stringForTextMarkerRange(range)", "`button\n`");
+    // Try to get the ignored element using line text marker calls.
+    var marker = element.endTextMarkerForTextMarkerRange(range);
+    marker = element.nextTextMarker(marker);
+    marker = element.nextTextMarker(marker);
+    range = element.lineTextMarkerRangeForTextMarker(marker);
+    // The range for the line containing the button must include a '\n' since the <button> element is followed by <br>.
+    output += expect("element.stringForTextMarkerRange(range)", "`button\n`");
 
-        marker = element.startTextMarkerForTextMarkerRange(range);
-        var startElement = element.accessibilityElementForTextMarker(marker);
+    marker = element.startTextMarkerForTextMarkerRange(range);
+    var startElement = element.accessibilityElementForTextMarker(marker);
 
-        // Search forward
-        var resultElement = container.uiElementForSearchPredicate(startElement, true, "AXAnyTypeSearchKey", "", false);
-        output += expect("resultElement.stringValue", "'AXValue: Third line of text'");
+    // Search forward
+    var resultElement = container.uiElementForSearchPredicate(startElement, true, "AXAnyTypeSearchKey", "", false);
+    output += expect("resultElement.stringValue", "'AXValue: Third line of text'");
 
-        // Search backward
-        resultElement = container.uiElementForSearchPredicate(startElement, false, "AXAnyTypeSearchKey", "", false);
-        output += expect("resultElement.stringValue", "'AXValue: First line of text'");
+    // Search backward
+    resultElement = container.uiElementForSearchPredicate(startElement, false, "AXAnyTypeSearchKey", "", false);
+    output += expect("resultElement.stringValue", "'AXValue: First line of text'");
 
-        document.getElementById("container").style.visibility = "hidden";
-        debug(output);
-    }
+    document.getElementById("container").style.visibility = "hidden";
+    debug(output);
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 32c2683c8c727d51eff7ef20863fb7f2dc7adb8c
<pre>
AX: Update several layout tests to accessibility current standards.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304255">https://bugs.webkit.org/show_bug.cgi?id=304255</a>
&lt;<a href="https://rdar.apple.com/problem/166621708">rdar://problem/166621708</a>&gt;

Reviewed by Tyler Wilcock.

This patch cleans up and update the accessibility tests touched in <a href="https://bugs.webkit.org/show_bug.cgi?id=304225">https://bugs.webkit.org/show_bug.cgi?id=304225</a> to meet our coding standards. No change in functionality.

* LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines-expected.txt:
* LayoutTests/accessibility/mac/attributed-string-with-listitem-multiple-lines.html:
* LayoutTests/accessibility/mac/line-range-continuity-expected.txt: Renamed from LayoutTests/accessibility/mac/character-offset-from-upstream-position-expected.txt.
* LayoutTests/accessibility/mac/line-range-continuity.html: Renamed from LayoutTests/accessibility/mac/character-offset-from-upstream-position.html.
* LayoutTests/accessibility/mac/line-range-for-text-marker-expected.txt:
* LayoutTests/accessibility/mac/line-range-for-text-marker.html:
* LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html:

Canonical link: <a href="https://commits.webkit.org/304542@main">https://commits.webkit.org/304542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c570ca07f0bd32c591054b0a568ca002b1610083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143575 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c839a8a-df38-4a34-9811-84705721ab1d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e5ae8ca-b8ce-464d-8991-63a3f2991030) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3781 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7921 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112573 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6051 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61827 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7969 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->