### PR TITLE
Add user prompt before invoking ARQuickLook for 3D Asset Parsing

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1207,6 +1207,7 @@
 		A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */; };
 		A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5329F733D300A7FB2F /* hab.reality */; };
 		A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
+		A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5329F733D300A7FB2F /* hab.reality */; };
 		A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
 		A17C48162C98E5C20023F3C7 /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
 		A17C48172C98E5C20023F3C7 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DF22357E45D00E85E09 /* web-authentication-get-assertion-hid-cancel.html */; };


### PR DESCRIPTION
#### 22edb559eb10973c849e07781dd333ead94370dd
<pre>
Add user prompt before invoking ARQuickLook for 3D Asset Parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=299065">https://bugs.webkit.org/show_bug.cgi?id=299065</a>
<a href="https://rdar.apple.com/159192457">rdar://159192457</a>

Reviewed by Mike Wyrzykowski and Abrar Rahman Protyasha.

Certain code flows allow 3D asset parsing outside of WebContent
without user prompts. This fix adds a user prompt for those flows and thus introduces
a user-in-the-loop mechanism to mitigate this attack surface.

These flows specifically are top level navigations to 3D assets
and &lt;a&gt; WITHOUT rel=ar. A new user prompt/message is needed because the
existing &quot;View in AR?&quot; prompt for &lt;a&gt; WITH rel=ar does not fit here. In the two flows here,
the user prompt precedes handing the file off to ARQL to generate a preview image.
The existing &quot;View in AR?&quot; prompt already has a user provided preview image,
and its prompt in contrast precedes ARQL launching into the camera and placing the asset into user surroundings.
As a result, our new prompt &quot;Display Model Preview?&quot; reflects the behavior appopriately to
the user.

Appropriate API tests are added to verify that alert shows up in all
3 flows (&lt;a&gt; WITH rel=ar, &lt;a&gt; WITHOUT rel=ar, and top level navigations) and for both usdz
and reality files. We also test to make sure that ARQL is only invoked when user presses allow action.
The RelARPrompt has its own testing logic because of its slightly different behavior
and the need to execute the cancel and allow action handlers separately due to std::exchange()
being used in SystemPreviewControllerCocoa.mm.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:data:]):
* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProvider.h:
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKPDFView web_setContentProviderData:suggestedFilename:]): Deleted.
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:]): Deleted.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::testModelPreviewPrompt):
(TestWebKitAPI::testRelARPrompt):
(TestWebKitAPI::TEST(WebKit, PromptUSDZTopLevelNavigation)):
(TestWebKitAPI::TEST(WebKit, PromptRealityTopLevelNavigation)):
(TestWebKitAPI::TEST(WebKit, PromptUSDZLinkWithoutRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptRealityLinkWithoutRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptUSDZLinkWithRelAR)):
(TestWebKitAPI::TEST(WebKit, PromptRealityLinkWithRelAR)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/hab.reality: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html:

Originally-landed-as: 297297.491@safari-7622-branch (053b792933f4). <a href="https://rdar.apple.com/166337969">rdar://166337969</a>
Canonical link: <a href="https://commits.webkit.org/304564@main">https://commits.webkit.org/304564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e5b8313eace2a1841d0eef02584c9fc581dfe90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87468 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf248c73-584b-4c53-85ef-09ee20e620ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103863 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd8e1fe9-36b5-421f-b241-7980ef4362af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84739 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d87d091b-dd8d-4788-b50e-4e512838dc19) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3810 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146367 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112218 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6075 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61861 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36181 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7737 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->