### PR TITLE
[Swift in WebKit] Correct the availability of WebGPU in some configurations

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -99,14 +99,17 @@ OTHER_LDFLAGS_SHARED_CACHE_NO = -Wl,-not_for_dyld_shared_cache;
 OTHER_LDFLAGS = $(inherited) $(UNEXPORT_SWIFT_CXX_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) $(OTHER_LDFLAGS_SHARED_CACHE) $(OTHER_LDFLAGS_ADDITIONAL_FRAMEWORKS) -Wl,-unexported_symbol,*s_heapSpec;
 
 ENABLE_WEBGPU_SWIFT = ;
-ENABLE_WEBGPU_SWIFT[sdk=macosx*][arch=arm64*] = ENABLE_WEBGPU_SWIFT;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*] = ENABLE_WEBGPU_SWIFT;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26.0*] = ;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26.1*] = ;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26.2*] = ;
+ENABLE_WEBGPU_SWIFT[sdk=macosx*26.3*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=macosx*14*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=macosx*15*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=iphoneos*] = ENABLE_WEBGPU_SWIFT;
 // FIXME: Support WebGPU swift in iOS simulator builds once the underlying
 // modules issue is fixed (https://bugs.webkit.org/show_bug.cgi?id=300146).
 ENABLE_WEBGPU_SWIFT[sdk=iphonesimulator*] = ;
-ENABLE_WEBGPU_SWIFT[sdk=macosx*][arch=x86*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=xros*] = ENABLE_WEBGPU_SWIFT;
 ENABLE_WEBGPU_SWIFT[sdk=appletvos*] = ;
 ENABLE_WEBGPU_SWIFT[sdk=watchos*] = ;

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -219,17 +219,32 @@ extension WebGPU.CommandEncoder {
         commandBuffer?.label = CxxBridging.convertWTFStringToNSString(descriptor.label)
 
         #if arch(x86_64) && (os(macOS) || targetEnvironment(macCatalyst))
-        if m_managedBuffers.count != 0 || m_managedTextures.count != 0 {
+        if (m_managedBuffers?.count ?? 0) != 0 || (m_managedTextures?.count ?? 0) != 0 {
             let blitCommandEncoder = commandBuffer?.makeBlitCommandEncoder()
-            for case let buffer as MTLBuffer in m_managedBuffers {
-                blitCommandEncoder?.synchronize(resource: buffer)
+
+            // swift-format-ignore: AlwaysUseLowerCamelCase
+            if let m_managedBuffers {
+                for buffer in m_managedBuffers {
+                    // FIXME: `NSSet` should not be used, and then this cast will not be needed.
+                    // This is safe because `m_managedBuffers` is a `NSMutableSet<id<MTLBuffer>>`.
+                    // swift-format-ignore: NeverForceUnwrap
+                    blitCommandEncoder?.synchronize(resource: buffer as! any MTLBuffer)
+                }
             }
-            for case let texture as MTLTexture in m_managedTextures {
-                blitCommandEncoder?.synchronize(resource: texture)
+
+            // swift-format-ignore: AlwaysUseLowerCamelCase
+            if let m_managedTextures {
+                for texture in m_managedTextures {
+                    // FIXME: `NSSet` should not be used, and then this cast will not be needed.
+                    // This is safe because `m_managedTextures` is a `NSMutableSet<id<MTLTexture>>`.
+                    // swift-format-ignore: NeverForceUnwrap
+                    blitCommandEncoder?.synchronize(resource: texture as! any MTLTexture)
+                }
             }
+
             blitCommandEncoder?.endEncoding()
         }
-        #endif
+        #endif // arch(x86_64) && (os(macOS) || targetEnvironment(macCatalyst))
 
         let result = createCommandBuffer(commandBuffer, m_device.ptr(), m_sharedEvent, m_sharedEventSignalValue)
         m_sharedEvent = nil


### PR DESCRIPTION
#### 5d5641f156b607733738a6a43eb92fd6a6352372
<pre>
[Swift in WebKit] Correct the availability of WebGPU in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=304281">https://bugs.webkit.org/show_bug.cgi?id=304281</a>
<a href="https://rdar.apple.com/166646850">rdar://166646850</a>

Reviewed by Mike Wyrzykowski.

- The enablement of `ENABLE_WEBGPU_SWIFT` for macOS was conditionalized on the architecture.
However, in some parts of the build, this value is `undefined`. This leads to incredibly
confusing and surprising results. To address this, and to allow module verification to
actually be conditionalized on `ENABLE_WEBGPU_SWIFT`, just enable `ENABLE_WEBGPU_SWIFT` at
build time on all architectures on macOS.

- Disable `ENABLE_WEBGPU_SWIFT` on macOS SDKs that do not have a modularized WTF library, since
that is an invalid combination.

* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.finish(_:)):

Canonical link: <a href="https://commits.webkit.org/304571@main">https://commits.webkit.org/304571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d21fa3cb24a73a8baf553eaf1c38759784486e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143651 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a5f03ae-ceed-4e91-96d5-3af9db0c5d56) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84763 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e51315e4-17c1-40db-8d9e-1187f0c106bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6193 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3835 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115458 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146400 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112238 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6102 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61885 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8038 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36202 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7985 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->