### PR TITLE
Big5 decoder doesn't recover to emit ASCII after an invalid leading byte

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js
@@ -9,10 +9,15 @@ test(() => {
   assert_equals(new TextDecoder().decode(new Uint8Array([0xF0, 0x41, 0x42])), "\uFFFDAB");
   assert_equals(new TextDecoder().decode(new Uint8Array([0xF0, 0x41, 0xF0])), "\uFFFDA\uFFFD");
   assert_equals(new TextDecoder().decode(new Uint8Array([0xF0, 0x8F, 0x92])), "\uFFFD\uFFFD\uFFFD");
+  assert_equals(new TextDecoder("Big5").decode(new Uint8Array([0x81, 0x40])), "\uFFFD@");
+  assert_equals(new TextDecoder("Big5").decode(new Uint8Array([0x81, 0x81])), "\uFFFD");
+  assert_equals(new TextDecoder("Big5").decode(new Uint8Array([0x87, 0x87, 0x40])), "\uFFFD@");
 }, "TextDecoder end-of-queue handling");
 
 test(() => {
   const decoder = new TextDecoder();
+  const big5Decoder = new TextDecoder("Big5");
+
   assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
   assert_equals(decoder.decode(), "\uFFFD");
 
@@ -55,4 +60,11 @@ test(() => {
   assert_equals(decoder.decode(new Uint8Array([0xF0]), { stream: true }), "");
   assert_equals(decoder.decode(new Uint8Array([0xC2, 0x80, 0x2A]), { stream: true }), "\uFFFD\x80*");
   assert_equals(decoder.decode(), "");
+
+  assert_equals(big5Decoder.decode(new Uint8Array([0x81, 0x40]), { stream: true }), "\uFFFD@");
+  assert_equals(big5Decoder.decode(), "");
+
+  assert_equals(big5Decoder.decode(new Uint8Array([0x81]), { stream: true }), "");
+  assert_equals(big5Decoder.decode(new Uint8Array([0x40]), { stream: true }), "\uFFFD@");
+  assert_equals(big5Decoder.decode(), "");
 }, "TextDecoder end-of-queue handling using stream: true");

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -1138,8 +1138,11 @@ String TextCodecCJK::big5Decode(std::span<const uint8_t> bytes, bool flush, bool
                 else {
                     if (auto codePoint = findFirstInSortedPairs(big5(), pointer))
                         result.append(*codePoint);
-                    else
+                    else {
+                        if (isASCII(byte))
+                            m_prependedByte = byte;
                         return SawError::Yes;
+                    }
                 }
                 return SawError::No;
             }


### PR DESCRIPTION
#### 5f7d3882def00cd53293dd709c853518f8af0705
<pre>
Big5 decoder doesn&apos;t recover to emit ASCII after an invalid leading byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=304238">https://bugs.webkit.org/show_bug.cgi?id=304238</a>
<a href="https://rdar.apple.com/166672674">rdar://166672674</a>

Reviewed by Anne van Kesteren.

* LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-eof.any.js:
Added test cases for this bug and a couple other Big5 decoding bugs that were
reported at the same time. This is probably not the ideal place for these tests,
but it&apos;s better to have them somewhere inside WPT rather than waiting to find
the perfect place. Anyone is welcome to reorganize and clean up the location of
these in WPT, I will not be offended.

* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::big5Decode): Added m_prependedByte logic to one place it
was missing.

Canonical link: <a href="https://commits.webkit.org/304591@main">https://commits.webkit.org/304591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf535695d03b3e8f8cace881a96e2ea1ece48dab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143724 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/88996 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eba397d7-1372-4ad7-a0e5-a2ac40185907) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103947 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/88996 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121895 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84825 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/079a9cc2-0058-4941-928f-40ff842d1331) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3896 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4326 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146478 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6764 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112696 "Found 36 new API test failures: WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/ignored-objects, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/extents, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/basic-hierarchy, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/action/basic, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed/focus, WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6153 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118199 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62038 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8110 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36266 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8049 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->