### PR TITLE
ANGLE: Avoid using UNPACK_SKIP_IMAGES, UNPACK_IMAGE_HEIGHT for non-3d textures <rdar://164155603>

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/capture/capture_gles_2_0_params.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/capture/capture_gles_2_0_params.cpp
@@ -714,16 +714,12 @@ void CaptureTexImage2D_pixels(const State &glState,
 
     const gl::InternalFormat &internalFormatInfo = gl::GetInternalFormatInfo(format, type);
     const gl::PixelUnpackState &unpack           = glState.getUnpackState();
-
     GLuint srcRowPitch = 0;
-    (void)internalFormatInfo.computeRowPitch(type, width, unpack.alignment, unpack.rowLength,
-                                             &srcRowPitch);
     GLuint srcDepthPitch = 0;
-    (void)internalFormatInfo.computeDepthPitch(height, unpack.imageHeight, srcRowPitch,
-                                               &srcDepthPitch);
     GLuint srcSkipBytes = 0;
-    (void)internalFormatInfo.computeSkipBytes(type, srcRowPitch, srcDepthPitch, unpack, false,
-                                              &srcSkipBytes);
+    (void)internalFormatInfo.computeRowDepthSkipBytes(type, gl::Extents{width, height, 0}, unpack,
+                                                      false, &srcRowPitch, &srcDepthPitch,
+                                                      &srcSkipBytes);
 
     // For the last row of pixels, we don't round up to the unpack alignment. This often affects
     // 1x1 sized textures because they may be 1 or 2 bytes wide with an alignment of 4 bytes.

--- a/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.h
@@ -180,7 +180,20 @@ struct InternalFormat
 
     [[nodiscard]] bool computeBufferRowLength(uint32_t width, uint32_t *resultOut) const;
     [[nodiscard]] bool computeBufferImageHeight(uint32_t height, uint32_t *resultOut) const;
-
+    // FIXME: When computePackUnpackEndByte does not call this, change PixelStoreStateBase
+    // to glPixelUnpackState.
+    [[nodiscard]] bool computeRowDepthSkipBytes(GLenum formatType,
+                                                const Extents &size,
+                                                const gl::PixelStoreStateBase &unpack,
+                                                bool is3D,
+                                                GLuint *rowPitchOut,
+                                                GLuint *depthPitchOut,
+                                                GLuint *skipBytesOut) const;
+    [[nodiscard]] bool computeRowSkipBytes(GLenum formatType,
+                                           GLsizei width,
+                                           const gl::PixelPackState &pack,
+                                           GLuint *rowPitchOut,
+                                           GLuint *skipBytesOut) const;
     [[nodiscard]] bool computeRowPitch(GLenum formatType,
                                        GLsizei width,
                                        GLint alignment,
@@ -209,12 +222,12 @@ struct InternalFormat
     [[nodiscard]] bool computeCompressedImageSize(const Extents &size, GLuint *resultOut) const;
 
     [[nodiscard]] std::pair<GLuint, GLuint> getCompressedImageMinBlocks() const;
-
     [[nodiscard]] bool computeSkipBytes(GLenum formatType,
                                         GLuint rowPitch,
                                         GLuint depthPitch,
-                                        const PixelStoreStateBase &state,
-                                        bool is3D,
+                                        GLuint skipRows,
+                                        GLuint skipPixels,
+                                        GLuint skipImages,
                                         GLuint *resultOut) const;
 
     [[nodiscard]] bool computePackUnpackEndByte(GLenum formatType,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/FramebufferD3D.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/FramebufferD3D.cpp
@@ -224,13 +224,10 @@ angle::Result FramebufferD3D::readPixels(const gl::Context *context,
     ContextD3D *contextD3D = GetImplAs<ContextD3D>(context);
 
     GLuint outputPitch = 0;
-    ANGLE_CHECK_GL_MATH(contextD3D,
-                        sizedFormatInfo.computeRowPitch(type, area.width, pack.alignment,
-                                                        pack.rowLength, &outputPitch));
-
     GLuint outputSkipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextD3D, sizedFormatInfo.computeSkipBytes(type, outputPitch, 0, pack,
-                                                                     false, &outputSkipBytes));
+
+    ANGLE_CHECK_GL_MATH(contextD3D, sizedFormatInfo.computeRowSkipBytes(
+                                        type, area.width, pack, &outputPitch, &outputSkipBytes));
     outputSkipBytes += (clippedArea.x - area.x) * sizedFormatInfo.pixelBytes +
                        (clippedArea.y - area.y) * outputPitch;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/d3d11/Image11.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/d3d11/Image11.cpp
@@ -281,16 +281,14 @@ angle::Result Image11::loadData(const gl::Context *context,
     Context11 *context11 = GetImplAs<Context11>(context);
 
     const gl::InternalFormat &formatInfo = gl::GetSizedInternalFormatInfo(mInternalFormat);
-    GLuint inputRowPitch                 = 0;
-    ANGLE_CHECK_GL_MATH(context11, formatInfo.computeRowPitch(type, area.width, unpack.alignment,
-                                                              unpack.rowLength, &inputRowPitch));
+
+    GLuint inputRowPitch   = 0;
     GLuint inputDepthPitch = 0;
-    ANGLE_CHECK_GL_MATH(context11, formatInfo.computeDepthPitch(area.height, unpack.imageHeight,
-                                                                inputRowPitch, &inputDepthPitch));
     GLuint inputSkipBytes = 0;
     ANGLE_CHECK_GL_MATH(context11,
-                        formatInfo.computeSkipBytes(type, inputRowPitch, inputDepthPitch, unpack,
-                                                    applySkipImages, &inputSkipBytes));
+                        formatInfo.computeRowDepthSkipBytes(
+                            type, gl::Extents{area.width, area.height, area.depth}, unpack,
+                            applySkipImages, &inputRowPitch, &inputDepthPitch, &inputSkipBytes));
 
     const d3d11::DXGIFormatSize &dxgiFormatInfo = d3d11::GetDXGIFormatSizeInfo(mDXGIFormat);
     GLuint outputPixelSize                      = dxgiFormatInfo.pixelBytes;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
@@ -904,20 +904,14 @@ angle::Result TextureStorage11::setData(const gl::Context *context,
 
     Context11 *context11 = GetImplAs<Context11>(context);
 
-    const int width    = destBox ? destBox->width : static_cast<int>(image->getWidth());
-    const int height   = destBox ? destBox->height : static_cast<int>(image->getHeight());
-    const int depth    = destBox ? destBox->depth : static_cast<int>(image->getDepth());
+    const gl::Box area = destBox ? *destBox : gl::Box{static_cast<int>(image->getWidth(), static_cast<int>(image->getHeight()), static_cast<int>(image->getDepth())};
     GLuint srcRowPitch = 0;
-    ANGLE_CHECK_GL_MATH(context11,
-                        internalFormatInfo.computeRowPitch(type, width, unpack.alignment,
-                                                           unpack.rowLength, &srcRowPitch));
     GLuint srcDepthPitch = 0;
-    ANGLE_CHECK_GL_MATH(context11, internalFormatInfo.computeDepthPitch(
-                                       height, unpack.imageHeight, srcRowPitch, &srcDepthPitch));
     GLuint srcSkipBytes = 0;
-    ANGLE_CHECK_GL_MATH(
-        context11, internalFormatInfo.computeSkipBytes(type, srcRowPitch, srcDepthPitch, unpack,
-                                                       index.usesTex3D(), &srcSkipBytes));
+
+    ANGLE_CHECK_GL_MATH(context11, internalFormatInfo.computeRowDepthSkipBytes(
+                                       type, area, unpack, index.usesTex3D(), &srcRowPitch,
+                                       &srcDepthPitch, &srcSkipBytes));
 
     const d3d11::Format &d3d11Format =
         d3d11::Format::Get(image->getInternalFormat(), mRenderer->getRenderer11DeviceCaps());

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FramebufferGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FramebufferGL.cpp
@@ -362,13 +362,10 @@ angle::Result RearrangeEXTTextureNorm16Pixels(const gl::Context *context,
         gl::GetInternalFormatInfo(originalReadFormat, type);
 
     GLuint originalReadFormatRowBytes = 0;
-    ANGLE_CHECK_GL_MATH(
-        contextGL, glFormatOriginal.computeRowPitch(type, area.width, pack.alignment,
-                                                    pack.rowLength, &originalReadFormatRowBytes));
     GLuint originalReadFormatSkipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL,
-                        glFormatOriginal.computeSkipBytes(type, originalReadFormatRowBytes, 0, pack,
-                                                          false, &originalReadFormatSkipBytes));
+    ANGLE_CHECK_GL_MATH(contextGL, glFormatOriginal.computeRowSkipBytes(
+                                       type, area.width, pack, &originalReadFormatRowBytes,
+                                       &originalReadFormatSkipBytes));
 
     GLuint originalReadFormatPixelBytes = glFormatOriginal.computePixelBytes(type);
     GLuint alphaChannelBytes            = glFormatOriginal.alphaBits / 8;
@@ -1595,11 +1592,9 @@ angle::Result FramebufferGL::readPixelsRowByRow(const gl::Context *context,
     const gl::InternalFormat &glFormat = gl::GetInternalFormatInfo(format, type);
 
     GLuint rowBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowPitch(type, area.width, pack.alignment,
-                                                            pack.rowLength, &rowBytes));
     GLuint skipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL,
-                        glFormat.computeSkipBytes(type, rowBytes, 0, pack, false, &skipBytes));
+    ANGLE_CHECK_GL_MATH(
+        contextGL, glFormat.computeRowSkipBytes(type, area.width, pack, &rowBytes, &skipBytes));
 
     ScopedEXTTextureNorm16ReadbackWorkaround workaround;
     angle::Result result =
@@ -1650,11 +1645,9 @@ angle::Result FramebufferGL::readPixelsAllAtOnce(const gl::Context *context,
     const gl::InternalFormat &glFormat = gl::GetInternalFormatInfo(format, type);
 
     GLuint rowBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowPitch(type, area.width, pack.alignment,
-                                                            pack.rowLength, &rowBytes));
     GLuint skipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL,
-                        glFormat.computeSkipBytes(type, rowBytes, 0, pack, false, &skipBytes));
+    ANGLE_CHECK_GL_MATH(
+        contextGL, glFormat.computeRowSkipBytes(type, area.width, pack, &rowBytes, &skipBytes));
 
     ScopedEXTTextureNorm16ReadbackWorkaround workaround;
     angle::Result result =

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/TextureGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/TextureGL.cpp
@@ -443,17 +443,15 @@ angle::Result TextureGL::setSubImageRowByRowWorkaround(const gl::Context *contex
     ANGLE_TRY(stateManager->setPixelUnpackBuffer(context, unpackBuffer));
 
     const gl::InternalFormat &glFormat = gl::GetInternalFormatInfo(format, type);
-    GLuint rowBytes                    = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowPitch(type, area.width, unpack.alignment,
-                                                            unpack.rowLength, &rowBytes));
-    GLuint imageBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeDepthPitch(area.height, unpack.imageHeight,
-                                                              rowBytes, &imageBytes));
 
-    bool useTexImage3D = nativegl::UseTexImage3D(getType());
+    GLuint rowBytes    = 0;
+    GLuint imageBytes  = 0;
     GLuint skipBytes   = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeSkipBytes(type, rowBytes, imageBytes, unpack,
-                                                             useTexImage3D, &skipBytes));
+    bool useTexImage3D = nativegl::UseTexImage3D(getType());
+
+    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowDepthSkipBytes(
+                                       type, gl::Extents{area.width, area.height, area.depth},
+                                       unpack, useTexImage3D, &rowBytes, &imageBytes, &skipBytes));
 
     GLint rowsPerChunk =
         std::min(std::max(static_cast<GLint>(maxBytesUploadedPerChunk / rowBytes), 1), area.height);
@@ -518,15 +516,13 @@ angle::Result TextureGL::setSubImagePaddingWorkaround(const gl::Context *context
 
     const gl::InternalFormat &glFormat = gl::GetInternalFormatInfo(format, type);
     GLuint rowBytes                    = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowPitch(type, area.width, unpack.alignment,
-                                                            unpack.rowLength, &rowBytes));
-    GLuint imageBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeDepthPitch(area.height, unpack.imageHeight,
-                                                              rowBytes, &imageBytes));
+    GLuint imageBytes                  = 0;
     bool useTexImage3D = nativegl::UseTexImage3D(getType());
     GLuint skipBytes   = 0;
-    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeSkipBytes(type, rowBytes, imageBytes, unpack,
-                                                             useTexImage3D, &skipBytes));
+
+    ANGLE_CHECK_GL_MATH(contextGL, glFormat.computeRowDepthSkipBytes(
+                                       type, gl::Extents{area.width, area.height, area.depth},
+                                       unpack, useTexImage3D, &rowBytes, &imageBytes, &skipBytes));
 
     ANGLE_TRY(stateManager->setPixelUnpackState(context, unpack));
     ANGLE_TRY(stateManager->setPixelUnpackBuffer(context, unpackBuffer));

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -344,12 +344,9 @@ angle::Result FramebufferMtl::readPixels(const gl::Context *context,
     const gl::InternalFormat &sizedFormatInfo = gl::GetInternalFormatInfo(format, type);
 
     GLuint outputPitch = 0;
-    ANGLE_CHECK_GL_MATH(contextMtl,
-                        sizedFormatInfo.computeRowPitch(type, area.width, pack.alignment,
-                                                        pack.rowLength, &outputPitch));
     GLuint outputSkipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextMtl, sizedFormatInfo.computeSkipBytes(type, outputPitch, 0, pack,
-                                                                     false, &outputSkipBytes));
+    ANGLE_CHECK_GL_MATH(contextMtl, sizedFormatInfo.computeRowSkipBytes(
+                                        type, area.width, pack, &outputPitch, &outputSkipBytes));
 
     outputSkipBytes += (clippedArea.x - area.x) * sizedFormatInfo.pixelBytes +
                        (clippedArea.y - area.y) * outputPitch;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -2195,14 +2195,10 @@ angle::Result TextureMtl::setSubImageImpl(const gl::Context *context,
     GLuint sourceRowPitch   = 0;
     GLuint sourceDepthPitch = 0;
     GLuint sourceSkipBytes  = 0;
-    ANGLE_CHECK_GL_MATH(contextMtl, formatInfo.computeRowPitch(type, area.width, unpack.alignment,
-                                                               unpack.rowLength, &sourceRowPitch));
     ANGLE_CHECK_GL_MATH(
-        contextMtl, formatInfo.computeDepthPitch(area.height, unpack.imageHeight, sourceRowPitch,
-                                                 &sourceDepthPitch));
-    ANGLE_CHECK_GL_MATH(contextMtl,
-                        formatInfo.computeSkipBytes(type, sourceRowPitch, sourceDepthPitch, unpack,
-                                                    index.usesTex3D(), &sourceSkipBytes));
+        contextMtl, formatInfo.computeRowDepthSkipBytes(
+                        type, gl::Extents{area.width, area.height, area.depth}, unpack,
+                        index.usesTex3D(), &sourceRowPitch, &sourceDepthPitch, &sourceSkipBytes));
 
     // Get corresponding source data's ANGLE format
     angle::FormatID srcAngleFormatId;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/null/FramebufferNULL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/null/FramebufferNULL.cpp
@@ -123,12 +123,9 @@ angle::Result FramebufferNULL::readPixels(const gl::Context *context,
     ContextNULL *contextNull = GetImplAs<ContextNULL>(context);
 
     GLuint rowBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextNull, glFormat.computeRowPitch(type, origArea.width, pack.alignment,
-                                                              pack.rowLength, &rowBytes));
-
     GLuint skipBytes = 0;
-    ANGLE_CHECK_GL_MATH(contextNull,
-                        glFormat.computeSkipBytes(type, rowBytes, 0, pack, false, &skipBytes));
+    ANGLE_CHECK_GL_MATH(contextNull, glFormat.computeRowSkipBytes(type, origArea.width, pack,
+                                                                  &rowBytes, &skipBytes));
     pixels += skipBytes;
 
     // Skip OOB region up to first in bounds pixel

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/vk_helpers.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/vk_helpers.cpp
@@ -9544,18 +9544,9 @@ angle::Result ImageHelper::calculateBufferInfo(ContextVk *contextVk,
         return angle::Result::Continue;
     }
 
-    ANGLE_VK_CHECK_MATH(contextVk,
-                        formatInfo.computeRowPitch(type, glExtents.width, unpack.alignment,
-                                                   unpack.rowLength, inputRowPitch));
-
-    ANGLE_VK_CHECK_MATH(contextVk,
-                        formatInfo.computeDepthPitch(glExtents.height, unpack.imageHeight,
-                                                     *inputRowPitch, inputDepthPitch));
-
     ANGLE_VK_CHECK_MATH(
-        contextVk, formatInfo.computeSkipBytes(type, *inputRowPitch, *inputDepthPitch, unpack, is3D,
-                                               inputSkipBytes));
-
+        contextVk, formatInfo.computeRowDepthSkipBytes(type, glExtents, unpack, is3D, inputRowPitch,
+                                                       inputDepthPitch, inputSkipBytes));
     return angle::Result::Continue;
 }
 
@@ -11514,11 +11505,8 @@ angle::Result ImageHelper::GetReadPixelsParams(ContextVk *contextVk,
     const gl::InternalFormat &sizedFormatInfo = gl::GetInternalFormatInfo(format, type);
 
     GLuint outputPitch = 0;
-    ANGLE_VK_CHECK_MATH(contextVk,
-                        sizedFormatInfo.computeRowPitch(type, area.width, packState.alignment,
-                                                        packState.rowLength, &outputPitch));
-    ANGLE_VK_CHECK_MATH(contextVk, sizedFormatInfo.computeSkipBytes(type, outputPitch, 0, packState,
-                                                                    false, skipBytesOut));
+    ANGLE_VK_CHECK_MATH(contextVk, sizedFormatInfo.computeRowSkipBytes(type, area.width, packState,
+                                                                       &outputPitch, skipBytesOut));
 
     ANGLE_TRY(GetPackPixelsParams(sizedFormatInfo, outputPitch, packState, packBuffer, area,
                                   clippedArea, paramsOut, skipBytesOut));

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/wgpu/TextureWgpu.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/wgpu/TextureWgpu.cpp
@@ -568,14 +568,11 @@ angle::Result TextureWgpu::setSubImageImpl(const gl::Context *context,
     gl::Extents glExtents                 = gl::Extents(area.width, area.height, area.depth);
 
     GLuint inputRowPitch = 0;
-    ANGLE_CHECK_GL_MATH(contextWgpu, inputInternalFormatInfo.computeRowPitch(
-                                         type, glExtents.width, unpack.alignment, unpack.rowLength,
-                                         &inputRowPitch));
-
     GLuint inputDepthPitch = 0;
-    ANGLE_CHECK_GL_MATH(
-        contextWgpu, inputInternalFormatInfo.computeDepthPitch(glExtents.height, unpack.imageHeight,
-                                                               inputRowPitch, &inputDepthPitch));
+    GLuint inputSkipBytes  = 0;  // FIXME: Input skip bytes not handled.
+    ANGLE_CHECK_GL_MATH(contextWgpu, inputInternalFormatInfo.computeRowDepthSkipBytes(
+                                         type, glExtents, unpack, index.usesTex3D(), &inputRowPitch,
+                                         &inputDepthPitch, &inputSkipBytes));
 
     const angle::Format &actualFormat = webgpuFormat.getActualImageFormat();
     uint32_t outputRowPitch           = roundUp(actualFormat.pixelBytes * glExtents.width,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/wgpu/wgpu_helpers.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/wgpu/wgpu_helpers.cpp
@@ -397,11 +397,8 @@ angle::Result ImageHelper::getReadPixelsParams(rx::ContextWgpu *contextWgpu,
     const gl::InternalFormat &sizedFormatInfo = gl::GetInternalFormatInfo(format, type);
 
     GLuint outputPitch = 0;
-    ANGLE_CHECK_GL_MATH(contextWgpu,
-                        sizedFormatInfo.computeRowPitch(type, area.width, packState.alignment,
-                                                        packState.rowLength, &outputPitch));
-    ANGLE_CHECK_GL_MATH(contextWgpu, sizedFormatInfo.computeSkipBytes(
-                                         type, outputPitch, 0, packState, false, skipBytesOut));
+    ANGLE_CHECK_GL_MATH(contextWgpu, sizedFormatInfo.computeRowSkipBytes(
+                                         type, area.width, packState, &outputPitch, skipBytesOut));
 
     ANGLE_TRY(GetPackPixelsParams(sizedFormatInfo, outputPitch, packState, packBuffer, area,
                                   clippedArea, paramsOut, skipBytesOut));


### PR DESCRIPTION
#### 93ddb5c2ffabbf8d106482aa0a3fa71d7d34fef4
<pre>
ANGLE: Avoid using UNPACK_SKIP_IMAGES, UNPACK_IMAGE_HEIGHT for non-3d textures &lt;<a href="https://rdar.apple.com/164155603">rdar://164155603</a>&gt;

Reviewed by Mike Wyrzykowski.

Avoid using UNPACK_SKIP_IMAGES, UNPACK_IMAGE_HEIGHT when uploading
textures with TexImage2D. The UNPACK_IMAGE_HEIGHT was being
being used in Metal texture uploads even when slices was == 1. This
causes validation failure. During TexImage2D the values are not
validated at ANGLE validation level since they are not supposed to
affect anything.

Consider pattern:
formatInfo.computeRowPitch(type, area.width, unpack.alignment,
    unpack.rowLength, &amp;rowPitch);
formatInfo.computeDepthPitch(area.height, unpack.imageHeight,
    sourceRowPitch, &amp;depthPitch);
formatInfo.computeSkipBytes(type, sourceRowPitch, sourceDepthPitch,
    unpack, index.usesTex3D(), &amp;sourceSkipBytes);

Computing the depthPitch would not take into account wheter the
originating command was Tex*Image2D or Tex*Image3D. It would
unconditionally use UNPACK_SKIP_IMAGES, UNPACK_IMAGE_HEIGHT.
The computed depthPitch would then be used to size buffers, read amounts
and write amounts by the implementations.

Combine the pattern to InternalFormat::computeRowDepthSkipBytes(...)
call that uses PixelUnpackState::imageHeight,
PixelUnpackState::imageSkip only for 3D texture uploads.

Compine the pack buffer parameter resolution logic other to function:
InternalFormat::computeRowSkipBytes(..., PixelPackState&amp;,...).

* Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp:
(gl::Context::texImage2D):
* Source/ThirdParty/ANGLE/src/libANGLE/capture/capture_gles_2_0_params.cpp:
(gl::CaptureTexImage2D_pixels):
* Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp:
(gl::InternalFormat::computeRowDepthSkipBytes const):
(gl::InternalFormat::computeSkipBytes const):
(gl::InternalFormat::computePackUnpackEndByte const):
* Source/ThirdParty/ANGLE/src/libANGLE/formatutils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/d3d/d3d11/Image11.cpp:
(rx::Image11::loadData):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/TextureGL.cpp:
(rx::TextureGL::setSubImageRowByRowWorkaround):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::setSubImageImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/vk_helpers.cpp:
(rx::vk::ImageHelper::calculateBufferInfo):

Change-Id: Iefac5156412787709ee577a9a71f19a480778e78

Originally-landed-as: 02d2cd92abb8. <a href="https://rdar.apple.com/166336157">rdar://166336157</a>
Canonical link: <a href="https://commits.webkit.org/304611@main">https://commits.webkit.org/304611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecda70573fb364da02b18a444ffdc9101c957f46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143681 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10c41699-e96a-42ec-b197-6a93a7bc6c52) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/478f4e3a-df0f-457a-8d67-654a0ee7d2be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c93876a1-7073-464e-8c80-4cf7d394c4e8) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6216 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3856 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146432 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112263 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112656 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6117 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118158 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20964 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8067 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36227 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->