### PR TITLE
Drop special handling for WebTransport on Page and treat it like other ActiveDOMObjects

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -186,7 +186,6 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
     , m_receiveStreamSource(WTFMove(receiveStreamSource))
     , m_bidirectionalStreamSource(WTFMove(bidirectionalStreamSource))
 {
-    context.createdWebTransport(*this);
 }
 
 WebTransport::~WebTransport() = default;
@@ -200,6 +199,14 @@ bool WebTransport::virtualHasPendingActivity() const
 {
     // https://www.w3.org/TR/webtransport/#web-transport-gc
     return m_state == State::Connecting || m_state == State::Connected;
+}
+
+void WebTransport::suspend(ReasonForSuspension why)
+{
+    if (why == ReasonForSuspension::BackForwardCache) {
+        if (RefPtr context = scriptExecutionContext())
+            cleanupContext(*context);
+    }
 }
 
 void WebTransport::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<Exception>&& exception)

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -112,6 +112,7 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
+    void suspend(ReasonForSuspension) final;
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -160,7 +160,6 @@ dom/Position.cpp
 dom/QualifiedNameCache.cpp
 dom/RadioButtonGroups.cpp
 dom/Range.cpp
-dom/ScriptExecutionContext.cpp
 dom/ShadowRoot.cpp
 dom/SimpleRange.cpp
 dom/SimulatedClick.cpp

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -71,7 +71,6 @@
 #include "SocketProvider.h"
 #include "WebCoreJSClientData.h"
 #include "WebCoreOpaqueRoot.h"
-#include "WebTransport.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerNavigator.h"
@@ -347,11 +346,6 @@ URL ScriptExecutionContext::currentSourceURL(CallStackPosition position) const
     return sourceURL;
 }
 
-void ScriptExecutionContext::createdWebTransport(WebTransport& transport)
-{
-    m_activeWebTransports.add(transport);
-}
-
 void ScriptExecutionContext::suspendActiveDOMObjects(ReasonForSuspension why)
 {
     checkConsistency();
@@ -365,11 +359,6 @@ void ScriptExecutionContext::suspendActiveDOMObjects(ReasonForSuspension why)
     }
 
     m_activeDOMObjectsAreSuspended = true;
-
-    if (why == ReasonForSuspension::BackForwardCache) {
-        for (auto& webTransport : m_activeWebTransports)
-            webTransport.cleanupContext(*this);
-    }
 
     forEachActiveDOMObject([why](auto& activeDOMObject) {
         activeDOMObject.suspend(why);

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -102,7 +102,6 @@ class ServiceWorkerContainer;
 class SocketProvider;
 class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
-class WebTransport;
 enum class AdvancedPrivacyProtections : uint16_t;
 enum class CrossOriginMode : bool;
 enum class LoadedFromOpaqueSource : bool;
@@ -387,8 +386,6 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
-    void createdWebTransport(WebTransport&);
-
 protected:
     class AddConsoleMessageTask : public Task {
     public:
@@ -469,7 +466,6 @@ private:
 
     RefPtr<GuaranteedSerialFunctionDispatcher> m_nativePromiseDispatcher;
     WeakHashSet<NativePromiseRequest> m_nativePromiseRequests;
-    ThreadSafeWeakHashSet<WebTransport> m_activeWebTransports;
 };
 
 WebCoreOpaqueRoot root(ScriptExecutionContext*);


### PR DESCRIPTION
#### 4e516a5d361ba9901ee6dc0d3c45b4dec563b718
<pre>
Drop special handling for WebTransport on Page and treat it like other ActiveDOMObjects
<a href="https://bugs.webkit.org/show_bug.cgi?id=304312">https://bugs.webkit.org/show_bug.cgi?id=304312</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::suspend):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::suspendActiveDOMObjects):
(WebCore::ScriptExecutionContext::createdWebTransport): Deleted.
* Source/WebCore/dom/ScriptExecutionContext.h:

Canonical link: <a href="https://commits.webkit.org/304629@main">https://commits.webkit.org/304629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/991fb2ff2fc2f07b626f68b2fdaaede895152765

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143757 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fb5f885d-79f2-4b24-b761-e9436094c408) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/63c1cd41-9fb6-42f6-9793-4c1dbd44000b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121922 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84851 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/beaaba2b-d338-4c25-8017-28c785fa9ceb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3917 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4355 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146507 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8093 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6798 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112724 "Found 36 new API test failures: WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/iterator, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28619 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6179 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118222 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8141 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36285 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7933 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->