### PR TITLE
[OAS][JSC] Callee reads should not escape closure vars in OAS

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1825,7 +1825,7 @@ void ByteCodeParser::inlineCall(Node* callTargetNode, Operand result, CallVarian
     VariableAccessData* calleeVariable = nullptr;
     if (callee.isClosureCall()) {
         Node* calleeSet = set(
-            VirtualRegister(registerOffsetAfterFixup + CallFrameSlot::callee), callTargetNode, ImmediateNakedSet);
+            VirtualRegister(registerOffsetAfterFixup + CallFrameSlot::callee), callTargetNode, ImmediateSetWithFlush);
         
         calleeVariable = calleeSet->variableAccessData();
         calleeVariable->mergeShouldNeverUnbox(true);

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -734,6 +734,7 @@ private:
 
         Allocation unescaped = WTFMove(allocation);
         allocation = Allocation(unescaped.identifier(), Allocation::Kind::Escaped);
+        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Escaping allocation D@", identifier->index());
 
         for (const auto& entry : unescaped.fields())
             escapeAllocation(entry.value);
@@ -964,6 +965,8 @@ private:
         UncheckedKeyHashMap<PromotedLocationDescriptor, LazyNode> writes;
         PromotedLocationDescriptor exactRead;
 
+        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Handling node D@", node->index());
+
         switch (node->op()) {
         // We model sinking of Arrays by splitting the allocation of the Butterfly and the Array itself into two nodes.
         // This is necessary because this phase only considers one allocation per Node and the butterfly is not an implementation
@@ -1115,7 +1118,7 @@ private:
                 target = &m_heap.newAllocation(node, Allocation::Kind::Function);
 
             writes.add(FunctionExecutablePLoc, LazyNode(node->cellOperand()));
-            writes.add(FunctionActivationPLoc, LazyNode(node->child1().node()));
+            // writes.add(FunctionActivationPLoc, LazyNode(node->child1().node()));
             break;
         }
 
@@ -1193,6 +1196,7 @@ private:
                 m_heap.escape(node->child1().node());
             break;
 
+        case AssertNotEmpty:
         case CheckStructureOrEmpty:
         case CheckStructure: {
             Allocation* allocation = m_heap.onlyLocalAllocation(node->child1().node());
@@ -1384,6 +1388,11 @@ private:
                 m_heap.escape(node->child1().node());
                 m_heap.escape(node->child2().node());
             }
+            break;
+        }
+
+        case Identity: {
+            m_heap.newPointer(node, node->child1().node());
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -426,8 +426,10 @@ private:
                     break;
                 }
 
-                if (accessesOverlap(m_graph, node, AbstractHeap(Stack, operand)))
+                if (accessesOverlap(m_graph, node, AbstractHeap(Stack, operand))) {
+                    dataLogLnIf(Options::verboseObjectAllocationSinking(), "Could not remove flush D@", m_node->index(), " due to conflict with D@", node->index());
                     break;
+                }
 
             }
             


### PR DESCRIPTION
#### 368dcb6d5f62da0b4fc508e751024ea5306c7b1c
<pre>
[OAS][JSC] Callee reads should not escape closure vars in OAS
<a href="https://bugs.webkit.org/show_bug.cgi?id=304304">https://bugs.webkit.org/show_bug.cgi?id=304304</a>

Reviewed by NOBODY (OOPS!).

We have:

D@1: CreateActivaiton
D@2: NewFunction(D@1)
&lt;--- Inlined
D@3: PutClosureVar(D@1)
D@4: PutStack(D@2, calleeSlot) &lt;--- Escapes everything
&lt;something that can exit&gt;
D@5: GetClosureVar(D@1)

This PutStack is emitted because we cannot remove the associated Flush
in the original SetLocal/Flush pair it comes from. The flush conflicts
with the other inlined nodes, which read callee.

This is very annoying. TODO
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b021c3e72f74018bcc96c6fe8c22ff5ae44a6f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8859 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104496 "Failure limit exceed. At least found 196 new test failures: fast/dom/gc-acid3.html fast/workers/stress-js-execution.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html imported/w3c/web-platform-tests/IndexedDB/blob-composite-blob-reads.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76308 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139599 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7095 "Found 60 new test failures: fast/canvas/webgl/drawingbuffer-test.html fast/css/ios/system-color-for-css-value.html fast/dom/gc-acid3.html fast/mediastream/captureStream/canvas2d-heavy-drawing.html fast/mediastream/image-capture-grabFrame.html fast/scrolling/ios/overflow-scrolling-touch-enabled-stacking.html fast/xmlhttprequest/xmlhttprequest-responsetype-before-open-sync-request.html http/wpt/identity/idl.https.html js/dom/document-all-class-extends.html js/dom/document-all-typeof-is-function-fold.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122446 "Found 1 new API test failure: TestWebKitAPI.WKUserContentController.DidAssociateFormControlsFromShadowTree (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85333 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6739 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html imported/w3c/web-platform-tests/IndexedDB/blob-composite-blob-reads.any.html imported/w3c/web-platform-tests/IndexedDB/blob-composite-blob-reads.any.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4422 "Found 2 new API test failures: TestWebKitAPI.RemoteObjectRegistry.CallReplyBlockWithBadInvocation, TestWebKitAPI.IPCTestingAPI.SpeechSynthesisWithFeatureFlag (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4974 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128615 "Found 1 new JSC stress test failure: Too many failures: 3374 jsc tests failed (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116054 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40634 "Found 60 new test failures: fast/canvas/webgl/uninitialized-test.html fast/css/aspect-ratio-min-height-replaced.html fast/dom/gc-acid3.html fast/workers/stress-js-execution.html fast/xmlhttprequest/xmlhttprequest-responsetype-arraybuffer.html http/tests/security/referrer-policy-rel-noreferrer.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147138 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135140 "Found 1 new JSC stress test failure: Too many failures: 3320 jsc tests failed (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8697 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41208 "Found 60 new test failures: fast/canvas/webgl/uninitialized-test.html fast/css/aspect-ratio-min-height-replaced.html fast/dom/gc-acid3.html fast/mediastream/image-capture-grabFrame.html fast/scrolling/mac/stateless-user-scroll-scrollend.html fast/webgpu/nocrash/fuzz-291988b.html fast/workers/stress-js-execution.html fast/xmlhttprequest/xmlhttprequest-responsetype-arraybuffer.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/tests/webgpu/webgpu/api/operation/vertex_state/correctness.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112852 "Failure limit exceed. At least found 199 new test failures: fast/dom/gc-acid3.html fast/workers/stress-js-execution.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html imported/w3c/web-platform-tests/IndexedDB/blob-composite-blob-reads.any.html imported/w3c/web-platform-tests/IndexedDB/blob-composite-blob-reads.any.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8715 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7316 "Found 60 new test failures: fast/canvas/webgl/debug-messages-to-console.html fast/canvas/webgl/uninitialized-test.html fast/dom/gc-acid3.html fast/scrolling/latching/scroll-div-no-latching.html fast/workers/stress-js-execution.html fullscreen/full-screen-keyboard-lock-option-enabled.html http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html http/tests/multipart/multipart-async-image.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/tests/webgpu/webgpu/api/operation/adapter/requestDevice.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113181 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6663 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/idlharness.https.window.html (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62814 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8745 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36792 "Found 60 new test failures: accessibility/mac/misspelled-attributed-string.html accessibility/mac/search-predicate.html accessibility/mac/spellcheck-with-voiceover.html accessibility/misspelling-range.html accessibility/search-misspellings.html css3/masking/mask-base64.html editing/mac/spelling/advance-to-next-misspelling.html editing/spelling/context-menu-suggestions.html editing/spelling/spelling-dots-position-2.html editing/spelling/spelling-dots-position-3.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167919 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72311 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43811 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->