### PR TITLE
[Test] Make iframe-zoom-nested.html WPT test less flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html
@@ -7,6 +7,7 @@
 <link rel="author" title="Google" href="http://www.google.com/">
 <link href="reference/iframe-zoom-nested-ref.html" rel="match">
 <link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<script src="/common/reftest-wait.js"></script>
 
 <style>
 body {
@@ -26,24 +27,23 @@ iframe {
 </head>
 
 <body>
+<script>
+const totalLeafIframes = 4;
 
+addEventListener("load", () => {
+  let loadedCount = 0;
+  addEventListener("message", ({ data }) => {
+    // We need to wait for the nested iframe (leaf.html) to load, in addition
+    // to the top-level iframe (nested-iframe.html).
+    if (data != "leaf_loaded") return;
+      loadedCount += 1;
+      if (loadedCount == totalLeafIframes) {
+        takeScreenshot();
+      }
+  });
+});
+</script>
 <iframe id="baseline" src="resources/nested-iframe.html" scrolling="no"></iframe>
 <iframe id="zoom-child" src="resources/nested-iframe.html?zoom=2" scrolling="no"></iframe>
 <iframe id="zoom-top" class="zoom" src="resources/nested-iframe.html" scrolling="no"></iframe>
 <iframe id="zoom-top-child" class="zoom" src="resources/nested-iframe.html?zoom=2" scrolling="no"></iframe>
-
-<script>
-// Wait for all iframes to load before allowing the screenshot
-let loadedCount = 0;
-const iframes = document.querySelectorAll('iframe');
-const totalFrames = iframes.length;
-
-iframes.forEach(iframe => {
-  iframe.onload = function() {
-    loadedCount++;
-    if (loadedCount === totalFrames) {
-      document.documentElement.classList.remove("reftest-wait");
-    }
-  };
-});
-</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/resources/leaf.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/resources/leaf.html
@@ -21,4 +21,10 @@ let params = new URLSearchParams(location.search);
 if (params.has("scale")) {
   document.body.style.setProperty("--scale", parseFloat(params.get("scale")));
 }
+addEventListener(
+    "load",
+    () => {
+        top.postMessage("leaf_loaded", "*");
+    },
+);
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8377,7 +8377,6 @@ imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-007.x
 imported/w3c/web-platform-tests/css/CSS2/linebox/inline-formatting-context-022.xht [ ImageOnlyFailure ]
 
 # webkit.org/b/302331 REGRESSION(302097@main): [macOS iOS] 2x imported/w3c/web-platform-tests/css/css-viewport tests are flaky failure
-imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/zoom-iframe-dynamic.html [ Failure ]
 
 imported/w3c/web-platform-tests/css/CSS2/box-display/block-in-inline-001.xht [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3304,7 +3304,10 @@ webkit.org/b/298211 accessibility/mac/increase-contrast-system-color-changes.htm
 
 webkit.org/b/289382 fast/canvas/offscreen-no-script-context-crash.html [ Skip ]
 
+webkit.org/b/302331 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ Pass Failure ]
+
 webkit.org/b/298748 css3/text-decoration/text-decoration-line-grammar-error-1.html [ Skip ]
+
 webkit.org/b/298748 css3/text-decoration/text-decoration-line-grammar-error-2.html [ Skip ]
 webkit.org/b/298748 css3/text-decoration/text-decoration-line-grammar-error-3.html [ Skip ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2525,8 +2525,6 @@ fast/css/accent-color/datalist.html [ Skip ]
 
 webkit.org/b/302273 accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Pass Timeout ]
 
-webkit.org/b/302331 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ Pass Failure ]
-
 webkit.org/b/302364 http/tests/site-isolation/window-open-with-name-cross-site.html [ Pass Crash ]
 
 webkit.org/b/301013 http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Pass Failure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4361,8 +4361,6 @@ fast/html/body-color-legacy-parsing-3.html [ Pass ImageOnlyFailure ]
 # Fails on Buildbot
 fast/picture/viewport-resize.html [ Pass Failure ]
 
-imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure Pass ]
-
 fast/text/backslash-to-yen-sign.html [ Pass Failure ]
 
 fast/text/all-small-caps-whitespace.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 4d172df73828e6c6f735795468f8dce5628dd6ba
<pre>
[Test] Make iframe-zoom-nested.html WPT test less flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=304258">https://bugs.webkit.org/show_bug.cgi?id=304258</a>

Reviewed by Tim Nguyen.

This test is using iframes (nested-iframe.html) of iframes (leaf.html) :
iframe loading via &quot;.src = &quot; is async,
we need to send a message to be sure to wait for the 4 leaf iframes to load
before capturing the rendering.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/resources/leaf.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/304857@main">https://commits.webkit.org/304857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf121782db14b81872ba93b2f3d60f685c3c4259

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89616 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d066122-9fbb-4f88-b43d-a7c8eba8d1a3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104485 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f99aba7a-5e5f-4de2-a2ec-383ceb7d594b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d0d47c2d-607f-463d-aac7-62dc1a00ee6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4412 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112838 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6652 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8734 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36781 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8454 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->