### PR TITLE
REGRESSION(303533@main): Caused webrtc/vp9-profile2.html to time out

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -409,12 +409,12 @@ static void clampDimension(WebGPU::Extent3D& extent3D, size_t dimension, WebGPU:
     });
 }
 
-static void getImageBytesFromVideoFrame(const RefPtr<VideoFrame>& videoFrame, WebGPU::Extent3D& backingCopySize, NOESCAPE const ImageDataCallback& callback)
+static void getImageBytesFromVideoFrame(WebGPU::Queue& backing, const RefPtr<VideoFrame>& videoFrame, WebGPU::Extent3D& backingCopySize, NOESCAPE const ImageDataCallback& callback)
 {
     if (!videoFrame.get())
         return callback({ }, 0, 0);
 
-    RefPtr nativeImage = videoFrame->copyNativeImage();
+    RefPtr<NativeImage> nativeImage = backing.getNativeImage(*videoFrame.get());
     if (!nativeImage)
         return callback({ }, 0, 0);
 
@@ -627,14 +627,14 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
         if (RefPtr player = videoElement ? videoElement->player() : nullptr; player && player->isVideoPlayer())
-            return getImageBytesFromVideoFrame(player->videoFrameForCurrentTime(), backingCopySize, callback);
+            return getImageBytesFromVideoFrame(backing, player->videoFrameForCurrentTime(), backingCopySize, callback);
 #else
         UNUSED_PARAM(videoElement);
 #endif
         return callback({ }, 0, 0);
     }, [&](const RefPtr<WebCodecsVideoFrame> webCodecsFrame) -> ResultType {
 #if PLATFORM(COCOA)
-        return getImageBytesFromVideoFrame(webCodecsFrame->internalFrame(), backingCopySize, callback);
+        return getImageBytesFromVideoFrame(backing, webCodecsFrame->internalFrame(), backingCopySize, callback);
 #else
         UNUSED_PARAM(webCodecsFrame);
         return callback({ }, 0, 0);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -142,6 +142,11 @@ void QueueImpl::setLabelInternal(const String& label)
     wgpuQueueSetLabel(m_backing.get(), label.utf8().data());
 }
 
+RefPtr<WebCore::NativeImage> QueueImpl::getNativeImage(WebCore::VideoFrame&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebCore::WebGPU
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -95,6 +95,7 @@ private:
         const Extent3D& copySize) final;
 
     void setLabelInternal(const String&) final;
+    RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;
 
     WebGPUPtr<WGPUQueue> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -98,6 +98,7 @@ public:
         const ImageCopyTextureTagged& destination,
         const Extent3D& copySize) = 0;
 
+    virtual RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) = 0;
     virtual bool isRemoteQueueProxy() const { return false; }
 
 protected:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3427,7 +3427,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
     }
 
     // Fallback pure SW path.
-    RefPtr image = BitmapImage::create(internalFrame->copyNativeImage());
+    auto image = context->videoFrameToImage(*internalFrame);
     if (!image)
         return { };
 

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -71,6 +71,10 @@ public:
     static void addMockMediaSourceEngine();
 #endif
 
+#if ENABLE(VIDEO)
+    virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
+#endif
+
     virtual bool enableWebMMediaPlayer() const { return true; }
     virtual bool isWebMediaStrategy() const { return false; }
 
@@ -80,5 +84,12 @@ protected:
     bool m_mockMediaSourceEnabled { false };
     WTF::BitSet<16> m_remoteRenderersEnabled;
 };
+
+#if ENABLE(VIDEO)
+inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -112,6 +112,10 @@ void VideoFrame::copyTo(std::span<uint8_t>, VideoPixelFormat, Vector<ComputedPla
     callback({ });
 }
 
+void VideoFrame::draw(GraphicsContext&, const FloatRect&, ImageOrientation, bool)
+{
+    // FIXME: Add support.
+}
 #endif // !PLATFORM(COCOA)
 
 }

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -102,7 +102,6 @@ public:
 
     virtual IntSize presentationSize() const = 0;
     virtual uint32_t pixelFormat() const = 0;
-    virtual RefPtr<NativeImage> copyNativeImage() const = 0;
 
     virtual bool isRemoteProxy() const { return false; }
     virtual bool isLibWebRTC() const { return false; }
@@ -117,6 +116,8 @@ public:
     WEBCORE_EXPORT virtual void setOwnershipIdentity(const ProcessIdentity&) { }
 
     void initializeCharacteristics(MediaTime presentationTime, bool isMirrored, Rotation);
+
+    void draw(GraphicsContext&, const FloatRect&, ImageOrientation, bool shouldDiscardAlpha);
 
     const PlatformVideoColorSpace& colorSpace() const { return m_colorSpace; }
 

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -450,7 +450,7 @@ ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const Fl
 }
 
 #if ENABLE(VIDEO)
-void BifurcatedGraphicsContext::drawVideoFrame(const VideoFrame& videoFrame, const FloatRect& destination, WebCore::ImageOrientation orientation, bool shouldDiscardAlpha)
+void BifurcatedGraphicsContext::drawVideoFrame(VideoFrame& videoFrame, const FloatRect& destination, WebCore::ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     m_primaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);
     m_secondaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -115,7 +115,7 @@ public:
     void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 
 #if ENABLE(VIDEO)
-    void drawVideoFrame(const VideoFrame&, const FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(VideoFrame&, const FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
 
     using GraphicsContext::scale;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -440,16 +440,9 @@ void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect&
 }
 
 #if ENABLE(VIDEO)
-void GraphicsContext::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void GraphicsContext::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
-    RefPtr image = frame.copyNativeImage();
-    if (!image)
-        return;
-    IntSize size = image->size();
-    if (orientation.usesWidthAsHeight())
-        size = size.transposedSize();
-    auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
-    drawNativeImage(*image, destination, { { }, size }, { compositeOperator, orientation });
+    frame.draw(*this, destination, orientation, shouldDiscardAlpha);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -289,7 +289,7 @@ public:
     WEBCORE_EXPORT virtual void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&);
 
 #if ENABLE(VIDEO)
-    WEBCORE_EXPORT virtual void drawVideoFrame(const VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha);
+    WEBCORE_EXPORT virtual void drawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha);
 #endif
 
     // Clipping

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -645,6 +645,18 @@ void GraphicsContextGL::forceContextLost()
         m_client->forceContextLost();
 }
 
+#if ENABLE(VIDEO)
+RefPtr<Image> GraphicsContextGL::videoFrameToImage(VideoFrame& frame)
+{
+    IntSize size { static_cast<int>(frame.presentationSize().width()), static_cast<int>(frame.presentationSize().height()) };
+    auto imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    if (!imageBuffer)
+        return { };
+    imageBuffer->context().drawVideoFrame(frame, { { }, size }, ImageOrientation::Orientation::None, true);
+    return BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTFMove(imageBuffer)));
+}
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1673,6 +1673,7 @@ public:
 
 #if ENABLE(VIDEO)
     virtual bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum  format, GCGLenum type, bool premultiplyAlpha, bool flipY) = 0;
+    WEBCORE_EXPORT virtual RefPtr<Image> videoFrameToImage(VideoFrame&);
 #endif
 
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -139,7 +139,7 @@ private:
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final { }
 
 #if ENABLE(VIDEO)
-    void drawVideoFrame(const VideoFrame&, const FloatRect&, ImageOrientation, bool) final { }
+    void drawVideoFrame(VideoFrame&, const FloatRect&, ImageOrientation, bool) final { }
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -1182,7 +1182,7 @@ void OperationRecorder::append(std::unique_ptr<PaintingOperation>&& command)
 }
 
 #if ENABLE(VIDEO)
-void OperationRecorder::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void OperationRecorder::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     // FIXME: Not implemented.
     GraphicsContext::drawVideoFrame(frame, destination, orientation, shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -104,7 +104,7 @@ private:
     WebCore::IntRect clipBounds() const override;
     void clipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect&) override;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(const WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
+    void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
 #endif
 
     void applyDeviceScaleFactor(float) override;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -50,7 +50,6 @@ public:
     // VideoFrame overrides.
     WEBCORE_EXPORT WebCore::IntSize presentationSize() const final;
     WEBCORE_EXPORT uint32_t pixelFormat() const final;
-    WEBCORE_EXPORT RefPtr<NativeImage> copyNativeImage() const final;
     WEBCORE_EXPORT void setOwnershipIdentity(const ProcessIdentity&) final;
     bool isCV() const final { return true; }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -373,7 +373,7 @@ void RecorderImpl::fillEllipse(const FloatRect& rect)
 }
 
 #if ENABLE(VIDEO)
-void RecorderImpl::drawVideoFrame(const VideoFrame&, const FloatRect&, ImageOrientation, bool)
+void RecorderImpl::drawVideoFrame(VideoFrame&, const FloatRect&, ImageOrientation, bool)
 {
     appendStateChangeItemIfNecessary();
     // FIXME: TODO

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -97,7 +97,7 @@ public:
     void drawGlyphsImmediate(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void drawDisplayList(const DisplayList&, ControlFactory&) final;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(const VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(VideoFrame&, const FloatRect& destination, ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
     void strokeRect(const FloatRect&, float) final;
     void strokeEllipse(const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4135,8 +4135,8 @@ void MediaPlayerPrivateGStreamer::paint(GraphicsContext& context, const FloatRec
     if (!presentationSize)
         return;
 
-    Ref frame = VideoFrameGStreamer::create(WTFMove(sample), { IntSize(*presentationSize), { *m_videoInfo } });
-    context.drawVideoFrame(frame, rect, m_videoSourceOrientation, false);
+    auto frame = VideoFrameGStreamer::create(WTFMove(sample), { IntSize(*presentationSize), { *m_videoInfo } });
+    frame->draw(context, rect, m_videoSourceOrientation, false);
 }
 
 DestinationColorSpace MediaPlayerPrivateGStreamer::colorSpace()

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -30,7 +30,6 @@
 #include "GStreamerCommon.h"
 #include "GStreamerVideoFrameConverter.h"
 #include "GraphicsContext.h"
-#include "ImageBuffer.h"
 #include "ImageGStreamer.h"
 #include "ImageOrientation.h"
 #include "PixelBuffer.h"
@@ -469,8 +468,6 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
     initializeCharacteristics(options.presentationTime, isMirrored, videoRotationFromMeta);
 }
 
-VideoFrameGStreamer::~VideoFrameGStreamer() = default;
-
 void VideoFrameGStreamer::setFrameRate(double frameRate)
 {
     auto caps = adoptGRef(gst_caps_copy(gst_sample_get_caps(m_sample.get())));
@@ -627,13 +624,21 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
     callback({ });
 }
 
-RefPtr<NativeImage> VideoFrameGStreamer::copyNativeImage() const
+void VideoFrame::draw(GraphicsContext& context, const FloatRect& destination, ImageOrientation destinationImageOrientation, bool shouldDiscardAlpha)
 {
     auto& gstFrame = downcast<VideoFrameGStreamer>(*this);
     auto image = convertSampleToImage(gstFrame.sample(), gstFrame.info());
     if (!image)
-        return nullptr;
-    return NativeImage::create(image->image());
+        return;
+
+    auto imageRect = image->rect();
+    auto source = destinationImageOrientation.usesWidthAsHeight() ? FloatRect(imageRect.location(), imageRect.size().transposedSize()) : imageRect;
+    auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
+    auto platformImage = image->image();
+    auto bitmapImage = BitmapImage::create(WTFMove(platformImage));
+    if (!bitmapImage)
+        return;
+    context.drawImage(*bitmapImage.get(), destination, source, { compositeOperator, destinationImageOrientation });
 }
 
 GRefPtr<GstSample> VideoFrameGStreamer::resizedSample(const IntSize& destinationSize)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -66,7 +66,6 @@ public:
     static Ref<VideoFrameGStreamer> createWrappedSample(const GRefPtr<GstSample>&, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation videoRotation = Rotation::None);
 
     static RefPtr<VideoFrameGStreamer> createFromPixelBuffer(Ref<PixelBuffer>&&, const IntSize& destinationSize, double frameRate, const CreateOptions&, PlatformVideoColorSpace&& = { });
-    ~VideoFrameGStreamer();
 
     void setFrameRate(double);
     void setMaxFrameRate(double);
@@ -86,7 +85,6 @@ public:
 
     IntSize presentationSize() const final { return m_presentationSize; }
     uint32_t pixelFormat() const final { return GST_VIDEO_INFO_FORMAT(&m_info.info); }
-    RefPtr<NativeImage> copyNativeImage() const final;
 
     enum class MemoryType : uint8_t {
         Unsupported,

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -29,9 +29,6 @@
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
 
 #include "LibWebRTCRefWrappers.h"
-#include "NativeImage.h"
-#include "PixelBufferConformerCV.h"
-
 #include "CoreVideoSoftLink.h"
 #include <pal/cf/CoreMediaSoftLink.h>
 
@@ -79,18 +76,10 @@ VideoFrameLibWebRTC::VideoFrameLibWebRTC(MediaTime presentationTime, bool isMirr
 
 CVPixelBufferRef VideoFrameLibWebRTC::pixelBuffer() const
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=302866 VideoFrameLibWebRTC should construct its CVPixelBuffer from the LibWebRTC buffer.
     Locker locker { m_pixelBufferLock };
     if (!m_pixelBuffer && m_conversionCallback)
         m_pixelBuffer = std::exchange(m_conversionCallback, { })(m_buffer.get());
     return m_pixelBuffer.get();
-}
-
-RefPtr<NativeImage> VideoFrameLibWebRTC::copyNativeImage() const
-{
-    // FIXME: It is not efficient to create a conformer everytime. We might want to make it more efficient, for instance by storing it in GraphicsContext.
-    auto conformer = makeUnique<PixelBufferConformerCV>(kCVPixelFormatType_32BGRA);
-    return NativeImage::create(conformer->createImageFromPixelBuffer(protectedPixelBuffer().get()));
 }
 
 Ref<VideoFrame> VideoFrameLibWebRTC::clone()

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -56,7 +56,6 @@ private:
     IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final { return m_videoPixelFormat; }
     CVPixelBufferRef pixelBuffer() const final;
-    RefPtr<NativeImage> copyNativeImage() const final;
 
     Ref<VideoFrame> clone() final;
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -157,14 +157,11 @@ std::optional<audit_token_t> GPUProcessConnection::auditToken()
 }
 #endif
 
-RemoteSharedResourceCacheProxy& GPUProcessConnection::sharedResourceCache()
+Ref<RemoteSharedResourceCacheProxy> GPUProcessConnection::sharedResourceCache()
 {
-    return WebProcess::singleton().gpuProcessSharedResourceCache();
-}
-
-Ref<RemoteSharedResourceCacheProxy> GPUProcessConnection::protectedSharedResourceCache()
-{
-    return sharedResourceCache();
+    if (!m_sharedResourceCache)
+        m_sharedResourceCache = RemoteSharedResourceCacheProxy::create();
+    return *m_sharedResourceCache;
 }
 
 void GPUProcessConnection::invalidate()
@@ -218,7 +215,9 @@ void GPUProcessConnection::resetAudioMediaStreamTrackRendererInternalUnit(AudioM
 #if ENABLE(VIDEO)
 RemoteVideoFrameObjectHeapProxy& GPUProcessConnection::videoFrameObjectHeapProxy()
 {
-    return protectedSharedResourceCache()->videoFrameObjectHeapProxy();
+    if (!m_videoFrameObjectHeapProxy)
+        m_videoFrameObjectHeapProxy = RemoteVideoFrameObjectHeapProxy::create(*this);
+    return *m_videoFrameObjectHeapProxy;
 }
 
 Ref<RemoteVideoFrameObjectHeapProxy> GPUProcessConnection::protectedVideoFrameObjectHeapProxy()

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -88,8 +88,7 @@ public:
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> auditToken();
 #endif
-    RemoteSharedResourceCacheProxy& sharedResourceCache();
-    Ref<RemoteSharedResourceCacheProxy> protectedSharedResourceCache();
+    Ref<RemoteSharedResourceCacheProxy> sharedResourceCache();
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager();
     Ref<SampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager();
@@ -166,11 +165,15 @@ private:
     IPC::MessageReceiverMap m_messageReceiverMap;
     GPUProcessConnectionIdentifier m_identifier { GPUProcessConnectionIdentifier::generate() };
     bool m_hasInitialized { false };
+    RefPtr<RemoteSharedResourceCacheProxy> m_sharedResourceCache;
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> m_auditToken;
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     const std::unique_ptr<SampleBufferDisplayLayerManager> m_sampleBufferDisplayLayerManager;
+#endif
+#if ENABLE(VIDEO)
+    RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #endif
 #if PLATFORM(COCOA) && ENABLE(WEB_AUDIO)
     RefPtr<RemoteAudioSourceProviderManager> m_audioSourceProviderManager;

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp
@@ -29,10 +29,6 @@
 #include "RemoteSharedResourceCacheProxy.h"
 #include <wtf/TZoneMallocInlines.h>
 
-#if ENABLE(VIDEO)
-#include "RemoteVideoFrameObjectHeapProxy.h"
-#endif
-
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSharedResourceCacheProxy);
@@ -45,32 +41,6 @@ Ref<RemoteSharedResourceCacheProxy> RemoteSharedResourceCacheProxy::create()
 RemoteSharedResourceCacheProxy::RemoteSharedResourceCacheProxy() = default;
 
 RemoteSharedResourceCacheProxy::~RemoteSharedResourceCacheProxy() = default;
-
-void RemoteSharedResourceCacheProxy::gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection& gpuProcessConnection)
-{
-    UNUSED_PARAM(gpuProcessConnection);
-#if ENABLE(VIDEO)
-    if (RefPtr proxy = m_videoFrameObjectHeapProxy)
-        proxy->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
-#endif
-}
-
-#if ENABLE(VIDEO)
-RemoteVideoFrameObjectHeapProxy& RemoteSharedResourceCacheProxy::videoFrameObjectHeapProxy()
-{
-    if (!m_videoFrameObjectHeapProxy) {
-        lazyInitialize(m_videoFrameObjectHeapProxy, RemoteVideoFrameObjectHeapProxy::create());
-        if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
-            m_videoFrameObjectHeapProxy->gpuProcessConnectionDidBecomeAvailable(*gpuProcessConnection);
-    }
-    return *m_videoFrameObjectHeapProxy;
-}
-
-Ref<RemoteVideoFrameObjectHeapProxy> RemoteSharedResourceCacheProxy::protectedVideoFrameObjectHeapProxy()
-{
-    return videoFrameObjectHeapProxy();
-}
-#endif
 
 }
 

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
@@ -32,7 +32,6 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
-class RemoteVideoFrameObjectHeapProxy;
 
 // Class for maintaining view of GPU process RemoteSharedResourceCache state in Web process.
 // Thread-safe.
@@ -42,18 +41,8 @@ public:
     static Ref<RemoteSharedResourceCacheProxy> create();
     virtual ~RemoteSharedResourceCacheProxy();
 
-#if ENABLE(VIDEO)
-    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy();
-    Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy();
-#endif
-
-    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
-
 private:
     RemoteSharedResourceCacheProxy();
-#if ENABLE(VIDEO)
-    const RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
-#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -255,6 +255,21 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
 #endif
 }
 
+RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFrame& frame)
+{
+    if (isContextLost())
+        return { };
+
+#if PLATFORM(COCOA)
+    RefPtr<NativeImage> nativeImage;
+    callOnMainRunLoopAndWait([&] {
+        nativeImage = protectedVideoFrameObjectHeapProxy()->getNativeImage(frame);
+    });
+    return BitmapImage::create(WTFMove(nativeImage));
+#else
+    return GraphicsContextGL::videoFrameToImage(frame);
+#endif
+}
 #endif
 
 GCGLErrorCodeSet RemoteGraphicsContextGLProxy::getErrors()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -86,6 +86,7 @@ public:
     GCGLErrorCodeSet getErrors() final;
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(WebCore::VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type , bool premultiplyAlpha, bool flipY) final;
+    RefPtr<WebCore::Image> videoFrameToImage(WebCore::VideoFrame&) final;
 #endif
 
     void simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -516,7 +516,7 @@ void RemoteGraphicsContextProxy::fillEllipse(const FloatRect& rect)
 }
 
 #if ENABLE(VIDEO)
-void RemoteGraphicsContextProxy::drawVideoFrame(const VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
+void RemoteGraphicsContextProxy::drawVideoFrame(VideoFrame& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
     appendStateChangeItemIfNecessary();
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -125,7 +125,7 @@ private:
     void fillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&) final;
     void fillEllipse(const WebCore::FloatRect&) final;
 #if ENABLE(VIDEO)
-    void drawVideoFrame(const WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
+    void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& distination, WebCore::ImageOrientation, bool shouldDiscardAlpha) final;
 #endif
     void strokePath(const WebCore::Path&) final;
     void strokeRect(const WebCore::FloatRect&, float) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -33,6 +33,7 @@
 #include "WebGPUConvertToBackingContext.h"
 #include "WebProcess.h"
 #include <WebCore/NativeImage.h>
+#include <WebCore/WebCodecsVideoFrame.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
@@ -44,6 +45,14 @@ RemoteQueueProxy::RemoteQueueProxy(RemoteAdapterProxy& parent, ConvertToBackingC
     , m_convertToBackingContext(convertToBackingContext)
     , m_parent(parent)
 {
+#if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
+    RefPtr<RemoteVideoFrameObjectHeapProxy> videoFrameObjectHeapProxy;
+    callOnMainRunLoopAndWait([&videoFrameObjectHeapProxy] {
+        videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
+    });
+
+    m_videoFrameObjectHeapProxy = videoFrameObjectHeapProxy;
+#endif
 }
 
 RemoteQueueProxy::~RemoteQueueProxy()
@@ -161,6 +170,25 @@ void RemoteQueueProxy::setLabelInternal(const String& label)
     auto sendResult = send(Messages::RemoteQueue::SetLabel(label));
     UNUSED_VARIABLE(sendResult);
 }
+
+RefPtr<WebCore::NativeImage> RemoteQueueProxy::getNativeImage(WebCore::VideoFrame& videoFrame)
+{
+    RefPtr<WebCore::NativeImage> nativeImage;
+#if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
+    callOnMainRunLoopAndWait([&nativeImage, videoFrame = Ref { videoFrame }, videoFrameHeap = protectedVideoFrameObjectHeapProxy()] {
+        nativeImage = videoFrameHeap->getNativeImage(videoFrame);
+    });
+#endif
+    return nativeImage;
+}
+
+#if ENABLE(VIDEO)
+RefPtr<RemoteVideoFrameObjectHeapProxy> RemoteQueueProxy::protectedVideoFrameObjectHeapProxy() const
+{
+    return m_videoFrameObjectHeapProxy;
+}
+#endif
+
 
 } // namespace WebKit::WebGPU
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteAdapterProxy.h"
+#include "RemoteVideoFrameObjectHeapProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUQueue.h>
 #include <wtf/TZoneMalloc.h>
@@ -109,10 +110,17 @@ private:
         const WebCore::WebGPU::Extent3D& copySize) final;
 
     void setLabelInternal(const String&) final;
+#if ENABLE(VIDEO)
+    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const;
+#endif
+    RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;
 
     WebGPUIdentifier m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
     const Ref<RemoteAdapterProxy> m_parent;
+#if ENABLE(VIDEO)
+    RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
+#endif
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -295,8 +295,18 @@ void AudioVideoRendererRemote::paintCurrentVideoFrameInContext(GraphicsContext& 
 
 RefPtr<NativeImage> AudioVideoRendererRemote::currentNativeImage() const
 {
+#if PLATFORM(COCOA)
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     RefPtr videoFrame = currentVideoFrame();
-    return videoFrame ? videoFrame->copyNativeImage() : nullptr;
+    if (!videoFrame)
+        return nullptr;
+    ASSERT(gpuProcessConnection);
+
+    return gpuProcessConnection->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
+#else
+    ASSERT_NOT_REACHED();
+    return nullptr;
+#endif
 }
 
 std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererRemote::videoPlaybackQualityMetrics()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -39,8 +39,6 @@
 #include <WebCore/VideoFrameCV.h>
 #include <wtf/MainThread.h>
 #include <wtf/threads/BinarySemaphore.h>
-#else
-#include <WebCore/ImageBuffer.h>
 #endif
 
 namespace WebKit {
@@ -81,7 +79,7 @@ RemoteVideoFrameProxy::RemoteVideoFrameProxy(IPC::Connection& connection, Remote
     , m_referenceTracker(properties.reference)
     , m_size(properties.size)
     , m_pixelFormat(properties.pixelFormat)
-    , m_videoFrameObjectHeapProxy(videoFrameObjectHeapProxy)
+    , m_videoFrameObjectHeapProxy(&videoFrameObjectHeapProxy)
 {
 }
 
@@ -90,7 +88,6 @@ RemoteVideoFrameProxy::RemoteVideoFrameProxy(CloneConstructor, RemoteVideoFrameP
     , m_baseVideoFrame(&baseVideoFrame)
     , m_size(baseVideoFrame.m_size)
     , m_pixelFormat(baseVideoFrame.m_pixelFormat)
-    , m_videoFrameObjectHeapProxy(baseVideoFrame.m_videoFrameObjectHeapProxy)
 {
 }
 
@@ -115,17 +112,6 @@ uint32_t RemoteVideoFrameProxy::pixelFormat() const
     return m_pixelFormat;
 }
 
-RefPtr<WebCore::NativeImage> RemoteVideoFrameProxy::copyNativeImage() const
-{
-    // FIXME: This will change in the future to create GPUP side reference.
-#if PLATFORM(COCOA)
-    Ref frame = m_baseVideoFrame ? *m_baseVideoFrame : const_cast<RemoteVideoFrameProxy&>(*this);
-    return m_videoFrameObjectHeapProxy->getNativeImage(frame.get());
-#else
-    return nullptr;
-#endif
-}
-
 #if PLATFORM(COCOA)
 CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
 {
@@ -133,13 +119,15 @@ CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
         return m_baseVideoFrame->pixelBuffer();
 
     Locker lock(m_pixelBufferLock);
-    if (!m_pixelBuffer) {
+    if (!m_pixelBuffer && m_videoFrameObjectHeapProxy) {
+        auto videoFrameObjectHeapProxy = std::exchange(m_videoFrameObjectHeapProxy, nullptr);
+
         bool canSendSync = isMainRunLoop(); // FIXME: we should be able to sendSync from other threads too.
         bool canUseIOSurface = !WebProcess::singleton().shouldUseRemoteRenderingForWebGL();
         if (!canUseIOSurface || !canSendSync) {
             Ref protectedThis { *this };
             BinarySemaphore semaphore;
-            m_videoFrameObjectHeapProxy->getVideoFrameBuffer(*this, canUseIOSurface, [&protectedThis, &semaphore](auto pixelBuffer) {
+            videoFrameObjectHeapProxy->getVideoFrameBuffer(*this, canUseIOSurface, [&protectedThis, &semaphore](auto pixelBuffer) {
                 protectedThis->m_pixelBuffer = WTFMove(pixelBuffer);
                 semaphore.signal();
             });

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -70,7 +70,6 @@ public:
     // WebCore::VideoFrame overrides.
     WebCore::IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final;
-    RefPtr<WebCore::NativeImage> copyNativeImage() const final;
     bool isRemoteProxy() const final { return true; }
 #if PLATFORM(COCOA)
     CVPixelBufferRef pixelBuffer() const final;
@@ -91,7 +90,8 @@ private:
     std::optional<RemoteVideoFrameReferenceTracker> m_referenceTracker;
     const WebCore::IntSize m_size;
     uint32_t m_pixelFormat { 0 };
-    const Ref<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
+    // FIXME: Remove this.
+    mutable RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #if PLATFORM(COCOA)
     mutable Lock m_pixelBufferLock;
     mutable RetainPtr<CVPixelBufferRef> m_pixelBuffer;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -141,4 +141,12 @@ void WebMediaStrategy::enableMockMediaSource()
 }
 #endif
 
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
+{
+    // FIMXE: Move out of sync IPC.
+    completionHandler(WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -54,6 +54,9 @@ private:
 #if ENABLE(MEDIA_SOURCE)
     void enableMockMediaSource() final;
 #endif
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    void nativeImageFromVideoFrame(const WebCore::VideoFrame&, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&&) final;
+#endif
 
 #if ENABLE(GPU_PROCESS)
     std::atomic<bool> m_useGPUProcess { false };

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -64,7 +64,10 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
         return { };
 
     RefPtr videoFrame = videoFrameForCurrentTime();
-    return videoFrame ? videoFrame->copyNativeImage() : nullptr;
+    if (!videoFrame)
+        return nullptr;
+
+    return WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -46,18 +46,17 @@ class RemoteVideoFrameProxy;
 // Wrapper around RemoteVideoFrameObjectHeapProxyProcessor that will always be destroyed on main thread.
 class RemoteVideoFrameObjectHeapProxy : public ThreadSafeRefCounted<RemoteVideoFrameObjectHeapProxy, WTF::DestructionThread::MainRunLoop> {
 public:
-    static Ref<RemoteVideoFrameObjectHeapProxy> create() { return adoptRef(*new RemoteVideoFrameObjectHeapProxy()); }
+    static Ref<RemoteVideoFrameObjectHeapProxy> create(GPUProcessConnection& connection) { return adoptRef(*new RemoteVideoFrameObjectHeapProxy(connection)); }
 
-    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
 #if PLATFORM(COCOA)
     void getVideoFrameBuffer(const RemoteVideoFrameProxy& proxy, bool canUseIOSurface, RemoteVideoFrameObjectHeapProxyProcessor::Callback&& callback) { m_processor->getVideoFrameBuffer(proxy, canUseIOSurface, WTFMove(callback)); }
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame& frame) { return m_processor->getNativeImage(frame); }
 #endif
 
 private:
-    explicit RemoteVideoFrameObjectHeapProxy()
+    explicit RemoteVideoFrameObjectHeapProxy(GPUProcessConnection& connection)
 #if PLATFORM(COCOA)
-        : m_processor(RemoteVideoFrameObjectHeapProxyProcessor::create())
+        : m_processor(RemoteVideoFrameObjectHeapProxyProcessor::create(connection))
 #endif
     {
     }
@@ -65,14 +64,6 @@ private:
     const Ref<RemoteVideoFrameObjectHeapProxyProcessor> m_processor;
 #endif
 };
-
-inline void RemoteVideoFrameObjectHeapProxy::gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection& gpuProcessConnection)
-{
-    UNUSED_PARAM(gpuProcessConnection);
-#if PLATFORM(COCOA)
-    m_processor->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
-#endif
-}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -57,9 +57,8 @@ class RemoteVideoFrameProxy;
 
 class RemoteVideoFrameObjectHeapProxyProcessor : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>, public GPUProcessConnection::Client {
 public:
-    static Ref<RemoteVideoFrameObjectHeapProxyProcessor> create();
+    static Ref<RemoteVideoFrameObjectHeapProxyProcessor> create(GPUProcessConnection&);
     ~RemoteVideoFrameObjectHeapProxyProcessor();
-    void gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection&);
 
     using Callback = Function<void(RetainPtr<CVPixelBufferRef>&&)>;
     void getVideoFrameBuffer(const RemoteVideoFrameProxy&, bool canUseIOSurfce, Callback&&);
@@ -72,8 +71,8 @@ public:
     void deref() const final { IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::deref(); }
 
 private:
-    explicit RemoteVideoFrameObjectHeapProxyProcessor();
-    RefPtr<IPC::Connection> connection();
+    explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);
+    void initialize();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -47,7 +47,6 @@
 #include "RemoteMediaEngineConfigurationFactory.h"
 #include "RemoteMediaSessionManagerProxyMessages.h"
 #include "RemoteRemoteCommandListener.h"
-#include "RemoteSharedResourceCacheProxy.h"
 #include "RemoteWebLockRegistry.h"
 #include "RemoteWorkerType.h"
 #include "SpeechRecognitionRealtimeMediaSourceManager.h"
@@ -1548,13 +1547,10 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
         if (gpuConnection->ignoreInvalidMessageForTesting())
             gpuConnection->setIgnoreInvalidMessageForTesting();
 #endif
-        Ref gpuProcessConnection = GPUProcessConnection::create(WTFMove(gpuConnection));
-        m_gpuProcessConnection = gpuProcessConnection.ptr();
+        m_gpuProcessConnection = GPUProcessConnection::create(WTFMove(gpuConnection));
         protectedParentProcessConnection()->send(Messages::WebProcessProxy::CreateGPUProcessConnection(m_gpuProcessConnection->identifier(),  WTFMove(connectionIdentifiers->client)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
         for (auto& page : m_pageMap.values())
-            page->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
-        if (m_sharedResourceCache)
-            Ref { *m_sharedResourceCache }->gpuProcessConnectionDidBecomeAvailable(gpuProcessConnection);
+            page->gpuProcessConnectionDidBecomeAvailable(Ref { *m_gpuProcessConnection });
     }
     return *m_gpuProcessConnection;
 }
@@ -1613,15 +1609,6 @@ AudioMediaStreamTrackRendererInternalUnitManager& WebProcess::audioMediaStreamTr
 }
 #endif
 
-RemoteSharedResourceCacheProxy& WebProcess::gpuProcessSharedResourceCache()
-{
-    if (!m_sharedResourceCache) {
-        m_sharedResourceCache = RemoteSharedResourceCacheProxy::create();
-        if (m_gpuProcessConnection)
-            Ref { *m_sharedResourceCache }->gpuProcessConnectionDidBecomeAvailable(Ref { *m_gpuProcessConnection });
-    }
-    return *m_sharedResourceCache;
-}
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -145,7 +145,6 @@ class RemoteImageDecoderAVFManager;
 class RemoteLegacyCDMFactory;
 class RemoteMediaEngineConfigurationFactory;
 class RemoteMediaPlayerManager;
-class RemoteSharedResourceCacheProxy;
 class StorageAreaMap;
 class UserData;
 class WebAutomationSessionProxy;
@@ -341,7 +340,6 @@ public:
     Ref<RemoteCDMFactory> protectedCDMFactory();
 #endif
     RemoteMediaEngineConfigurationFactory& mediaEngineConfigurationFactory();
-    RemoteSharedResourceCacheProxy& gpuProcessSharedResourceCache();
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS)
@@ -845,7 +843,6 @@ private:
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     std::unique_ptr<AudioMediaStreamTrackRendererInternalUnitManager> m_audioMediaStreamTrackRendererInternalUnitManager;
 #endif
-    RefPtr<RemoteSharedResourceCacheProxy> m_sharedResourceCache;
 #endif
 
 #if ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### 96976b9fef469b3cfe97ac105ec2773a342fc21d
<pre>
REGRESSION(303533@main): Caused webrtc/vp9-profile2.html to time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=303325">https://bugs.webkit.org/show_bug.cgi?id=303325</a>
<a href="https://rdar.apple.com/165628091">rdar://165628091</a>

Reviewed by Youenn Fablet.

Revert 303533@main &quot;Add a common way to get NativeImage from a
VideoFrame (VideoFrame::copyNativeImage())&quot;&quot;.
Will be re-landed when the timeout is solved.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromVideoFrame):
(WebCore::imageBytesForSource):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::getNativeImage):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::createImageBitmapViaDrawing):
(WebCore::createImageBitmapFromNativeImage):
(WebCore::createImageBitmap):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
* Source/WebCore/platform/MediaStrategy.h:
(WebCore::MediaStrategy::nativeImageFromVideoFrame):
* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::draw):
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawVideoFrame):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawVideoFrame):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::videoFrameToImage):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::drawVideoFrame):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::draw):
(WebCore::VideoFrameCV::copyNativeImage const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::drawVideoFrame):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::paint):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::draw):
(WebCore::VideoFrameGStreamer::copyNativeImage const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::VideoFrameLibWebRTC::pixelBuffer const):
(WebCore::VideoFrameLibWebRTC::copyNativeImage const): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::sharedResourceCache):
(WebKit::GPUProcessConnection::videoFrameObjectHeapProxy):
(WebKit::GPUProcessConnection::protectedSharedResourceCache): Deleted.
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp:
(WebKit::RemoteSharedResourceCacheProxy::gpuProcessConnectionDidBecomeAvailable): Deleted.
(WebKit::RemoteSharedResourceCacheProxy::videoFrameObjectHeapProxy): Deleted.
(WebKit::RemoteSharedResourceCacheProxy::protectedVideoFrameObjectHeapProxy): Deleted.
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::videoFrameToImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawVideoFrame):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::RemoteQueueProxy):
(WebKit::WebGPU::RemoteQueueProxy::getNativeImage):
(WebKit::WebGPU::RemoteQueueProxy::protectedVideoFrameObjectHeapProxy const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::currentNativeImage const):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
(WebKit::RemoteVideoFrameProxy::RemoteVideoFrameProxy):
(WebKit::m_pixelFormat):
(WebKit::RemoteVideoFrameProxy::pixelBuffer const):
(WebKit::m_videoFrameObjectHeapProxy): Deleted.
(WebKit::RemoteVideoFrameProxy::copyNativeImage const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h:
(WebKit::RemoteVideoFrameObjectHeapProxy::create):
(WebKit::RemoteVideoFrameObjectHeapProxy::RemoteVideoFrameObjectHeapProxy):
(WebKit::RemoteVideoFrameObjectHeapProxy::gpuProcessConnectionDidBecomeAvailable): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::create):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::RemoteVideoFrameObjectHeapProxyProcessor):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::initialize):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidClose):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidBecomeAvailable): Deleted.
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::connection): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureGPUProcessConnection):
(WebKit::WebProcess::gpuProcessSharedResourceCache): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/304584@main">https://commits.webkit.org/304584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d5567b8a841703380485f04a95a96e3088ec32d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143762 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e374542a-c997-4b78-9b08-91168a5f38ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103993 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121929 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84857 "Found 2 new API test failures: WPE/TestWebKitWebView:/webkit/WebKitWebView/save, WPE/TestAuthentication:/webkit/Authentication/authentication-success (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4ddceb0e-9e2e-453d-b6c4-192d29da42ef) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4360 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146512 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8098 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40690 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/28601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6186 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118229 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20949 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8146 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71705 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->