### PR TITLE
REGRESSION (298981@main): fetch() throws TypeError when using targetAddressSpace: 'loopback' with localhost requests

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-loopback-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-loopback-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fetch with targetAddressSpace set to "loopback" should succeed
+

--- a/LayoutTests/http/wpt/fetch/fetch-loopback.html
+++ b/LayoutTests/http/wpt/fetch/fetch-loopback.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+promise_test((t) => {
+    return fetch(location.origin + '/resources/gc.js', {
+        targetAddressSpace: 'loopback'
+    });
+}, 'fetch with targetAddressSpace set to "loopback" should succeed');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchRequestInit.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestInit.idl
@@ -43,5 +43,5 @@ dictionary FetchRequestInit {
     any signal;
     RequestPriority priority;
     any window; // can only be set to null
-    IPAddressSpace targetAddressSpace;
+    [EnabledBySetting=LocalNetworkAccessEnabled] IPAddressSpace targetAddressSpace;
 };


### PR DESCRIPTION
#### 295fd224c10d6c7c09fc511bf3536934f02fd31f
<pre>
REGRESSION (298981@main): fetch() throws TypeError when using targetAddressSpace: &apos;loopback&apos; with localhost requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=304164">https://bugs.webkit.org/show_bug.cgi?id=304164</a>
<a href="https://rdar.apple.com/166574523">rdar://166574523</a>

Reviewed by Alex Christensen.

Hide the dictionary entry behind a runtime check since this feature (IPAddressSpace) shouldn&apos;t be enabled anywhere.

Test: http/wpt/fetch/fetch-loopback.html

* LayoutTests/http/wpt/fetch/fetch-loopback-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-loopback.html: Added.
* Source/WebCore/Modules/fetch/FetchRequestInit.idl:

Canonical link: <a href="https://commits.webkit.org/304577@main">https://commits.webkit.org/304577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b92c45ba5e6bbcb65fc6815185b6e1da78ac5e62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143696 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/63cd39d5-b0e5-4525-9f34-2b9d0049ee85) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba855766-5155-4847-8357-f6069f1a32db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23ec91e8-a7f9-4112-87b9-67b6f4b18190) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3868 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4298 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146448 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8034 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112276 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112669 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6133 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118170 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8082 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36237 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->