### PR TITLE
[Site Isolation] [resize-observer] Add observer in cross-origin frame test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Cross-origin observer responds to explicitly set physical size
+PASS When size is viewport-dependant, cross-origin observer responds to viewport size changes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+
+<title>Tests that Resize Observer in a cross-origin frame works when observing its own element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/resizeTestHelper.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 200px;
+    outline: 1px black solid;
+  }
+</style>
+
+<body>
+
+<iframe id="iframe" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/resize-observer/resources/cross-origin-subframe.html" sandbox="allow-scripts" frameborder="0"></iframe>
+
+<script>
+let borderBoxBlockSize = null;
+let borderBoxInlineSize = null;
+
+function rafPromise() {
+  return new Promise(requestAnimationFrame);
+}
+
+async function setSize(width, height) {
+  iframe.contentWindow.postMessage({
+    msgName: "setSize",
+    width: width,
+    height: height
+  }, "*");
+
+  await rafPromise();
+  await rafPromise();
+  await rafPromise();
+}
+
+promise_setup(() => {
+  // Wait for iframe to be loaded.
+  return new Promise(resolve => {
+    window.addEventListener("message", event => {
+      if (event.data.msgName === "loaded") {
+        // Install a long-lasting event listener, since this listener is one-shot
+        window.addEventListener("message", event => {
+          if (event.data.msgName === "event") {
+            borderBoxBlockSize = event.data.borderBoxBlockSize;
+            borderBoxInlineSize = event.data.borderBoxInlineSize;
+          }
+        });
+
+        resolve();
+      }
+    }, { once: true });
+  });
+});
+
+promise_test(async t => {
+  await setSize("200px", "100px");
+
+  assert_equals(borderBoxInlineSize, 200);
+  assert_equals(borderBoxBlockSize, 100)
+}, "Cross-origin observer responds to explicitly set physical size");
+
+promise_test(async t => {
+  // Initial iframe size is 300x200
+  await setSize("50vw", "50vh");
+  assert_equals(borderBoxInlineSize, 150);
+  assert_equals(borderBoxBlockSize, 100);
+
+  iframe.style.width = "400px";
+  iframe.style.height = "500px";
+  await setSize("50vw", "50vh");
+
+  assert_equals(borderBoxInlineSize, 200);
+  assert_equals(borderBoxBlockSize, 250);
+}, "When size is viewport-dependant, cross-origin observer responds to viewport size changes");
+
+</script>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/resources/cross-origin-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/resources/cross-origin-subframe.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <style>
+    #target { background: green; }
+  </style>
+</head>
+
+<body>
+  <p>Cross-origin iframe</p>
+  <div id="target"></div>
+
+  <script>
+    function messageHandler(msg) {
+      if (msg.msgName === "setSize") {
+        target.style.width = msg.width;
+        target.style.height = msg.height;
+      }
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        window.top.postMessage({
+          msgName: "event",
+          borderBoxBlockSize: entry.borderBoxSize[0].blockSize,
+          borderBoxInlineSize: entry.borderBoxSize[0].inlineSize
+        }, "*");
+      }
+    });
+
+    window.addEventListener("load", () => {
+      observer.observe(target);
+      window.addEventListener("message", (event) => messageHandler(event.data));
+
+      window.top.postMessage({ "msgName": "loaded" }, "*");
+    }, { once: true });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### acb83b76fc03cd994144ac7374ccbc7b3cfc4a27
<pre>
[Site Isolation] [resize-observer] Add observer in cross-origin frame test
<a href="https://rdar.apple.com/166652709">rdar://166652709</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304295">https://bugs.webkit.org/show_bug.cgi?id=304295</a>

Reviewed by Simon Fraser.

Add a regression test for Resize Observer when Site Isolation is enabled.

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observer-in-cross-origin-frame.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/resources/cross-origin-subframe.html: Added.

Canonical link: <a href="https://commits.webkit.org/305162@main">https://commits.webkit.org/305162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d15896d9d44413517b6d148180f26b5dbeda59e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90653 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7e9bfdbc-c606-4771-a7f6-90bcf665d39f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8535d4fa-7d83-4ec6-a386-0ec9d7014980) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0fd8b5e8-cdef-45b8-9652-157b5a228c03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5343 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6023 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9724 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113706 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28948 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7548 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64412 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9772 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37679 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9503 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->