### PR TITLE
En

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2761,17 +2761,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2320,6 +2320,11 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
 
         DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Unable to load main resource, returning empty document");
 
+        if (mainResourceOrError.error().localizedDescription() == "Loading in a new process"_s) {
+            DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Skipping maybeLoadEmpty for ContentRuleList redirect");
+            return;
+        }
+
         setRequest(ResourceRequest());
         maybeLoadEmpty();
         return;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1754,7 +1754,16 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData());
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
-    loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+
+    // For Enhanced Security process swaps: ContentRuleList redirects OR cross-domain redirects need continuing load flag
+    bool isCrossDomainRedirect = request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision
+        && RegistrableDomain(request.resourceRequest().url()) != RegistrableDomain(request.requesterSecurityOrigin().data());
+
+    loader->setIsContinuingLoadAfterProvisionalLoadStarted(
+        request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted
+        || request.isContentRuleListRedirect()
+        || isCrossDomainRedirect
+    );
     if (crossSiteRequester)
         loader->setCrossSiteRequester(WTFMove(*crossSiteRequester));
 

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -214,7 +214,8 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     m_contentFilterUnblockHandler = { };
 #endif
 
-    frameLoader->clearProvisionalLoadForPolicyCheck();
+    if (!loader->isContentRuleListRedirect())
+        frameLoader->clearProvisionalLoadForPolicyCheck();
 
     RefPtr formState = formSubmission ? formSubmission->protectedState(): nullptr;
     auto blobURLLifetimeExtension = extendBlobURLLifetimeIfNecessary(request, *frame->protectedDocument(), policyDecisionMode);


### PR DESCRIPTION
#### 181a9bd314cc74b62a9ad74299e3b34472070a44
<pre>
Enhanced Security Heuristics - Enable by default TEST

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
</pre>
----------------------------------------------------------------------
#### 3481d209827dfe52337ceccfe042868191eb51c3
<pre>
Enable Enhanced Security HTTP heuristics by default.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303635">https://bugs.webkit.org/show_bug.cgi?id=303635</a>
<a href="https://rdar.apple.com/165921010">rdar://165921010</a>

Reviewed by NOBODY (OOPS!).

Toggle this on by default on Apple platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/181a9bd314cc74b62a9ad74299e3b34472070a44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87475 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f025e1d0-63ac-4b78-bf1a-e34c34605f18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/71861 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4523103-ab74-4a8e-aade-d9c7a1fd8d3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6472 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121812 "Found 18 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84749 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/25afe917-5d6f-47af-8eca-ee4d99c132da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6176 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3820 "Found 25 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SiteIsolation.IframeOpener, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.WKContentRuleListStoreTest.MainResourceCrossOriginRedirect ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4231 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127889 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115441 "Found 18 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.HistoryDelegate.NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146376 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134399 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112226 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7992 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6691 "Found 4 new test failures: http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/permissions-policy.html http/tests/site-isolation/window-open-with-name.html http/tests/site-isolation/window-properties.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112615 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6093 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61868 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8017 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36189 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71569 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43639 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->