### PR TITLE
WebDriver BiDi browsingContext.close should reject child contexts with invalid arguments.

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -90,12 +90,18 @@ void BidiBrowsingContextAgent::close(const BrowsingContext& browsingContext, std
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
     // FIXME: implement `promptUnload` option.
-    // FIXME: raise `invalid argument` if `browsingContext` is not a top-level traversable.
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(browsingContext.isEmpty(), FrameNotFound);
 
-    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+    auto handles = session->extractBrowsingContextHandles(browsingContext);
+    ASYNC_FAIL_IF_UNEXPECTED_RESULT(handles);
+    auto [pageHandle, frameHandle] = handles.value();
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!frameHandle.isEmpty(), InvalidParameter);
+
+    RefPtr webPageProxy = session->webPageProxyForHandle(pageHandle);
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, FrameNotFound);
 
-    session->closeBrowsingContext(browsingContext, WTF::move(callback));
+    session->closeBrowsingContext(pageHandle, WTF::move(callback));
 }
 
 static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
@@ -347,4 +353,3 @@ void BidiBrowsingContextAgent::traverseHistory(const BrowsingContext& browsingCo
 } // namespace WebKit
 
 #endif // ENABLE(WEBDRIVER_BIDI)
-

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2159,13 +2159,6 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/origin.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/close/invalid.py": {
-        "subtests": {
-            "test_child_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288326"}}
-            }
-        }
-    },
     "imported/w3c/webdriver/tests/bidi/browsing_context/close/prompt_unload.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288326"}}
     },


### PR DESCRIPTION
#### 3ed4c197ac72a9cc85a3048e4cb9c3e7abce66f6
<pre>
WebDriver BiDi browsingContext.close should reject child contexts with invalid arguments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288326.">https://bugs.webkit.org/show_bug.cgi?id=288326.</a>

Reviewed by BJ Burg. Patch by Julio Piubello.

Per the WebDriver BiDi spec, browsingContext.close must return invalid argument
when the provided context resolves to a non–top-level traversable (e.g. an iframe).
WebKit now resolves the provided context via extractBrowsingContextHandles and
returns InvalidParameter (mapped to BiDi invalid argument) for child contexts,
while preserving the existing “no such frame” behavior for unknown ids. The
promptUnload option remains unimplemented.
overview doc: <a href="https://docs.google.com/document/d/10_pzxIfW-7xoMfE4f1HX5ADEo-7zFiSr_oLeKdDD3EI/edit?usp=sharing">https://docs.google.com/document/d/10_pzxIfW-7xoMfE4f1HX5ADEo-7zFiSr_oLeKdDD3EI/edit?usp=sharing</a>

This fixes:
imported/w3c/webdriver/tests/bidi/browsing_context/close/invalid.py::test_child_context

Test: imported/w3c/webdriver/tests/bidi/browsing_context/close/invalid.py

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::close): Return invalid argument for non-top-level contexts.
* WebDriverTests/TestExpectations.json: Remove FAIL expectation for test_child_context.

Canonical link: <a href="https://commits.webkit.org/306722@main">https://commits.webkit.org/306722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2110c54c73e747ae302e481438609fa767efdba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108609 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78620 "1 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8352 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/12 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119995 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152332 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13437 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13097 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123150 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13479 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77192 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->