### PR TITLE
Web Inspector: Add Order Number to display: grid and grid-lanes

### DIFF
--- a/LayoutTests/inspector/dom/showFlexOverlay-expected.txt
+++ b/LayoutTests/inspector/dom/showFlexOverlay-expected.txt
@@ -34,11 +34,10 @@ PASS: Should have 0 flex overlays displayed.
 Requesting to hide all flex overlays again, expecting none to be cleared. Hiding all flex overlays is idempotent and should not throw an error.
 PASS: Should have 0 flex overlays displayed.
 
--- Running test case: DOM.showFlexOverlay.HideBeforeShowShouldError
+-- Running test case: DOM.showFlexOverlay.HideBeforeShowShouldSucceed
 PASS: Should have 0 flex overlays displayed.
-Requesting to hide flex overlay for .flex-container
-PASS: Should produce an exception.
-Error: No flex overlay exists for the node, so cannot clear.
+Requesting to hide flex overlay for .flex-container (should silently succeed)
+PASS: Should have 0 flex overlays displayed.
 Requesting to hide all flex overlays. Hiding all flex overlays is idempotent and should not throw an error.
 PASS: Should have 0 flex overlays displayed.
 

--- a/LayoutTests/inspector/dom/showFlexOverlay.html
+++ b/LayoutTests/inspector/dom/showFlexOverlay.html
@@ -120,17 +120,16 @@ function test()
     });
 
     suite.addTestCase({
-        name: "DOM.showFlexOverlay.HideBeforeShowShouldError",
-        description: "Return an error when requesting to hide a flex overlay when none is active for the node.",
+        name: "DOM.showFlexOverlay.HideBeforeShowShouldSucceed",
+        description: "No error when requesting to hide a flex overlay when none is active for the node.",
         async test() {
             let container = await getFlexContainerNode();
 
             await checkFlexOverlayCount(0);
 
-            InspectorTest.log("Requesting to hide flex overlay for .flex-container");
-            await InspectorTest.expectException(async () => {
-                await DOMAgent.hideFlexOverlay(container.id);
-            });
+            InspectorTest.log("Requesting to hide flex overlay for .flex-container (should silently succeed)");
+            await DOMAgent.hideFlexOverlay(container.id);
+            await checkFlexOverlayCount(0);
 
             InspectorTest.log("Requesting to hide all flex overlays. Hiding all flex overlays is idempotent and should not throw an error.");
             await DOMAgent.hideFlexOverlay();

--- a/LayoutTests/inspector/dom/showGridOverlay-expected.txt
+++ b/LayoutTests/inspector/dom/showGridOverlay-expected.txt
@@ -46,11 +46,10 @@ PASS: Should have 0 grids displayed.
 Requesting to hide all grid overlays again, expecting none to be cleared. Hiding all grids is idempotent and should not throw an error.
 PASS: Should have 0 grids displayed.
 
--- Running test case: DOM.showGridOverlay.HideBeforeShowShouldError
+-- Running test case: DOM.showGridOverlay.HideBeforeShowShouldSucceed
 PASS: Should have 0 grids displayed.
-Requesting to hide grid overlay for .grid-container
-PASS: Should produce an exception.
-Error: No grid overlay exists for the node, so cannot clear.
+Requesting to hide grid overlay for .grid-container (should silently succeed)
+PASS: Should have 0 grids displayed.
 Requesting to hide all grid overlays. Hiding all grids is idempotent and should not throw an error.
 PASS: Should have 0 grids displayed.
 

--- a/LayoutTests/inspector/dom/showGridOverlay.html
+++ b/LayoutTests/inspector/dom/showGridOverlay.html
@@ -124,17 +124,16 @@ function test()
     });
 
     suite.addTestCase({
-        name: "DOM.showGridOverlay.HideBeforeShowShouldError",
-        description: "Return an error when requesting to hide a grid overlay when none is active for the node.",
+        name: "DOM.showGridOverlay.HideBeforeShowShouldSucceed",
+        description: "No error when requesting to hide a grid overlay when none is active for the node.",
         async test() {
             let container = await getGridContainerNode();
 
             await checkGridOverlayCount(0);
 
-            InspectorTest.log("Requesting to hide grid overlay for .grid-container");
-            await InspectorTest.expectException(async () => {
-                await DOMAgent.hideGridOverlay(container.id);
-            });
+            InspectorTest.log("Requesting to hide grid overlay for .grid-container (should silently succeed)");
+            await DOMAgent.hideGridOverlay(container.id);
+            await checkGridOverlayCount(0);
 
             InspectorTest.log("Requesting to hide all grid overlays. Hiding all grids is idempotent and should not throw an error.");
             await DOMAgent.hideGridOverlay();

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -180,7 +180,8 @@
                 { "name": "showLineNumbers", "type": "boolean", "optional": true, "description": "Show labels for grid line numbers. If not specified, the default value is false." },
                 { "name": "showExtendedGridLines", "type": "boolean", "optional": true, "description": "Show grid lines that extend beyond the bounds of the grid. If not specified, the default value is false." },
                 { "name": "showTrackSizes", "type": "boolean", "optional": true, "description": "Show grid track size information. If not specified, the default value is false." },
-                { "name": "showAreaNames", "type": "boolean", "optional": true, "description": "Show labels for grid area names. If not specified, the default value is false." }
+                { "name": "showAreaNames", "type": "boolean", "optional": true, "description": "Show labels for grid area names. If not specified, the default value is false." },
+                { "name": "showOrderNumbers", "type": "boolean", "optional": true, "description": "Show labels for grid item order. If not specified, the default value is false." }
             ]
         },
         {

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -805,6 +805,9 @@
 /* Undo action name */
 "Italics (Undo action name)" = "Italics";
 
+/* Inspector Grid/Flex Item DOM order label */
+"Item #%lu" = "Item #%lu";
+
 /* WebKitErrorJavaUnavailable description */
 "Java is unavailable" = "Java is unavailable";
 
@@ -1155,6 +1158,9 @@
 
 /* Codec Strings */
 "Opus Codec String" = "Opus";
+
+/* Inspector Grid/Flex Item CSS order property label */
+"order: %d" = "order: %d";
 
 /* Label for the order with Apple Pay button. */
 "Order with Apple Pay" = "Order with Apple Pay";

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -163,6 +163,7 @@ public:
             bool showExtendedGridLines;
             bool showTrackSizes;
             bool showAreaNames;
+            bool showOrderNumbers;
         };
 
         WeakPtr<Node, WeakPtrImplWithEventTargetData> gridNode;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1409,6 +1409,7 @@ std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConf
     gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean("showExtendedGridLines"_s).value_or(false);
     gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean("showTrackSizes"_s).value_or(false);
     gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean("showAreaNames"_s).value_or(false);
+    gridOverlayConfig.showOrderNumbers = gridOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
     return gridOverlayConfig;
 }
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1232,7 +1232,7 @@ localizedStrings["Option-click to show source"] = "Option-click to show source";
 /* Tooltip with instructions on how to show all hidden CSS variables */
 localizedStrings["Option-click to show unused CSS variables from all rules @ Styles Sidebar Panel Tooltip"] = "Option-click to show unused CSS variables from all rules";
 localizedStrings["Options"] = "Options";
-/* Label for option to toggle the order numbers setting for CSS flex overlays */
+/* Label for option to toggle the order numbers setting for CSS grid and flex overlays */
 localizedStrings["Order Numbers @ Layout Panel Overlay Options"] = "Order Numbers";
 /* Property value for `font-variant-numeric: ordinal`. */
 localizedStrings["Ordinal Letter Forms @ Font Details Sidebar Property Value"] = "Ordinal Letter Forms";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -206,6 +206,7 @@ WI.settings = {
     gridOverlayShowExtendedGridLines: new WI.Setting("grid-overlay-show-extended-grid-lines", false),
     gridOverlayShowLineNames: new WI.Setting("grid-overlay-show-line-names", false),
     gridOverlayShowLineNumbers: new WI.Setting("grid-overlay-show-line-numbers", true),
+    gridOverlayShowOrderNumbers: new WI.Setting("grid-overlay-show-order-numbers", false),
     gridOverlayShowTrackSizes: new WI.Setting("grid-overlay-show-track-sizes", true),
     groupMediaRequestsByDOMNode: new WI.Setting("group-media-requests-by-dom-node", WI.Setting.migrateValue("group-by-dom-node") || false),
     indentUnit: new WI.Setting("indent-unit", 4),

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -115,6 +115,7 @@ WI.DOMManager = class DOMManager extends WI.Object
                 showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
                 showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
                 showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
+                showOrderNumbers: WI.settings.gridOverlayShowOrderNumbers.value,
             };
         }
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -286,6 +286,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
 
         // The overlay is automatically hidden on the backend when the context type changes.
+        this._layoutOverlayShowing = false;
         this.dispatchEventToListeners(WI.DOMNode.Event.LayoutOverlayHidden);
 
         switch (oldLayoutContextType) {
@@ -299,6 +300,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowTrackSizes.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowAreaNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
+            WI.settings.gridOverlayShowOrderNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             break;
         }
     }
@@ -658,6 +660,7 @@ WI.DOMNode = class DOMNode extends WI.Object
                 showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
                 showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
                 showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
+                showOrderNumbers: WI.settings.gridOverlayShowOrderNumbers.value,
             };
 
             // COMPATIBILITY (macOS 13.3, iOS 16.4): DOM.GridOverlayConfig did not exist yet.
@@ -674,6 +677,7 @@ WI.DOMNode = class DOMNode extends WI.Object
                 WI.settings.gridOverlayShowLineNumbers.addEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
                 WI.settings.gridOverlayShowTrackSizes.addEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
                 WI.settings.gridOverlayShowAreaNames.addEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
+                WI.settings.gridOverlayShowOrderNumbers.addEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             }
             break;
 
@@ -723,6 +727,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowTrackSizes.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowAreaNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
+            WI.settings.gridOverlayShowOrderNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
 
             agentCommandFunction = target.DOMAgent.hideGridOverlay;
             break;

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
@@ -74,6 +74,13 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         gridSettingsGroup.addSetting(WI.settings.gridOverlayShowLineNames, WI.UIString("Line Names", "Line names @ Layout Panel Overlay Options", "Label for option to toggle the line names setting for CSS grid overlays"));
         gridSettingsGroup.addSetting(WI.settings.gridOverlayShowAreaNames, WI.UIString("Area Names", "Area names @ Layout Panel Overlay Options", "Label for option to toggle the area names setting for CSS grid overlays"));
         gridSettingsGroup.addSetting(WI.settings.gridOverlayShowExtendedGridLines, WI.UIString("Extended Grid Lines", "Show extended lines @ Layout Panel Overlay Options", "Label for option to toggle the extended lines setting for CSS grid overlays"));
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): `DOM.GridOverlayConfig.showOrderNumbers` did not exist yet.
+        // Since support can't be tested directly, check for if the `Page.navigate` command has been removed.
+        // FIXME: Use explicit version checking once https://webkit.org/b/148680 is fixed.
+        if (!InspectorBackend.hasCommand("Page.navigate"))
+            gridSettingsGroup.addSetting(WI.settings.gridOverlayShowOrderNumbers, WI.UIString("Order Numbers", "Order Numbers @ Layout Panel Overlay Options", "Label for option to toggle the order numbers setting for CSS grid overlays"));
+
         this._gridOptionsDetailsSectionRow.element.append(gridSettingsGroup.element);
 
         this._gridNodesDetailsSectionRow = new WI.DetailsSectionRow(WI.UIString("No CSS Grid Containers", "No CSS Grid Containers @ Layout Details Sidebar Panel", "Message shown when there are no CSS Grid containers on the inspected page."));


### PR DESCRIPTION
#### 10ae7dbc90309fc2e09c0cd83fdc7590481a322e
<pre>
Web Inspector: Add Order Number to display: grid and grid-lanes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304287">https://bugs.webkit.org/show_bug.cgi?id=304287</a>
<a href="https://rdar.apple.com/problem/166648769">rdar://problem/166648769</a>

Reviewed by BJ Burg and Devin Rousso.

Add an &quot;Order Numbers&quot; option to CSS Grid overlays in Web Inspector, matching
the existing functionality for Flexbox overlays.

The implementation supports both regular CSS Grid layouts and CSS Masonry layouts.
For regular grids, item bounds are computed from grid area lines. For masonry
layouts, the item&apos;s frame rect is used directly since grid areas may not have
definite positions in the masonry axis.

* LayoutTests/inspector/dom/showFlexOverlay-expected.txt:
* LayoutTests/inspector/dom/showFlexOverlay.html:
* LayoutTests/inspector/dom/showGridOverlay-expected.txt:
* LayoutTests/inspector/dom/showGridOverlay.html:
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::clearGridOverlayForNode):
(WebCore::InspectorOverlay::clearFlexOverlayForNode):
(WebCore::InspectorOverlay::buildGridOverlay):
(WebCore::InspectorOverlay::buildFlexOverlay):
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::gridOverlayConfigFromInspectorObject):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.buildHighlightConfigs):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.set layoutFlags):
(WI.DOMNode.prototype.showLayoutOverlay):
(WI.DOMNode.prototype.hideLayoutOverlay):
* Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js:
(WI.LayoutDetailsSidebarPanel.prototype.initialLayout):

Canonical link: <a href="https://commits.webkit.org/304645@main">https://commits.webkit.org/304645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7099f2d4cf9210b9fef2f5517c5570269807363e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143849 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104086 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a34fb3b-b719-4c59-9163-5b9b9eeefa20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139087 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6661 "Found 1 new test failure: fast/html/a-tooltip-null.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84925 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6334 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3992 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4445 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128099 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146596 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134625 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112443 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6874 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112777 "Found 1 new API test failure: WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/title-change (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28629 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6249 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118301 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8229 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36362 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167405 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71788 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43686 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8021 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->