### PR TITLE
[resize-observer] Re-import WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3880,8 +3880,10 @@ webkit.org/b/196274 imported/w3c/web-platform-tests/xhr/send-redirect-post-uploa
 
 # If requestAnimationFrame is invoked before ResizeObserver timer fired, it would pass, otherwise it would fail same as eventloop-expected.txt
 webkit.org/b/157743 imported/w3c/web-platform-tests/resize-observer/eventloop.html [ Pass Failure ]
-imported/w3c/web-platform-tests/resize-observer/devicepixel.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/resize-observer/devicepixel2.html [ ImageOnlyFailure ]
+
+# These test ResizeObserverEntry.devicePixelContentBoxSize, which is not implemented yet.
+webkit.org/b/219005 imported/w3c/web-platform-tests/resize-observer/devicepixel.html [ Skip ]
+webkit.org/b/219005 imported/w3c/web-platform-tests/resize-observer/devicepixel2.html [ Skip ]
 
 webkit.org/b/198103 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: resize-observer
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/multiple-observers-with-mutation-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/multiple-observers-with-mutation-crash.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html class="test-wait">
+<!--
+  This test is for crbug.com/1368458 which is a crash where we expected
+  up-to-date style&layout when delivering resize observations. We would crash
+  if a resize observer in one frame caused a modification in the presence of a
+  resize observer in another frame.
+-->
+<iframe id="iframe" style="border: none;" srcdoc="
+  <!doctype html>
+  <style>body { margin: 0; }</style>
+  <div id='inner_element'>hello</div>
+  <script>
+    const resizeObserver = new ResizeObserver((entries) => {
+      const size = entries[0].borderBoxSize[0].inlineSize;
+      const event = new CustomEvent('onIframeResizeObserved', {detail: size});
+      parent.document.dispatchEvent(event);
+    });
+    resizeObserver.observe(inner_element);
+  </script>
+"></iframe>
+<div id="outer_element" style="width: 200px;">world</div>
+
+<script>
+  const onInnerElementInitialResize = (event) => {
+    // `inner_element` should result in an initial observation of width 300px.
+    window.document.removeEventListener(
+        'onIframeResizeObserved', onInnerElementInitialResize, false);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      // `outer_element` should result in an initial observation of width 200px.
+
+      // Modify styles so that inner_element is resized.
+      iframe.contentDocument.body.style.width = "200px";
+    });
+    resizeObserver.observe(outer_element);
+
+    const onInnerElementSecondResize = (event) => {
+      // `inner_element` should result in a second observation of width 100px.
+
+      // Finish the test.
+      document.documentElement.classList.remove('test-wait');
+    };
+    window.document.addEventListener(
+        'onIframeResizeObserved', onInnerElementSecondResize, false);
+  };
+  window.document.addEventListener(
+      'onIframeResizeObserved', onInnerElementInitialResize, false);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/resizeTestHelper.js"></script>
@@ -596,7 +597,8 @@ test(_ => {
   guard = async_test('guard');
 }, "ResizeObserver implemented")
 
-test0()
+document.fonts.ready
+  .then(() => { return test0(); })
   .then(() => { return test1(); })
   .then(() => { return test2(); })
   .then(() => { return test3(); })

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/resize-observer/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/callback-cross-realm-report-exception.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/change-layout-in-error.html
@@ -31,6 +32,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/iframe-same-origin-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/iframe-same-origin-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/iframe-same-origin.html
+/LayoutTests/imported/w3c/web-platform-tests/resize-observer/multiple-observers-with-mutation-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering.html
@@ -39,3 +41,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-001.html
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-002.svg
 /LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html
+/LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom.html

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL ResizeObserver sizes account for zoom promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'sizeArray.length')"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-om">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9398">
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<title>ResizeObserver sizes account for zoom</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    border: 5px solid;
+    padding: 5px;
+    margin: 5px;
+    box-sizing: border-box;
+  }
+</style>
+<div></div>
+<div style="zoom: 2"></div>
+<div style="zoom: 4"></div>
+<script>
+promise_test(async function() {
+  let { promise, resolve } = Promise.withResolvers();
+  let observer = new ResizeObserver(entries => {
+    resolve(entries);
+  });
+  for (let div of document.querySelectorAll("div")) {
+    observer.observe(div);
+  }
+  let entries = await promise;
+  observer.disconnect();
+  assert_equals(entries.length, 3, "Should have three entries");
+  for (let entry of entries) {
+    assert_equals(entry.contentRect.top, 5, "content-rect top should be scaled by zoom");
+    assert_equals(entry.contentRect.left, 5, "content-rect left should be scaled by zoom");
+    assert_equals(entry.contentRect.width, 80, "content-rect width should be scaled by zoom");
+    assert_equals(entry.contentRect.height, 80, "content-rect height should be scaled by zoom");
+
+    for (let sizeArray of [entry.borderBoxSize, entry.contentBoxSize, entry.devicePixelContentBoxSize]) {
+      assert_equals(sizeArray.length, 1, "Should have one box");
+    }
+    let borderBoxSize = entry.borderBoxSize[0];
+    let contentBoxSize = entry.contentBoxSize[0];
+    let devicePixelContentBoxSize = entry.devicePixelContentBoxSize[0];
+    assert_equals(borderBoxSize.inlineSize, 100, "border inline size should be scaled by zoom");
+    assert_equals(borderBoxSize.blockSize, 100, "border block size should be scaled by zoom");
+    assert_equals(contentBoxSize.inlineSize, 80, "content inline size should be scaled by zoom");
+    assert_equals(contentBoxSize.blockSize, 80, "content block size should be scaled by zoom");
+    assert_equals(devicePixelContentBoxSize.inlineSize, 80 * entry.target.currentCSSZoom * window.devicePixelRatio, "dev-px size should _not_ be scaled by zoom");
+    assert_equals(devicePixelContentBoxSize.blockSize, 80 * entry.target.currentCSSZoom * window.devicePixelRatio, "dev-px size should _not_ be scaled by zoom");
+  }
+});
+</script>


### PR DESCRIPTION
#### 68c71c50f15ac04b973fc16b30f95345fac84a49
<pre>
[resize-observer] Re-import WPT tests
<a href="https://rdar.apple.com/166649781">rdar://166649781</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304290">https://bugs.webkit.org/show_bug.cgi?id=304290</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a94b616f3d392dba0131be07b86f794365ae9614">https://github.com/web-platform-tests/wpt/commit/a94b616f3d392dba0131be07b86f794365ae9614</a>

Also skip devicepixel.html and devicepixel2.html - they test
ResizeObserverEntry.devicePixelContentBoxSize, which is not implemented
in WebKit.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/multiple-observers-with-mutation-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/zoom.html: Added.

Canonical link: <a href="https://commits.webkit.org/304628@main">https://commits.webkit.org/304628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f1065d6a72591f606f0de6c6b75492a908f18c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143682 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/66dd39ef-91bb-4162-a01d-33dd3f413fcb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9de8e7a9-a7c7-404e-bb07-9138ec2dedaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1c10f71a-90ca-427c-847a-fe93879a8a96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3859 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4284 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146433 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112264 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8039 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6732 "Found 2 new test failures: fast/webgpu/repro_301290.html inspector/unit-tests/iterableweakset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6118 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118164 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8068 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36233 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7789 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8010 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7870 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->