### PR TITLE
[WPE] Link jsc and other jsc-related binaries (testb3, testair, TestJavaScriptCore, etc) against libWPEWebKit

### DIFF
--- a/Source/JavaScriptCore/shell/PlatformWPE.cmake
+++ b/Source/JavaScriptCore/shell/PlatformWPE.cmake
@@ -1,0 +1,22 @@
+# For WPE, JavaScriptCore is built as an OBJECT library whose object files
+# are bundled directly into libWPEWebKit, rather than being a separate
+# shared library like in GTK.
+#
+# We only list the shared WebKit library in the frameworks lists below, but
+# not the other non-shared libs WTF/bmalloc/JavaScriptCore, because the
+# _WEBKIT_TARGET_LINK_FRAMEWORK macro adds object files for OBJECT libraries
+# via $<TARGET_OBJECTS:> and their WebKit:: alias interface libraries,
+# regardless of whether those objects are already contained in a SHARED
+# library in the list. Including both WebKit and the OBJECT frameworks
+# would cause duplicate symbols and bloated binaries.
+set(jsc_FRAMEWORKS WebKit)
+
+if (DEVELOPER_MODE)
+    set(testapi_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testmasm_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testRegExp_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testb3_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testair_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testdfg_FRAMEWORKS ${jsc_FRAMEWORKS})
+    set(testwasmdebugger_FRAMEWORKS ${jsc_FRAMEWORKS})
+endif ()

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -103,17 +103,17 @@ set(TestJSC_SOURCES
 set(TestJSC_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
     ${TESTWEBKITAPI_DIR}
+    "${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}"
+    "${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}"
     "${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc"
 )
 
-set(TestJSC_FRAMEWORKS
-    JavaScriptCore
-    WTF
-)
-
-if (NOT USE_SYSTEM_MALLOC)
-    list(APPEND TestJSC_FRAMEWORKS bmalloc)
-endif ()
+# To reduce binary bloat, link only against the shared libWPEWebKit library
+# without embedding the object files from the OBJECT library frameworks
+# (WTF, bmalloc, JavaScriptCore) that are already bundled into libWPEWebKit.
+# See detailed explanation at Source/JavaScriptCore/shell/PlatformWPE.cmake
+set(TestJSC_FRAMEWORKS WebKit)
+set(TestJavaScriptCore_FRAMEWORKS WebKit)
 
 set(TestJSC_DEFINITIONS
     WEBKIT_SRC_DIR="${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
#### 0936e747abc47dba5d68c16b96553b5db391984c
<pre>
[WPE] Link jsc and other jsc-related binaries (testb3, testair, TestJavaScriptCore, etc) against libWPEWebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=304326">https://bugs.webkit.org/show_bug.cgi?id=304326</a>

Reviewed by Nikolas Zimmermann.

We are having issues with the size of the Debug builds on WPE, currently at ~5GB are causing
issues with the upload of the build products on the CI.

An important part of this problem is the fact that in WPE there is no shared libjavascriptcore
library like in GTK, and instead of linking against the shared library libWPEWebKit we are
embedding (statically linking) all the libjavascriptcore code into the binaries. So we end with
9 binaries around 700MB in Debug when we could shrink all those binaries to a few megabytes by
just linking dynamically against libWPEWebKit.

This patch makes all those jsc-related binaries to link against libWPEWebKit. The net effect is
a reduction in size from 5GB to 3.3GB for the debug.zip built-product.

* Source/JavaScriptCore/shell/PlatformWPE.cmake: Added.
* Tools/TestWebKitAPI/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/304666@main">https://commits.webkit.org/304666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c956050815e617ded96ef515ffffd0cf673abf11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143860 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84933 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3998 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4455 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128109 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146606 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134636 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6881 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112791 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 37 api tests failed or timed out; re-run-api-tests (cancelled)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6258 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118305 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20990 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8239 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36365 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167415 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71798 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43688 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->