### PR TITLE
AX: [LiveRegionManagement] Buttons aren't included in live region announcements

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-button-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-button-expected.txt
@@ -1,0 +1,14 @@
+This tests that buttons with inner text are properly handled by live regions.
+
+Received announcement request:
+AnnouncementKey: Press Me{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Press Me

--- a/LayoutTests/accessibility/mac/live-regions/live-region-button.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-button.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite">
+</div>
+
+<script>
+var output = "This tests that buttons with inner text are properly handled by live regions.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    const button = document.createElement("button");
+    button.innerText = "Press Me";
+    document.getElementById("polite-region").appendChild(button);
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1633,7 +1633,7 @@ static bool isDescriptiveText(AccessibilityTextSource textSource)
     }
 }
 
-String AXCoreObject::descriptionAttributeValue() const
+String AXCoreObject::descriptionAttributeValue(Vector<AccessibilityText>* computedText) const
 {
     if (isStaticText()) {
         // Static text objects shouldn't return a description. Their content is communicated via AXValue.
@@ -1641,11 +1641,14 @@ String AXCoreObject::descriptionAttributeValue() const
     }
 
     Vector<AccessibilityText> textOrder;
-    accessibilityText(textOrder);
+    if (!computedText) {
+        accessibilityText(textOrder);
+        computedText = &textOrder;
+    }
 
     // Determine if any visible text is available, which influences our usage of title tag.
     bool visibleTextAvailable = false;
-    for (const auto& text : textOrder) {
+    for (const auto& text : *computedText) {
         if (isVisibleText(text.textSource) && !text.text.isEmpty()) {
             visibleTextAvailable = true;
             break;
@@ -1653,7 +1656,7 @@ String AXCoreObject::descriptionAttributeValue() const
     }
 
     StringBuilder returnText;
-    for (const auto& text : textOrder) {
+    for (const auto& text : *computedText) {
         if (text.textSource == AccessibilityTextSource::Alternative || text.textSource == AccessibilityTextSource::Heading) {
             returnText.append(text.text);
             break;
@@ -1712,7 +1715,7 @@ String AXCoreObject::helpTextAttributeValue() const
 }
 #endif // PLATFORM(COCOA)
 
-String AXCoreObject::title() const
+String AXCoreObject::title(Vector<AccessibilityText>* computedText) const
 {
     if (isWebArea()) {
         String title = webAreaTitle();
@@ -1732,11 +1735,14 @@ String AXCoreObject::title() const
         return stringValue();
 
     Vector<AccessibilityText> textOrder;
-    accessibilityText(textOrder);
+    if (!computedText) {
+        accessibilityText(textOrder);
+        computedText = &textOrder;
+    }
 
     if (elementName() == ElementName::HTML_area && isLink()) {
         String summaryText;
-        for (auto& text : textOrder) {
+        for (auto& text : *computedText) {
             if (text.textSource == AccessibilityTextSource::TitleTag)
                 return text.text;
             if (text.textSource == AccessibilityTextSource::Summary)
@@ -1745,7 +1751,7 @@ String AXCoreObject::title() const
         return summaryText;
     }
 
-    for (const auto& text : textOrder) {
+    for (const auto& text : *computedText) {
         // If we have alternative text, then we should not expose a title.
         if (text.textSource == AccessibilityTextSource::Alternative || text.textSource == AccessibilityTextSource::Heading)
             break;

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -826,7 +826,8 @@ public:
     }
     // This should be the visible text that's actually on the screen if possible.
     // If there's alternative text (e.g. provided by description()), that can override the title.
-    virtual String title() const;
+    // The `computedText` parameter is a performance optimization for callsites that have already computed the AccessibilityText.
+    virtual String title(Vector<AccessibilityText>* computedText = nullptr) const;
     // This is the value of the title HTML / SVG attribute, differing from the above function which refers to
     // the notion of "title" accessibility text, a composite of many different attributes and page text.
     virtual String titleAttribute() const = 0;
@@ -1245,7 +1246,9 @@ public:
     virtual void setPreventKeyboardDOMEventDispatch(bool) = 0;
     virtual Style::SpeakAs speakAs() const = 0;
     String speechHint() const;
-    String descriptionAttributeValue() const;
+
+    // The `computedText` parameter is a performance optimization for callsites that have already computed the AccessibilityText.
+    String descriptionAttributeValue(Vector<AccessibilityText>* computedText = nullptr) const;
     String helpTextAttributeValue() const;
 
     virtual bool hasApplePDFAnnotationAttribute() const = 0;

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -233,11 +233,18 @@ bool AXLiveRegionManager::shouldIncludeInSnapshot(AccessibilityObject& object) c
     if (!object.stringValue().isEmpty())
         return true;
 
+    Vector<AccessibilityText> accessibilityText;
+    object.accessibilityText(accessibilityText);
+
 #if PLATFORM(COCOA)
     // For leaf objects, include if they have accessible description text (e.g., images with alt text).
-    if (!object.descriptionAttributeValue().isEmpty())
+    if (!object.descriptionAttributeValue(&accessibilityText).isEmpty())
         return true;
 #endif
+
+    // Some leaf objects (like buttons) return their text via `title`.
+    if (!object.title(&accessibilityText).isEmpty())
+        return true;
 
     return false;
 }


### PR DESCRIPTION
#### 5bf123876b61a6b0172fd0001980f52f929e3da0
<pre>
AX: [LiveRegionManagement] Buttons aren&apos;t included in live region announcements
<a href="https://bugs.webkit.org/show_bug.cgi?id=304289">https://bugs.webkit.org/show_bug.cgi?id=304289</a>
<a href="https://rdar.apple.com/166649406">rdar://166649406</a>

Reviewed by Tyler Wilcock.

Buttons return their inner text via `title()`, which was not in the consideration criteria
for live region objects. Now, we check if leaf elements have non-empty title before excluding
them.

Test: accessibility/mac/live-regions/live-region-button.html

* LayoutTests/accessibility/mac/live-regions/live-region-button-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-button.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::descriptionAttributeValue const):
(WebCore::AXCoreObject::title const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::shouldIncludeInSnapshot const):

Canonical link: <a href="https://commits.webkit.org/304607@main">https://commits.webkit.org/304607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fa31ce619d70c74b6eb3c0d148ee0731615a17a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143703 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ca2d3c3-164f-4364-a6b7-116cf863df61) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103927 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0d3b7c77-ddfc-4ebd-9f3f-ecea38720c62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84804 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9bfd0e39-d048-40bc-8d73-fac1728a59b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6234 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3930 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4305 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146457 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112285 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6135 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118178 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8089 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36243 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7889 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->