### PR TITLE
`JSON.parse` could allocate Array backing stores uninitialized

### DIFF
--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -28,6 +28,7 @@
 #include "LiteralParser.h"
 
 #include "CodeBlock.h"
+#include "GCDeferralContextInlines.h"
 #include "JSArray.h"
 #include "JSCInlines.h"
 #include "JSONAtomStringCacheInlines.h"
@@ -1358,7 +1359,13 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
     auto scope = DECLARE_THROW_SCOPE(vm);
     TokenType type = m_lexer.currentToken()->type;
     if (type == TokLBracket) {
-        JSArray* array = constructEmptyArray(m_globalObject, nullptr);
+        GCDeferralContext deferralContext(vm);
+        ObjectInitializationScope initializationScope(vm);
+        JSArray* array = JSArray::tryCreateUninitializedRestricted(initializationScope, &deferralContext, m_globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+        if (!array) [[unlikely]] {
+            throwOutOfMemoryError(m_globalObject, scope);
+            return { };
+        }
         RETURN_IF_EXCEPTION(scope, { });
         TokenType type = m_lexer.next();
         if (type == TokRBracket) {


### PR DESCRIPTION
#### 4bab56c1da97a9a139a60a4b9c1ccf503467e981
<pre>
`JSON.parse` could allocate Array backing stores uninitialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=304264">https://bugs.webkit.org/show_bug.cgi?id=304264</a>
<a href="https://rdar.apple.com/164716376">rdar://164716376</a>

Reviewed by NOBODY (OOPS!).

Instead of constructEmptyArray in LiteralParser::parseRecursively, this patch
uses JSArray::tryCreateUninitializedRestricted with a GCDeferralContext.
This avoids the overhead of zeroing out the array&apos;s backing store.

This is a performance change that&apos;s covered by existing tests,
such as JetStream&apos;s json-parse-inspector benchmark.

* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser::parseRecursively): replaces usage of constructEmptyArray with JSArray::tryCreateUninitializedRestricted
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bab56c1da97a9a139a60a4b9c1ccf503467e981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87471 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8127 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103866 "Found 2 new test failures: js/JSON-parse-reviver.html js/dom/JSON-parse.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71857 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84743 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6170 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3815 "Found 18 new API test failures: TestWebKitAPI.RemoteObjectRegistry.CallReplyBlockWithBadInvocation, TestWebKitAPI.WKInspectorDelegate.ShowURLExternally, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground, TestWebKitAPI.WKInspectorExtensionHost.RegisterExtension, TestWebKitAPI.WKWebExtensionAPIDevTools.Basics, TestWebKitAPI.IPCTestingAPI.SpeechSynthesisWithFeatureFlag, TestWebKitAPI.WKWebExtensionAPIDevTools.PanelsThemeName, TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4227 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127885 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146372 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134395 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40565 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112220 "Found 2 new test failures: js/JSON-parse-reviver.html js/dom/JSON-parse.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7988 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6686 "Found 2 new test failures: js/JSON-parse-reviver.html js/dom/JSON-parse.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112609 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6080 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118109 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61864 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8013 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36188 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167197 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71565 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43638 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->