### PR TITLE
REGRESSION (Safari 26.2): shape-outside initially incorrect when used with imported font

### DIFF
--- a/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load-expected.txt
+++ b/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load-expected.txt
@@ -1,0 +1,11 @@
+OOnce upon a time there was text that wrapped around a float.
+Test that shape-outside is invalidated when font changes, even when CSS shape properties remain unchanged.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Content position changed, indicating shape was properly invalidated
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load.html
+++ b/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .container {
+        width: 200px;
+        font: 20px/1 Ahem;
+    }
+
+    .float-shape {
+        float: left;
+        font-size: 60px;
+        line-height: 1;
+        font-family: serif;
+        shape-outside: margin-box;
+        margin-right: 10px;
+        background-color: blue;
+        color: white;
+    }
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="float-shape" id="float">O</div>
+    <span id="firstWord">Once</span> upon a time there was text that wrapped around a float.
+</div>
+<div id="console"></div>
+<script>
+jsTestIsAsync = true;
+
+function runTest() {
+    description("Test that shape-outside is invalidated when font changes, even when CSS shape properties remain unchanged.");
+
+    const floatElem = document.getElementById('float');
+    const firstWord = document.getElementById('firstWord');
+
+    document.body.offsetTop;
+
+    const initialLeft = firstWord.getBoundingClientRect().left;
+    const initialTop = firstWord.getBoundingClientRect().top;
+
+    floatElem.style.fontFamily = 'Ahem';
+
+    document.body.offsetTop;
+
+    const newLeft = firstWord.getBoundingClientRect().left;
+    const newTop = firstWord.getBoundingClientRect().top;
+
+    const positionChanged = (Math.abs(newLeft - initialLeft) > 1) || (Math.abs(newTop - initialTop) > 1);
+
+    if (positionChanged) {
+        testPassed("Content position changed, indicating shape was properly invalidated");
+    } else {
+        testFailed("Content position unchanged. Shape was not invalidated when font metrics changed.");
+    }
+
+    finishJSTest();
+}
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener('load', () => {
+    runTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -415,7 +415,7 @@ void RenderBox::styleDidChange(Style::Difference diff, const RenderStyle* oldSty
     }
 
     if ((oldStyle && !oldStyle->shapeOutside().isNone()) || !style().shapeOutside().isNone())
-        updateShapeOutsideInfoAfterStyleChange(style(), oldStyle);
+        updateShapeOutsideInfoAfterStyleChange(style(), oldStyle, diff);
     updateGridPositionAfterStyleChange(style(), oldStyle);
 
     // Changing the position from/to absolute can potentially create/remove flex/grid items, as absolutely positioned
@@ -474,7 +474,7 @@ void RenderBox::updateGridPositionAfterStyleChange(const RenderStyle& style, con
     parentGrid->setNeedsItemPlacement();
 }
 
-void RenderBox::updateShapeOutsideInfoAfterStyleChange(const RenderStyle& style, const RenderStyle* oldStyle)
+void RenderBox::updateShapeOutsideInfoAfterStyleChange(const RenderStyle& style, const RenderStyle* oldStyle, Style::Difference diff)
 {
     Style::ShapeOutside shapeOutside = style.shapeOutside();
     Style::ShapeOutside oldShapeOutside = oldStyle ? oldStyle->shapeOutside() : Style::ComputedStyle::initialShapeOutside();
@@ -482,11 +482,7 @@ void RenderBox::updateShapeOutsideInfoAfterStyleChange(const RenderStyle& style,
     Style::ShapeMargin shapeMargin = style.shapeMargin();
     Style::ShapeMargin oldShapeMargin = oldStyle ? oldStyle->shapeMargin() : Style::ComputedStyle::initialShapeMargin();
 
-    Style::ShapeImageThreshold shapeImageThreshold = style.shapeImageThreshold();
-    Style::ShapeImageThreshold oldShapeImageThreshold = oldStyle ? oldStyle->shapeImageThreshold() : Style::ComputedStyle::initialShapeImageThreshold();
-
-    // FIXME: A future optimization would do a deep comparison for equality. (bug 100811)
-    if (shapeOutside == oldShapeOutside && shapeMargin == oldShapeMargin && shapeImageThreshold == oldShapeImageThreshold)
+    if (diff <= Style::DifferenceResult::RecompositeLayer)
         return;
 
     if (shapeOutside.isNone())

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -698,7 +698,7 @@ protected:
 private:
     void addOverflowWithRendererOffset(const RenderBox&, LayoutSize, OptionSet<ComputeOverflowOptions> = { });
 
-    void updateShapeOutsideInfoAfterStyleChange(const RenderStyle&, const RenderStyle* oldStyle);
+    void updateShapeOutsideInfoAfterStyleChange(const RenderStyle&, const RenderStyle* oldStyle, Style::Difference);
 
     void updateGridPositionAfterStyleChange(const RenderStyle&, const RenderStyle* oldStyle);
 


### PR DESCRIPTION
#### acbb891ea04ca90cb32b107cfb87e9ae1f3214f4
<pre>
REGRESSION (Safari 26.2): shape-outside initially incorrect when used with imported font
<a href="https://bugs.webkit.org/show_bug.cgi?id=304019">https://bugs.webkit.org/show_bug.cgi?id=304019</a>
<a href="https://rdar.apple.com/166336491">rdar://166336491</a>

Reviewed by Simon Fraser and Alan Baradlay.

When web fonts load after initial layout, CSS shape properties remain unchanged
but box dimensions can change due to different font metrics. The regression caused
an early return when CSS is identical, preventing shape invalidation.

This issue was fixed by extending the early return condition to check whether
Style::Difference requires a repaint or layout. This ensures shapes are
invalidated when dimension-affecting properties change.

* LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load-expected.txt: Added.
* LayoutTests/fast/shapes/shape-outside-floats/shape-outside-invalidation-after-font-load.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::styleDidChange):
(WebCore::RenderBox::updateShapeOutsideInfoAfterStyleChange):
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/305299@main">https://commits.webkit.org/305299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9753f2a74a15c8aa0d74752de9ce0f83a700c940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105501 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76994 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5587 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6310 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7773 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64731 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10053 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73621 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->