### PR TITLE
Have WebContextSupplement leverage AbstractRefCounted

### DIFF
--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -89,16 +89,6 @@ void WebNotificationManagerProxy::processPoolDestroyed()
     m_provider->removeNotificationManager(*this);
 }
 
-void WebNotificationManagerProxy::refWebContextSupplement()
-{
-    API::Object::ref();
-}
-
-void WebNotificationManagerProxy::derefWebContextSupplement()
-{
-    API::Object::deref();
-}
-
 HashMap<String, bool> WebNotificationManagerProxy::notificationPermissions()
 {
     return m_provider->notificationPermissions();

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -85,16 +85,15 @@ public:
     void providerDidUpdateNotificationPolicy(const API::SecurityOrigin*, bool allowed);
     void providerDidRemoveNotificationPolicies(API::Array* origins);
 
-    using API::Object::ref;
-    using API::Object::deref;
+    // WebContextSupplement.
+    void ref() const final { API::ObjectImpl<API::Object::Type::NotificationManager>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::NotificationManager>::deref(); }
 
 private:
     explicit WebNotificationManagerProxy(WebProcessPool*);
 
     // WebContextSupplement
     void processPoolDestroyed() override;
-    void refWebContextSupplement() override;
-    void derefWebContextSupplement() override;
 
     bool showImpl(WebPageProxy*, Ref<WebNotification>&&, RefPtr<WebCore::NotificationResources>&&);
 

--- a/Source/WebKit/UIProcess/WebContextSupplement.h
+++ b/Source/WebKit/UIProcess/WebContextSupplement.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebProcessPool.h"
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -33,33 +34,23 @@ namespace WebKit {
 class NetworkProcessProxy;
 class WebProcessProxy;
 
-class WebContextSupplement {
+class WebContextSupplement : public AbstractRefCounted {
 public:
-    WebContextSupplement(WebProcessPool* processPool)
+    virtual ~WebContextSupplement() = default;
+
+    virtual void processPoolDestroyed() { }
+
+    WebProcessPool* processPool() { return m_processPool.get(); }
+    RefPtr<WebProcessPool> protectedProcessPool() { return processPool(); }
+    void clearProcessPool() { m_processPool = nullptr; }
+
+protected:
+    explicit WebContextSupplement(WebProcessPool* processPool)
         : m_processPool(processPool)
     {
     }
 
-    virtual ~WebContextSupplement()
-    {
-    }
-
-    virtual void processPoolDestroyed()
-    {
-    }
-
-    WebProcessPool* processPool() { return m_processPool.get(); }
-    RefPtr<WebProcessPool> protectedProcessPool() { return processPool(); }
-
-    void clearProcessPool() { m_processPool = nullptr; }
-
-    void ref() { refWebContextSupplement(); }
-    void deref() { derefWebContextSupplement(); }
-
 private:
-    virtual void refWebContextSupplement() = 0;
-    virtual void derefWebContextSupplement() = 0;
-
     WeakPtr<WebProcessPool> m_processPool;
 };
 

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -91,16 +91,6 @@ std::optional<SharedPreferencesForWebProcess> WebGeolocationManagerProxy::shared
     return WebProcessProxy::fromConnection(connection)->sharedPreferencesForWebProcess();
 }
 
-void WebGeolocationManagerProxy::refWebContextSupplement()
-{
-    API::Object::ref();
-}
-
-void WebGeolocationManagerProxy::derefWebContextSupplement()
-{
-    API::Object::deref();
-}
-
 void WebGeolocationManagerProxy::providerDidChangePosition(WebGeolocationPosition* position)
 {
     for (auto& [registrableDomain, perDomainData] : m_perDomainData) {

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -60,6 +60,7 @@ public:
     static Ref<WebGeolocationManagerProxy> create(WebProcessPool*);
     ~WebGeolocationManagerProxy();
 
+    // WebContextSupplement, IPC::MessageReceiver.
     void ref() const final { API::ObjectImpl<API::Object::Type::GeolocationManager>::ref(); }
     void deref() const final { API::ObjectImpl<API::Object::Type::GeolocationManager>::deref(); }
 
@@ -71,9 +72,6 @@ public:
     void resetPermissions();
 #endif
 
-    using API::Object::ref;
-    using API::Object::deref;
-
     void webProcessIsGoingAway(WebProcessProxy&);
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
 
@@ -82,8 +80,6 @@ private:
 
     // WebContextSupplement
     void processPoolDestroyed() override;
-    void refWebContextSupplement() override;
-    void derefWebContextSupplement() override;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;


### PR DESCRIPTION
#### d0c1e4142053b27876b98d69677e265cdd063018
<pre>
Have WebContextSupplement leverage AbstractRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=304320">https://bugs.webkit.org/show_bug.cgi?id=304320</a>

Reviewed by Geoffrey Garen.

Have WebContextSupplement leverage AbstractRefCounted to simplify the
code a bit.

* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::refWebContextSupplement): Deleted.
(WebKit::WebNotificationManagerProxy::derefWebContextSupplement): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/WebContextSupplement.h:
(WebKit::WebContextSupplement::processPoolDestroyed):
(WebKit::WebContextSupplement::protectedProcessPool):
(WebKit::WebContextSupplement::WebContextSupplement):
(WebKit::WebContextSupplement::~WebContextSupplement): Deleted.
(WebKit::WebContextSupplement::ref): Deleted.
(WebKit::WebContextSupplement::deref): Deleted.
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::refWebContextSupplement): Deleted.
(WebKit::WebGeolocationManagerProxy::derefWebContextSupplement): Deleted.
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/304654@main">https://commits.webkit.org/304654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f8f5b919b1302f65b19c07e00e419abccdde1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143880 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104117 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b8ce7fab-1d22-4076-aa4e-bd73493ac737) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84950 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85950bc0-89f1-418e-8ba3-2b31ad57307e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4015 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4475 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115645 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112801 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6275 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118327 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8259 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36386 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8198 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8051 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->