### PR TITLE
Use after free in NavigateEvent()

### DIFF
--- a/LayoutTests/fast/loader/navigate-event-crash-expected.txt
+++ b/LayoutTests/fast/loader/navigate-event-crash-expected.txt
@@ -1,0 +1,4 @@
+
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/loader/navigate-event-crash.html
+++ b/LayoutTests/fast/loader/navigate-event-crash.html
@@ -1,0 +1,113 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<body>
+  <p>This test passes if it does not crash.</p>
+  <script>
+    testRunner?.waitUntilDone();
+    testRunner?.dumpAsText();
+    const nodes = new Map();
+    const stuff = new Map();
+    const keep = [];
+    const indexedDbHelpers = {};
+    try {
+      function storeObject(key, o) {
+        if (o === null || o === undefined) {
+          return;
+        }
+        let weak = new WeakRef(o);
+        let entriesForKey = stuff.get(key) ?? [];
+        entriesForKey.push(weak);
+        stuff.set(key, entriesForKey);
+      }
+      function getObject(key) {
+        let entriesForKey = stuff.get(key);
+        while (entriesForKey.length) {
+          let nextEntry = entriesForKey.shift();
+          let theObject = nextEntry.deref();
+          if (theObject) {
+            entriesForKey.push(nextEntry);
+            return theObject;
+          }
+        }
+        return undefined;
+      }
+
+      function storeNode(key, node) {
+        let weak = new WeakRef(node);
+        nodes.set(key, weak);
+      }
+      function getNode(key) {
+        let weak = nodes.get(key);
+        if (!weak) {
+          throw new Error(`weak ref for ${key} is gone`);
+        }
+        return node;
+      }
+      function getNodeSafe(key) {
+        let weak = nodes.get(key);
+        if (!weak) {
+        }
+        let node = weak.deref();
+        if (!node) {
+          return undefined;
+        }
+        return node;
+      }
+
+      function toDataUrl(mediaType, payload) {
+        return toBlobUrl(mediaType, payload);
+      }
+      function toBlobUrl(mediaType, payload) {
+        let blob = new Blob([payload], { type: mediaType });
+      }
+      function cssBlobUrl(cssContents) {
+        return anUrl(type, `image/svg+xml`, contents);
+      }
+      function anUrl(type, mediaType, contents) {
+        switch (type) {
+          case 'blob':
+          case 'data':
+            return toDataUrl(mediaType, contents);
+        }
+      }
+    } catch (e) {
+      $vm.print('error during initialization: ' + e);
+    }
+    (async () => {
+
+      try {
+        (() => {
+          let n4 = document.createElement('video');
+          n4.src = '/resources/test-av-448k-44100Hz-1ch-640x480-30fps-10kfr.mp4';
+          n4.controls = true;
+          document.body.appendChild(n4);
+          storeNode('n4', n4);
+        })();
+      } catch { }
+      try {
+        (() => {
+          let n10 = document.createElementNS('http://www.w3.org/1999/xhtml', 'iframe');
+
+          document.body.prepend(n10);
+        })();
+      } catch { }
+      try { await (() => { let value = {}; return trustedTypes.isScript(value) })() } catch { }
+      try { await (() => { let options = { info: {} }; return frames[0].navigation.back(options) })(); } catch { }
+      try { await (() => { let request = `\u76b8\u0891\u0453\u{1fbce}\u45be`; return window.caches.match(request) })() } catch { }
+      try { await (() => { return frames.history.pushState({}, '') })() } catch { }
+      try { storeObject('ServiceWorker', await navigator.serviceWorker.controller); } catch { }
+      try { let z = await (() => { return getObject('TrustedTypePolicy').createScript('tv', {}) })(); keep.push(z); } catch { }
+      try { await (() => { let options = { state: {} }; return frames[0].navigation.reload(options) })(); } catch { }
+      try { await (() => { return CSS.paintWorklet.addModule('foo') })() } catch { }
+      try { await (() => { let grantedCallback = () => { }; return navigator.locks.request('b', grantedCallback) })() } catch { }
+      try { await (() => { let grantedCallback = () => { }; return navigator.locks.request('c', grantedCallback) })() } catch { }
+      $vm.gc();
+      try { await (() => { let options = { info: {} }; return frames[0].navigation.back(options) })(); } catch { }
+      try { await (() => { let options = { info: {} }; return frames[0].navigation.traverseTo(`\u828f`, options) })(); } catch { }
+      try { await (() => { let first = {}; return indexedDB.cmp({}, document.adoptedStyleSheets) })() } catch { }
+      try { await (() => { let options = { info: {} }; return frames[0].navigation.forward(options) })(); } catch { }
+      testRunner?.notifyDone();
+    })();
+  </script>
+</body>
+</html>

--- a/LayoutTests/fast/loader/navigate-event-info-gc-expected.txt
+++ b/LayoutTests/fast/loader/navigate-event-info-gc-expected.txt
@@ -1,0 +1,16 @@
+Validates that NavigateEvent.info remains valid, even after garbage collection
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.info.foo0 is "bar0"
+PASS testFrame.contentWindow.navigation.currentEntry.getState().foo1 is "bar1"
+PASS testFrame.contentWindow.navigation.currentEntry.getState().foo1 is "bar1"
+PASS e.info.foo2 is "bar2"
+PASS e.info.foo2 is "bar2"
+PASS e.info.foo3 is "bar3"
+PASS e.info.foo3 is "bar3"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/loader/navigate-event-info-gc.html
+++ b/LayoutTests/fast/loader/navigate-event-info-gc.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<iframe id="testFrame" src="resources/empty-subframe.html"></iframe>
+<script>
+description("Validates that NavigateEvent.info remains valid, even after garbage collection");
+jsTestIsAsync = true;
+
+onload = () => {
+    testFrame.contentWindow.navigation.onnavigate = (_e) => {
+        e = _e;
+        gc();
+        shouldBeEqualToString("e.info.foo0", "bar0");
+    };
+    testFrame.contentWindow.navigation.navigate("#1", { state: { foo1: "bar1" }, info: { foo0: "bar0" } }).committed.then(() => {
+        shouldBeEqualToString("testFrame.contentWindow.navigation.currentEntry.getState().foo1", "bar1");
+        gc();
+        setTimeout(() => {
+            gc();
+            shouldBeEqualToString("testFrame.contentWindow.navigation.currentEntry.getState().foo1", "bar1");
+
+            testFrame.contentWindow.navigation.onnavigate = (_e) => {
+                e = _e;
+                e.intercept();
+                gc();
+                shouldBeEqualToString("e.info.foo2", "bar2");
+                gc();
+                setTimeout(() => {
+                    gc();
+                    shouldBeEqualToString("e.info.foo2", "bar2");
+                    testFrame.contentWindow.navigation.onnavigate = (_e) => {
+                        e = _e;
+                        gc();
+                        shouldBeEqualToString("e.info.foo3", "bar3");
+                        setTimeout(() => {
+                            gc();
+                            shouldBeEqualToString("e.info.foo3", "bar3");
+                            finishJSTest();
+                        }, 0);
+                    };
+                    testFrame.contentWindow.navigation.back({ info: { foo3: "bar3" }, state: undefined });
+                    gc();
+                }, 0);
+            };
+            testFrame.contentWindow.navigation.reload({ info: { foo2: "bar2" }, state: undefined });
+            gc();
+        }, 0);
+    });
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSNavigationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigationCustom.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@ void JSNavigation::visitAdditionalChildren(Visitor& visitor)
     // We cannot ref the event on the GC thread.
     SUPPRESS_UNCOUNTED_ARG if (auto* event = wrapped().ongoingNavigateEvent())
         addWebCoreOpaqueRoot(visitor, event);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigation);

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -69,7 +69,7 @@ struct NavigationAPIMethodTracker : public RefCounted<NavigationAPIMethodTracker
 
     bool finishedBeforeCommit { false };
     String key;
-    JSC::JSValue info;
+    JSValueInWrappedObject info;
     RefPtr<SerializedScriptValue> serializedState;
     RefPtr<NavigationHistoryEntry> committedToEntry;
     Ref<DeferredPromise> committedPromise;
@@ -172,7 +172,9 @@ public:
     RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
-    NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const { return m_upcomingTraverseMethodTrackers.get(key); }
+    NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
 
     class AbortHandler : public RefCountedAndCanMakeWeakPtr<AbortHandler> {
     public:
@@ -258,11 +260,11 @@ private:
 
     RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
     RefPtr<NavigationAPIMethodTracker> addUpcomingTraverseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
-    void cleanupAPIMethodTracker(NavigationAPIMethodTracker*);
+    void cleanupAPIMethodTracker(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
     void resolveFinishedPromise(NavigationAPIMethodTracker*);
     void rejectFinishedPromise(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue exceptionObject);
     void abortOngoingNavigation(NavigateEvent&);
-    void promoteUpcomingAPIMethodTracker(const String& destinationKey);
+    void promoteUpcomingAPIMethodTracker(const String& destinationKey) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
 
@@ -280,9 +282,10 @@ private:
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;
     FocusDidChange m_focusChangedDuringOngoingNavigation { FocusDidChange::No };
     bool m_suppressNormalScrollRestorationDuringOngoingNavigation { false };
-    RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker;
-    RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker;
-    HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers;
+    mutable Lock m_apiMethodTrackersLock;
+    RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
+    RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
+    HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
     WeakHashSet<AbortHandler> m_abortHandlers;
     RateLimiter m_rateLimiter;
 };


### PR DESCRIPTION
#### 686a6f29353693d1904ca05b8b9cc949de78e3db
<pre>
Use after free in NavigateEvent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=301560">https://bugs.webkit.org/show_bug.cgi?id=301560</a>
<a href="https://rdar.apple.com/163476354">rdar://163476354</a>

Reviewed by Ryosuke Niwa.

NavigationAPIMethodTracker was storing a raw JSValue as data member, with
nothing keeping it alive. Use JSValueInWrappedObject instead and visit
it whenever the Navigation object gets visited.

* LayoutTests/fast/loader/navigate-event-crash-expected.txt: Added.
* LayoutTests/fast/loader/navigate-event-crash.html: Added.
* LayoutTests/fast/loader/navigate-event-info-gc-expected.txt: Added.
* LayoutTests/fast/loader/navigate-event-info-gc.html: Added.
* Source/WebCore/bindings/js/JSNavigationCustom.cpp:
(WebCore::JSNavigation::visitAdditionalChildren):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::promoteUpcomingAPIMethodTracker):
(WebCore::Navigation::cleanupAPIMethodTracker):
(WebCore::Navigation::upcomingTraverseMethodTracker const):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::visitAdditionalChildren):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/304582@main">https://commits.webkit.org/304582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2875b5d0e9a82acbda79933755469802ec1c82b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143708 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2eed086c-cc7d-46be-bbd7-207d32e043fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b0daa39f-1eff-4de1-9a4d-d7cc59b38b78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84811 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20e6ea60-40f6-4dd8-ae17-2d39a239fbc1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3877 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146462 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112290 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6148 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118182 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8094 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36247 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->