### PR TITLE
Prevent Safari crashes when scrolling reddit

### DIFF
--- a/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp
@@ -49,7 +49,13 @@ FindTextMatchCallbackAggregator::~FindTextMatchCallbackAggregator()
     Vector<WebFoundTextRange> ranges;
     uint64_t frameOrder = 0;
 
-    for (RefPtr frame = m_page->mainFrame(); frame; frame = frame->traverseNext().frame) {
+    RefPtr protectedPage = m_page.get();
+    if (!protectedPage) {
+        m_completionHandler(WTFMove(ranges));
+        return;
+    }
+
+    for (RefPtr frame = protectedPage->mainFrame(); frame; frame = frame->traverseNext().frame) {
         const auto frameID = frame->frameID();
         if (auto it = m_frameMatches.find(frameID); it != m_frameMatches.end()) {
             for (auto& match : it->value) {


### PR DESCRIPTION
#### 52e754af3c91a8217f89d99998d7de8aca79b0cf
<pre>
Prevent Safari crashes when scrolling reddit
<a href="https://bugs.webkit.org/show_bug.cgi?id=304296">https://bugs.webkit.org/show_bug.cgi?id=304296</a>
<a href="https://rdar.apple.com/166587473">rdar://166587473</a>

Reviewed by Aditya Keerthi.

A crash on safari was reported and the stack traces point to the
FindTextMatchCallbackAggregator. The aggregator holds a WeakPtr
to a WebPageProxy, which can be null at the aggregator&apos;s destruction
(which is when the page is used).

To fix this issue, I store the WebPageProxy in a RefPtr and check
for valid state before using the page.

* Source/WebKit/UIProcess/FindTextMatchesCallbackAggregator.cpp:
(WebKit::FindTextMatchCallbackAggregator::~FindTextMatchCallbackAggregator):

Canonical link: <a href="https://commits.webkit.org/304702@main">https://commits.webkit.org/304702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8529137efae78c36debf97becd0467b193e3e24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/88942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/158bdcd6-9b7e-4228-82af-519d43d01213) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103913 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/88942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4e05eff-63bd-45f8-bf48-8061b8513796) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5ab29687-2d79-44eb-a6c7-51b39db5d424) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3860 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115475 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146436 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112268 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112661 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6121 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118159 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8071 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36228 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->