### PR TITLE
ImageDecoderAVFObjC::createFrameImageAtIndex should ensure that the cursor is valid when rewinding to find earlier sample

### DIFF
--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -268,6 +268,20 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     return foundSample;
 }
 
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSamplePriorToDecodeKey(const KeyType& key)
+{
+    reverse_iterator reverseCursor = reverseFindSampleWithDecodeKey(key);
+    if (reverseCursor == rend())
+        return end();
+
+    reverseCursor = findSyncSamplePriorToDecodeIterator(reverseCursor);
+    if (reverseCursor == rend())
+        return end();
+
+    Ref sample = reverseCursor->second;
+    return findSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
+}
+
 DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIterator(iterator currentSampleDTS)
 {
     if (currentSampleDTS == end())

--- a/Source/WebCore/Modules/mediasource/SampleMap.h
+++ b/Source/WebCore/Modules/mediasource/SampleMap.h
@@ -99,6 +99,7 @@ public:
     WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime()) LIFETIME_BOUND;
     WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToDecodeIterator(reverse_iterator) LIFETIME_BOUND;
     WEBCORE_EXPORT iterator findSyncSampleAfterPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime()) LIFETIME_BOUND;
+    WEBCORE_EXPORT iterator findSyncSamplePriorToDecodeKey(const KeyType&) LIFETIME_BOUND;
     WEBCORE_EXPORT iterator findSyncSampleAfterDecodeIterator(iterator) LIFETIME_BOUND;
     WEBCORE_EXPORT reverse_iterator_range findDependentSamples(const MediaSample&) LIFETIME_BOUND;
     WEBCORE_EXPORT Vector<value_type> findSamplesBetweenDecodeKeys(const KeyType&, const KeyType&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -617,11 +617,9 @@ PlatformImagePtr ImageDecoderAVFObjC::createFrameImageAtIndex(size_t index, Subs
 
     if (decodeTime < Ref { m_cursor->second }->decodeTime()) {
         // Rewind cursor to the last sync sample to begin decoding
-        m_cursor = m_sampleData.decodeOrder().findSampleWithDecodeKey({decodeTime, sampleData->presentationTime()});
-        do {
-            if (Ref { m_cursor->second }->isSync())
-                break;
-        } while (--m_cursor != m_sampleData.decodeOrder().begin());
+        m_cursor = m_sampleData.decodeOrder().findSyncSamplePriorToDecodeKey({ decodeTime, sampleData->presentationTime() });
+        if (m_cursor == m_sampleData.decodeOrder().end())
+            return nullptr;
     }
 
     while (true) {


### PR DESCRIPTION
#### f17044b41c9006fbcf0cb7b9075368aa703d268a
<pre>
ImageDecoderAVFObjC::createFrameImageAtIndex should ensure that the cursor is valid when rewinding to find earlier sample
<a href="https://bugs.webkit.org/show_bug.cgi?id=301185">https://bugs.webkit.org/show_bug.cgi?id=301185</a>
<a href="https://rdar.apple.com/162449335">rdar://162449335</a>

Reviewed by Jer Noble.

ImageDecoderAVFObjC::createFrameImageAtIndex could go OOB when we search
for a decodeOrder frame which comes earlier than the first sync frame.
This change ensures that m_cursor always remains valid during this search.

* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToDecodeKey):
* Source/WebCore/Modules/mediasource/SampleMap.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::createFrameImageAtIndex):

Originally-landed-as: 301765.131@safari-7623-branch (db3be24f9f5b). <a href="https://rdar.apple.com/166338064">rdar://166338064</a>
Canonical link: <a href="https://commits.webkit.org/304558@main">https://commits.webkit.org/304558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2d4f744ffd46c10b529777126450a42d75dca69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143612 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ab56e51-bbc1-488f-978b-2123fc5e5a7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c2a313b1-ed0b-4768-a31b-3584f5d7a438) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84736 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d203e8f4-018c-427f-b9c6-2f644a0ea3ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6162 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3809 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112214 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112602 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6072 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61857 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8004 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36183 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->