### PR TITLE
[threaded-animations] scroll-driven animations don't update in sync with scroll updates on iOS

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -31,6 +31,7 @@
 #include <WebCore/AcceleratedEffectValues.h>
 #include <WebCore/PlatformCAFilters.h>
 #include <WebCore/PlatformLayer.h>
+#include <WebCore/ScrollingNodeID.h>
 #include <wtf/JSONValues.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -62,6 +63,9 @@ public:
 #endif
 
     void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
+
+    bool isDependentOnScrollingNodeWithID(WebCore::ScrollingNodeID) const;
+    bool isTimeDependent() const;
 
     void clear(PlatformLayer*);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -29,6 +29,7 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #import "RemoteAnimationUtilities.h"
+#import "RemoteProgressBasedTimeline.h"
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -216,6 +217,21 @@ void RemoteAnimationStack::clear(PlatformLayer *layer)
     m_transformPresentationModifier = nil;
     m_presentationModifierGroup = nil;
 #endif
+}
+
+bool RemoteAnimationStack::isDependentOnScrollingNodeWithID(WebCore::ScrollingNodeID scrollingNodeID) const
+{
+    return m_animations.containsIf([scrollingNodeID](auto& animation) {
+        RefPtr progressBasedTimeline = dynamicDowncast<RemoteProgressBasedTimeline>(animation->timeline());
+        return progressBasedTimeline && progressBasedTimeline->source() == scrollingNodeID;
+    });
+}
+
+bool RemoteAnimationStack::isTimeDependent() const
+{
+    return m_animations.containsIf([](auto& animation) {
+        return animation->timeline().isMonotonic();
+    });
 }
 
 Ref<JSON::Object> RemoteAnimationStack::toJSONForTesting() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -43,6 +43,9 @@ class RemoteAnimationTimeline : public RefCounted<RemoteAnimationTimeline> {
 public:
     virtual ~RemoteAnimationTimeline() = default;
 
+    bool isMonotonic() const { return !m_duration; }
+    bool isProgressBased() const { return !!m_duration; }
+
     const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
     const std::optional<WebCore::WebAnimationTime>& duration() const { return m_duration; }
     const TimelineID& identifier() const { return m_identifier; }
@@ -60,5 +63,10 @@ private:
 };
 
 } // namespace WebKit
+
+#define SPECIALIZE_TYPE_TRAITS_REMOTE_ANIMATION_TIMELINE(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ToValueTypeName) \
+    static bool isType(const WebKit::RemoteAnimationTimeline& node) { return node.predicate; } \
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.h
@@ -49,4 +49,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_REMOTE_ANIMATION_TIMELINE(RemoteMonotonicTimeline, isMonotonic())
+
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h
@@ -61,4 +61,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_REMOTE_ANIMATION_TIMELINE(RemoteProgressBasedTimeline, isProgressBased())
+
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
@@ -146,13 +146,6 @@ RemoteProgressBasedTimeline* RemoteProgressBasedTimelineRegistry::get(const Time
     return nullptr;
 }
 
-bool RemoteProgressBasedTimelineRegistry::hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode& node) const
-{
-    auto scrollingNodeID = node.scrollingNodeID();
-    auto it = m_timelines.find(scrollingNodeID.processIdentifier());
-    return it != m_timelines.end() && it->value.contains(scrollingNodeID);
-}
-
 void RemoteProgressBasedTimelineRegistry::updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
 {
     auto processIterator = m_timelines.find(node.scrollingNodeID().processIdentifier());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -44,7 +44,6 @@ public:
     void update(const RemoteScrollingTree&, WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
     RemoteProgressBasedTimeline* get(const TimelineID&) const;
     void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
-    bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -316,11 +316,6 @@ RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const Timeli
     return nullptr;
 }
 
-bool RemoteScrollingTree::hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode& node) const
-{
-    return m_progressBasedTimelineRegistry && m_progressBasedTimelineRegistry->hasTimelineForNode(node);
-}
-
 void RemoteScrollingTree::updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
 {
     if (m_progressBasedTimelineRegistry)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -95,7 +95,6 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
-    bool hasTimelineForNode(const WebCore::ScrollingTreeScrollingNode&) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -43,8 +43,8 @@ public:
 
     bool isRemoteLayerTreeDrawingAreaProxyIOS() const final { return true; }
 
-    void scheduleDisplayRefreshCallbacksForAnimation();
-    void pauseDisplayRefreshCallbacksForAnimation();
+    void scheduleDisplayRefreshCallbacksForMonotonicAnimations();
+    void pauseDisplayRefreshCallbacksForMonotonicAnimations();
 
     UIView *viewWithLayerIDForTesting(WebCore::PlatformLayerIdentifier) const;
 
@@ -68,7 +68,7 @@ private:
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
 
     bool m_needsDisplayRefreshCallbacksForDrawing { false };
-    bool m_needsDisplayRefreshCallbacksForAnimation { false };
+    bool m_needsDisplayRefreshCallbacksForMonotonicAnimations { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -238,7 +238,7 @@ void RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay()
     if (m_needsDisplayRefreshCallbacksForDrawing)
         RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay();
 
-    if (m_needsDisplayRefreshCallbacksForAnimation) {
+    if (m_needsDisplayRefreshCallbacksForMonotonicAnimations) {
         RefPtr page = this->page();
         if (!page)
             return;
@@ -256,19 +256,19 @@ void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacks()
 void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks()
 {
     m_needsDisplayRefreshCallbacksForDrawing = false;
-    if (!m_needsDisplayRefreshCallbacksForAnimation)
+    if (!m_needsDisplayRefreshCallbacksForMonotonicAnimations)
         [displayLinkHandler() pause];
 }
 
-void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForAnimation()
+void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations()
 {
-    m_needsDisplayRefreshCallbacksForAnimation = true;
+    m_needsDisplayRefreshCallbacksForMonotonicAnimations = true;
     [displayLinkHandler() schedule];
 }
 
-void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForAnimation()
+void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForMonotonicAnimations()
 {
-    m_needsDisplayRefreshCallbacksForAnimation = false;
+    m_needsDisplayRefreshCallbacksForMonotonicAnimations = false;
     if (!m_needsDisplayRefreshCallbacksForDrawing)
         [displayLinkHandler() pause];
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -77,7 +77,6 @@ public:
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const override;
     void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) override;
-    void updateAnimations();
 #endif
 
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
@@ -101,6 +100,12 @@ private:
 
     bool shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis) const;
     std::pair<float, std::optional<unsigned>> closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis, float currentScrollOffset, WebCore::FloatPoint scrollDestination, float velocity) const;
+
+#if ENABLE(THREADED_ANIMATIONS)
+    void updateTimeDependentAnimationStacks();
+    void updateAnimationStacksDependentOnScrollingNode(const WebCore::ScrollingTreeScrollingNode&);
+    void updateAnimationStacks(NOESCAPE const Function<bool(const RemoteAnimationStack&)>&);
+#endif
 
     HashMap<unsigned, OptionSet<WebCore::TouchAction>> m_touchActionsByTouchIdentifier;
 


### PR DESCRIPTION
#### 230a3fd2ec731e03af1199f9fdb712c603de333f
<pre>
[threaded-animations] scroll-driven animations don&apos;t update in sync with scroll updates on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=304189">https://bugs.webkit.org/show_bug.cgi?id=304189</a>
<a href="https://rdar.apple.com/166546662">rdar://166546662</a>

Reviewed by Anne van Kesteren.

On iOS, we would update all threaded animations, scroll-driven as well as time-based, as the
display refreshes. However, scroll-driven animations should be updated as the remote scrolling
three updates, and time-based animations should be updated as the display is updated.

We already update progress-based timelines correctly as the remote scrolling tree updates,
in `RemoteScrollingTreeIOS::scrollingTreeNodeDidScroll()`. That method already call
`RemoteScrollingCoordinatorProxyIOS::progressBasedTimelinesWereUpdatedForNode()`, so now
instead of scheduling a display refresh callback we call the new method
`updateAnimationStacksDependentOnScrollingNode()` such that all animations stacks that
have animations associated with a timeline that as that scrolling node as its source
get updated.

We also introduce a new `updateTimeDependentAnimationStacks()` method which only updates
animation stacks that contain animations associated with a monotonic timeline, and only
call this method under `displayDidRefresh()`.

Finally, we must make sure to only schedule display refresh callbacks for monotonic animations,
so we rename the various methods on `RemoteLayerTreeDrawingAreaProxyIOS` that are related
scheduling such updates to make it clear they&apos;re only relevant to monotonic animations, and then
we only call them in situations where we have animations stacks containing monotonic animations.

As a result, we update progress-based timelines and any animation stack containing an associated
scroll-driven animation as a remote scrolling tree node is updated, and we schedule display refresh
callbacks for animations only if we have monotonic animations, only updating animation stacks
containing such animations as those callbacks fire.

As a result we can remove `RemoteScrollingTree::hasTimelineForNode()` and the methods under it
since it is now unused.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::isDependentOnScrollingNodeWithID const):
(WebKit::RemoteAnimationStack::isTimeDependent const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
(WebKit::RemoteAnimationTimeline::isMonotonic const):
(WebKit::RemoteAnimationTimeline::isProgressBased const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp:
(WebKit::RemoteProgressBasedTimelineRegistry::hasTimelineForNode const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::hasTimelineForNode const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForAnimation): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForAnimation): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::displayDidRefresh):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::progressBasedTimelinesWereUpdatedForNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimeDependentAnimationStacks):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimationStacksDependentOnScrollingNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimationStacks):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimations): Deleted.

Canonical link: <a href="https://commits.webkit.org/304619@main">https://commits.webkit.org/304619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d995da3c27e23f6e4361a8a5bf9840a42de1d0aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143799 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50566d87-e4d0-4ce8-81c9-dd78334d2659) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104040 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ca9e2ff-f046-4c2f-98c6-065edd421e40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121963 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84887 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f959bdb4-5508-4fe9-96bc-e022a12da2ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3952 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4395 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115585 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146547 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112400 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6833 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6215 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118263 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20969 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36326 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71740 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->