### PR TITLE
Add retain callbacks for CFDictionary

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8191,3 +8191,5 @@ media/wireless-playback-media-player/ [ Skip ]
 webkit.org/b/295810 [ Debug ] fast/dynamic/disappearing-content-on-size-change-crash.html [ Timeout ]
 
 [ Debug ] fast/inline/continuation-with-anon-wrappers.html [ Slow ]
+
+webkit.org/b/301250 ipc/dictionary-callbacks.html [ Skip ]

--- a/LayoutTests/ipc/dictionary-callbacks-expected.txt
+++ b/LayoutTests/ipc/dictionary-callbacks-expected.txt
@@ -1,0 +1,8 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x576
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 258x18
+          text run at (0,0) width 258: "This test passes if WebKit did not crash."

--- a/LayoutTests/ipc/dictionary-callbacks.html
+++ b/LayoutTests/ipc/dictionary-callbacks.html
@@ -1,0 +1,197 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    class Helper {
+        constructor() {
+            this.connections = [{
+                connection: IPC.connectionForProcessTarget('GPU')
+            }]
+        }
+        extractCallResult(b, path) {
+            let currentIdx = path;
+            let a = b.replyArguments[currentIdx].name
+            let c = b.parsedReply[a];
+            return c
+        }
+        sendMessage(connectionID, messageDesc, destinationID, args) {
+            let connection = this.connections[connectionID].connection
+            if (messageDesc.replyArguments == null) {
+
+                const serializedArguments = ArgumentSerializer.serializeArguments(messageDesc.arguments, args);
+                connection.sendMessage(destinationID, messageDesc.name, serializedArguments)
+            } else {
+                if (messageDesc.d);
+                else {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(messageDesc.arguments, args)
+                    return new Promise((resolve) => {
+                        try {
+                            connection.sendWithAsyncReply(destinationID, messageDesc.name, serializedArguments, () => {});
+                        } catch {
+                            resolve0;
+                        }
+                    });
+                }
+            }
+        }
+    }
+async function main() {
+        const res_0 = {
+            replyArguments: [{
+                name: 'identifier'
+            }],
+            parsedReply: {
+                identifier: 0n
+            }
+        };
+        const helper = new Helper(true);
+        let ref_105827994978832 = res_0 ? helper.extractCallResult(res_0, 0) : null;
+        if (ref_105827994978832 !== null) {
+            helper.sendMessage(0, IPC.messages.RemoteMediaPlayerManagerProxy_CreateMediaPlayer, ref_105827994978832, {
+                identifier: 18446744073709551614n,
+                clientIdentifier: 18446744073709551614n,
+                remoteEngineIdentifier: 0,
+                proxyConfiguration: {
+                    referrer: 'x79',
+                    userAgent: '',
+                    sourceApplicationIdentifier: '',
+                    networkInterfaceName: '\e',
+                    audioOutputDeviceId: '',
+                    mediaContentTypesRequiringHardwareSupport: [],
+                    allowedMediaContainerTypes: {},
+                    allowedMediaCodecTypes: {
+                        optionalValue: ['', ]
+                    },
+                    allowedMediaVideoCodecIDs: {},
+                    allowedMediaAudioCodecIDs: {},
+                    allowedMediaCaptionFormatTypes: {},
+                    playerContentBoxRect: {
+                        m_location: {
+                            x: {
+                                rawValue: 936288880,
+                            },
+                            y: {
+                                rawValue: 278,
+                            }
+                        },
+                        m_size: {
+                            width: {
+                                rawValue: 4252677577,
+                            },
+                            height: {
+                                rawValue: 9,
+                            },
+                        }
+                    },
+                    preferredAudioCharacteristics: [],
+                    outOfBandTrackData: [],
+                    documentSecurityOrigin: {
+                        data: {
+                            variantIndex: 0,
+                            variant: {
+                                protocol: '',
+                                host: '\x2Ex31',
+                                port: {},
+                            }
+                        },
+                    },
+                    presentationSize: {
+                        width: 3480689791,
+                        height: 1,
+                    },
+                    logIdentifier: 2n,
+                    shouldUsePersistentCache: true,
+                    isVideo: true,
+                    renderingCanBeAccelerated: true,
+                    shouldDisableHDR: false,
+                },
+            });
+        }
+        let ref_105827994982928 = res_0 ? helper.extractCallResult : null;
+        if (ref_105827994982928 !== null);
+        if (true) {
+            helper.sendMessage(0, IPC.messages.RemoteMediaPlayerProxy_Load, 18446744073709551614n, {
+                url: {
+                    string: '\x77\x3Ax31x90x8Ax50x4ExA6xD6x77x4E',
+                },
+                sandboxExtension: {},
+                options: {
+                    contentType: {
+                        raw: '\f',
+                        typeWasInferredFromExtension: true,
+                    },
+                    requiresRemotePlayback: true,
+                    supportsLimitedMatroska: false,
+                    videoRendererPreferences: 9,
+                },
+            });
+        }
+        let ref_105827994983568 = res_0 ? helper.extractCallResult(res_0, 0) : null;
+        let ref_105827994983696 = 2n;
+        let ref_105827994983824 = 18446744073709551614n;
+        let ref_105827994983952 = 2n;
+        if (ref_105827994983568 !== null && ref_105827994983696 !== null && ref_105827994983824 !== null && ref_105827994983952 !== null) {
+            helper.sendMessage(0, IPC.messages.RemoteMediaResourceManager_LoadFailed, ref_105827994983568, {
+                identifier: ref_105827994983696,
+                error: {
+                    ipcData: {
+                        optionalValue: {
+                            type: 3,
+                            nsError: {
+                                optionalValue: {
+                                    wrapper: {
+                                        domain: '',
+                                        code: ref_105827994983824,
+                                        userInfo: {
+                                            vector: {},
+                                        },
+                                        underlyingError: {
+                                            optionalValue: {
+                                                domain: 'x74',
+                                                code: ref_105827994983952,
+                                                userInfo: {
+                                                    vector: {},
+                                                },
+                                                underlyingError: {},
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                            isSanitized: true,
+                        }
+                    },
+                },
+            });
+        }
+        if (true)
+            if (ref_105827994984144 !== null)
+                if (ref_105827994984400 !== null);
+    }
+
+globalThis.testRunner?.waitUntilDone();
+
+</script>
+<script type="module">
+
+import { CoreIPC, ArgumentSerializer, ArgumentParser } from './coreipc.js';
+if (window.IPC) {
+
+    window.CoreIPC = CoreIPC;
+    window.ArgumentSerializer = ArgumentSerializer;
+    window.ArgumentParser = ArgumentParser;
+
+    setTimeout(() => {
+        main().catch(e => {
+        }).finally(() => {
+            globalThis.testRunner?.notifyDone();
+        });
+    }, 100);
+} else {
+    window.testRunner?.notifyDone();
+}
+
+</script>
+</head>
+<body>
+    <p>This test passes if WebKit did not crash.</p>
+</body>
+</html>


### PR DESCRIPTION
#### e1f813179b3ffa7c18da156ab8846fbf9372c1d6
<pre>
Add retain callbacks for CFDictionary
<a href="https://rdar.apple.com/163085872">rdar://163085872</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301250">https://bugs.webkit.org/show_bug.cgi?id=301250</a>

Reviewed by Geoffrey Garen.

Adding retain callbacks will help manage lifetime management
of objects in the dictionary.

* LayoutTests/ipc/dictionary-callbacks-expected.txt: Added.
* LayoutTests/ipc/dictionary-callbacks.html: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):

Originally-landed-as: 301765.250@safari-7623-branch (d31dda933f5d). <a href="https://rdar.apple.com/166336459">rdar://166336459</a>
Canonical link: <a href="https://commits.webkit.org/304610@main">https://commits.webkit.org/304610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32a757867ca01fa8620af6b27aed563c3f108639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47384 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/143811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9134 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/8306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/143811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/143811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/4407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/8145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/40732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/146559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/8161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/8306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20963 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/8193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/7909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/8132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->