### PR TITLE
[experiment] Layout milestone notifications should be dispatched asynchronously

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3086,7 +3086,11 @@ void FrameLoader::didReachLayoutMilestone(OptionSet<LayoutMilestone> milestones)
 
     m_client->willDispatchDidReachLayoutMilestone(milestones);
 
-    m_frame->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [this, protectedThis = Ref { *this }, milestones, queuedNavigationID] {
+    RefPtr document = m_frame->document();
+    if (!document)
+        return;
+
+    document->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [this, protectedThis = Ref { *this }, milestones, queuedNavigationID] {
         RefPtr loader = activeDocumentLoader();
         if (!loader)
             return;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -55,6 +55,7 @@
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
 #include "DiagnosticLoggingResultType.h"
+#include "DocumentEventLoop.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
@@ -3081,7 +3082,19 @@ void FrameLoader::didReachLayoutMilestone(OptionSet<LayoutMilestone> milestones)
 {
     ASSERT(m_frame->isMainFrame());
 
-    m_client->dispatchDidReachLayoutMilestone(milestones);
+    auto queuedNavigationID = protectedActiveDocumentLoader()->navigationID();
+
+    m_client->willDispatchDidReachLayoutMilestone(milestones);
+
+    m_frame->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [this, protectedThis = Ref { *this }, milestones, queuedNavigationID] {
+        RefPtr loader = activeDocumentLoader();
+        if (!loader)
+            return;
+
+        auto taskNavigationID = loader->navigationID();
+        if (taskNavigationID && taskNavigationID == queuedNavigationID)
+            m_client->dispatchDidReachLayoutMilestone(milestones);
+    });
 }
 
 void FrameLoader::didFirstLayout()

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -190,6 +190,7 @@ public:
 #endif
 
     virtual void dispatchDidLayout() { }
+    virtual void willDispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) { }
     virtual void dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) { }
     virtual void dispatchDidReachVisuallyNonEmptyState() { }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -122,6 +122,7 @@ private:
     void dispatchDidFailLoad(const WebCore::ResourceError&) final;
     void dispatchDidFinishDocumentLoad() final;
     void dispatchDidFinishLoad() final;
+    void willDispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>);
     void dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>) final;
 
     WebCore::LocalFrame* dispatchCreatePage(const WebCore::NavigationAction&, WebCore::NewFrameOpenerPolicy) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -782,6 +782,17 @@ void WebFrameLoaderClient::dispatchDidFinishLoad()
     [m_webFrame->_private->internalLoadDelegate webFrame:m_webFrame.get() didFinishLoadWithError:nil];
 }
 
+void WebFrameLoaderClient::willDispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
+{
+#if !PLATFORM(IOS_FAMILY)
+    if (milestones & WebCore::LayoutMilestone::DidFirstLayout) {
+        WebDynamicScrollBarsView *scrollView = [m_webFrame->_private->webFrameView _scrollView];
+        [scrollView setVerticalScrollElasticity:NSScrollElasticityAutomatic];
+        [scrollView setHorizontalScrollElasticity:NSScrollElasticityAutomatic];
+    }
+#endif
+}
+
 void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
 {
     WebView *webView = getWebView(m_webFrame.get());
@@ -809,10 +820,6 @@ void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::La
         WebDynamicScrollBarsView *scrollView = [m_webFrame->_private->webFrameView _scrollView];
         if ([getWebView(m_webFrame.get()) drawsBackground])
             [scrollView setDrawsBackground:YES];
-#if !PLATFORM(IOS_FAMILY)
-        [scrollView setVerticalScrollElasticity:NSScrollElasticityAutomatic];
-        [scrollView setHorizontalScrollElasticity:NSScrollElasticityAutomatic];
-#endif
     }
 
     if (milestones & WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm
@@ -246,16 +246,17 @@ TEST(WebKit, AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize)
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    __block bool didFinishNavigation = false;
+    __block bool didFirstLayout = false;
     didInvalidateIntrinsicContentSize = false;
-    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
-        didFinishNavigation = true;
+    [navigationDelegate setRenderingProgressDidChange:^(WKWebView *, _WKRenderingProgressEvents events) {
+        if (events & _WKRenderingProgressEventFirstLayout)
+            didFirstLayout = true;
     }];
 
     [webView setExpectingIntrinsicContentSizeChange:YES];
     [webView loadHTMLString:@"<body style='margin: 0; height: 400px;'></body>" baseURL:nil];
     TestWebKitAPI::Util::run(&didInvalidateIntrinsicContentSize);
-    TestWebKitAPI::Util::run(&didFinishNavigation);
+    TestWebKitAPI::Util::run(&didFirstLayout);
 
     NSString *script = @"document.body.style.height = '800px';"
         "document.scrollingElement.scrollTop;"


### PR DESCRIPTION
#### 7daf383c2316eeaa97fb5c3ea649e5cbb3b30c09
<pre>
[experiment] Layout milestone notifications should be dispatched asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=303958">https://bugs.webkit.org/show_bug.cgi?id=303958</a>
<a href="https://rdar.apple.com/153254633">rdar://153254633</a>

Reviewed by NOBODY (OOPS!).

Run experimental fix in parallel to debugging. See debugging PR: #55213

No new tests needed.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didReachLayoutMilestone):
</pre>
----------------------------------------------------------------------
#### 1a6b869912f1c9025ab1571174a46fab9b3465c8
<pre>
Layout milestone notifications should be dispatched asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=303958">https://bugs.webkit.org/show_bug.cgi?id=303958</a>
<a href="https://rdar.apple.com/153254633">rdar://153254633</a>

Reviewed by NOBODY (OOPS!).

When a layout milestone notification fires, the layout may not be completed but client
callbacks to layout milestone notifications can trigger Javascript execution. This results
in javascript execution failing (and consequently crashing) to run during the
layout process because it is correctly not permitted to do so. We delay firing layout
milestone notifications by dispatching them asychronously in order to prevent this.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didReachLayoutMilestone):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::willDispatchDidReachLayoutMilestone):
(WebFrameLoaderClient::dispatchDidReachLayoutMilestone):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AutoLayoutIntegration.mm:
(TEST(WebKit, AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7daf383c2316eeaa97fb5c3ea649e5cbb3b30c09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135928 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143639 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7be65eec-9b5f-42f3-ad9d-479c3c290a42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103879 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84756 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3829 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4243 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146388 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112233 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112624 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6092 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8029 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36199 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->