### PR TITLE
[Re-land] [intersection-observer] Move layout information needed to compute intersections to FrameView

### DIFF
--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -110,6 +110,14 @@ public:
     IntRect convertFromContainingView(const IntRect&) const final;
     FloatRect convertFromContainingView(const FloatRect&) const final;
 
+    WEBCORE_EXPORT virtual LayoutRect layoutViewportRect() const = 0;
+
+    // Computes the visible area of a child frame in this frame as a rectangle.
+    // std::nullopt is returned if the child frame is entirely invisible, or
+    // the visible area is not computable. The given child frame must be a
+    // direct child of this frame.
+    virtual std::optional<LayoutRect> visibleRectOfChild(const Frame&) const = 0;
+
 private:
     ScrollableArea* enclosingScrollableArea() const final;
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -349,40 +349,83 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
     rootBounds.expand(rootMarginEdges);
 }
 
-static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const LayoutRect& rect, const SecurityOrigin& targetSecurityOrigin, const RenderElement* renderer, std::optional<IntersectionObserverMarginBox> scrollMargin)
+static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const LayoutRect& rect, const SecurityOrigin& targetSecurityOrigin, Variant<const RenderElement*, const Frame*> rendererOrFrame, std::optional<IntersectionObserverMarginBox> scrollMargin)
 {
+    auto rendererOrFrameSecurityOrigin = WTF::visit(WTF::makeVisitor(
+        [&] (const RenderElement* renderer) { return Ref<const Frame>(renderer->frame())->frameDocumentSecurityOrigin(); },
+        [&] (const Frame* frame) { return frame->frameDocumentSecurityOrigin(); }
+    ), rendererOrFrame);
+
     // targetSecurityOrigin is the security origin of the target (the element that originates the very first rect)
     // Scroll margin should not propagate past the first cross-origin frame in the chain leading to the main frame.
     // e.g given the chain: main frame <- cross-origin frame <- same-origin frame 2 <- same-origin frame 1 <- target
     // then scroll margin is applied to same-origin frame 1/2 but not to cross-origin and main frames.
     // Hence, clear out the scroll margin when we see a cross-origin frame.
-    bool shouldApplyScrollMargin = Ref<const Frame>(renderer->frame())->frameDocumentSecurityOrigin()->isSameOriginDomain(targetSecurityOrigin);
-    if (!shouldApplyScrollMargin)
+    bool isSameOriginDomain = [&] () {
+        if (rendererOrFrameSecurityOrigin)
+            return rendererOrFrameSecurityOrigin->isSameOriginDomain(targetSecurityOrigin);
+
+        return false;
+    }();
+    if (!isSameOriginDomain)
         scrollMargin.reset();
 
-    auto absoluteRects = renderer->computeVisibleRectsInContainer(
-        { rect },
-        &renderer->view(),
-        {
-            .hasPositionFixedDescendant = false,
-            .dirtyRectIsFlipped = false,
-            .descendantNeedsEnclosingIntRect = false,
-            .options = {
-                VisibleRectContext::Option::UseEdgeInclusiveIntersection,
-                VisibleRectContext::Option::ApplyCompositedClips,
-                VisibleRectContext::Option::ApplyCompositedContainerScrolls
-            },
-            .scrollMargin = scrollMargin
-        }
-    );
-    if (!absoluteRects)
+    RefPtr<const Frame> enclosingFrame = WTF::visit(WTF::makeVisitor(
+        [&] (const RenderElement* renderer) { return static_cast<const Frame*>(&renderer->frame()); },
+        [&] (const Frame* frame) { return static_cast<const Frame*>(frame->tree().parent()); }
+    ), rendererOrFrame);
+
+    if (!enclosingFrame)
         return std::nullopt;
 
-    auto absoluteClippedRect = absoluteRects->clippedOverflowRect;
-    if (renderer->frame().isMainFrame())
+    auto absoluteClippedRect = WTF::visit(WTF::makeVisitor(
+        [&] (const RenderElement* renderer) {
+            auto visibleRects = renderer->computeVisibleRectsInContainer(
+                { rect },
+                &renderer->view(),
+                {
+                    .hasPositionFixedDescendant = false,
+                    .dirtyRectIsFlipped = false,
+                    .descendantNeedsEnclosingIntRect = false,
+                    .options = {
+                        VisibleRectContext::Option::UseEdgeInclusiveIntersection,
+                        VisibleRectContext::Option::ApplyCompositedClips,
+                        VisibleRectContext::Option::ApplyCompositedContainerScrolls
+                    },
+                    .scrollMargin = scrollMargin
+                }
+            );
+
+            return visibleRects.transform([] (auto&& repaintRects) { return repaintRects.clippedOverflowRect; } );
+        },
+        [&] (const Frame* frame) -> std::optional<LayoutRect> {
+            auto visibleRectInParentFrame = enclosingFrame->virtualView()->visibleRectOfChild(*frame);
+            if (!visibleRectInParentFrame)
+                return std::nullopt;
+
+            auto clippedRect = rect;
+            if (!clippedRect.edgeInclusiveIntersect(*visibleRectInParentFrame))
+                return std::nullopt;
+
+            return std::make_optional(clippedRect);
+    }), rendererOrFrame);
+
+    if (!absoluteClippedRect)
+        return std::nullopt;
+
+    // If the renderer is in the main frame, there are no more frames to traverse to, so stop here.
+    if (enclosingFrame->isMainFrame())
         return absoluteClippedRect;
 
-    auto frameRect = renderer->view().frameView().layoutViewportRect();
+    // The computed visible rect is in the coordinate space of the document content box,
+    // and is what's visible in the iframe's content area (aka the iframe document content box)
+    // But only the iframe's viewport is visible, so clip by the iframe's viewport.
+
+    // Compute the frame's viewport (this is in the coordinate space of the document content box)
+    RefPtr<const FrameView> enclosingFrameView = enclosingFrame->virtualView();
+    ASSERT(enclosingFrameView);
+
+    auto frameRect = enclosingFrameView->layoutViewportRect();
     if (scrollMargin) {
         auto scrollMarginEdges = LayoutBoxExtent {
             LayoutUnit(Style::evaluate<int>(scrollMargin->top(), frameRect.height(), Style::ZoomNeeded { })),
@@ -393,33 +436,40 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
         frameRect.expand(scrollMarginEdges);
     }
 
-    bool intersects = absoluteClippedRect.edgeInclusiveIntersect(frameRect);
-    if (!intersects)
+    if (!absoluteClippedRect->edgeInclusiveIntersect(frameRect))
         return std::nullopt;
 
-    RefPtr ownerRenderer = renderer->frame().ownerRenderer();
-    if (!ownerRenderer)
-        return std::nullopt;
+    absoluteClippedRect = LayoutRect { enclosingFrameView->contentsToView(*absoluteClippedRect) };
 
-    LayoutRect rectInFrameViewSpace { renderer->view().frameView().contentsToView(absoluteClippedRect) };
+    if (RefPtr ownerRenderer = enclosingFrame->ownerRenderer()) {
+        absoluteClippedRect->moveBy(ownerRenderer->contentBoxLocation());
+        return computeClippedRectInRootContentsSpace(*absoluteClippedRect, targetSecurityOrigin, ownerRenderer.get(), scrollMargin);
+    }
 
-    rectInFrameViewSpace.moveBy(ownerRenderer->contentBoxLocation());
-    return computeClippedRectInRootContentsSpace(rectInFrameViewSpace, targetSecurityOrigin, ownerRenderer.get(), WTFMove(scrollMargin));
+    absoluteClippedRect->moveBy(enclosingFrameView->location());
+    return computeClippedRectInRootContentsSpace(*absoluteClippedRect, targetSecurityOrigin, enclosingFrame.get(), WTFMove(scrollMargin));
 }
 
-auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRegistration& registration, LocalFrameView& frameView, Element& target, ApplyRootMargin applyRootMargin) const -> IntersectionObservationState
+auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRegistration& registration, FrameView& hostFrameView, Element& target, ApplyRootMargin applyRootMargin) const -> IntersectionObservationState
 {
     bool isFirstObservation = !registration.previousThresholdIndex;
 
+    float rootUsedZoom = 1.0;
+    // Only available in explicit root situation.
     RenderBlock* rootRenderer = nullptr;
     RenderElement* targetRenderer = nullptr;
     IntersectionObservationState intersectionState;
 
     auto layoutViewportRectForIntersection = [&] {
-        if (m_includeObscuredInsets == IncludeObscuredInsets::Yes)
-            return frameView.layoutViewportRectIncludingObscuredInsets();
+        if (m_includeObscuredInsets == IncludeObscuredInsets::Yes) {
+            // IncludeObscuredInsets::Yes is only used by ContentVisibilityDocumentState, which
+            // tracks the visibility of an element wrt. its document.
+            // Therefore the intersection observer is guaranteed to be a local and explicit root
+            // observer, so frameView must be local too.
+            return downcast<LocalFrameView>(hostFrameView).layoutViewportRectIncludingObscuredInsets();
+        }
 
-        return frameView.layoutViewportRect();
+        return hostFrameView.layoutViewportRect();
     };
 
     auto computeRootBounds = [&]() {
@@ -446,16 +496,19 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             else
                 intersectionState.rootBounds = { FloatPoint(), rootRenderer->size() };
 
+            rootUsedZoom = rootRenderer->style().usedZoom();
+
             return;
         }
 
-        ASSERT(frameView.frame().isMainFrame());
+        ASSERT(hostFrameView.frame().isMainFrame());
         // FIXME: Handle the case of an implicit-root observer that has a target in a different frame tree.
-        if (&targetRenderer->frame().mainFrame() != &frameView.frame())
+        if (&targetRenderer->frame().mainFrame() != &hostFrameView.frame())
             return;
 
         intersectionState.canComputeIntersection = true;
-        rootRenderer = frameView.renderView();
+        // FIXME: provide this information in some way if the host frame is remote.
+        rootUsedZoom = downcast<LocalFrameView>(hostFrameView).renderView()->style().usedZoom();
         intersectionState.rootBounds = layoutViewportRectForIntersection();
     };
 
@@ -466,8 +519,8 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     }
 
     if (applyRootMargin == ApplyRootMargin::Yes) {
-        expandRootBoundsWithRootMargin(intersectionState.rootBounds, scrollMarginBox(), rootRenderer->style().usedZoom());
-        expandRootBoundsWithRootMargin(intersectionState.rootBounds, rootMarginBox(), rootRenderer->style().usedZoom());
+        expandRootBoundsWithRootMargin(intersectionState.rootBounds, scrollMarginBox(), rootUsedZoom);
+        expandRootBoundsWithRootMargin(intersectionState.rootBounds, rootMarginBox(), rootUsedZoom);
     }
 
     auto localTargetBounds = [&]() -> LayoutRect {
@@ -525,10 +578,10 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
         // If implicit root, rootLocalIntersectionRect is already in absolute coordinates.
         auto rootAbsoluteIntersectionRect = root() ? rootRenderer->localToAbsoluteQuad(rootLocalIntersectionRect).boundingBox() : rootLocalIntersectionRect;
 
-        if (&targetRenderer->frame() == &rootRenderer->frame())
+        if (rootRenderer && &targetRenderer->frame() == &rootRenderer->frame())
             intersectionState.absoluteIntersectionRect = rootAbsoluteIntersectionRect;
         else {
-            auto rootViewIntersectionRect = frameView.contentsToView(rootAbsoluteIntersectionRect);
+            auto rootViewIntersectionRect = hostFrameView.contentsToView(rootAbsoluteIntersectionRect);
             intersectionState.absoluteIntersectionRect = targetRenderer->view().frameView().rootViewToContents(rootViewIntersectionRect);
         }
 
@@ -572,8 +625,8 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
 auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNotify
 {
-    RefPtr frameView = dynamicDowncast<LocalFrameView>(hostFrame.virtualView());
-    if (!frameView)
+    RefPtr hostFrameView = hostFrame.virtualView();
+    if (!hostFrameView)
         return NeedNotify::No;
 
     auto timestamp = nowTimestamp();
@@ -597,7 +650,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
             return false;
         }();
         auto applyRootMargin = isSameOriginObservation ? ApplyRootMargin::Yes : ApplyRootMargin::No;
-        auto intersectionState = computeIntersectionState(registration, *frameView, *target, applyRootMargin);
+        auto intersectionState = computeIntersectionState(registration, *hostFrameView, *target, applyRootMargin);
 
         if (intersectionState.observationChanged) {
             FloatRect targetBoundingClientRect;
@@ -609,7 +662,9 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
                 RefPtr targetFrameView = target->document().view();
                 targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, target->renderer()->style().usedZoom());
-                clientRootBounds = frameView->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
+                // FIXME: compute this when hostFrameView is not local.
+                clientRootBounds = downcast<LocalFrameView>(hostFrameView)->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
+
                 if (intersectionState.isIntersecting) {
                     ASSERT(intersectionState.absoluteIntersectionRect);
                     clientIntersectionRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteIntersectionRect, target->renderer()->style().usedZoom());

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -46,6 +46,7 @@ namespace WebCore {
 class ContainerNode;
 class Document;
 class Element;
+class FrameView;
 class IntersectionObserverEntry;
 
 struct IntersectionObserverRegistration {
@@ -136,7 +137,7 @@ private:
     };
 
     enum class ApplyRootMargin : bool { No, Yes };
-    IntersectionObservationState computeIntersectionState(const IntersectionObserverRegistration&, LocalFrameView&, Element& target, ApplyRootMargin) const;
+    IntersectionObservationState computeIntersectionState(const IntersectionObserverRegistration&, FrameView&, Element& target, ApplyRootMargin) const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_implicitRootDocument;
     WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_root;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2107,6 +2107,34 @@ LayoutRect LocalFrameView::viewportConstrainedVisibleContentRect() const
     return viewportRect;
 }
 
+std::optional<LayoutRect> LocalFrameView::visibleRectOfChild(const Frame& child) const
+{
+    RefPtr childOwnerRenderer = child.ownerRenderer();
+    if (!childOwnerRenderer)
+        return std::nullopt;
+
+    // Ensure |child| is a child of this frame.
+    ASSERT(child.tree().parent()->frameID() == m_frame->frameID());
+    ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
+
+    auto rects = childOwnerRenderer->computeVisibleRectsInContainer(
+        { childOwnerRenderer->frameRect() },
+        &childOwnerRenderer->view(),
+        {
+            .hasPositionFixedDescendant = false,
+            .dirtyRectIsFlipped = false,
+            .descendantNeedsEnclosingIntRect = false,
+            .options = {
+                VisibleRectContext::Option::UseEdgeInclusiveIntersection,
+                VisibleRectContext::Option::ApplyCompositedClips,
+                VisibleRectContext::Option::ApplyCompositedContainerScrolls
+            },
+        }
+    );
+
+    return rects.transform([] (const auto& repaintRects) { return repaintRects.clippedOverflowRect; });
+}
+
 LayoutRect LocalFrameView::rectForFixedPositionLayout() const
 {
     if (m_frame->settings().visualViewportEnabled())

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -321,10 +321,12 @@ public:
     std::optional<LayoutRect> visualViewportOverrideRect() const { return m_visualViewportOverrideRect; }
 
     // These are in document coordinates, unaffected by page scale (but affected by zooming).
-    WEBCORE_EXPORT LayoutRect layoutViewportRect() const;
+    WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
     WEBCORE_EXPORT LayoutRect visualViewportRect() const;
 
     LayoutRect layoutViewportRectIncludingObscuredInsets() const;
+
+    std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
     
     static LayoutRect visibleDocumentRect(const FloatRect& visibleContentRect, float headerHeight, float footerHeight, const FloatSize& totalContentsSize, float pageScaleFactor);
 

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -48,6 +48,18 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
     FrameView::setFrameRect(newRect);
 }
 
+LayoutRect RemoteFrameView::layoutViewportRect() const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame&) const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 // FIXME: Implement all the stubs below.
 
 bool RemoteFrameView::isScrollableOrRubberbandable()

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -44,6 +44,9 @@ public:
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
     RemoteFrame& frame() const final { return m_frame; }
 
+    WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
+    std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
+
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 


### PR DESCRIPTION
#### 2b69d15d9a2285fa249f2b55b4f3bf1e60122797
<pre>
[Re-land] [intersection-observer] Move layout information needed to compute intersections to FrameView
<a href="https://rdar.apple.com/166644525">rdar://166644525</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304274">https://bugs.webkit.org/show_bug.cgi?id=304274</a>

Reviewed by Simon Fraser.

With Site Isolation, layout information of cross-origin frames are only available
in the process that loads up the frame. An intersection observer computing the
intersection in another process wouldn&apos;t have access to this info.

This patch makes the minimal set of needed layout information available in
FrameView. The intersection code is then changed to use the info in FrameView.

Getting these info from a LocalFrameView will calculate them on the fly (because
local frames have access to the render tree), while for now, RemoteFrameView will
ASSERT_NOT_REACHED. A future patch will make these info available in RemoteFrameView
by synchronizing them from Local to RemoteFrameView using FrameTreeSyncData.

Tested by the existing Intersection Observer test suites. This was previously
landed in 304349@main, then got reverted in 304375@main because of a missing
null check causing crashes.

* Source/WebCore/page/FrameView.h:
    - Make layoutViewportRect() virtual, so RemoteFrameView could override it
      (when information sync is implemented)

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::computeClippedRectInRootContentsSpace):
    - Accept either the RenderView to the frame (in the case of local frame)
      or Frame object of the frame (in the case of remote frame)
    - In the case of remote frame, compute intersection using FrameView::visibleRectOfChild

(WebCore::IntersectionObserver::computeIntersectionState const):
(WebCore::IntersectionObserver::updateObservations):
* Source/WebCore/page/IntersectionObserver.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::visibleRectOfChild const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::layoutViewportRect const):
(WebCore::RemoteFrameView::visibleRectOfChild const):
* Source/WebCore/page/RemoteFrameView.h:

Canonical link: <a href="https://commits.webkit.org/304640@main">https://commits.webkit.org/304640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32fdb8e3d197de85ebc2b8cf8e30d831f6dbe049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136155 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143864 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49fc36d0-f741-4613-896e-54716e08493f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/abb6c815-cf76-4114-9269-7739f7508032) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73501e91-935a-4186-86b1-54209c8ec6fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4004 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146610 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40776 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8211 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6887 "Found 1 new test failure: fast/webgpu/repro_301290.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6263 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118313 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8243 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36373 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8182 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->