### PR TITLE
Drop unnecessary `using RefCounted::ref` statements

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKey.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.h
@@ -143,9 +143,6 @@ public:
 
     size_t sizeEstimate() const { return m_sizeEstimate; }
 
-    using RefCounted<IDBKey>::ref;
-    using RefCounted<IDBKey>::deref;
-
 #if !LOG_DISABLED
     String loggingString() const;
 #endif

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
@@ -132,9 +132,6 @@ private:
         void suspend();
         void resume();
 
-        using RefCounted<Bridge>::ref;
-        using RefCounted<Bridge>::deref;
-
     private:
         Bridge(Ref<ThreadableWebSocketChannelClientWrapper>&&, WorkerGlobalScope&, const String& taskMode, Ref<SocketProvider>&&);
 

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -51,16 +51,14 @@ class ScriptExecutionContext;
 
 class CSSFontSelector final : public FontSelector, public CSSFontFaceClient, public ActiveDOMObject {
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
-    USING_CAN_MAKE_WEAKPTR(FontSelector);
-
-    using FontSelector::ref;
-    using FontSelector::deref;
-
     static Ref<CSSFontSelector> create(ScriptExecutionContext&);
     virtual ~CSSFontSelector();
+
+    // ActiveDOMObject, CSSFontFaceClient.
+    void ref() const final { FontSelector::ref(); }
+    void deref() const final { FontSelector::deref(); }
+
+    USING_CAN_MAKE_WEAKPTR(FontSelector);
 
     unsigned version() const final { return m_version; }
     unsigned uniqueId() const final { return m_uniqueId; }

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -53,9 +53,6 @@ public:
         String display;
         String sizeAdjust;
     };
-
-    using RefCounted::ref;
-    using RefCounted::deref;
     
     using Source = Variant<String, RefPtr<JSC::ArrayBuffer>, RefPtr<JSC::ArrayBufferView>>;
     static Ref<FontFace> create(ScriptExecutionContext&, const String& family, Source&&, const Descriptors&);

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -68,9 +68,6 @@ public:
     bool hasActiveTimeoutTimer() const { return m_hasActiveTimeoutTimer; }
     bool hasAbortEventListener() const { return m_hasAbortEventListener; }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
-
     using Algorithm = Function<void(JSC::JSValue reason)>;
     uint32_t addAlgorithm(Algorithm&&);
     void removeAlgorithm(uint32_t);

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -37,9 +37,6 @@ class HTMLMaybeFormAssociatedCustomElement final : public HTMLElement {
 public:
     static Ref<HTMLMaybeFormAssociatedCustomElement> create(const QualifiedName& tagName, Document&);
 
-    using Node::ref;
-    using Node::deref;
-
     bool isMaybeFormAssociatedCustomElement() const final { return true; }
     bool isFormListedElement() const final;
     bool isValidatedFormListedElement() const final;

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -85,9 +85,6 @@ public:
 
     const AtomString& playbackState() const;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
-
 private:
     explicit MediaController(ScriptExecutionContext&);
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -102,8 +102,8 @@ public:
 
     static Ref<Navigation> create(LocalDOMWindow& window) { return adoptRef(*new Navigation(window)); }
 
-    using RefCounted<Navigation>::ref;
-    using RefCounted<Navigation>::deref;
+    using RefCounted::ref;
+    using RefCounted::deref;
 
     using HistoryBehavior = NavigationHistoryBehavior;
 

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -136,9 +136,6 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
-
     void scheduleTaskIfNeeded();
 
     PerformanceNavigationTiming* navigationTiming() { return m_navigationTiming.get(); }

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -37,8 +37,6 @@ public:
     static Ref<SVGViewElement> create(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
-    using SVGElement::ref;
-    using SVGElement::deref;
 
     const SVGSVGElement* targetElement() const { return m_targetElement.get(); }
     void setTargetElement(const SVGSVGElement& targetElement) { m_targetElement = targetElement; }


### PR DESCRIPTION
#### 7b9848e3001ce05ec7b9a541b6ae87e104f5e343
<pre>
Drop unnecessary `using RefCounted::ref` statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=304325">https://bugs.webkit.org/show_bug.cgi?id=304325</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/indexeddb/IDBKey.h:
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/MediaController.h:
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/svg/SVGViewElement.h:

Canonical link: <a href="https://commits.webkit.org/304647@main">https://commits.webkit.org/304647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80f4cfb548a0520d63a6cd7284a5fcb0c43bcd57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143883 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef761532-ea24-4b42-82b7-efd94db9813e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104128 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d019fa0-dded-41d5-9ac1-388aff146e19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84954 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b96835d6-bab4-4d4f-b436-5ef0c596d0c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4020 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4478 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146629 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8214 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112470 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6282 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118330 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8262 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36389 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->