### PR TITLE
REGRESSION(300618@main): `letter-spacing` transition no longer works

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    font-size: 20px;
+    letter-spacing: 100%;
+  }
+</style>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>percentage letter-spacing animates when animating font-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel='help' href='https://www.w3.org/TR/css-text-3/#letter-spacing'>
+<link rel='match' href='reference/letter-spacing-animating-font-sizing-ref.html'>
+<style>
+  #target {
+    letter-spacing: 100%;
+  }
+</style>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+
+<script>
+  const target = document.querySelector('#target');
+
+  const animation = target.animate({ fontSize: ['0px', '40px'] }, 40);
+  animation.pause();
+  animation.currentTime = 20;
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    letter-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>letter-spacing animates when animating letter-spacing</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel='help' href='https://www.w3.org/TR/css-text-3/#letter-spacing'>
+<link rel='match' href='reference/letter-spacing-animating-letter-spacing-ref.html'>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+
+<script>
+  const target = document.querySelector('#target');
+
+  const animation = target.animate({ letterSpacing: ['0px', '40px'] }, 40);
+  animation.pause();
+  animation.currentTime = 20;
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-font-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-font-size-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    font-size: 20px;
+    letter-spacing: 100%;
+  }
+</style>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-letter-spacing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-letter-spacing-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    letter-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The letters below should be separated by 20 pixels.</div> 
+<div id="target">ABCD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-font-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-font-size-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    font-size: 20px;
+    word-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-word-spacing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-word-spacing-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    word-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    font-size: 20px;
+    word-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>percentage word-spacing animates when animating font-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel='help' href='https://www.w3.org/TR/css-text-3/#word-spacing'>
+<link rel='match' href='reference/word-spacing-animating-font-size-ref.html'>
+<style>
+  #target {
+    word-spacing: 100%;
+  }
+</style>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+
+<script>
+  const target = document.querySelector('#target');
+
+  const animation = target.animate({ fontSize: ['0px', '40px'] }, 40);
+  animation.pause();
+  animation.currentTime = 20;
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  #target {
+    word-spacing: 20px;
+  }
+</style>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>word-spacing animates when animating word-spacing</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel='help' href='https://www.w3.org/TR/css-text-3/#word-spacing'>
+<link rel='match' href='reference/word-spacing-animating-word-spacing-ref.html'>
+</head>
+<body>
+<div>The words below should be separated by 20 pixels.</div> 
+<div id="target">WORD WORD WORD</div>
+
+<script>
+  const target = document.querySelector('#target');
+
+  const animation = target.animate({ wordSpacing: ['0px', '40px'] }, 40);
+  animation.pause();
+  animation.currentTime = 20;
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -473,7 +473,6 @@ style/PseudoClassChangeInvalidation.cpp
 style/StyleAdjuster.cpp
 style/StyleBuilder.cpp
 style/StyleBuilderCustom.h
-style/StyleBuilderState.cpp
 style/StyleBuilderStateInlines.h
 style/StyleCustomPropertyRegistry.cpp
 style/StyleDifference.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5235,6 +5235,7 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "animation-wrapper-requires-getter": "computedLetterSpacing",
+                "animation-wrapper-requires-setter": "setLetterSpacingFromAnimation",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "font-property": true,
@@ -8987,6 +8988,7 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "animation-wrapper-requires-getter": "computedWordSpacing",
+                "animation-wrapper-requires-setter": "setWordSpacingFromAnimation",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "font-property": true,

--- a/Source/WebCore/rendering/style/RenderStyleBase.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase.h
@@ -587,6 +587,14 @@ public:
     void setSpecifiedLineHeight(Style::LineHeight&&);
 #endif
 
+    void setLetterSpacingFromAnimation(Style::LetterSpacing&&);
+    void setWordSpacingFromAnimation(Style::WordSpacing&&);
+
+    void synchronizeLetterSpacingWithFontCascade();
+    void synchronizeLetterSpacingWithFontCascadeWithoutUpdate();
+    void synchronizeWordSpacingWithFontCascade();
+    void synchronizeWordSpacingWithFontCascadeWithoutUpdate();
+
     // MARK: Writing Modes
 
     // FIXME: Rename to something that doesn't conflict with a property name.

--- a/Source/WebCore/rendering/style/RenderStylePropertiesSettersCustom.h
+++ b/Source/WebCore/rendering/style/RenderStylePropertiesSettersCustom.h
@@ -143,6 +143,10 @@ inline void RenderStyleProperties::setFontSize(float size)
     description.setSpecifiedSize(size);
     description.setComputedSize(size);
     setFontDescription(WTFMove(description));
+
+    // Whenever the font size changes, letter-spacing and word-spacing, which are dependent on font-size, must be re-synchronized.
+    synchronizeLetterSpacingWithFontCascade();
+    synchronizeWordSpacingWithFontCascade();
 }
 
 inline void RenderStyleProperties::setFontSizeAdjust(Style::FontSizeAdjust sizeAdjust)

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -254,30 +254,8 @@ void BuilderState::updateFontForOrientationChange()
 
 void BuilderState::updateFontForSizeChange()
 {
-    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
-    auto fontSize = fontCascade.size();
-
-    auto newWordSpacing = evaluate<float>(m_style.computedWordSpacing(), fontSize, m_style.usedZoomForLength());
-    auto newLetterSpacing = evaluate<float>(m_style.computedLetterSpacing(), fontSize, m_style.usedZoomForLength());
-
-    if (newWordSpacing != fontCascade.wordSpacing())
-        fontCascade.setWordSpacing(newWordSpacing);
-
-    if (newLetterSpacing != fontCascade.letterSpacing()) {
-        fontCascade.setLetterSpacing(newLetterSpacing);
-
-        const auto& oldFontDescription = m_style.fontDescription();
-
-        bool oldShouldDisableLigatures = oldFontDescription.shouldDisableLigaturesForSpacing();
-        bool newShouldDisableLigatures = newLetterSpacing != 0;
-
-        // Switching letter-spacing between zero and non-zero requires updating to enable/disable ligatures.
-        if (oldShouldDisableLigatures != newShouldDisableLigatures) {
-            auto newFontDescription = oldFontDescription;
-            newFontDescription.setShouldDisableLigaturesForSpacing(newShouldDisableLigatures);
-            m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
-        }
-    }
+    m_style.synchronizeLetterSpacingWithFontCascadeWithoutUpdate();
+    m_style.synchronizeWordSpacingWithFontCascadeWithoutUpdate();
 }
 
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -385,6 +385,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'animation-wrapper-requires-non-additive-or-cumulative-interpolation': self.validate_boolean,
             'animation-wrapper-requires-non-normalized-discrete-interpolation': self.validate_boolean,
             'animation-wrapper-requires-override-parameters': self.validate_array,
+            'animation-wrapper-requires-setter': self.validate_string,
             'cascade-alias': self.validate_string,
             'coordinated-value-list-property-getter': self.validate_string,
             'coordinated-value-list-property-initial': self.validate_string,


### PR DESCRIPTION
#### 3a3971d9fc9294d0819735461d788028b1cb5c73
<pre>
REGRESSION(300618@main): `letter-spacing` transition no longer works
<a href="https://bugs.webkit.org/show_bug.cgi?id=304172">https://bugs.webkit.org/show_bug.cgi?id=304172</a>
<a href="https://rdar.apple.com/166530064">rdar://166530064</a>

Reviewed by Antoine Quint.

When splitting the computed letter-spacing and word-spacing values
out of FontCascade in 300618@main, I neglected to account for the
case where the the style builder is not used: animations. So, while
the computed letter-spacing and word-spacing values got updated
during animations (which is what most test cases look at because
it can be queried from script), the used letter-spacing and
word-spacing values on FontCascade where not getting synchronized.

To rectify this, I extracted the synchronization code into new
helpers on RenderStyleBase (with both updating, for animation, and
non-updating, for style building, variants), and introduced new
setters for the letter-spacing and word-spacing interpolator to
call that invokes the new synchronizers.

While thinking about this, I realized we had another related issue
with letter-spacing and word-spacing during animations but when
animating font-size. When animating font-size, we also need to ensure
that letter-spacing and word-spacing are synchronized, as they
might be using percentage values.

Tests: imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size.html
       imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing.html
       imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-font-size-ref.html
       imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-letter-spacing-ref.html
       imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-font-size-ref.html
       imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-word-spacing-ref.html
       imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size.html
       imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-font-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-animating-letter-spacing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-font-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/letter-spacing/reference/letter-spacing-animating-letter-spacing-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-font-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/reference/word-spacing-animating-word-spacing-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-font-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-animating-word-spacing.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyleBase.cpp:
* Source/WebCore/rendering/style/RenderStyleBase.h:
* Source/WebCore/rendering/style/RenderStylePropertiesSettersCustom.h:
* Source/WebCore/style/StyleBuilderState.cpp:

Canonical link: <a href="https://commits.webkit.org/304575@main">https://commits.webkit.org/304575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c09c2d141431282067f633cb8597ef17a0cd79f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135985 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143688 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103918 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84795 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135333 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3863 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8026 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112273 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112666 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6127 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118165 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36234 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71631 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->