### PR TITLE
Add a way to control whether WKContentWorlds are seen in the Web Inspector

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -112,6 +112,7 @@ public:
         ContentRuleListAction,
         ContentRuleListStore,
         ContentWorld,
+        ContentWorldConfiguration,
 #if PLATFORM(IOS_FAMILY)
         ContextMenuElementInfo,
 #endif

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -73,6 +73,7 @@
 #import "_WKAttachmentInternal.h"
 #import "_WKAutomationSessionInternal.h"
 #import "_WKContentRuleListActionInternal.h"
+#import "_WKContentWorldConfigurationInternal.h"
 #import "_WKContextMenuElementInfoInternal.h"
 #import "_WKCustomHeaderFieldsInternal.h"
 #import "_WKDataTaskInternal.h"
@@ -384,6 +385,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::ContentWorld:
         SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [WKContentWorld alloc];
+        break;
+
+    case Type::ContentWorldConfiguration:
+        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKContentWorldConfiguration alloc];
         break;
 
     case Type::TargetedElementInfo:

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -29,6 +29,7 @@ header: "ContentWorldData.h"
     DisableLegacyBuiltinOverrides,
     AllowJSHandleCreation,
     AllowNodeSerialization,
+    Inspectable,
 };
 
 [DebugDecodingFailure] struct WebKit::ContentWorldData {

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -491,6 +491,7 @@ UIProcess/API/APIContentRuleList.cpp
 UIProcess/API/APIContentRuleListAction.cpp
 UIProcess/API/APIContentRuleListStore.cpp
 UIProcess/API/APIContentWorld.cpp
+UIProcess/API/APIContentWorldConfiguration.cpp
 UIProcess/API/APIContextMenuElementInfo.cpp
 UIProcess/API/APIDataTask.cpp
 UIProcess/API/APIDebuggableInfo.cpp

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -36,6 +36,11 @@
 
 namespace API {
 
+OptionSet<WebKit::ContentWorldOption> ContentWorld::defaultOptions()
+{
+    return WebKit::ContentWorldOption::Inspectable;
+}
+
 static HashMap<WTF::String, WeakRef<ContentWorld>>& sharedWorldNameMap()
 {
     static NeverDestroyed<HashMap<WTF::String, WeakRef<ContentWorld>>> sharedMap;
@@ -78,6 +83,7 @@ ContentWorld::ContentWorld(const WTF::String& name, OptionSet<WebKit::ContentWor
 
 ContentWorld::ContentWorld(WebKit::ContentWorldIdentifier identifier)
     : m_identifier(identifier)
+    , m_options(defaultOptions())
 {
     ASSERT(m_identifier == WebKit::pageContentWorldIdentifier());
 }
@@ -100,7 +106,7 @@ ContentWorld& ContentWorld::pageContentWorldSingleton()
 
 ContentWorld& ContentWorld::defaultClientWorldSingleton()
 {
-    static NeverDestroyed<Ref<ContentWorld>> world(adoptRef(*new ContentWorld(WTF::String { }, { })));
+    static NeverDestroyed<Ref<ContentWorld>> world(adoptRef(*new ContentWorld(WTF::String { }, defaultOptions())));
     return world.get();
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -40,8 +40,9 @@ namespace API {
 
 class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeWeakPtr<ContentWorld> {
 public:
+    static OptionSet<WebKit::ContentWorldOption> defaultOptions();
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
-    static Ref<ContentWorld> sharedWorldWithName(const WTF::String&, OptionSet<WebKit::ContentWorldOption> options = { });
+    static Ref<ContentWorld> sharedWorldWithName(const WTF::String&, OptionSet<WebKit::ContentWorldOption> = defaultOptions() );
     static ContentWorld& pageContentWorldSingleton();
     static ContentWorld& defaultClientWorldSingleton();
 

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "APIContentWorldConfiguration.h"
+
+namespace API {
+
+Ref<ContentWorldConfiguration> ContentWorldConfiguration::create()
+{
+    return adoptRef(*new ContentWorldConfiguration());
+}
+
+ContentWorldConfiguration::Data::Data() = default;
+
+ContentWorldConfiguration::ContentWorldConfiguration() = default;
+
+ContentWorldConfiguration::~ContentWorldConfiguration() = default;
+
+Ref<ContentWorldConfiguration> ContentWorldConfiguration::copy() const
+{
+    Ref other = create();
+    other->m_data = m_data;
+    return other;
+}
+
+const WTF::String& ContentWorldConfiguration::name() const
+{
+    return m_data.name;
+}
+
+void ContentWorldConfiguration::setName(WTF::String&& name)
+{
+    m_data.name = WTFMove(name);
+}
+
+bool ContentWorldConfiguration::allowAccessToClosedShadowRoots() const
+{
+    return m_data.allowAccessToClosedShadowRoots;
+}
+
+void ContentWorldConfiguration::setAllowAccessToClosedShadowRoots(bool allow)
+{
+    m_data.allowAccessToClosedShadowRoots = allow;
+}
+
+bool ContentWorldConfiguration::allowAutofill() const
+{
+    return m_data.allowAutofill;
+}
+
+void ContentWorldConfiguration::setAllowAutofill(bool allow)
+{
+    m_data.allowAutofill = allow;
+}
+
+bool ContentWorldConfiguration::allowElementUserInfo() const
+{
+    return m_data.allowElementUserInfo;
+}
+
+void ContentWorldConfiguration::setAllowElementUserInfo(bool allow)
+{
+    m_data.allowElementUserInfo = allow;
+}
+
+bool ContentWorldConfiguration::disableLegacyBuiltinOverrides() const
+{
+    return m_data.disableLegacyBuiltinOverrides;
+}
+
+void ContentWorldConfiguration::setDisableLegacyBuiltinOverrides(bool disable)
+{
+    m_data.disableLegacyBuiltinOverrides = disable;
+}
+
+bool ContentWorldConfiguration::allowJSHandleCreation() const
+{
+    return m_data.allowJSHandleCreation;
+}
+
+void ContentWorldConfiguration::setAllowJSHandleCreation(bool allow)
+{
+    m_data.allowJSHandleCreation = allow;
+}
+
+bool ContentWorldConfiguration::allowNodeSerialization() const
+{
+    return m_data.allowNodeSerialization;
+}
+
+void ContentWorldConfiguration::setAllowNodeSerialization(bool allow)
+{
+    m_data.allowNodeSerialization = allow;
+}
+
+bool ContentWorldConfiguration::isInspectable() const
+{
+    return m_data.inspectable;
+}
+
+void ContentWorldConfiguration::setInspectable(bool inspectable)
+{
+    m_data.inspectable = inspectable;
+}
+
+} // namespace API

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIObject.h"
+#include <wtf/text/WTFString.h>
+
+namespace API {
+
+class ContentWorldConfiguration : public ObjectImpl<Object::Type::ContentWorldConfiguration> {
+public:
+    static Ref<ContentWorldConfiguration> create();
+
+    explicit ContentWorldConfiguration();
+    virtual ~ContentWorldConfiguration();
+
+    Ref<ContentWorldConfiguration> copy() const;
+
+    const WTF::String& name() const;
+    void setName(WTF::String&&);
+
+    bool allowAccessToClosedShadowRoots() const;
+    void setAllowAccessToClosedShadowRoots(bool);
+
+    bool allowAutofill() const;
+    void setAllowAutofill(bool);
+
+    bool allowElementUserInfo() const;
+    void setAllowElementUserInfo(bool);
+
+    bool disableLegacyBuiltinOverrides() const;
+    void setDisableLegacyBuiltinOverrides(bool);
+
+    bool allowJSHandleCreation() const;
+    void setAllowJSHandleCreation(bool);
+
+    bool allowNodeSerialization() const;
+    void setAllowNodeSerialization(bool);
+
+    bool isInspectable() const;
+    void setInspectable(bool);
+
+private:
+    struct Data {
+        Data();
+
+        WTF::String name;
+        bool allowAccessToClosedShadowRoots : 1 { false };
+        bool allowAutofill : 1 { false };
+        bool allowElementUserInfo : 1 { false };
+        bool disableLegacyBuiltinOverrides : 1 { false };
+        bool allowJSHandleCreation : 1 { false };
+        bool allowNodeSerialization : 1 { false };
+        bool inspectable : 1 { true };
+    };
+
+    // All data members should be added to the Data structure to avoid breaking ContentWorldConfiguration::copy().
+    Data m_data;
+};
+
+} // namespace API
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(ContentWorldConfiguration);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -113,6 +113,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         optionSet.add(WebKit::ContentWorldOption::AllowJSHandleCreation);
     if (configuration.allowNodeSerialization)
         optionSet.add(WebKit::ContentWorldOption::AllowNodeSerialization);
+    if (configuration.isInspectable)
+        optionSet.add(WebKit::ContentWorldOption::Inspectable);
     Ref world = API::ContentWorld::sharedWorldWithName(configuration.name, optionSet);
     checkContentWorldOptions(world, configuration);
     return wrapper(WTFMove(world)).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -24,37 +24,42 @@
  */
 
 #include "config.h"
-#include "_WKContentWorldConfiguration.h"
+#include "_WKContentWorldConfigurationInternal.h"
 
-@implementation _WKContentWorldConfiguration {
-    String _name;
-}
+@implementation _WKContentWorldConfiguration
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
-- (NSString *)name
+- (instancetype)init
 {
-    return _name.createNSString().autorelease();
+    if (!(self = [super init]))
+        return nil;
+
+    API::Object::constructInWrapper<API::ContentWorldConfiguration>(self);
+
+    return self;
 }
 
-- (void)setName:(NSString *)name
+- (void)dealloc
 {
-    _name = name;
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKContentWorldConfiguration.class, self))
+        return;
+
+    self._protectedWorldConfiguration->API::ContentWorldConfiguration::~ContentWorldConfiguration();
+
+    [super dealloc];
+}
+
+- (Ref<API::ContentWorldConfiguration>)_protectedWorldConfiguration
+{
+    return *_worldConfiguration;
 }
 
 #pragma mark NSCopying protocol implementation
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    RetainPtr clone = adoptNS([(_WKContentWorldConfiguration *)[[self class] allocWithZone:zone] init]);
-
-    clone.get().name = self.name;
-    clone.get().allowAccessToClosedShadowRoots = self.allowAccessToClosedShadowRoots;
-    clone.get().allowAutofill = self.allowAutofill;
-    clone.get().allowElementUserInfo = self.allowElementUserInfo;
-    clone.get().disableLegacyBuiltinOverrides = self.disableLegacyBuiltinOverrides;
-
-    return clone.leakRef();
+    return wrapper(self._protectedWorldConfiguration->copy()).autorelease();
 }
 
 #pragma mark NSSecureCoding protocol implementation
@@ -71,6 +76,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
     [coder encodeBool:self.allowElementUserInfo forKey:@"allowElementUserInfo"];
     [coder encodeBool:self.disableLegacyBuiltinOverrides forKey:@"disableLegacyBuiltinOverrides"];
+    [coder encodeBool:self.allowJSHandleCreation forKey:@"allowJSHandleCreation"];
+    [coder encodeBool:self.allowNodeSerialization forKey:@"allowNodeSerialization"];
+    [coder encodeBool:self.isInspectable forKey:@"inspectable"];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
@@ -83,8 +91,98 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     self.allowAutofill = [coder decodeBoolForKey:@"allowAutofill"];
     self.allowElementUserInfo = [coder decodeBoolForKey:@"allowElementUserInfo"];
     self.disableLegacyBuiltinOverrides = [coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"];
+    self.allowJSHandleCreation = [coder decodeBoolForKey:@"allowJSHandleCreation"];
+    self.allowNodeSerialization = [coder decodeBoolForKey:@"allowNodeSerialization"];
+    self.inspectable = [coder decodeBoolForKey:@"inspectable"];
 
     return self;
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_worldConfiguration;
+}
+
+- (NSString *)name
+{
+    return self._protectedWorldConfiguration->name().createNSString().autorelease();
+}
+
+- (void)setName:(NSString *)name
+{
+    self._protectedWorldConfiguration->setName(name);
+}
+
+- (BOOL)allowAccessToClosedShadowRoots
+{
+    return self._protectedWorldConfiguration->allowAccessToClosedShadowRoots();
+}
+
+- (void)setAllowAccessToClosedShadowRoots:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowAccessToClosedShadowRoots(allow);
+}
+
+- (BOOL)allowAutofill
+{
+    return self._protectedWorldConfiguration->allowAutofill();
+}
+
+- (void)setAllowAutofill:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowAutofill(allow);
+}
+
+- (BOOL)allowElementUserInfo
+{
+    return self._protectedWorldConfiguration->allowElementUserInfo();
+}
+
+- (void)setAllowElementUserInfo:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowElementUserInfo(allow);
+}
+
+- (BOOL)disableLegacyBuiltinOverrides
+{
+    return self._protectedWorldConfiguration->disableLegacyBuiltinOverrides();
+}
+
+- (void)setDisableLegacyBuiltinOverrides:(BOOL)disable
+{
+    self._protectedWorldConfiguration->setDisableLegacyBuiltinOverrides(disable);
+}
+
+- (BOOL)allowJSHandleCreation
+{
+    return self._protectedWorldConfiguration->allowJSHandleCreation();
+}
+
+- (void)setAllowJSHandleCreation:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowJSHandleCreation(allow);
+}
+
+- (BOOL)allowNodeSerialization
+{
+    return self._protectedWorldConfiguration->allowNodeSerialization();
+}
+
+- (void)setAllowNodeSerialization:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowNodeSerialization(allow);
+}
+
+- (BOOL)isInspectable
+{
+    return self._protectedWorldConfiguration->isInspectable();
+}
+
+- (void)setInspectable:(BOOL)inspectable
+{
+    self._protectedWorldConfiguration->setInspectable(inspectable);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -48,6 +48,7 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 @property (nonatomic) BOOL allowElementUserInfo;
 
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
+// FIXME: Give this a positive name like enableLegacyBuiltinOverrides to avoid double-negatives in code.
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
 /*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
@@ -55,6 +56,9 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 
 /*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
 @property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/*! @abstract A boolean indicating whether the JavaScript in this world is visible to the Web Inspector. */
+@property (nonatomic, getter=isInspectable) BOOL inspectable NS_SWIFT_NAME(isInspectable) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfigurationInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,32 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/ProcessQualified.h>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/ObjectIdentifier.h>
+#import "APIContentWorldConfiguration.h"
+#import "_WKContentWorldConfiguration.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
-struct ContentWorldIdentifierType;
-using NonProcessQualifiedContentWorldIdentifier = ObjectIdentifier<ContentWorldIdentifierType>;
-using ContentWorldIdentifier = WebCore::ProcessQualified<NonProcessQualifiedContentWorldIdentifier>;
-
-inline ContentWorldIdentifier pageContentWorldIdentifier()
-{
-    static NeverDestroyed<ContentWorldIdentifier> identifier(ObjectIdentifier<ContentWorldIdentifierType>(1), WebCore::ProcessIdentifier(1));
-    return identifier;
-}
-
-enum class ContentWorldOption : uint8_t {
-    AllowAccessToClosedShadowRoots = 1 << 0,
-    AllowAutofill = 1 << 1,
-    AllowElementUserInfo = 1 << 2,
-    DisableLegacyBuiltinOverrides = 1 << 3,
-    AllowJSHandleCreation = 1 << 4,
-    AllowNodeSerialization = 1 << 5,
-    Inspectable = 1 << 6,
+template<> struct WrapperTraits<API::ContentWorldConfiguration> {
+    using WrapperClass = _WKContentWorldConfiguration;
 };
 
-} // namespace WebKit
+}
+
+@interface _WKContentWorldConfiguration () <WKObject> {
+@package
+    AlignedStorage<API::ContentWorldConfiguration> _worldConfiguration;
+}
+@end

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -33,6 +33,7 @@
 #import "PasteboardAccessIntent.h"
 #import "RemotePageProxy.h"
 #import "SandboxExtension.h"
+#import "WebPageMessages.h"
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
 #import "WebProcessMessages.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8906,6 +8906,9 @@
 		FA5AAE9A2E6A217A00FE693D /* NetworkSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkSoftLink.mm; sourceTree = "<group>"; };
 		FA5C22422DC5710500B13EF3 /* RemoteWebTouchEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWebTouchEvent.h; sourceTree = "<group>"; };
 		FA5C22432DC5719D00B13EF3 /* RemoteWebTouchEvent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWebTouchEvent.serialization.in; sourceTree = "<group>"; };
+		FA601C012EF1F71D005A14BC /* APIContentWorldConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIContentWorldConfiguration.h; sourceTree = "<group>"; };
+		FA601C022EF1F71D005A14BC /* APIContentWorldConfiguration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIContentWorldConfiguration.cpp; sourceTree = "<group>"; };
+		FA601C042EF1F8CB005A14BC /* _WKContentWorldConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKContentWorldConfigurationInternal.h; sourceTree = "<group>"; };
 		FA6342192D9D98D300A6BECE /* WebFrame.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrame.messages.in; sourceTree = "<group>"; };
 		FA63421A2D9D990400A6BECE /* WebFrameProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrameProxy.messages.in; sourceTree = "<group>"; };
 		FA6757052B815C8300C1566A /* FrameProcess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameProcess.cpp; sourceTree = "<group>"; };
@@ -12482,6 +12485,7 @@
 				5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */,
 				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
 				9B17FFC52CD975EC002DDA6E /* _WKContentWorldConfiguration.h */,
+				FA601C042EF1F8CB005A14BC /* _WKContentWorldConfigurationInternal.h */,
 				1A5704F61BE01FF400874AF1 /* _WKContextMenuElementInfo.h */,
 				1A5704F51BE01FF400874AF1 /* _WKContextMenuElementInfo.mm */,
 				DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */,
@@ -15539,6 +15543,8 @@
 				7C3A06A61AAB903E009D74BA /* APIContentRuleListStore.h */,
 				5183722123CE973A0003CF83 /* APIContentWorld.cpp */,
 				5183722023CE973A0003CF83 /* APIContentWorld.h */,
+				FA601C022EF1F71D005A14BC /* APIContentWorldConfiguration.cpp */,
+				FA601C012EF1F71D005A14BC /* APIContentWorldConfiguration.h */,
 				076E884D1A13CADF005E90FC /* APIContextMenuClient.h */,
 				5CE0C366229F2D3D003695F0 /* APIContextMenuElementInfo.cpp */,
 				5CE0C367229F2D3E003695F0 /* APIContextMenuElementInfo.h */,

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -131,7 +131,12 @@ void WebUserContentController::addContentWorldIfNecessary(const ContentWorldData
         if (auto* existingWorld = InjectedBundleScriptWorld::find(world.name))
             return Ref<InjectedBundleScriptWorld> { *existingWorld };
 #endif
-        return InjectedBundleScriptWorld::create(world.identifier, world.name, InjectedBundleScriptWorld::Type::User);
+#if PLATFORM(COCOA)
+        auto type = world.options.contains(ContentWorldOption::Inspectable) ? InjectedBundleScriptWorld::Type::User : InjectedBundleScriptWorld::Type::Internal;
+#else
+        auto type = InjectedBundleScriptWorld::Type::User;
+#endif
+        return InjectedBundleScriptWorld::create(world.identifier, world.name, type);
     });
 
     if (!addResult.isNewEntry)


### PR DESCRIPTION
#### fddc90feb0d5ced1cd6e61da72db44ea11a3780f
<pre>
Add a way to control whether WKContentWorlds are seen in the Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=304297">https://bugs.webkit.org/show_bug.cgi?id=304297</a>
<a href="https://rdar.apple.com/166654991">rdar://166654991</a>

Reviewed by BJ Burg.

JSContext, WKWebExtensionContext, and WKWebView all have API to turn on and off the inspector.
This adds a similar mechanism for WKContentWorld.

* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::ContentWorld::defaultOptions):
(API::ContentWorld::ContentWorld):
(API::ContentWorld::defaultClientWorldSingleton):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp: Added.
(API::ContentWorldConfiguration::create):
(API::ContentWorldConfiguration::copy const):
(API::ContentWorldConfiguration::name const):
(API::ContentWorldConfiguration::setName):
(API::ContentWorldConfiguration::allowAccessToClosedShadowRoots const):
(API::ContentWorldConfiguration::setAllowAccessToClosedShadowRoots):
(API::ContentWorldConfiguration::allowAutofill const):
(API::ContentWorldConfiguration::setAllowAutofill):
(API::ContentWorldConfiguration::allowElementUserInfo const):
(API::ContentWorldConfiguration::setAllowElementUserInfo):
(API::ContentWorldConfiguration::disableLegacyBuiltinOverrides const):
(API::ContentWorldConfiguration::setDisableLegacyBuiltinOverrides):
(API::ContentWorldConfiguration::allowJSHandleCreation const):
(API::ContentWorldConfiguration::setAllowJSHandleCreation):
(API::ContentWorldConfiguration::allowNodeSerialization const):
(API::ContentWorldConfiguration::setAllowNodeSerialization):
(API::ContentWorldConfiguration::isInspectable const):
(API::ContentWorldConfiguration::setInspectable):
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[_WKContentWorldConfiguration init]):
(-[_WKContentWorldConfiguration dealloc]):
(-[_WKContentWorldConfiguration _protectedWorldConfiguration]):
(-[_WKContentWorldConfiguration copyWithZone:]):
(-[_WKContentWorldConfiguration encodeWithCoder:]):
(-[_WKContentWorldConfiguration initWithCoder:]):
(-[_WKContentWorldConfiguration _apiObject]):
(-[_WKContentWorldConfiguration name]):
(-[_WKContentWorldConfiguration setName:]):
(-[_WKContentWorldConfiguration allowAccessToClosedShadowRoots]):
(-[_WKContentWorldConfiguration setAllowAccessToClosedShadowRoots:]):
(-[_WKContentWorldConfiguration allowAutofill]):
(-[_WKContentWorldConfiguration setAllowAutofill:]):
(-[_WKContentWorldConfiguration allowElementUserInfo]):
(-[_WKContentWorldConfiguration setAllowElementUserInfo:]):
(-[_WKContentWorldConfiguration disableLegacyBuiltinOverrides]):
(-[_WKContentWorldConfiguration setDisableLegacyBuiltinOverrides:]):
(-[_WKContentWorldConfiguration allowJSHandleCreation]):
(-[_WKContentWorldConfiguration setAllowJSHandleCreation:]):
(-[_WKContentWorldConfiguration allowNodeSerialization]):
(-[_WKContentWorldConfiguration setAllowNodeSerialization:]):
(-[_WKContentWorldConfiguration isInspectable]):
(-[_WKContentWorldConfiguration setInspectable:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfigurationInternal.h: Copied from Source/WebKit/Shared/ContentWorldShared.h.
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorldIfNecessary):

Canonical link: <a href="https://commits.webkit.org/304691@main">https://commits.webkit.org/304691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64ecb5852ca1b8b80552c3a05f71b5724ce2e56c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2607896c-b6bd-4634-ad0e-93c8711789b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104103 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea6a4586-58e1-4cf7-9f60-43ec1981db83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/25d94a9f-3e60-4d72-8889-fa52be51630d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6350 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4007 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4463 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115631 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146614 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8199 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112465 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112793 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6269 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118315 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21003 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8247 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36375 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71806 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->