### PR TITLE
Hold CheckedPtr in CSSRules

### DIFF
--- a/Source/WebCore/Modules/push-api/PushSubscription.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscription.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PushSubscription.h"
 
+#include "CSSStyleSheet.h"
 #include "EventLoop.h"
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
+++ b/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ServiceWorkerRegistrationPushAPI.h"
 
+#include "CSSRule.h"
+#include "CSSStyleSheet.h"
 #include "PushManager.h"
 #include "ScriptExecutionContext.h"
 #include "ServiceWorkerRegistration.h"

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -28,6 +28,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "ContextDestructionObserverInlines.h"
+#include "CSSRule.h"
 #include "Document.h"
 #include "FormData.h"
 #include "HeaderFieldTokenizer.h"

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "WebSocketHandshake.h"
 
+#include "CSSRule.h"
 #include "Cookie.h"
 #include "CookieJar.h"
 #include "HTTPHeaderMap.h"

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationEventBase.h"
 #include "CSSAnimation.h"
+#include "CSSStyleSheet.h"
 #include "CSSTransition.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentEventLoop.h"

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -29,6 +29,7 @@
 #include "AnimationEventBase.h"
 #include "AnimationTimelinesController.h"
 #include "CSSProperty.h"
+#include "CSSStyleSheet.h"
 #include "CSSTransition.h"
 #include "CustomAnimationOptions.h"
 #include "CustomEffect.h"

--- a/Source/WebCore/bindings/js/JSCSSRuleListCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleListCustom.cpp
@@ -42,18 +42,18 @@ bool JSCSSRuleListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
     if (!jsCSSRuleList->hasCustomProperties())
         return false;
 
-    if (CSSStyleSheet* styleSheet = jsCSSRuleList->wrapped().styleSheet()) {
+    if (RefPtr styleSheet = jsCSSRuleList->wrapped().styleSheet()) {
         if (reason) [[unlikely]]
             *reason = "CSSStyleSheet is opaque root"_s;
 
-        return containsWebCoreOpaqueRoot(visitor, styleSheet);
+        return containsWebCoreOpaqueRoot(visitor, styleSheet.get());
     }
     
-    if (CSSRule* cssRule = jsCSSRuleList->wrapped().item(0)) {
+    if (RefPtr cssRule = jsCSSRuleList->wrapped().item(0)) {
         if (reason) [[unlikely]]
             *reason = "CSSRule is opaque root"_s;
 
-        return containsWebCoreOpaqueRoot(visitor, cssRule);
+        return containsWebCoreOpaqueRoot(visitor, cssRule.get());
     }
     return false;
 }

--- a/Source/WebCore/bindings/js/JSMediaListCustom.h
+++ b/Source/WebCore/bindings/js/JSMediaListCustom.h
@@ -35,8 +35,8 @@ namespace WebCore {
 
 inline WebCoreOpaqueRoot root(MediaList* mediaList)
 {
-    if (CSSRule* parentRule = mediaList->parentRule())
-        return root(parentRule);
+    if (RefPtr parentRule = mediaList->parentRule())
+        return root(parentRule.get());
     if (CSSStyleSheet* parentStyleSheet = mediaList->parentStyleSheet())
         return root(parentStyleSheet);
     return WebCoreOpaqueRoot { mediaList };

--- a/Source/WebCore/css/CSSConditionRule.cpp
+++ b/Source/WebCore/css/CSSConditionRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,14 @@
 #include "config.h"
 #include "CSSConditionRule.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 
-CSSConditionRule::CSSConditionRule(StyleRuleGroup& group, CSSStyleSheet* parent)
-    : CSSGroupingRule(group, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSConditionRule);
+
+CSSConditionRule::CSSConditionRule(StyleRuleGroup& group, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(group, WTFMove(parent))
 {
 }
 

--- a/Source/WebCore/css/CSSConditionRule.h
+++ b/Source/WebCore/css/CSSConditionRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,13 +34,15 @@
 namespace WebCore {
 
 class CSSConditionRule : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSConditionRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSConditionRule);
 public:
     virtual String conditionText() const = 0;
 
     bool isCSSConditionRule() const final { return true; }
 
 protected:
-    CSSConditionRule(StyleRuleGroup&, CSSStyleSheet* parent);
+    CSSConditionRule(StyleRuleGroup&, CheckedPtr<CSSStyleSheet>&& parent);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,18 +30,21 @@
 #include "CSSStyleSheet.h"
 #include "GenericMediaQuerySerialization.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSContainerRule::CSSContainerRule(StyleRuleContainer& rule, CSSStyleSheet* parent)
-    : CSSConditionRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSContainerRule);
+
+CSSContainerRule::CSSContainerRule(StyleRuleContainer& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSConditionRule(rule, WTFMove(parent))
 {
 }
 
-Ref<CSSContainerRule> CSSContainerRule::create(StyleRuleContainer& rule, CSSStyleSheet* parent)
+Ref<CSSContainerRule> CSSContainerRule::create(StyleRuleContainer& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSContainerRule(rule, parent));
+    return adoptRef(*new CSSContainerRule(rule, WTFMove(parent)));
 }
 
 const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,10 @@ namespace WebCore {
 class StyleRuleContainer;
 
 class CSSContainerRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSContainerRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSContainerRule);
 public:
-    static Ref<CSSContainerRule> create(StyleRuleContainer&, CSSStyleSheet* parent);
+    static Ref<CSSContainerRule> create(StyleRuleContainer&, CheckedPtr<CSSStyleSheet>&& parent);
 
     String cssText() const final;
     String conditionText() const final;
@@ -43,7 +45,7 @@ public:
 private:
     const StyleRuleContainer& styleRuleContainer() const;
 
-    CSSContainerRule(StyleRuleContainer&, CSSStyleSheet*);
+    CSSContainerRule(StyleRuleContainer&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Container; }
 };
 

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Tyler Wilcock <twilco.o@protonmail.com>.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +36,13 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSCounterStyleRule);
 
 StyleRuleCounterStyle::StyleRuleCounterStyle(const AtomString& name, CSSCounterStyleDescriptors&& descriptors)
     : StyleRuleBase(StyleRuleType::CounterStyle)
@@ -102,13 +106,13 @@ CSSCounterStyleDescriptors::System toCounterStyleSystemEnum(const CSSValue* syst
 
 StyleRuleCounterStyle::~StyleRuleCounterStyle() = default;
 
-Ref<CSSCounterStyleRule> CSSCounterStyleRule::create(StyleRuleCounterStyle& rule, CSSStyleSheet* sheet)
+Ref<CSSCounterStyleRule> CSSCounterStyleRule::create(StyleRuleCounterStyle& rule, CheckedPtr<CSSStyleSheet>&& sheet)
 {
-    return adoptRef(*new CSSCounterStyleRule(rule, sheet));
+    return adoptRef(*new CSSCounterStyleRule(rule, WTFMove(sheet)));
 }
 
-CSSCounterStyleRule::CSSCounterStyleRule(StyleRuleCounterStyle& counterStyleRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSCounterStyleRule::CSSCounterStyleRule(StyleRuleCounterStyle& counterStyleRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_counterStyleRule(counterStyleRule)
 {
 }

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Tyler Wilcock <twilco.o@protonmail.com>.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,8 +67,10 @@ private:
 };
 
 class CSSCounterStyleRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSCounterStyleRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSCounterStyleRule);
 public:
-    static Ref<CSSCounterStyleRule> create(StyleRuleCounterStyle&, CSSStyleSheet*);
+    static Ref<CSSCounterStyleRule> create(StyleRuleCounterStyle&, CheckedPtr<CSSStyleSheet>&&);
     virtual ~CSSCounterStyleRule();
 
     String cssText() const final;
@@ -100,6 +103,7 @@ public:
 
 private:
     CSSCounterStyleRule(StyleRuleCounterStyle&, CSSStyleSheet* parent);
+    CSSCounterStyleRule(StyleRuleCounterStyle&, CheckedPtr<CSSStyleSheet>&& parent);
 
     bool setterInternal(CSSPropertyID, const String&);
     RefPtr<CSSValue> cssValueFromText(CSSPropertyID, const String&);

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2021 Apple Inc. All right reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSStyleSheet.h"
 #include "StyleBuilderState.h"
 #include "StyleFilterImage.h"
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2005, 2006, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,13 +27,16 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSFontFaceRule::CSSFontFaceRule(StyleRuleFontFace& fontFaceRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFaceRule);
+
+CSSFontFaceRule::CSSFontFaceRule(StyleRuleFontFace& fontFaceRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_fontFaceRule(fontFaceRule)
 {
 }

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -29,8 +29,10 @@ class CSSFontFaceDescriptors;
 class StyleRuleFontFace;
 
 class CSSFontFaceRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFaceRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontFaceRule);
 public:
-    static Ref<CSSFontFaceRule> create(StyleRuleFontFace& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFaceRule(rule, sheet)); }
+    static Ref<CSSFontFaceRule> create(StyleRuleFontFace& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSFontFaceRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSFontFaceRule();
 
@@ -38,6 +40,7 @@ public:
 
 private:
     CSSFontFaceRule(StyleRuleFontFace&, CSSStyleSheet* parent);
+    CSSFontFaceRule(StyleRuleFontFace&, CheckedPtr<CSSStyleSheet>&& parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFace; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSFontFeatureValue.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValue.cpp
@@ -28,6 +28,7 @@
 #include "CSSFontFeatureValue.h"
 
 #include "CSSPrimitiveValue.h"
+#include "CSSStyleSheet.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,11 +27,21 @@
 #include "CSSFontFeatureValuesRule.h"
 
 #include "CSSMarkup.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFeatureValuesRule);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFeatureValuesBlockRule);
+
 CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& fontFeatureValuesRule, CSSStyleSheet* parent)
     : CSSRule(parent)
+    , m_fontFeatureValuesRule(fontFeatureValuesRule)
+{
+}
+
+CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& fontFeatureValuesRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_fontFeatureValuesRule(fontFeatureValuesRule)
 {
 }
@@ -85,8 +95,8 @@ void CSSFontFeatureValuesRule::reattach(StyleRuleBase& rule)
     m_fontFeatureValuesRule = downcast<StyleRuleFontFeatureValues>(rule);
 }
 
-CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock& block , CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock& block, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_fontFeatureValuesBlockRule(block)
 {
 }

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,12 +28,15 @@
 #include "CSSRule.h"
 
 #include "StyleRule.h"
+#include <wtf/Forward.h>
 
 namespace WebCore {
 
 class CSSFontFeatureValuesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFeatureValuesRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontFeatureValuesRule);
 public:
-    static Ref<CSSFontFeatureValuesRule> create(StyleRuleFontFeatureValues& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesRule(rule, sheet)); }
+    static Ref<CSSFontFeatureValuesRule> create(StyleRuleFontFeatureValues& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSFontFeatureValuesRule(rule, WTFMove(sheet))); }
     virtual ~CSSFontFeatureValuesRule() = default;
 
     const Vector<AtomString>& fontFamilies() const
@@ -59,6 +62,7 @@ public:
 
 private:
     CSSFontFeatureValuesRule(StyleRuleFontFeatureValues&, CSSStyleSheet* parent);
+    CSSFontFeatureValuesRule(StyleRuleFontFeatureValues&, CheckedPtr<CSSStyleSheet>&& parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValues; }
     String cssText() const final;
@@ -68,12 +72,16 @@ private:
 };
 
 class CSSFontFeatureValuesBlockRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFeatureValuesBlockRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontFeatureValuesBlockRule);
 public:
     static Ref<CSSFontFeatureValuesBlockRule> create(StyleRuleFontFeatureValuesBlock& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesBlockRule(rule, sheet)); }
+    static Ref<CSSFontFeatureValuesBlockRule> create(StyleRuleFontFeatureValuesBlock& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSFontFeatureValuesBlockRule(rule, WTFMove(sheet))); }
     virtual ~CSSFontFeatureValuesBlockRule() = default;
 
 private:
     CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock&, CSSStyleSheet* parent);
+    CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock&, CheckedPtr<CSSStyleSheet>&& parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValuesBlock; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,14 +31,17 @@
 #include "JSDOMMapLike.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-CSSFontPaletteValuesRule::CSSFontPaletteValuesRule(StyleRuleFontPaletteValues& fontPaletteValuesRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontPaletteValuesRule);
+
+CSSFontPaletteValuesRule::CSSFontPaletteValuesRule(StyleRuleFontPaletteValues& fontPaletteValuesRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_fontPaletteValuesRule(fontPaletteValuesRule)
 {
 }

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,10 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleFontPaletteValues;
 
 class CSSFontPaletteValuesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontPaletteValuesRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFontPaletteValuesRule);
 public:
-    static Ref<CSSFontPaletteValuesRule> create(StyleRuleFontPaletteValues& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontPaletteValuesRule(rule, sheet)); }
+    static Ref<CSSFontPaletteValuesRule> create(StyleRuleFontPaletteValues& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSFontPaletteValuesRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSFontPaletteValuesRule();
 
@@ -46,6 +48,7 @@ public:
 
 private:
     CSSFontPaletteValuesRule(StyleRuleFontPaletteValues&, CSSStyleSheet* parent);
+    CSSFontPaletteValuesRule(StyleRuleFontPaletteValues&, CheckedPtr<CSSStyleSheet>&& parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontPaletteValues; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSFunctionDeclarations.cpp
+++ b/Source/WebCore/css/CSSFunctionDeclarations.cpp
@@ -28,14 +28,18 @@
 
 #include "CSSFunctionDescriptors.h"
 #include "CSSSerializationContext.h"
+#include "CSSStyleSheet.h"
 #include "MutableStyleProperties.h"
 #include "StylePropertiesInlines.h"
 #include "StyleRuleFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-CSSFunctionDeclarations::CSSFunctionDeclarations(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFunctionDeclarations);
+
+CSSFunctionDeclarations::CSSFunctionDeclarations(StyleRuleFunctionDeclarations& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_styleRule(rule)
 {
 }

--- a/Source/WebCore/css/CSSFunctionDeclarations.h
+++ b/Source/WebCore/css/CSSFunctionDeclarations.h
@@ -33,15 +33,17 @@ class CSSFunctionDescriptors;
 class StyleRuleFunctionDeclarations;
 
 class CSSFunctionDeclarations final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFunctionDeclarations);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFunctionDeclarations);
 public:
-    static Ref<CSSFunctionDeclarations> create(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFunctionDeclarations(rule, sheet)); };
+    static Ref<CSSFunctionDeclarations> create(StyleRuleFunctionDeclarations& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSFunctionDeclarations(rule, WTFMove(sheet))); };
 
     virtual ~CSSFunctionDeclarations();
 
     CSSFunctionDescriptors& style();
 
 private:
-    CSSFunctionDeclarations(StyleRuleFunctionDeclarations&, CSSStyleSheet*);
+    CSSFunctionDeclarations(StyleRuleFunctionDeclarations&, CheckedPtr<CSSStyleSheet>&&);
 
     String cssText() const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;

--- a/Source/WebCore/css/CSSFunctionRule.cpp
+++ b/Source/WebCore/css/CSSFunctionRule.cpp
@@ -28,16 +28,19 @@
 
 #include "CSSMarkup.h"
 #include "StyleRuleFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-Ref<CSSFunctionRule> CSSFunctionRule::create(StyleRuleFunction& rule, CSSStyleSheet* parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFunctionRule);
+
+Ref<CSSFunctionRule> CSSFunctionRule::create(StyleRuleFunction& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSFunctionRule(rule, parent));
+    return adoptRef(*new CSSFunctionRule(rule, WTFMove(parent)));
 }
 
-CSSFunctionRule::CSSFunctionRule(StyleRuleFunction& rule, CSSStyleSheet* parent)
-    : CSSGroupingRule(rule, parent)
+CSSFunctionRule::CSSFunctionRule(StyleRuleFunction& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(rule, WTFMove(parent))
 {
 }
 

--- a/Source/WebCore/css/CSSFunctionRule.h
+++ b/Source/WebCore/css/CSSFunctionRule.h
@@ -32,8 +32,10 @@ namespace WebCore {
 class StyleRuleFunction;
 
 class CSSFunctionRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFunctionRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSFunctionRule);
 public:
-    static Ref<CSSFunctionRule> create(StyleRuleFunction&, CSSStyleSheet* parent);
+    static Ref<CSSFunctionRule> create(StyleRuleFunction&, CheckedPtr<CSSStyleSheet>&& parent);
 
     struct FunctionParameter {
         String name;
@@ -50,7 +52,7 @@ public:
 private:
     const StyleRuleFunction& styleRuleFunction() const;
 
-    CSSFunctionRule(StyleRuleFunction&, CSSStyleSheet*);
+    CSSFunctionRule(StyleRuleFunction&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Function; }
 };
 

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,12 +36,15 @@
 #include "CSSStyleSheet.h"
 #include "StylePropertiesInlines.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSGroupingRule::CSSGroupingRule(StyleRuleGroup& groupRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSGroupingRule);
+
+CSSGroupingRule::CSSGroupingRule(StyleRuleGroup& groupRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_groupRule(groupRule)
     , m_childRuleCSSOMWrappers(groupRule.childRules().size())
 {
@@ -132,8 +135,8 @@ ExceptionOr<void> CSSGroupingRule::deleteRule(unsigned index)
 
     m_groupRule->wrapperRemoveRule(index);
 
-    if (m_childRuleCSSOMWrappers[index])
-        m_childRuleCSSOMWrappers[index]->setParentRule(nullptr);
+    if (RefPtr wrapper = m_childRuleCSSOMWrappers[index])
+        wrapper->setParentRule(nullptr);
     m_childRuleCSSOMWrappers.removeAt(index);
 
     return { };
@@ -202,15 +205,15 @@ unsigned CSSGroupingRule::length() const
     return m_groupRule->childRules().size(); 
 }
 
-CSSRule* CSSGroupingRule::item(unsigned index) const
-{ 
+RefPtr<CSSRule> CSSGroupingRule::item(unsigned index) const
+{
     if (index >= length())
-        return nullptr;
+        return { };
     ASSERT(m_childRuleCSSOMWrappers.size() == m_groupRule->childRules().size());
     auto& rule = m_childRuleCSSOMWrappers[index];
     if (!rule)
         rule = m_groupRule->childRules()[index]->createCSSOMWrapper(const_cast<CSSGroupingRule&>(*this));
-    return rule.get();
+    return rule;
 }
 
 CSSRuleList& CSSGroupingRule::cssRules() const
@@ -224,8 +227,8 @@ void CSSGroupingRule::reattach(StyleRuleBase& rule)
 {
     m_groupRule = downcast<StyleRuleGroup>(rule);
     for (unsigned i = 0; i < m_childRuleCSSOMWrappers.size(); ++i) {
-        if (m_childRuleCSSOMWrappers[i])
-            m_childRuleCSSOMWrappers[i]->reattach(m_groupRule->childRules()[i]);
+        if (RefPtr wrapper = m_childRuleCSSOMWrappers[i])
+            wrapper->reattach(m_groupRule->childRules()[i]);
     }
 }
 

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -32,6 +32,8 @@ class CSSRuleList;
 class StyleRuleGroup;
 
 class CSSGroupingRule : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSGroupingRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSGroupingRule);
 public:
     virtual ~CSSGroupingRule();
 
@@ -39,11 +41,11 @@ public:
     WEBCORE_EXPORT ExceptionOr<unsigned> insertRule(const String& rule, unsigned index);
     WEBCORE_EXPORT ExceptionOr<void> deleteRule(unsigned index);
     unsigned length() const;
-    CSSRule* item(unsigned index) const;
+    RefPtr<CSSRule> item(unsigned index) const;
     virtual bool isCSSConditionRule() const { return false; }
 
 protected:
-    CSSGroupingRule(StyleRuleGroup&, CSSStyleSheet* parent);
+    CSSGroupingRule(StyleRuleGroup&, CheckedPtr<CSSStyleSheet>&& parent);
     const StyleRuleGroup& groupRule() const { return m_groupRule; }
     StyleRuleGroup& groupRule() { return m_groupRule; }
     Ref<const StyleRuleGroup> protectedGroupRule() const;

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2005, 2006, 2008, 2009, 2010, 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -31,20 +31,23 @@
 #include "MediaQueryParser.h"
 #include "StyleRuleImport.h"
 #include "StyleSheetContents.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSImportRule);
+
+CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_importRule(importRule)
 {
 }
 
 CSSImportRule::~CSSImportRule()
 {
-    if (m_styleSheetCSSOMWrapper)
-        m_styleSheetCSSOMWrapper->clearOwnerRule();
+    if (RefPtr wrapper = m_styleSheetCSSOMWrapper)
+        wrapper->clearOwnerRule();
     if (m_mediaCSSOMWrapper)
         m_mediaCSSOMWrapper->detachFromParent();
 }
@@ -118,8 +121,8 @@ String CSSImportRule::cssText(const CSS::SerializationContext& context) const
     return replacementURLString.isEmpty() ? cssTextInternal(urlString) : cssTextInternal(replacementURLString);
 }
 
-CSSStyleSheet* CSSImportRule::styleSheet() const
-{ 
+RefPtr<CSSStyleSheet> CSSImportRule::styleSheet() const
+{
     if (!m_importRule.get().styleSheet())
         return nullptr;
 
@@ -129,12 +132,7 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
 
     if (!m_styleSheetCSSOMWrapper)
         m_styleSheetCSSOMWrapper = CSSStyleSheet::create(*m_importRule.get().styleSheet(), const_cast<CSSImportRule*>(this), isOriginClean);
-    return m_styleSheetCSSOMWrapper.get(); 
-}
-
-RefPtr<CSSStyleSheet> CSSImportRule::protectedStyleSheet() const
-{
-    return styleSheet();
+    return m_styleSheetCSSOMWrapper;
 }
 
 void CSSImportRule::reattach(StyleRuleBase&)

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -34,15 +34,16 @@ using MediaQueryList = Vector<MediaQuery>;
 }
 
 class CSSImportRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSImportRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSImportRule);
 public:
-    static Ref<CSSImportRule> create(StyleRuleImport& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSImportRule(rule, sheet)); }
+    static Ref<CSSImportRule> create(StyleRuleImport& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSImportRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSImportRule();
 
     WEBCORE_EXPORT String href() const;
     WEBCORE_EXPORT MediaList& media() const;
-    WEBCORE_EXPORT CSSStyleSheet* styleSheet() const;
-    RefPtr<CSSStyleSheet> protectedStyleSheet() const;
+    WEBCORE_EXPORT RefPtr<CSSStyleSheet> styleSheet() const;
     String layerName() const;
     String supportsText() const;
 
@@ -50,6 +51,7 @@ private:
     friend class MediaList;
 
     CSSImportRule(StyleRuleImport&, CSSStyleSheet*);
+    CSSImportRule(StyleRuleImport&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Import; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
@@ -27,11 +27,14 @@
 #include "CSSInternalBaseAppearanceRule.h"
 
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
-    : CSSGroupingRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSInternalBaseAppearanceRule);
+
+CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(rule, WTFMove(parent))
 {
 }
 

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
@@ -32,16 +32,19 @@ namespace WebCore {
 class StyleRuleInternalBaseAppearance;
 
 class CSSInternalBaseAppearanceRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSInternalBaseAppearanceRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSInternalBaseAppearanceRule);
 public:
-    static Ref<CSSInternalBaseAppearanceRule> create(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
+    static Ref<CSSInternalBaseAppearanceRule> create(StyleRuleInternalBaseAppearance& rule, CheckedPtr<CSSStyleSheet>&& parent)
     {
-        return adoptRef(*new CSSInternalBaseAppearanceRule(rule, parent));
+        return adoptRef(*new CSSInternalBaseAppearanceRule(rule, WTFMove(parent)));
     }
 
     String cssText() const final;
 
 private:
     CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance&, CSSStyleSheet*);
+    CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::InternalBaseAppearance; }
 };

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -33,10 +33,13 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSKeyframeRule);
 
 void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
 {

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -76,6 +76,8 @@ private:
 };
 
 class CSSKeyframeRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSKeyframeRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSKeyframeRule);
 public:
     virtual ~CSSKeyframeRule();
 

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,9 +32,12 @@
 #include "CSSRuleList.h"
 #include "CSSStyleSheet.h"
 #include "Document.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSKeyframesRule);
 
 StyleRuleKeyframes::StyleRuleKeyframes(const AtomString& name)
     : StyleRuleBase(StyleRuleType::Keyframes)
@@ -100,8 +103,8 @@ void StyleRuleKeyframes::shrinkToFit()
     m_keyframes.shrinkToFit();
 }
 
-CSSKeyframesRule::CSSKeyframesRule(StyleRuleKeyframes& keyframesRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSKeyframesRule::CSSKeyframesRule(StyleRuleKeyframes& keyframesRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_keyframesRule(keyframesRule)
     , m_childRuleCSSOMWrappers(keyframesRule.keyframes().size())
 {
@@ -111,9 +114,9 @@ CSSKeyframesRule::~CSSKeyframesRule()
 {
     ASSERT(m_childRuleCSSOMWrappers.size() == m_keyframesRule->keyframes().size());
 
-    for (unsigned i = 0; i < m_childRuleCSSOMWrappers.size(); ++i) {
-        if (m_childRuleCSSOMWrappers[i])
-            m_childRuleCSSOMWrappers[i]->setParentRule(0);
+    for (RefPtr wrapper : m_childRuleCSSOMWrappers) {
+        if (wrapper)
+            wrapper->setParentRule(nullptr);
     }
 }
 
@@ -151,8 +154,8 @@ void CSSKeyframesRule::deleteRule(const String& s)
 
     m_keyframesRule->wrapperRemoveKeyframe(*i);
 
-    if (m_childRuleCSSOMWrappers[*i])
-        m_childRuleCSSOMWrappers[*i]->setParentRule(nullptr);
+    if (RefPtr wrapper = m_childRuleCSSOMWrappers[*i])
+        wrapper->setParentRule(nullptr);
     m_childRuleCSSOMWrappers.removeAt(*i);
 }
 

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2012, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,8 +66,10 @@ private:
 };
 
 class CSSKeyframesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSKeyframesRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSKeyframesRule);
 public:
-    static Ref<CSSKeyframesRule> create(StyleRuleKeyframes& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSKeyframesRule(rule, sheet)); }
+    static Ref<CSSKeyframesRule> create(StyleRuleKeyframes& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSKeyframesRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSKeyframesRule();
 
@@ -90,7 +92,7 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
 
 private:
-    CSSKeyframesRule(StyleRuleKeyframes&, CSSStyleSheet* parent);
+    CSSKeyframesRule(StyleRuleKeyframes&, CheckedPtr<CSSStyleSheet>&& parent);
 
     Ref<StyleRuleKeyframes> m_keyframesRule;
     mutable Vector<RefPtr<CSSKeyframeRule>> m_childRuleCSSOMWrappers;

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,19 +33,22 @@
 #include "CSSMarkup.h"
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSLayerBlockRule::CSSLayerBlockRule(StyleRuleLayer& rule, CSSStyleSheet* parent)
-    : CSSGroupingRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSLayerBlockRule);
+
+CSSLayerBlockRule::CSSLayerBlockRule(StyleRuleLayer& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(rule, WTFMove(parent))
 {
     ASSERT(!rule.isStatement());
 }
 
-Ref<CSSLayerBlockRule> CSSLayerBlockRule::create(StyleRuleLayer& rule, CSSStyleSheet* parent)
+Ref<CSSLayerBlockRule> CSSLayerBlockRule::create(StyleRuleLayer& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSLayerBlockRule(rule, parent));
+    return adoptRef(*new CSSLayerBlockRule(rule, WTFMove(parent)));
 }
 
 String CSSLayerBlockRule::cssText() const

--- a/Source/WebCore/css/CSSLayerBlockRule.h
+++ b/Source/WebCore/css/CSSLayerBlockRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,14 +39,16 @@ class StyleRuleLayer;
 using CascadeLayerName = Vector<AtomString>;
 
 class CSSLayerBlockRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSLayerBlockRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSLayerBlockRule);
 public:
-    static Ref<CSSLayerBlockRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
+    static Ref<CSSLayerBlockRule> create(StyleRuleLayer&, CheckedPtr<CSSStyleSheet>&& parent);
 
     String cssText() const final;
     String name() const;
 
 private:
-    CSSLayerBlockRule(StyleRuleLayer&, CSSStyleSheet*);
+    CSSLayerBlockRule(StyleRuleLayer&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::LayerBlock; }
 };
 

--- a/Source/WebCore/css/CSSLayerStatementRule.cpp
+++ b/Source/WebCore/css/CSSLayerStatementRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,20 +33,23 @@
 #include "CSSLayerBlockRule.h"
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSLayerStatementRule::CSSLayerStatementRule(StyleRuleLayer& rule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSLayerStatementRule);
+
+CSSLayerStatementRule::CSSLayerStatementRule(StyleRuleLayer& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_layerRule(rule)
 {
     ASSERT(rule.isStatement());
 }
 
-Ref<CSSLayerStatementRule> CSSLayerStatementRule::create(StyleRuleLayer& rule, CSSStyleSheet* parent)
+Ref<CSSLayerStatementRule> CSSLayerStatementRule::create(StyleRuleLayer& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSLayerStatementRule(rule, parent));
+    return adoptRef(*new CSSLayerStatementRule(rule, WTFMove(parent)));
 }
 
 CSSLayerStatementRule::~CSSLayerStatementRule() = default;

--- a/Source/WebCore/css/CSSLayerStatementRule.h
+++ b/Source/WebCore/css/CSSLayerStatementRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,15 +36,17 @@ namespace WebCore {
 class StyleRuleLayer;
 
 class CSSLayerStatementRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSLayerStatementRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSLayerStatementRule);
 public:
-    static Ref<CSSLayerStatementRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
+    static Ref<CSSLayerStatementRule> create(StyleRuleLayer&, CheckedPtr<CSSStyleSheet>&& parent);
     virtual ~CSSLayerStatementRule();
 
     String cssText() const final;
     Vector<String> nameList() const;
 
 private:
-    CSSLayerStatementRule(StyleRuleLayer&, CSSStyleSheet*);
+    CSSLayerStatementRule(StyleRuleLayer&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::LayerStatement; }
     void reattach(StyleRuleBase&) final;
 

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -1,7 +1,7 @@
 /**
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig (sam@webkit.org)
  *
  * This library is free software; you can redistribute it and/or
@@ -27,12 +27,15 @@
 #include "MediaList.h"
 #include "MediaQueryParser.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSMediaRule::CSSMediaRule(StyleRuleMedia& mediaRule, CSSStyleSheet* parent)
-    : CSSConditionRule(mediaRule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSMediaRule);
+
+CSSMediaRule::CSSMediaRule(StyleRuleMedia& mediaRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSConditionRule(mediaRule, WTFMove(parent))
 {
 }
 

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -35,8 +35,10 @@ using MediaQueryList = Vector<MediaQuery>;
 }
 
 class CSSMediaRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSMediaRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSMediaRule);
 public:
-    static Ref<CSSMediaRule> create(StyleRuleMedia& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSMediaRule(rule, sheet)); }
+    static Ref<CSSMediaRule> create(StyleRuleMedia& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSMediaRule(rule, WTFMove(sheet))); }
     virtual ~CSSMediaRule();
 
     WEBCORE_EXPORT MediaList* media() const;
@@ -44,7 +46,7 @@ public:
 private:
     friend class MediaList;
 
-    CSSMediaRule(StyleRuleMedia&, CSSStyleSheet*);
+    CSSMediaRule(StyleRuleMedia&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Media; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSNamespaceRule.cpp
+++ b/Source/WebCore/css/CSSNamespaceRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,12 +28,15 @@
 
 #include "CSSMarkup.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSNamespaceRule::CSSNamespaceRule(StyleRuleNamespace& namespaceRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSNamespaceRule);
+
+CSSNamespaceRule::CSSNamespaceRule(StyleRuleNamespace& namespaceRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_namespaceRule(namespaceRule)
 {
 }

--- a/Source/WebCore/css/CSSNamespaceRule.h
+++ b/Source/WebCore/css/CSSNamespaceRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,10 @@ namespace WebCore {
 class StyleRuleNamespace;
 
 class CSSNamespaceRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSNamespaceRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSNamespaceRule);
 public:
-    static Ref<CSSNamespaceRule> create(StyleRuleNamespace& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSNamespaceRule(rule, sheet)); }
+    static Ref<CSSNamespaceRule> create(StyleRuleNamespace& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSNamespaceRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSNamespaceRule();
 
@@ -42,6 +44,7 @@ public:
 
 private:
     CSSNamespaceRule(StyleRuleNamespace&, CSSStyleSheet*);
+    CSSNamespaceRule(StyleRuleNamespace&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Namespace; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSNestedDeclarations.cpp
+++ b/Source/WebCore/css/CSSNestedDeclarations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,13 +26,15 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
-
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSNestedDeclarations::CSSNestedDeclarations(StyleRuleNestedDeclarations& rule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSNestedDeclarations);
+
+CSSNestedDeclarations::CSSNestedDeclarations(StyleRuleNestedDeclarations& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_styleRule(rule)
 {
 }

--- a/Source/WebCore/css/CSSNestedDeclarations.h
+++ b/Source/WebCore/css/CSSNestedDeclarations.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -31,15 +31,17 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleNestedDeclarations;
 
 class CSSNestedDeclarations final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSNestedDeclarations);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSNestedDeclarations);
 public:
-    static Ref<CSSNestedDeclarations> create(StyleRuleNestedDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSNestedDeclarations(rule, sheet)); };
+    static Ref<CSSNestedDeclarations> create(StyleRuleNestedDeclarations& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(* new CSSNestedDeclarations(rule, WTFMove(sheet))); };
 
     virtual ~CSSNestedDeclarations();
 
     WEBCORE_EXPORT CSSStyleProperties& style();
 
 private:
-    CSSNestedDeclarations(StyleRuleNestedDeclarations&, CSSStyleSheet*);
+    CSSNestedDeclarations(StyleRuleNestedDeclarations&, CheckedPtr<CSSStyleSheet>&&);
 
     String cssText() const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2005, 2006, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -31,12 +31,15 @@
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
-CSSPageRule::CSSPageRule(StyleRulePage& pageRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPageRule);
+
+CSSPageRule::CSSPageRule(StyleRulePage& pageRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_pageRule(pageRule)
 {
 }

--- a/Source/WebCore/css/CSSPageRule.h
+++ b/Source/WebCore/css/CSSPageRule.h
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2006, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -30,8 +30,10 @@ class CSSStyleSheet;
 class StyleRulePage;
 
 class CSSPageRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPageRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSPageRule);
 public:
-    static Ref<CSSPageRule> create(StyleRulePage& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSPageRule(rule, sheet)); }
+    static Ref<CSSPageRule> create(StyleRulePage& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSPageRule(rule, WTFMove(sheet))); }
 
     virtual ~CSSPageRule();
 
@@ -41,7 +43,7 @@ public:
     WEBCORE_EXPORT void setSelectorText(const String&);
 
 private:
-    CSSPageRule(StyleRulePage&, CSSStyleSheet*);
+    CSSPageRule(StyleRulePage&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Page; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -28,8 +28,11 @@
 
 #include "CSSPositionTryDescriptors.h"
 #include "CSSSerializationContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPositionTryRule);
 
 Ref<StyleRulePositionTry> StyleRulePositionTry::create(AtomString&& name, Ref<StyleProperties>&& properties)
 {
@@ -60,13 +63,13 @@ MutableStyleProperties& StyleRulePositionTry::mutableProperties()
     return downcast<MutableStyleProperties>(m_properties.get());
 }
 
-Ref<CSSPositionTryRule> CSSPositionTryRule::create(StyleRulePositionTry& rule, CSSStyleSheet* parent)
+Ref<CSSPositionTryRule> CSSPositionTryRule::create(StyleRulePositionTry& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSPositionTryRule(rule, parent));
+    return adoptRef(*new CSSPositionTryRule(rule, WTFMove(parent)));
 }
 
-CSSPositionTryRule::CSSPositionTryRule(StyleRulePositionTry& rule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSPositionTryRule::CSSPositionTryRule(StyleRulePositionTry& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_positionTryRule(rule)
     , m_propertiesCSSOMWrapper(nullptr)
 {

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -57,8 +57,10 @@ private:
 };
 
 class CSSPositionTryRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPositionTryRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSPositionTryRule);
 public:
-    static Ref<CSSPositionTryRule> create(StyleRulePositionTry&, CSSStyleSheet*);
+    static Ref<CSSPositionTryRule> create(StyleRulePositionTry&, CheckedPtr<CSSStyleSheet>&&);
     virtual ~CSSPositionTryRule();
 
     StyleRuleType styleRuleType() const { return StyleRuleType::PositionTry; }
@@ -72,7 +74,7 @@ public:
     WEBCORE_EXPORT CSSPositionTryDescriptors& style();
 
 private:
-    CSSPositionTryRule(StyleRulePositionTry&, CSSStyleSheet*);
+    CSSPositionTryRule(StyleRulePositionTry&, CheckedPtr<CSSStyleSheet>&&);
 
     Ref<StyleRulePositionTry> m_positionTryRule;
     RefPtr<CSSPositionTryDescriptors> m_propertiesCSSOMWrapper;

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,19 +30,22 @@
 #include "CSSParserTokenRange.h"
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSPropertyRule::CSSPropertyRule(StyleRuleProperty& rule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPropertyRule);
+
+CSSPropertyRule::CSSPropertyRule(StyleRuleProperty& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_propertyRule(rule)
 {
 }
 
-Ref<CSSPropertyRule> CSSPropertyRule::create(StyleRuleProperty& rule, CSSStyleSheet* parent)
+Ref<CSSPropertyRule> CSSPropertyRule::create(StyleRuleProperty& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSPropertyRule(rule, parent));
+    return adoptRef(*new CSSPropertyRule(rule, WTFMove(parent)));
 }
 
 CSSPropertyRule::~CSSPropertyRule() = default;

--- a/Source/WebCore/css/CSSPropertyRule.h
+++ b/Source/WebCore/css/CSSPropertyRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,10 @@ namespace WebCore {
 class StyleRuleProperty;
 
 class CSSPropertyRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPropertyRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSPropertyRule);
 public:
-    static Ref<CSSPropertyRule> create(StyleRuleProperty&, CSSStyleSheet* parent);
+    static Ref<CSSPropertyRule> create(StyleRuleProperty&, CheckedPtr<CSSStyleSheet>&& parent);
     virtual ~CSSPropertyRule();
 
     String name() const;
@@ -44,7 +46,7 @@ public:
     String cssText() const final;
 
 private:
-    CSSPropertyRule(StyleRuleProperty&, CSSStyleSheet*);
+    CSSPropertyRule(StyleRuleProperty&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Property; }
     void reattach(StyleRuleBase&) final;
 

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -28,16 +28,19 @@
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
 #include "css/parser/CSSParserEnum.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-struct SameSizeAsCSSRule : public RefCountedAndCanMakeWeakPtr<SameSizeAsCSSRule> {
+struct SameSizeAsCSSRule : public RefCountedAndCanMakeWeakPtr<SameSizeAsCSSRule>, public CanMakeCheckedPtr<SameSizeAsCSSRule> {
     virtual ~SameSizeAsCSSRule();
     unsigned char bitfields;
-    void* pointerUnion;
+    WTF::CompactVariant<CheckedPtr<CSSRule>> pointerUnion;
 };
 
 static_assert(sizeof(CSSRule) == sizeof(SameSizeAsCSSRule), "CSSRule should stay small");
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSRule);
 
 unsigned short CSSRule::typeForCSSOM() const
 {

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Andreas Kling (kling@webkit.org)
  *
  * This library is free software; you can redistribute it and/or
@@ -24,6 +24,8 @@
 
 #include <WebCore/CSSParserEnum.h>
 #include <WebCore/StyleRuleType.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/CompactVariant.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 
@@ -42,7 +44,9 @@ namespace CSS {
 struct SerializationContext;
 }
 
-class CSSRule : public RefCountedAndCanMakeWeakPtr<CSSRule> {
+class CSSRule : public RefCountedAndCanMakeWeakPtr<CSSRule>, public CanMakeCheckedPtr<CSSRule> {
+    WTF_MAKE_TZONE_ALLOCATED(CSSRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSRule);
 public:
     virtual ~CSSRule() = default;
 
@@ -54,10 +58,12 @@ public:
     virtual String cssText(const CSS::SerializationContext&) const { return cssText(); }
     virtual void reattach(StyleRuleBase&) = 0;
 
-    void setParentStyleSheet(CSSStyleSheet*);
-    void setParentRule(CSSRule*);
+    void setParentStyleSheet(CheckedPtr<CSSStyleSheet>&&);
+    void setParentRule(CheckedPtr<CSSRule>&&);
     CSSStyleSheet* parentStyleSheet() const;
-    CSSRule* parentRule() const { return m_parentIsRule ? m_parentRule : nullptr; }
+    CheckedPtr<CSSStyleSheet> checkedParentStyleSheet() const;
+    CSSRule* parentRule() const;
+    CheckedPtr<CSSRule> checkedParentRule() const;
     bool hasStyleRuleAncestor() const;
     CSSParserEnum::NestedContext nestedContext() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
@@ -66,7 +72,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
 
 protected:
-    explicit CSSRule(CSSStyleSheet*);
+    explicit CSSRule(CheckedPtr<CSSStyleSheet>&&);
 
     bool hasCachedSelectorText() const { return m_hasCachedSelectorText; }
     void setHasCachedSelectorText(bool hasCachedSelectorText) const { m_hasCachedSelectorText = hasCachedSelectorText; }
@@ -75,38 +81,59 @@ protected:
 
 private:
     mutable unsigned char m_hasCachedSelectorText : 1;
-    unsigned char m_parentIsRule : 1;
-    union {
-        CSSRule* m_parentRule;
-        CSSStyleSheet* m_parentStyleSheet;
-    };
+
+    using ParentRuleOrStyleSheet = WTF::CompactVariant<CheckedPtr<CSSRule>, CheckedPtr<CSSStyleSheet>>;
+    ParentRuleOrStyleSheet m_parentRuleOrStyleSheet;
 };
 
-inline CSSRule::CSSRule(CSSStyleSheet* parent)
+inline CSSRule::CSSRule(CheckedPtr<CSSStyleSheet>&& parent)
     : m_hasCachedSelectorText(false)
-    , m_parentIsRule(false)
-    , m_parentStyleSheet(parent)
+    , m_parentRuleOrStyleSheet(WTFMove(parent))
 {
 }
 
-inline void CSSRule::setParentStyleSheet(CSSStyleSheet* styleSheet)
+inline void CSSRule::setParentStyleSheet(CheckedPtr<CSSStyleSheet>&& checkedStyleSheet)
 {
-    m_parentIsRule = false;
-    m_parentStyleSheet = styleSheet;
+    m_parentRuleOrStyleSheet = WTFMove(checkedStyleSheet);
 }
 
-inline void CSSRule::setParentRule(CSSRule* rule)
+inline void CSSRule::setParentRule(CheckedPtr<CSSRule>&& checkedRule)
 {
-    m_parentIsRule = true;
-    m_parentRule = rule;
+    m_parentRuleOrStyleSheet = WTFMove(checkedRule);
 }
 
 inline CSSStyleSheet* CSSRule::parentStyleSheet() const
 {
-    if (m_parentIsRule)
-        return m_parentRule ? m_parentRule->parentStyleSheet() : nullptr;
-    return m_parentStyleSheet;
+    return WTF::switchOn(m_parentRuleOrStyleSheet,
+        [&](const CheckedPtr<CSSStyleSheet>& stylesheet) { return stylesheet.get(); },
+        [&](const CheckedPtr<CSSRule>& rule) { return rule ? rule->parentStyleSheet() : nullptr; }
+    );
 }
+
+inline CheckedPtr<CSSStyleSheet> CSSRule::checkedParentStyleSheet() const
+{
+    return WTF::switchOn(m_parentRuleOrStyleSheet,
+        [&](const CheckedPtr<CSSStyleSheet>& stylesheet) { return stylesheet; },
+        [&](const CheckedPtr<CSSRule>& rule) { return CheckedPtr<CSSStyleSheet>(rule->parentStyleSheet()); }
+    );
+}
+
+inline CSSRule* CSSRule::parentRule() const
+{
+    return WTF::switchOn(m_parentRuleOrStyleSheet,
+        [&](const CheckedPtr<CSSStyleSheet>&) { return static_cast<CSSRule*>(nullptr); },
+        [&](const CheckedPtr<CSSRule>& rule) { return rule.get(); }
+    );
+}
+
+inline CheckedPtr<CSSRule> CSSRule::checkedParentRule() const
+{
+    return WTF::switchOn(m_parentRuleOrStyleSheet,
+        [&](const CheckedPtr<CSSStyleSheet>&) { return CheckedPtr<CSSRule>(); },
+        [&](const CheckedPtr<CSSRule>& rule) { return rule; }
+    );
+}
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -21,15 +21,15 @@
 
 #pragma once
 
+#include <WebCore/CSSRule.h>
 #include <wtf/AbstractRefCounted.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
-class CSSRule;
 class CSSStyleSheet;
 
 class CSSRuleList : public AbstractRefCounted {
@@ -38,7 +38,7 @@ public:
     virtual ~CSSRuleList();
 
     virtual unsigned length() const = 0;
-    virtual CSSRule* item(unsigned index) const = 0;
+    virtual RefPtr<CSSRule> item(unsigned index) const = 0;
     bool isSupportedPropertyIndex(unsigned index) const { return item(index); }
     
     virtual CSSStyleSheet* styleSheet() const = 0;
@@ -63,7 +63,7 @@ private:
     StaticCSSRuleList();
 
     unsigned length() const final { return m_rules.size(); }
-    CSSRule* item(unsigned index) const final { return index < m_rules.size() ? m_rules[index].get() : nullptr; }
+    RefPtr<CSSRule> item(unsigned index) const final { return index < m_rules.size() ? m_rules[index] : nullptr; }
 
     Vector<RefPtr<CSSRule>> m_rules;
 };
@@ -78,15 +78,15 @@ public:
     {
     }
     
-    void ref() const final { m_rule.ref(); }
-    void deref() const final { m_rule.deref(); }
+    void ref() const final { m_rule->ref(); }
+    void deref() const final { m_rule->deref(); }
 
 private:
-    unsigned length() const final { return m_rule.length(); }
-    CSSRule* item(unsigned index) const final { return m_rule.item(index); }
-    CSSStyleSheet* styleSheet() const final { return m_rule.parentStyleSheet(); }
+    unsigned length() const final { return m_rule->length(); }
+    RefPtr<CSSRule> item(unsigned index) const final { return m_rule->item(index); }
+    CSSStyleSheet* styleSheet() const final { return m_rule->parentStyleSheet(); }
     
-    Rule& m_rule;
+    CheckedRef<Rule> m_rule;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<class Rule>, LiveCSSRuleList<Rule>);

--- a/Source/WebCore/css/CSSScopeRule.cpp
+++ b/Source/WebCore/css/CSSScopeRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,18 +27,21 @@
 #include "CSSScopeRule.h"
 
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSScopeRule::CSSScopeRule(StyleRuleScope& rule, CSSStyleSheet* parent)
-    : CSSGroupingRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSScopeRule);
+
+CSSScopeRule::CSSScopeRule(StyleRuleScope& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(rule, WTFMove(parent))
 {
 }
 
-Ref<CSSScopeRule> CSSScopeRule::create(StyleRuleScope& rule, CSSStyleSheet* parent)
+Ref<CSSScopeRule> CSSScopeRule::create(StyleRuleScope& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSScopeRule(rule, parent));
+    return adoptRef(*new CSSScopeRule(rule, WTFMove(parent)));
 }
 
 const StyleRuleScope& CSSScopeRule::styleRuleScope() const

--- a/Source/WebCore/css/CSSScopeRule.h
+++ b/Source/WebCore/css/CSSScopeRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,10 @@ namespace WebCore {
 class StyleRuleScope;
 
 class CSSScopeRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSScopeRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSScopeRule);
 public:
-    static Ref<CSSScopeRule> create(StyleRuleScope&, CSSStyleSheet* parent);
+    static Ref<CSSScopeRule> create(StyleRuleScope&, CheckedPtr<CSSStyleSheet>&& parent);
 
     String cssText() const final;
     String start() const;
@@ -42,7 +44,7 @@ public:
 private:
     const StyleRuleScope& styleRuleScope() const;
 
-    CSSScopeRule(StyleRuleScope&, CSSStyleSheet*);
+    CSSScopeRule(StyleRuleScope&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Scope; }
 };
 

--- a/Source/WebCore/css/CSSStartingStyleRule.cpp
+++ b/Source/WebCore/css/CSSStartingStyleRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,11 +27,14 @@
 #include "CSSStartingStyleRule.h"
 
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-CSSStartingStyleRule::CSSStartingStyleRule(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
-    : CSSGroupingRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSStartingStyleRule);
+
+CSSStartingStyleRule::CSSStartingStyleRule(StyleRuleStartingStyle& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSGroupingRule(rule, WTFMove(parent))
 {
 }
 

--- a/Source/WebCore/css/CSSStartingStyleRule.h
+++ b/Source/WebCore/css/CSSStartingStyleRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,16 +32,18 @@ namespace WebCore {
 class StyleRuleStartingStyle;
 
 class CSSStartingStyleRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSStartingStyleRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSStartingStyleRule);
 public:
-    static Ref<CSSStartingStyleRule> create(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
+    static Ref<CSSStartingStyleRule> create(StyleRuleStartingStyle& rule, CheckedPtr<CSSStyleSheet>&& parent)
     {
-        return adoptRef(*new CSSStartingStyleRule(rule, parent));
+        return adoptRef(*new CSSStartingStyleRule(rule, WTFMove(parent)));
     }
 
     String cssText() const final;
 
 private:
-    CSSStartingStyleRule(StyleRuleStartingStyle&, CSSStyleSheet*);
+    CSSStartingStyleRule(StyleRuleStartingStyle&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::StartingStyle; }
 };

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,10 +36,13 @@
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSStyleRule);
 
 typedef HashMap<const CSSStyleRule*, String> SelectorTextCache;
 static SelectorTextCache& selectorTextCache()
@@ -48,16 +51,16 @@ static SelectorTextCache& selectorTextCache()
     return cache;
 }
 
-CSSStyleRule::CSSStyleRule(StyleRule& styleRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSStyleRule::CSSStyleRule(StyleRule& styleRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_styleRule(styleRule)
     , m_styleMap(DeclaredStylePropertyMap::create(*this))
     , m_childRuleCSSOMWrappers(0)
 {
 }
 
-CSSStyleRule::CSSStyleRule(StyleRuleWithNesting& styleRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSStyleRule::CSSStyleRule(StyleRuleWithNesting& styleRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_styleRule(styleRule)
     , m_styleMap(DeclaredStylePropertyMap::create(*this))
     , m_childRuleCSSOMWrappers(styleRule.nestedRules().size())
@@ -281,8 +284,8 @@ ExceptionOr<void> CSSStyleRule::deleteRule(unsigned index)
     CSSStyleSheet::RuleMutationScope mutationScope(this);
     rules.removeAt(index);
 
-    if (m_childRuleCSSOMWrappers[index])
-        m_childRuleCSSOMWrappers[index]->setParentRule(nullptr);
+    if (RefPtr wrapper = m_childRuleCSSOMWrappers[index])
+        wrapper->setParentRule(nullptr);
     m_childRuleCSSOMWrappers.removeAt(index);
 
     return { };
@@ -293,7 +296,7 @@ unsigned CSSStyleRule::length() const
     return nestedRules().size();
 }
 
-CSSRule* CSSStyleRule::item(unsigned index) const
+RefPtr<CSSRule> CSSStyleRule::item(unsigned index) const
 {
     if (index >= length())
         return nullptr;
@@ -304,7 +307,7 @@ CSSRule* CSSStyleRule::item(unsigned index) const
     if (!rule)
         rule = nestedRules()[index]->createCSSOMWrapper(const_cast<CSSStyleRule&>(*this));
 
-    return rule.get();
+    return rule;
 }
 
 CSSRuleList& CSSStyleRule::cssRules() const

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2006, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,10 +36,11 @@ class StyleRuleWithNesting;
 class StyleRuleCSSStyleProperties;
 
 class CSSStyleRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSStyleRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSStyleRule);
 public:
-    static Ref<CSSStyleRule> create(StyleRule& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSStyleRule(rule, sheet)); }
-    static Ref<CSSStyleRule> create(StyleRuleWithNesting& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSStyleRule(rule, sheet)); };
-
+    static Ref<CSSStyleRule> create(StyleRule& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(*new CSSStyleRule(rule, WTFMove(sheet))); }
+    static Ref<CSSStyleRule> create(StyleRuleWithNesting& rule, CheckedPtr<CSSStyleSheet>&& sheet) { return adoptRef(* new CSSStyleRule(rule, WTFMove(sheet))); };
     virtual ~CSSStyleRule();
 
     WEBCORE_EXPORT String selectorText() const;
@@ -54,13 +55,13 @@ public:
     WEBCORE_EXPORT ExceptionOr<unsigned> insertRule(const String& rule, unsigned index);
     WEBCORE_EXPORT ExceptionOr<void> deleteRule(unsigned index);
     unsigned length() const;
-    CSSRule* item(unsigned index) const;
+    RefPtr<CSSRule> item(unsigned index) const;
 
     StylePropertyMap& styleMap();
 
 private:
-    CSSStyleRule(StyleRule&, CSSStyleSheet*);
-    CSSStyleRule(StyleRuleWithNesting&, CSSStyleSheet*);
+    CSSStyleRule(StyleRule&, CheckedPtr<CSSStyleSheet>&&);
+    CSSStyleRule(StyleRuleWithNesting&, CheckedPtr<CSSStyleSheet>&&);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
     String cssText() const final;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -45,10 +45,13 @@
 #include "StyleSheetContents.h"
 #include "StyleSheetContentsCache.h"
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSStyleSheet);
 
 static Style::Scope& styleScopeFor(ContainerNode& treeScope)
 {
@@ -69,7 +72,7 @@ private:
     void deref() const final { m_styleSheet->deref(); }
 
     unsigned length() const final { return m_styleSheet->length(); }
-    CSSRule* item(unsigned index) const final { return m_styleSheet->item(index); }
+    RefPtr<CSSRule> item(unsigned index) const final { return m_styleSheet->item(index); }
 
     CSSStyleSheet* styleSheet() const final { return m_styleSheet.get(); }
 
@@ -314,7 +317,7 @@ unsigned CSSStyleSheet::length() const
     return m_contents->ruleCount();
 }
 
-CSSRule* CSSStyleSheet::item(unsigned index)
+RefPtr<CSSRule> CSSStyleSheet::item(unsigned index)
 {
     unsigned ruleCount = length();
     if (index >= ruleCount)
@@ -327,7 +330,7 @@ CSSRule* CSSStyleSheet::item(unsigned index)
     RefPtr<CSSRule>& cssRule = m_childRuleCSSOMWrappers[index];
     if (!cssRule)
         cssRule = m_contents->ruleAt(index)->createCSSOMWrapper(*this);
-    return cssRule.get();
+    return cssRule;
 }
 
 bool CSSStyleSheet::canAccessRules() const

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -57,7 +57,9 @@ namespace Style {
 class Scope;
 }
 
-class CSSStyleSheet final : public StyleSheet, public CanMakeSingleThreadWeakPtr<CSSStyleSheet> {
+class CSSStyleSheet final : public StyleSheet, public CanMakeSingleThreadWeakPtr<CSSStyleSheet>, CanMakeCheckedPtr<CSSStyleSheet> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSStyleSheet);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSStyleSheet);
 public:
     struct Init {
         String baseURL;
@@ -98,7 +100,7 @@ public:
 
     // For CSSRuleList.
     unsigned length() const;
-    CSSRule* item(unsigned index);
+    RefPtr<CSSRule> item(unsigned index);
 
     void clearOwnerNode() final;
     WEBCORE_EXPORT CSSImportRule* ownerRule() const final;
@@ -163,6 +165,9 @@ public:
     void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&);
 
     bool isDetached() const;
+
+    void decrementCheckedPtrCount() const { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void incrementCheckedPtrCount() const { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
 
 private:
     CSSStyleSheet(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule, std::optional<bool> isOriginClean);

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Motorola Mobility Inc. All rights reserved.
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -34,18 +34,21 @@
 #include "CSSStyleSheet.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSSupportsRule::CSSSupportsRule(StyleRuleSupports& rule, CSSStyleSheet* parent)
-    : CSSConditionRule(rule, parent)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSupportsRule);
+
+CSSSupportsRule::CSSSupportsRule(StyleRuleSupports& rule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSConditionRule(rule, WTFMove(parent))
 {
 }
 
-Ref<CSSSupportsRule> CSSSupportsRule::create(StyleRuleSupports& rule, CSSStyleSheet* parent)
+Ref<CSSSupportsRule> CSSSupportsRule::create(StyleRuleSupports& rule, CheckedPtr<CSSStyleSheet>&& parent)
 {
-    return adoptRef(*new CSSSupportsRule(rule, parent));
+    return adoptRef(*new CSSSupportsRule(rule, WTFMove(parent)));
 }
 
 String CSSSupportsRule::cssText() const

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Motorola Mobility Inc. All rights reserved.
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -37,15 +37,17 @@ namespace WebCore {
 class StyleRuleSupports;
 
 class CSSSupportsRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSSupportsRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSSupportsRule);
 public:
-    static Ref<CSSSupportsRule> create(StyleRuleSupports&, CSSStyleSheet* parent);
+    static Ref<CSSSupportsRule> create(StyleRuleSupports&, CheckedPtr<CSSStyleSheet>&& parent);
 
     String cssText() const final;
     String cssText(const CSS::SerializationContext&) const final;
     String conditionText() const final;
 
 private:
-    CSSSupportsRule(StyleRuleSupports&, CSSStyleSheet*);
+    CSSSupportsRule(StyleRuleSupports&, CheckedPtr<CSSStyleSheet>&&);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Supports; }
 };
 

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,9 +34,12 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSViewTransitionRule);
 
 static std::optional<ViewTransitionNavigation> toViewTransitionNavigationEnum(RefPtr<CSSValue> navigation)
 {
@@ -76,13 +79,13 @@ Ref<StyleRuleViewTransition> StyleRuleViewTransition::create(Ref<StyleProperties
 
 StyleRuleViewTransition::~StyleRuleViewTransition() = default;
 
-Ref<CSSViewTransitionRule> CSSViewTransitionRule::create(StyleRuleViewTransition& rule, CSSStyleSheet* sheet)
+Ref<CSSViewTransitionRule> CSSViewTransitionRule::create(StyleRuleViewTransition& rule, CheckedPtr<CSSStyleSheet>&& sheet)
 {
-    return adoptRef(*new CSSViewTransitionRule(rule, sheet));
+    return adoptRef(*new CSSViewTransitionRule(rule, WTFMove(sheet)));
 }
 
-CSSViewTransitionRule::CSSViewTransitionRule(StyleRuleViewTransition& viewTransitionRule, CSSStyleSheet* parent)
-    : CSSRule(parent)
+CSSViewTransitionRule::CSSViewTransitionRule(StyleRuleViewTransition& viewTransitionRule, CheckedPtr<CSSStyleSheet>&& parent)
+    : CSSRule(WTFMove(parent))
     , m_viewTransitionRule(viewTransitionRule)
 {
 }

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,10 +57,12 @@ private:
 };
 
 class CSSViewTransitionRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSViewTransitionRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSViewTransitionRule);
 public:
     using ViewTransitionNavigation = WebCore::ViewTransitionNavigation;
 
-    static Ref<CSSViewTransitionRule> create(StyleRuleViewTransition&, CSSStyleSheet*);
+    static Ref<CSSViewTransitionRule> create(StyleRuleViewTransition&, CheckedPtr<CSSStyleSheet>&&);
     virtual ~CSSViewTransitionRule();
 
     String cssText() const final;
@@ -71,7 +73,7 @@ public:
     Vector<AtomString> types() const { return Ref { m_viewTransitionRule }->types(); }
 
 private:
-    CSSViewTransitionRule(StyleRuleViewTransition&, CSSStyleSheet* parent);
+    CSSViewTransitionRule(StyleRuleViewTransition&, CheckedPtr<CSSStyleSheet>&&);
 
     Ref<StyleRuleViewTransition> m_viewTransitionRule;
 };

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CSSStyleSheet.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
 #include "ElementChildIteratorInlines.h"

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -178,81 +178,82 @@ Ref<StyleRuleBase> StyleRuleBase::copy() const
 
 Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRule* parentRule) const
 {
+    CheckedPtr<CSSStyleSheet> checkedParentSheet { parentSheet };
     // FIXME: const_cast is required here because a wrapper for a style rule can be used to *modify* the style rule's selector; use of const in the style system is thus inaccurate.
     auto wrapper = const_cast<StyleRuleBase&>(*this).visitDerived(WTF::makeVisitor(
-        [&](StyleRule& rule) -> Ref<CSSRule> {
-            return CSSStyleRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRule& rule) mutable -> Ref<CSSRule> {
+            return CSSStyleRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleWithNesting& rule) -> Ref<CSSRule> {
-            return CSSStyleRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleWithNesting& rule) mutable -> Ref<CSSRule> {
+            return CSSStyleRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleNestedDeclarations& rule) -> Ref<CSSRule> {
-            return CSSNestedDeclarations::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleNestedDeclarations& rule) mutable -> Ref<CSSRule> {
+            return CSSNestedDeclarations::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRulePage& rule) -> Ref<CSSRule> {
-            return CSSPageRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRulePage& rule) mutable -> Ref<CSSRule> {
+            return CSSPageRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFontFace& rule) -> Ref<CSSRule> {
-            return CSSFontFaceRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFontFace& rule) mutable -> Ref<CSSRule> {
+            return CSSFontFaceRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFontFeatureValues& rule) -> Ref<CSSRule> {
-            return CSSFontFeatureValuesRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFontFeatureValues& rule) mutable -> Ref<CSSRule> {
+            return CSSFontFeatureValuesRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFontFeatureValuesBlock& rule) -> Ref<CSSRule> {
-            return CSSFontFeatureValuesBlockRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFontFeatureValuesBlock& rule) mutable -> Ref<CSSRule> {
+            return CSSFontFeatureValuesBlockRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFontPaletteValues& rule) -> Ref<CSSRule> {
-            return CSSFontPaletteValuesRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFontPaletteValues& rule) mutable -> Ref<CSSRule> {
+            return CSSFontPaletteValuesRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleMedia& rule) -> Ref<CSSRule> {
-            return CSSMediaRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleMedia& rule) mutable -> Ref<CSSRule> {
+            return CSSMediaRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleSupports& rule) -> Ref<CSSRule> {
-            return CSSSupportsRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleSupports& rule) mutable -> Ref<CSSRule> {
+            return CSSSupportsRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleImport& rule) -> Ref<CSSRule> {
-            return CSSImportRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleImport& rule) mutable -> Ref<CSSRule> {
+            return CSSImportRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleKeyframes& rule) -> Ref<CSSRule> {
-            return CSSKeyframesRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleKeyframes& rule) mutable -> Ref<CSSRule> {
+            return CSSKeyframesRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleNamespace& rule) -> Ref<CSSRule> {
-            return CSSNamespaceRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleNamespace& rule) mutable -> Ref<CSSRule> {
+            return CSSNamespaceRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleCounterStyle& rule) -> Ref<CSSRule> {
-            return CSSCounterStyleRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleCounterStyle& rule) mutable -> Ref<CSSRule> {
+            return CSSCounterStyleRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleLayer& rule) -> Ref<CSSRule> {
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleLayer& rule) mutable -> Ref<CSSRule> {
             if (rule.isStatement())
-                return CSSLayerStatementRule::create(rule, parentSheet);
-            return CSSLayerBlockRule::create(rule, parentSheet);
+                return CSSLayerStatementRule::create(rule, WTFMove(parentSheet));
+            return CSSLayerBlockRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleContainer& rule) -> Ref<CSSRule> {
-            return CSSContainerRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleContainer& rule) mutable -> Ref<CSSRule> {
+            return CSSContainerRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleProperty& rule) -> Ref<CSSRule> {
-            return CSSPropertyRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleProperty& rule) mutable -> Ref<CSSRule> {
+            return CSSPropertyRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleScope& rule) -> Ref<CSSRule> {
-            return CSSScopeRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleScope& rule) mutable -> Ref<CSSRule> {
+            return CSSScopeRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleStartingStyle& rule) -> Ref<CSSRule> {
-            return CSSStartingStyleRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleStartingStyle& rule) mutable -> Ref<CSSRule> {
+            return CSSStartingStyleRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleViewTransition& rule) -> Ref<CSSRule> {
-            return CSSViewTransitionRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleViewTransition& rule) mutable -> Ref<CSSRule> {
+            return CSSViewTransitionRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRulePositionTry& rule) -> Ref<CSSRule> {
-            return CSSPositionTryRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRulePositionTry& rule) mutable -> Ref<CSSRule> {
+            return CSSPositionTryRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFunction& rule) -> Ref<CSSRule> {
-            return CSSFunctionRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFunction& rule) mutable -> Ref<CSSRule> {
+            return CSSFunctionRule::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleFunctionDeclarations& rule) -> Ref<CSSRule> {
-            return CSSFunctionDeclarations::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleFunctionDeclarations& rule) mutable -> Ref<CSSRule> {
+            return CSSFunctionDeclarations::create(rule, WTFMove(parentSheet));
         },
-        [&](StyleRuleInternalBaseAppearance& rule) -> Ref<CSSRule> {
-            return CSSInternalBaseAppearanceRule::create(rule, parentSheet);
+        [&, parentSheet = WTFMove(checkedParentSheet)](StyleRuleInternalBaseAppearance& rule) mutable -> Ref<CSSRule> {
+            return CSSInternalBaseAppearanceRule::create(rule, WTFMove(parentSheet));
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -79,22 +79,22 @@ static Ref<CSSStyleSheet> createExtensionsStyleSheet(Document& document, URL url
     return styleSheet;
 }
 
-CSSStyleSheet* ExtensionStyleSheets::pageUserSheet()
+RefPtr<CSSStyleSheet> ExtensionStyleSheets::pageUserSheet()
 {
     if (m_pageUserSheet)
-        return m_pageUserSheet.get();
+        return m_pageUserSheet;
     
     RefPtr owningPage = m_document->page();
     if (!owningPage)
-        return nullptr;
+        return { };
     
     String userSheetText = owningPage->userStyleSheet();
     if (userSheetText.isEmpty())
-        return nullptr;
+        return { };
     
     m_pageUserSheet = createExtensionsStyleSheet(protectedDocument().get(), m_document->settings().userStyleSheetLocation(), userSheetText, UserStyleLevel::User);
 
-    return m_pageUserSheet.get();
+    return m_pageUserSheet;
 }
 
 void ExtensionStyleSheets::clearPageUserSheet()

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -58,7 +58,7 @@ public:
     explicit ExtensionStyleSheets(Document&);
     ~ExtensionStyleSheets();
 
-    CSSStyleSheet* pageUserSheet();
+    RefPtr<CSSStyleSheet> pageUserSheet();
     const Vector<RefPtr<CSSStyleSheet>>& documentUserStyleSheets() const { return m_userStyleSheets; }
     const Vector<RefPtr<CSSStyleSheet>>& injectedUserStyleSheets() const;
     const Vector<RefPtr<CSSStyleSheet>>& injectedAuthorStyleSheets() const;

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "UserGestureIndicator.h"
 
+#include "CSSStyleSheet.h"
 #include "DocumentPage.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalDOMWindow.h"

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -31,6 +31,7 @@
 #import "CSSColorValue.h"
 #import "CSSComputedStyleDeclaration.h"
 #import "CSSPrimitiveValue.h"
+#import "CSSRule.h"
 #import "CSSSerializationContext.h"
 #import "CharacterData.h"
 #import "ColorCocoa.h"

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -31,6 +31,7 @@
 #import "CSSColorValue.h"
 #import "CSSComputedStyleDeclaration.h"
 #import "CSSPrimitiveValue.h"
+#import "CSSRule.h"
 #import "CSSSerializationContext.h"
 #import "CachedImage.h"
 #import "CharacterData.h"

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -31,6 +31,7 @@
 #import "CSSColorValue.h"
 #import "CSSComputedStyleDeclaration.h"
 #import "CSSPrimitiveValue.h"
+#import "CSSRule.h"
 #import "CSSSerializationContext.h"
 #import "CachedImage.h"
 #import "CharacterData.h"

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1194,10 +1194,10 @@ ExceptionOr<CSSStyleRule*> InspectorStyleSheet::addRule(const String& selector)
 
     ASSERT(m_pageStyleSheet->length());
     unsigned lastRuleIndex = m_pageStyleSheet->length() - 1;
-    CSSRule* rule = m_pageStyleSheet->item(lastRuleIndex);
+    RefPtr rule = m_pageStyleSheet->item(lastRuleIndex);
     ASSERT(rule);
 
-    CSSStyleRule* styleRule = dynamicDowncast<CSSStyleRule>(rule);
+    CSSStyleRule* styleRule = dynamicDowncast<CSSStyleRule>(rule.get());
     if (!styleRule) {
         // What we just added has to be a CSSStyleRule - we cannot handle other types of rules yet.
         // If it is not a style rule, pretend we never touched the stylesheet.
@@ -1816,7 +1816,7 @@ void InspectorStyleSheet::collectFlatRules(RefPtr<CSSRuleList>&& ruleList, Vecto
         return;
 
     for (unsigned i = 0, size = ruleList->length(); i < size; ++i) {
-        CSSRule* rule = ruleList->item(i);
+        RefPtr rule = ruleList->item(i);
         if (!rule)
             continue;
 
@@ -1824,7 +1824,7 @@ void InspectorStyleSheet::collectFlatRules(RefPtr<CSSRuleList>&& ruleList, Vecto
         case RuleFlatteningStrategy::CommitSelfThenChildren: {
             result->append(rule);
 
-            auto childRuleList = asCSSRuleList(rule);
+            auto childRuleList = asCSSRuleList(rule.get());
             ASSERT(childRuleList);
             collectFlatRules(WTFMove(childRuleList), result);
             break;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -667,9 +667,9 @@ void InspectorCSSAgent::collectStyleSheets(CSSStyleSheet* styleSheet, Vector<CSS
     result.append(styleSheet);
 
     for (unsigned i = 0, size = styleSheet->length(); i < size; ++i) {
-        if (auto* rule = dynamicDowncast<CSSImportRule>(styleSheet->item(i))) {
-            if (CSSStyleSheet* importedStyleSheet = rule->styleSheet())
-                collectStyleSheets(importedStyleSheet, result);
+        if (auto* rule = dynamicDowncast<CSSImportRule>(styleSheet->item(i).get())) {
+            if (RefPtr importedStyleSheet = rule->styleSheet())
+                collectStyleSheets(importedStyleSheet.get(), result);
         }
     }
 }

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "Crypto.h"
 
+#include "CSSStyleSheet.h"
 #include "Document.h"
 #include "ExceptionOr.h"
 #include "SubtleCrypto.h"

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -242,7 +242,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
 {
     StringBuilder cssText;
     for (unsigned i = 0; i < styleSheet->length(); ++i) {
-        CSSRule* rule = styleSheet->item(i);
+        RefPtr rule = styleSheet->item(i);
         String itemText = rule->cssText();
         if (!itemText.isEmpty()) {
             cssText.append(itemText);
@@ -255,7 +255,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
             auto importURL = document->completeURL(importRule->href());
             if (m_resourceURLs.contains(importURL))
                 continue;
-            serializeCSSStyleSheet(importRule->protectedStyleSheet().get(), importURL);
+            serializeCSSStyleSheet(importRule->styleSheet().get(), importURL);
         } else if (is<CSSFontFaceRule>(*rule)) {
             // FIXME: Add support for font face rule. It is not clear to me at this point if the actual otf/eot file can
             // be retrieved from the CSSFontFaceRule object.

--- a/Source/WebCore/style/InspectorCSSOMWrappers.cpp
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.cpp
@@ -63,37 +63,37 @@ void InspectorCSSOMWrappers::collect(ListType* listType)
         return;
     unsigned size = listType->length();
     for (unsigned i = 0; i < size; ++i) {
-        CSSRule* cssRule = listType->item(i);
+        RefPtr<CSSRule> cssRule = listType->item(i);
         if (!cssRule)
             continue;
         
         switch (cssRule->styleRuleType()) {
         case StyleRuleType::Container:
-            collect(uncheckedDowncast<CSSContainerRule>(cssRule));
+            collect(uncheckedDowncast<CSSContainerRule>(cssRule.get()));
             break;
         case StyleRuleType::Import:
-            collect(uncheckedDowncast<CSSImportRule>(*cssRule).styleSheet());
+            collect(uncheckedDowncast<CSSImportRule>(*cssRule).styleSheet().get());
             break;
         case StyleRuleType::LayerBlock:
-            collect(uncheckedDowncast<CSSLayerBlockRule>(cssRule));
+            collect(uncheckedDowncast<CSSLayerBlockRule>(cssRule.get()));
             break;
         case StyleRuleType::Media:
-            collect(uncheckedDowncast<CSSMediaRule>(cssRule));
+            collect(uncheckedDowncast<CSSMediaRule>(cssRule.get()));
             break;
         case StyleRuleType::Supports:
-            collect(uncheckedDowncast<CSSSupportsRule>(cssRule));
+            collect(uncheckedDowncast<CSSSupportsRule>(cssRule.get()));
             break;
         case StyleRuleType::Scope:
-            collect(uncheckedDowncast<CSSScopeRule>(cssRule));
+            collect(uncheckedDowncast<CSSScopeRule>(cssRule.get()));
             break;
         case StyleRuleType::StartingStyle:
-            collect(uncheckedDowncast<CSSStartingStyleRule>(cssRule));
+            collect(uncheckedDowncast<CSSStartingStyleRule>(cssRule.get()));
             break;
         case StyleRuleType::Style:
             m_styleRuleToCSSOMWrapperMap.add(&uncheckedDowncast<CSSStyleRule>(*cssRule).styleRule(), uncheckedDowncast<CSSStyleRule>(cssRule));
 
             // Eagerly collect rules nested in this style rule.
-            collect(uncheckedDowncast<CSSStyleRule>(cssRule));
+            collect(uncheckedDowncast<CSSStyleRule>(cssRule.get()));
             break;
         default:
             break;
@@ -142,7 +142,7 @@ void InspectorCSSOMWrappers::collectDocumentWrappers(ExtensionStyleSheets& exten
 #endif
         collectFromStyleSheetContents(UserAgentStyle::mediaQueryStyleSheet);
 
-        collect(extensionStyleSheets.pageUserSheet());
+        collect(extensionStyleSheets.pageUserSheet().get());
         collectFromStyleSheets(extensionStyleSheets.injectedUserStyleSheets());
         collectFromStyleSheets(extensionStyleSheets.documentUserStyleSheets());
         collectFromStyleSheets(extensionStyleSheets.injectedAuthorStyleSheets());

--- a/Source/WebCore/style/ResolvedScopedName.cpp
+++ b/Source/WebCore/style/ResolvedScopedName.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "ResolvedScopedName.h"
 
+#include "CSSStyleSheet.h"
 #include "ScopedName.h"
 #include "StyleScope.h"
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -668,8 +668,8 @@ const Vector<RefPtr<CSSStyleSheet>> Scope::activeStyleSheetsForInspector()
     Vector<RefPtr<CSSStyleSheet>> result;
 
     if (CheckedPtr extensionStyleSheets = m_document->extensionStyleSheetsIfExists()) {
-        if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet())
-            result.append(pageUserSheet);
+        if (RefPtr pageUserSheet = extensionStyleSheets->pageUserSheet())
+            result.append(WTFMove(pageUserSheet));
         result.appendVector(extensionStyleSheets->documentUserStyleSheets());
         result.appendVector(extensionStyleSheets->injectedUserStyleSheets());
         result.appendVector(extensionStyleSheets->injectedAuthorStyleSheets());

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -123,7 +123,7 @@ void ScopeRuleSets::initializeUserStyle()
 
     auto userStyle = RuleSet::create();
 
-    if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet()) {
+    if (RefPtr pageUserSheet = extensionStyleSheets->pageUserSheet()) {
         RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver);
         builder.addRulesFromSheet(pageUserSheet->contents());
     }

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -24,6 +24,7 @@
 #include "SVGFilterPrimitiveStandardAttributes.h"
 
 #include "ContainerNodeInlines.h"
+#include "CSSRule.h"
 #include "FilterEffect.h"
 #include "LegacyRenderSVGResourceFilterPrimitive.h"
 #include "NodeName.h"

--- a/Source/WebCore/svg/SVGZoomAndPan.cpp
+++ b/Source/WebCore/svg/SVGZoomAndPan.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGZoomAndPan.h"
 
+#include "CSSRule.h"
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "DOMParser.h"
 
+#include "CSSRule.h"
 #include "CommonAtomStrings.h"
 #include "ExceptionOr.h"
 #include "HTMLDocument.h"

--- a/Source/WebCore/xml/XMLSerializer.cpp
+++ b/Source/WebCore/xml/XMLSerializer.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "XMLSerializer.h"
 
+#include "CSSRule.h"
 #include "markup.h"
 
 namespace WebCore {

--- a/Source/WebCore/xml/XPathVariableReference.cpp
+++ b/Source/WebCore/xml/XPathVariableReference.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,8 @@
 
 #include "config.h"
 #include "XPathVariableReference.h"
+
+#include "CSSRule.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### f85c19b3b1420a34d3ccbb451c17eaab3996f827
<pre>
Hold CheckedPtr in CSSRules
<a href="https://bugs.webkit.org/show_bug.cgi?id=304283">https://bugs.webkit.org/show_bug.cgi?id=304283</a>
&lt;<a href="https://rdar.apple.com/problem/166647483">rdar://problem/166647483</a>&gt;

Reviewed by NOBODY (OOPS!).

Let&apos;s harden CSSRule by switching from a union of pointers to a WTF::Variant of
CheckedPtr values.

This patch also resolves SaferCPP issues triggered by touching relevant files.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
* Source/WebCore/animation/DocumentTimeline.cpp:
* Source/WebCore/css/CSSConditionRule.cpp:
(WebCore::CSSConditionRule::CSSConditionRule):
* Source/WebCore/css/CSSConditionRule.h:
* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::CSSContainerRule):
(WebCore::CSSContainerRule::create):
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::CSSCounterStyleRule::create):
(WebCore::CSSCounterStyleRule::CSSCounterStyleRule):
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSFilterImageValue.cpp:
* Source/WebCore/css/CSSFontFaceRule.cpp:
(WebCore::CSSFontFaceRule::CSSFontFaceRule):
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSFontFeatureValue.cpp:
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::CSSFontFeatureValuesRule):
(WebCore::CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule):
* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
(WebCore::CSSFontPaletteValuesRule::CSSFontPaletteValuesRule):
* Source/WebCore/css/CSSFontPaletteValuesRule.h:
* Source/WebCore/css/CSSFunctionDeclarations.cpp:
(WebCore::CSSFunctionDeclarations::CSSFunctionDeclarations):
* Source/WebCore/css/CSSFunctionDeclarations.h:
* Source/WebCore/css/CSSFunctionRule.cpp:
(WebCore::CSSFunctionRule::create):
(WebCore::CSSFunctionRule::CSSFunctionRule):
* Source/WebCore/css/CSSFunctionRule.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::CSSGroupingRule):
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::CSSImportRule):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp:
(WebCore::CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule):
* Source/WebCore/css/CSSInternalBaseAppearanceRule.h:
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::CSSKeyframesRule::CSSKeyframesRule):
(WebCore::CSSKeyframesRule::~CSSKeyframesRule):
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSLayerBlockRule.cpp:
(WebCore::CSSLayerBlockRule::CSSLayerBlockRule):
(WebCore::CSSLayerBlockRule::create):
* Source/WebCore/css/CSSLayerBlockRule.h:
* Source/WebCore/css/CSSLayerStatementRule.cpp:
(WebCore::CSSLayerStatementRule::CSSLayerStatementRule):
(WebCore::CSSLayerStatementRule::create):
* Source/WebCore/css/CSSLayerStatementRule.h:
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::CSSMediaRule):
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSNamespaceRule.cpp:
(WebCore::CSSNamespaceRule::CSSNamespaceRule):
* Source/WebCore/css/CSSNamespaceRule.h:
* Source/WebCore/css/CSSNestedDeclarations.cpp:
(WebCore::CSSNestedDeclarations::CSSNestedDeclarations):
* Source/WebCore/css/CSSNestedDeclarations.h:
* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::CSSPageRule):
* Source/WebCore/css/CSSPageRule.h:
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::CSSPositionTryRule::create):
(WebCore::CSSPositionTryRule::CSSPositionTryRule):
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::CSSPropertyRule):
(WebCore::CSSPropertyRule::create):
* Source/WebCore/css/CSSPropertyRule.h:
* Source/WebCore/css/CSSRule.cpp:
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::CSSRule):
(WebCore::CSSRule::setParentStyleSheet):
(WebCore::CSSRule::setParentRule):
(WebCore::CSSRule::parentStyleSheet const):
(WebCore::CSSRule::checkedParentStyleSheet const):
(WebCore::CSSRule::parentRule const):
(WebCore::CSSRule::checkedParentRule const):
(): Deleted.
* Source/WebCore/css/CSSScopeRule.cpp:
(WebCore::CSSScopeRule::CSSScopeRule):
(WebCore::CSSScopeRule::create):
* Source/WebCore/css/CSSScopeRule.h:
* Source/WebCore/css/CSSStartingStyleRule.cpp:
(WebCore::CSSStartingStyleRule::CSSStartingStyleRule):
* Source/WebCore/css/CSSStartingStyleRule.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::CSSStyleRule):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::CSSSupportsRule):
(WebCore::CSSSupportsRule::create):
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::CSSViewTransitionRule::create):
(WebCore::CSSViewTransitionRule::CSSViewTransitionRule):
* Source/WebCore/css/CSSViewTransitionRule.h:
* Source/WebCore/css/SelectorChecker.cpp:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::createCSSOMWrapper const):
* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/style/ResolvedScopedName.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f85c19b3b1420a34d3ccbb451c17eaab3996f827

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143941 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89214 "Hash f85c19b3 for PR 55509 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8432 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104164 "Found 94 new test failures: animations/change-keyframes-name.html css-custom-properties-api/inline.html fast/css/CSSStyleDeclaration-setProperty-unicode.html fast/css/css-set-selector-text.html fast/css/css3-ch-unit.html fast/css/cssom-insertrule-crash.html fast/css/custom-properties/rule-property-set.html fast/css/font-property-priority.html fast/css/import-style-update.html fast/css/inherit-initial-shorthand-values.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/89214 "Hash f85c19b3 for PR 55509 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139177 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6735 "Found 14 new test failures: animations/change-keyframes-name.html fast/css/import-style-update.html fast/css/nested-at-rules.html fast/css/nested-rule-parent-sheet.html fast/css/rule-selector-nesting-overflow.html fast/css/stylesheet-parentStyleSheet.html fast/css/webkit-keyframes-crash.html fast/dom/StyleSheet/gc-rule-children-wrappers.html fast/dom/css-mediarule-deleteRule-update.html fast/dom/css-mediarule-insertRule-update.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84995 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53420b7b-ea6d-480a-81ce-a6fbbf200cf4) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6393 "Found 42 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom.html imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching-001.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching-002.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-cascade/import-conditional-001.html imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-additive-symbols-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-fallback-setter.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4055 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115679 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40275 "Found 60 new test failures: animations/change-keyframes-name.html fast/css/import-style-update.html fast/css/nested-at-rules.html fast/css/nested-rule-parent-sheet.html fast/css/rule-selector-nesting-overflow.html fast/css/stylesheet-parentStyleSheet.html fast/css/webkit-keyframes-crash.html fast/dom/StyleSheet/gc-rule-children-wrappers.html fast/dom/css-mediarule-deleteRule-update.html fast/dom/css-mediarule-insertRule-update.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146687 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8271 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40842 "Found 60 new test failures: accessibility/mac/replaced-element-text-selection.html animations/change-keyframes-name.html fast/css/aspect-ratio-min-height-replaced.html fast/css/import-style-update.html fast/css/nested-at-rules.html fast/css/nested-rule-parent-sheet.html fast/css/rule-selector-nesting-overflow.html fast/css/stylesheet-parentStyleSheet.html fast/css/webkit-keyframes-crash.html fast/dom/StyleSheet/gc-rule-children-wrappers.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112506 "Found 123 new test failures: css-custom-properties-api/inline.html fast/css/CSSStyleDeclaration-setProperty-unicode.html fast/css/css-set-selector-text.html fast/css/css3-ch-unit.html fast/css/cssom-insertrule-crash.html fast/css/custom-properties/rule-property-set.html fast/css/font-property-priority.html fast/css/import-style-update.html fast/css/inherit-initial-shorthand-values.html fast/css/nested-at-rules.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6946 "Found 60 new test failures: animations/change-keyframes-name.html fast/css/import-style-update.html fast/css/nested-at-rules.html fast/css/nested-rule-parent-sheet.html fast/css/rule-selector-nesting-overflow.html fast/css/stylesheet-parentStyleSheet.html fast/css/webkit-keyframes-crash.html fast/dom/StyleSheet/gc-rule-children-wrappers.html fast/dom/css-inline-style-declaration-crash.html fast/dom/css-mediarule-deleteRule-update.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112847 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6323 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118379 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62258 "Hash f85c19b3 for PR 55509 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8319 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36436 "Found 60 new test failures: animations/change-keyframes-name.html fast/css/import-style-update.html fast/css/nested-at-rules.html fast/css/nested-rule-parent-sheet.html fast/css/rule-selector-nesting-overflow.html fast/css/stylesheet-parentStyleSheet.html fast/css/webkit-keyframes-crash.html fast/dom/StyleSheet/gc-rule-children-wrappers.html fast/dom/css-mediarule-deleteRule-update.html fast/dom/css-mediarule-insertRule-update.html ... (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8037 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71878 "Found 38 new failures in bindings/js/JSMediaListCustom.h, bindings/js/JSCSSRuleCustom.cpp, mac/DOM/DOMCSSStyleSheet.mm, mac/DOM/DOMCSSMediaRule.mm, mac/DOM/DOMCSSStyleRule.mm, bindings/js/JSCSSRuleCustom.h, css/StyleSheetContents.cpp, mac/DOM/DOMCSSImportRule.mm, mac/DOM/DOMCSSFontFaceRule.mm, mac/DOM/DOMCSSStyleDeclaration.mm ... and found 5 fixed files: css/CSSGroupingRule.cpp, bindings/js/JSCSSRuleListCustom.cpp, style/InspectorCSSOMWrappers.cpp, css/CSSRuleList.h, css/CSSRule.h") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->