### PR TITLE
Have ThreadableLoader leverage AbstractRefCounted

### DIFF
--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -69,13 +69,9 @@ class CachedRawResource;
         friend class InspectorInstrumentation;
         friend class InspectorNetworkAgent;
 
-        // CachedResourceClient.
+        // CachedResourceClient, ThreadableLoader.
         void ref() const final { RefCounted::ref(); }
         void deref() const final { RefCounted::deref(); }
-
-    protected:
-        void refThreadableLoader() override { ref(); }
-        void derefThreadableLoader() override { deref(); }
 
     private:
         enum BlockingBehavior {

--- a/Source/WebCore/loader/ThreadableLoader.h
+++ b/Source/WebCore/loader/ThreadableLoader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <WebCore/ResourceLoaderOptions.h>
+#include <wtf/AbstractRefCounted.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/AtomString.h>
@@ -70,7 +71,7 @@ namespace WebCore {
 
     // Useful for doing loader operations from any thread (not threadsafe,
     // just able to run on threads other than the main thread).
-    class ThreadableLoader {
+    class ThreadableLoader : public AbstractRefCounted {
         WTF_MAKE_NONCOPYABLE(ThreadableLoader);
     public:
         static void loadResourceSynchronously(ScriptExecutionContext&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&);
@@ -78,16 +79,12 @@ namespace WebCore {
 
         virtual void computeIsDone() = 0;
         virtual void cancel() = 0;
-        void ref() { refThreadableLoader(); }
-        void deref() { derefThreadableLoader(); }
 
         static void logError(ScriptExecutionContext&, const ResourceError&, const String&);
 
     protected:
         ThreadableLoader() = default;
         virtual ~ThreadableLoader() = default;
-        virtual void refThreadableLoader() = 0;
-        virtual void derefThreadableLoader() = 0;
     };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -62,15 +62,11 @@ public:
     void cancel() override;
 
     bool done() const { return m_workerClientWrapper->done(); }
-
     void notifyIsDone(bool isDone);
 
-    using RefCounted<WorkerThreadableLoader>::ref;
-    using RefCounted<WorkerThreadableLoader>::deref;
-
-protected:
-    void refThreadableLoader() override { ref(); }
-    void derefThreadableLoader() override { deref(); }
+    // ThreadableLoader.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     // Creates a loader on the main thread and bridges communication between


### PR DESCRIPTION
#### 2c1ec1280aa6dc26b0e317600f5dd0012c9268f0
<pre>
Have ThreadableLoader leverage AbstractRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=304323">https://bugs.webkit.org/show_bug.cgi?id=304323</a>

Reviewed by Geoffrey Garen.

Have ThreadableLoader leverage AbstractRefCounted to simplify the code
a bit.

* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/ThreadableLoader.h:
(WebCore::ThreadableLoader::ref): Deleted.
(WebCore::ThreadableLoader::deref): Deleted.
* Source/WebCore/loader/WorkerThreadableLoader.h:
(WebCore::WorkerThreadableLoader::done const):

Canonical link: <a href="https://commits.webkit.org/304652@main">https://commits.webkit.org/304652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0f83ecb692f057c0e482a6b6cae223e0aa35c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/716b4424-5971-4054-a38c-da216a0efc86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104127 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20e3401a-1ffa-4711-b008-1971bd607845) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84952 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe47f60b-add1-4af7-b680-f952f8448d93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6365 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4019 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4477 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8213 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112466 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6281 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118329 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8261 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36388 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8200 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->