### PR TITLE
Have AuthenticationClient leverage AbstractRefCounted

### DIFF
--- a/Source/WebCore/platform/network/AuthenticationClient.h
+++ b/Source/WebCore/platform/network/AuthenticationClient.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class AuthenticationChallenge;
 class Credential;
 
-class AuthenticationClient : public CanMakeWeakPtr<AuthenticationClient> {
+class AuthenticationClient : public AbstractRefCountedAndCanMakeWeakPtr<AuthenticationClient> {
 public:
     virtual void receivedCredential(const AuthenticationChallenge&, const Credential&) = 0;
     virtual void receivedRequestToContinueWithoutCredential(const AuthenticationChallenge&) = 0;
@@ -40,15 +40,8 @@ public:
     virtual void receivedRequestToPerformDefaultHandling(const AuthenticationChallenge&) = 0;
     virtual void receivedChallengeRejection(const AuthenticationChallenge&) = 0;
 
-    void ref() { refAuthenticationClient(); }
-    void deref() { derefAuthenticationClient(); }
-
 protected:
     virtual ~AuthenticationClient() = default;
-
-private:
-    virtual void refAuthenticationClient() = 0;
-    virtual void derefAuthenticationClient() = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -158,8 +158,9 @@ public:
 
     NetworkingContext* context() const;
 
-    using RefCounted<ResourceHandle>::ref;
-    using RefCounted<ResourceHandle>::deref;
+    // AuthenticationClient.
+    void ref() const override { RefCounted::ref(); }
+    void deref() const override { RefCounted::deref(); }
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT static CFStringRef synchronousLoadRunLoopMode();
@@ -187,9 +188,6 @@ private:
 
     bool start();
     static void platformLoadResourceSynchronously(NetworkingContext*, const ResourceRequest&, StoredCredentialsPolicy, SecurityOrigin*, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);
-
-    void refAuthenticationClient() override { ref(); }
-    void derefAuthenticationClient() override { deref(); }
 
 #if PLATFORM(COCOA)
     enum class SchedulingBehavior { Asynchronous, Synchronous };


### PR DESCRIPTION
#### 9a220966b16fc1424f70d2d63af080423cfe9dba
<pre>
Have AuthenticationClient leverage AbstractRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=304322">https://bugs.webkit.org/show_bug.cgi?id=304322</a>

Reviewed by Geoffrey Garen.

Have AuthenticationClient leverage AbstractRefCounted to simplify the
code a bit.

* Source/WebCore/platform/network/AuthenticationClient.h:
(WebCore::AuthenticationClient::ref): Deleted.
(WebCore::AuthenticationClient::deref): Deleted.
* Source/WebCore/platform/network/ResourceHandle.h:

Canonical link: <a href="https://commits.webkit.org/304653@main">https://commits.webkit.org/304653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5898a9747d872361f60505306a7275042a5d877

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143881 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cee53374-6d83-4bf6-9672-3b0ff434251a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104121 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5391b25c-9c14-4f44-a03c-413ffa0cb2b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139118 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6689 "Found 1 new test failure: fast/html/a-tooltip-null.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84953 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09a38605-da47-46f4-8c17-4c974a04d3b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4018 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4476 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146627 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6279 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118328 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8260 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36387 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71819 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->