### PR TITLE
REGRESSION(303851@main): [ macOS iOS Debug ] ipc/serialized-type-info.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8454,8 +8454,6 @@ fast/forms/ios/scroll-to-reveal-focused-select.html [ Pass ]
 fast/events/ios/should-be-able-to-dismiss-form-accessory-after-tapping-outside-iframe-with-focused-field.html [ Pass ]
 http/tests/site-isolation/remote-frame-loaded-while-hidden.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/303876 [ Debug ] ipc/serialized-type-info.html [ Failure ]
-
 # from fast/ tests that are flaky: adding timeout 
 webkit.org/b/304027 fast/block/basic/001.html [ Pass Failure Timeout ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2439,6 +2439,4 @@ webkit.org/b/303507 [ Sonoma+ Debug ] inspector/injected-script/observable.html 
 webkit.org/b/303507 [ Sonoma+ Debug ] inspector/network/intercept-aborted-request.html [ Timeout ]
 webkit.org/b/303507 [ Sonoma+ Debug ] inspector/page/filter-cookies-for-domain.html [ Timeout ]
 
-webkit.org/b/303876 [ Debug ] ipc/serialized-type-info.html [ Failure ]
-
 webkit.org/b/304079 [ Debug ] http/tests/ipc/ipc-fetch-task-message-crash.html [ Timeout ]

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -210,12 +210,12 @@ Ref<NavigationScheduler> Frame::protectedNavigationScheduler() const
     return m_navigationScheduler.get();
 }
 
-std::optional<size_t> Frame::indexInFrameTreeSiblings() const
+std::optional<uint64_t> Frame::indexInFrameTreeSiblings() const
 {
     if (!tree().parent())
         return std::nullopt;
 
-    for (size_t i = 0; i < tree().parent()->tree().childCount(); i++) {
+    for (uint64_t i = 0; i < tree().parent()->tree().childCount(); i++) {
         if (auto child = tree().parent()->tree().child(i); child->frameID() == this->frameID())
             return i;
     }
@@ -224,9 +224,9 @@ std::optional<size_t> Frame::indexInFrameTreeSiblings() const
     return std::nullopt;
 }
 
-Vector<size_t> Frame::pathToFrame() const
+Vector<uint64_t> Frame::pathToFrame() const
 {
-    Vector<size_t> path;
+    Vector<uint64_t> path;
     RefPtr current = this;
 
     while (current) {

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -80,8 +80,8 @@ public:
     DOMWindow* window() const { return virtualWindow(); }
     RefPtr<DOMWindow> protectedWindow() const;
     FrameTree& tree() const { return m_treeNode; }
-    WEBCORE_EXPORT std::optional<size_t> indexInFrameTreeSiblings() const;
-    WEBCORE_EXPORT Vector<size_t> pathToFrame() const;
+    WEBCORE_EXPORT std::optional<uint64_t> indexInFrameTreeSiblings() const;
+    WEBCORE_EXPORT Vector<uint64_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in DocumentPage.h.
     inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1027,10 +1027,10 @@ Ref<SecurityOrigin> Page::protectedMainFrameOrigin() const
     return mainFrameOrigin();
 }
 
-RefPtr<Frame> Page::findFrameByPath(const Vector<size_t>& path) const
+RefPtr<Frame> Page::findFrameByPath(const Vector<uint64_t>& path) const
 {
     RefPtr current = m_mainFrame.get();
-    for (size_t i = 0; i < path.size() && current; i++)
+    for (uint64_t i = 0; i < path.size() && current; i++)
         current = current->tree().child(path[i]);
 
     return current;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -432,7 +432,7 @@ public:
     WEBCORE_EXPORT const URL& mainFrameURL() const;
     SecurityOrigin& mainFrameOrigin() const;
     Ref<SecurityOrigin> protectedMainFrameOrigin() const;
-    WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<size_t>& path) const;
+    WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
 
     WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
 #if ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -55,7 +55,7 @@ struct WebFoundTextRange {
     };
 
     Variant<DOMData, PDFData> data { DOMData { } };
-    Vector<size_t> pathToFrame;
+    Vector<uint64_t> pathToFrame;
     uint64_t order { 0 };
 
     unsigned hash() const;
@@ -105,7 +105,7 @@ public:
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
     static WebKit::WebFoundTextRange emptyValue() { return { }; }
 
-    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { slot.pathToFrame = Vector<size_t> { HashTableDeletedValue }; }
+    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { slot.pathToFrame = Vector<uint64_t> { HashTableDeletedValue }; }
     static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.pathToFrame.isHashTableDeletedValue(); }
 };
 

--- a/Source/WebKit/Shared/WebFoundTextRange.serialization.in
+++ b/Source/WebKit/Shared/WebFoundTextRange.serialization.in
@@ -34,6 +34,6 @@
 
 struct WebKit::WebFoundTextRange {
     Variant<WebKit::WebFoundTextRange::DOMData, WebKit::WebFoundTextRange::PDFData> data;
-    Vector<size_t> pathToFrame;
+    Vector<uint64_t> pathToFrame;
     uint64_t order;
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -804,10 +804,10 @@ WebFrameProxy* WebFrameProxy::previousSibling() const
     return (--it)->ptr();
 }
 
-RefPtr<WebFrameProxy> WebFrameProxy::childFrame(size_t index) const
+RefPtr<WebFrameProxy> WebFrameProxy::childFrame(uint64_t index) const
 {
     RefPtr child = firstChild();
-    for (size_t i = 0; i < index && child; i++)
+    for (uint64_t i = 0; i < index && child; i++)
         child = child->nextSibling();
     return child;
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -211,7 +211,7 @@ public:
 
     WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
     Ref<WebFrameProxy> rootFrame();
-    RefPtr<WebFrameProxy> childFrame(size_t index) const;
+    RefPtr<WebFrameProxy> childFrame(uint64_t index) const;
 
     WebProcessProxy& process() const;
     Ref<WebProcessProxy> protectedProcess() const;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -15976,7 +15976,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     );
 
-    [range setPathToFrame:createNSArray(webRange.pathToFrame, [](size_t index) {
+    [range setPathToFrame:createNSArray(webRange.pathToFrame, [](uint64_t index) {
         return @(index);
     }).get()];
     [range setOrder:webRange.order];
@@ -16020,7 +16020,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WebKit::WebFoundTextRange)webFoundTextRange
 {
     WebKit::WebFoundTextRange::DOMData data { self.location, self.length };
-    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<size_t> {
+    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<uint64_t> {
         return [number unsignedLongValue];
     });
     return { data, WTFMove(pathToFrameVector), self.order };
@@ -16057,7 +16057,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WebKit::WebFoundTextRange)webFoundTextRange
 {
     WebKit::WebFoundTextRange::PDFData data { self.startPage, self.startPageOffset, self.endPage, self.endPageOffset };
-    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<size_t> {
+    auto pathToFrameVector = makeVector(self.pathToFrame, [](id number) -> std::optional<uint64_t> {
         return [number unsignedLongValue];
     });
     return { data, WTFMove(pathToFrameVector), self.order };


### PR DESCRIPTION
#### 54930403f69c19dbf0c7644430b72056fa091439
<pre>
REGRESSION(303851@main): [ macOS iOS Debug ] ipc/serialized-type-info.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=303876">https://bugs.webkit.org/show_bug.cgi?id=303876</a>
<a href="https://rdar.apple.com/166170583">rdar://166170583</a>

Reviewed by Alex Christensen.

The problem is that size_t cannot be serialized. This originated
in this patch: <a href="https://commits.webkit.org/303851@main">https://commits.webkit.org/303851@main</a>, where I
added a Vector&lt;size_t&gt; as a member of a struct.

I have changed this to be a Vector&lt;uint64_t&gt;. The type size_t cannot
be serialized for IPC because sizeof(size_t) is dependant on architecture
and watchOS sometimes communicates via IPC from a 32 bit machine to a
64 bit machine.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::indexInFrameTreeSiblings const):
(WebCore::Frame::pathToFrame const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findFrameByPath const):
* Source/WebCore/page/Page.h:
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::constructDeletedValue):
* Source/WebKit/Shared/WebFoundTextRange.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::childFrame const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(+[WKFoundTextRange foundTextRangeWithWebFoundTextRange:]):
(-[WKFoundDOMTextRange webFoundTextRange]):
(-[WKFoundPDFTextRange webFoundTextRange]):

Canonical link: <a href="https://commits.webkit.org/304617@main">https://commits.webkit.org/304617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1182ac59f4a127a07ead48fca64f29faf0b9848b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143677 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6383d960-bf9c-4d1d-91ab-b60f4aafd355) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f0e9068-a184-45b1-945a-c644f50eb2f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84791 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b290461a-2774-4151-bd3b-6dc83d30ede8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3854 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4279 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112261 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112654 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6125 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118153 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61946 "Failed to checkout and rebase branch from PR 55515") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20966 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8063 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7785 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->