### PR TITLE
[GTK] Add WebKitContextMenuGAction to use as GAction for WebContextMenuItemGlib instead of GSimpleAction

### DIFF
--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
@@ -29,7 +29,6 @@
 #include "WebContextMenuItemData.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
-#include <wtf/glib/GUniquePtr.h>
 
 #if PLATFORM(GTK) && !USE(GTK4)
 typedef struct _GtkAction GtkAction;
@@ -61,7 +60,6 @@ public:
 #endif
 
 private:
-    GUniquePtr<char> buildActionName() const;
     void createActionIfNeeded();
 
     GRefPtr<GAction> m_gAction;

--- a/Source/WebKit/Shared/glib/WebKitContextMenuGAction.cpp
+++ b/Source/WebKit/Shared/glib/WebKitContextMenuGAction.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitContextMenuGAction.h"
+
+#if ENABLE(CONTEXT_MENUS)
+#include "WebContextMenuItemData.h"
+#include "WebContextMenuProxy.h"
+#include "WebPageProxy.h"
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+
+using namespace WebKit;
+
+static void webkitContextMenuGActionGActionInterfaceInit(GActionInterface*);
+
+struct _WebKitContextMenuGActionPrivate {
+    GUniquePtr<char> name;
+    WebContextMenuItemData item;
+    GRefPtr<GVariant> state;
+    WeakPtr<WebPageProxy> page;
+#if PLATFORM(GTK) && !USE(GTK4)
+    GRefPtr<GtkAction> gtkAction;
+#endif
+};
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(WebKitContextMenuGAction, webkit_context_menu_gaction, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(G_TYPE_ACTION, webkitContextMenuGActionGActionInterfaceInit))
+
+enum {
+    PROP_0,
+    PROP_NAME,
+    PROP_PARAMETER_TYPE,
+    PROP_ENABLED,
+    PROP_STATE_TYPE,
+    PROP_STATE
+};
+
+static const char* webkitContextMenuGActionGetName(GAction* action)
+{
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    return priv->name.get();
+}
+
+static const GVariantType* webkitContextMenuGActionGetParameterType(GAction*)
+{
+    return nullptr;
+}
+
+static gboolean webkitContextMenuGActionGetEnabled(GAction* action)
+{
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    return priv->item.enabled();
+}
+
+static const GVariantType* webkitContextMenuGActionGetStateType(GAction* action)
+{
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    return priv->state ? g_variant_get_type(priv->state.get()) : nullptr;
+}
+
+static GVariant* webkitContextMenuGActionGetState(GAction* action)
+{
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    return priv->state ? g_variant_ref(priv->state.get()) : nullptr;
+}
+
+static GVariant* webkitContextMenuGActionGetStateHint(GAction*)
+{
+    return nullptr;
+}
+
+static void webkitContextMenuGActionChangeState(GAction* action, GVariant* value)
+{
+    RELEASE_ASSERT(value && g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN));
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    GRefPtr<GVariant> state(value);
+    if (priv->state) {
+        RELEASE_ASSERT(g_variant_is_of_type(value, g_variant_get_type(priv->state.get())));
+        if (g_variant_equal(priv->state.get(), state.get()))
+            return;
+    }
+
+    priv->state = WTF::move(state);
+    g_object_notify(G_OBJECT(action), "state");
+}
+
+static void webkitContextMenuGActionActivate(GAction* action, GVariant*)
+{
+    auto* priv = WEBKIT_CONTEXT_MENU_GACTION(action)->priv;
+    RefPtr<WebPageProxy> page = priv->page.get();
+    if (!page)
+        return;
+
+    auto* proxy = page->activeContextMenu();
+    if (!proxy)
+        return;
+
+    if (!priv->item.enabled())
+        return;
+
+    if (priv->state)
+        g_action_change_state(action, g_variant_new_boolean(!g_variant_get_boolean(priv->state.get())));
+
+#if PLATFORM(GTK) && !USE(GTK4)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    if (priv->gtkAction)
+        gtk_action_activate(priv->gtkAction.get());
+ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
+
+    page->contextMenuItemSelected(priv->item, proxy->frameInfo());
+}
+
+static void webkitContextMenuGActionGActionInterfaceInit(GActionInterface* iface)
+{
+    iface->get_name = webkitContextMenuGActionGetName;
+    iface->get_parameter_type = webkitContextMenuGActionGetParameterType;
+    iface->get_enabled = webkitContextMenuGActionGetEnabled;
+    iface->get_state_type = webkitContextMenuGActionGetStateType;
+    iface->get_state = webkitContextMenuGActionGetState;
+    iface->get_state_hint = webkitContextMenuGActionGetStateHint;
+    iface->change_state = webkitContextMenuGActionChangeState;
+    iface->activate = webkitContextMenuGActionActivate;
+}
+
+static void webkitContextMenuGActionGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* action = G_ACTION(object);
+
+    switch (propId) {
+    case PROP_NAME:
+        g_value_set_string(value, webkitContextMenuGActionGetName(action));
+        break;
+    case PROP_PARAMETER_TYPE:
+        g_value_set_boxed(value, webkitContextMenuGActionGetParameterType(action));
+        break;
+    case PROP_ENABLED:
+        g_value_set_boolean(value, webkitContextMenuGActionGetEnabled(action));
+        break;
+    case PROP_STATE_TYPE:
+        g_value_set_boxed(value, webkitContextMenuGActionGetStateType(action));
+        break;
+    case PROP_STATE:
+        g_value_take_variant(value, webkitContextMenuGActionGetState(action));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void webkit_context_menu_gaction_class_init(WebKitContextMenuGActionClass* actionClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(actionClass);
+    objectClass->get_property = webkitContextMenuGActionGetProperty;
+
+    g_object_class_override_property(objectClass, PROP_NAME, "name");
+    g_object_class_override_property(objectClass, PROP_PARAMETER_TYPE, "parameter-type");
+    g_object_class_override_property(objectClass, PROP_ENABLED, "enabled");
+    g_object_class_override_property(objectClass, PROP_STATE_TYPE, "state-type");
+    g_object_class_override_property(objectClass, PROP_STATE, "state");
+}
+
+GAction* webkitContextMenuGActionNew(const char* name, const WebContextMenuItemData& item)
+{
+    RELEASE_ASSERT(item.type() == WebCore::ContextMenuItemType::Action || item.type() == WebCore::ContextMenuItemType::CheckableAction);
+    auto* action = WEBKIT_CONTEXT_MENU_GACTION(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_GACTION, nullptr));
+    if (name)
+        action->priv->name.reset(g_strdup(name));
+    else {
+        static uint64_t actionID = 0;
+        action->priv->name.reset(g_strdup_printf("action-%" PRIu64, ++actionID));
+    }
+    if (item.type() == WebCore::ContextMenuItemType::CheckableAction)
+        action->priv->state = g_variant_new_boolean(item.checked());
+    action->priv->item = item;
+
+    return G_ACTION(action);
+}
+
+void webkitContextMenuGActionSetPage(WebKitContextMenuGAction* action, WebPageProxy* page)
+{
+    RELEASE_ASSERT(WEBKIT_IS_CONTEXT_MENU_GACTION(action));
+    action->priv->page = page;
+}
+
+#if PLATFORM(GTK) && !USE(GTK4)
+void webkitContextMenuGActionSetGtkAction(WebKitContextMenuGAction* action, GtkAction* gtkAction)
+{
+    RELEASE_ASSERT(WEBKIT_IS_CONTEXT_MENU_GACTION(action));
+    action->priv->gtkAction = gtkAction;
+}
+#endif
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/glib/WebKitContextMenuGAction.h
+++ b/Source/WebKit/Shared/glib/WebKitContextMenuGAction.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(CONTEXT_MENUS)
+#include "WebKitDefines.h"
+#include <gio/gio.h>
+
+#if PLATFORM(GTK) && !USE(GTK4)
+#include <gtk/gtk.h>
+#endif
+
+namespace WebKit {
+class WebContextMenuItemData;
+class WebPageProxy;
+}
+
+#define WEBKIT_TYPE_CONTEXT_MENU_GACTION            (webkit_context_menu_gaction_get_type())
+#if !ENABLE(2022_GLIB_API)
+#define WEBKIT_CONTEXT_MENU_GACTION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_CONTEXT_MENU_GACTION, WebKitContextMenuGAction))
+#define WEBKIT_IS_CONTEXT_MENU_GACTION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_CONTEXT_MENU_GACTION))
+#define WEBKIT_CONTEXT_MENU_GACTION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_CONTEXT_MENU_GACTION, WebKitContextMenuGActionClass))
+#define WEBKIT_IS_CONTEXT_MENU_GACTION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_CONTEXT_MENU_GACTION))
+#define WEBKIT_CONTEXT_MENU_GACTION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_CONTEXT_MENU_GACTION, WebKitContextMenuGActionClass))
+
+struct _WebKitContextMenuGActionClass {
+    GObjectClass parentClass;
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE(WebKitContextMenuGAction, webkit_context_menu_gaction, WEBKIT, CONTEXT_MENU_GACTION, GObject)
+
+GAction* webkitContextMenuGActionNew(const char*, const WebKit::WebContextMenuItemData&);
+void webkitContextMenuGActionSetPage(WebKitContextMenuGAction*, WebKit::WebPageProxy*);
+
+#if PLATFORM(GTK) && !USE(GTK4)
+void webkitContextMenuGActionSetGtkAction(WebKitContextMenuGAction*, GtkAction*);
+#endif
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -90,6 +90,7 @@ Shared/glib/JavaScriptEvaluationResultGLib.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp
 Shared/glib/UserMessage.cpp
 Shared/glib/WebContextMenuItemGlib.cpp
+Shared/glib/WebKitContextMenuGAction.cpp @no-unify
 
 Shared/gtk/ArgumentCodersGtk.cpp
 Shared/gtk/NativeWebKeyboardEventGtk.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -88,6 +88,7 @@ Shared/glib/JavaScriptEvaluationResultGLib.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp
 Shared/glib/UserMessage.cpp
 Shared/glib/WebContextMenuItemGlib.cpp
+Shared/glib/WebKitContextMenuGAction.cpp @no-unify
 
 Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
 Shared/libwpe/NativeWebMouseEventLibWPE.cpp

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -312,9 +312,9 @@ RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy& pag
 }
 
 #if ENABLE(CONTEXT_MENUS)
-Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& page, FrameInfoData&&, ContextMenuContextData&& context, const UserData& userData)
+Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
 {
-    return WebContextMenuProxyWPE::create(page, WTF::move(context), userData);
+    return WebContextMenuProxyWPE::create(page, WTF::move(frameInfo), WTF::move(context), userData);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -36,9 +36,10 @@
 
 namespace WebKit {
 
-WebContextMenuProxy::WebContextMenuProxy(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+WebContextMenuProxy::WebContextMenuProxy(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
     : m_context(WTF::move(context))
     , m_userData(userData)
+    , m_frameInfo(WTF::move(frameInfo))
     , m_page(page)
 {
 }

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(CONTEXT_MENUS)
 
 #include "ContextMenuContextData.h"
+#include "FrameInfoData.h"
 #include "UserData.h"
 #include "WebContextMenuListenerProxy.h"
 #include "WebPageProxy.h"
@@ -53,6 +54,7 @@ public:
 
     WebPageProxy* page() const { return m_page.get(); }
     RefPtr<WebPageProxy> protectedPage() const;
+    const FrameInfoData& frameInfo() const { return m_frameInfo; }
 
 #if PLATFORM(COCOA)
     virtual NSMenu *platformMenu() const = 0;
@@ -64,13 +66,14 @@ public:
 #endif
 
 protected:
-    WebContextMenuProxy(WebPageProxy&, ContextMenuContextData&&, const UserData&);
+    WebContextMenuProxy(WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
 
     // WebContextMenuListenerProxyClient
     void useContextMenuItems(Vector<Ref<WebContextMenuItem>>&&) override;
 
     ContextMenuContextData m_context;
     const UserData m_userData;
+    const FrameInfoData m_frameInfo;
 
 private:
     virtual Vector<Ref<WebContextMenuItem>> proposedItems() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2423,7 +2423,7 @@ public:
     void setHasExecutedAppBoundBehaviorBeforeNavigation() { m_hasExecutedAppBoundBehaviorBeforeNavigation = true; }
 
     WebPopupMenuProxy* activePopupMenu() const { return m_activePopupMenu.get(); }
-#if ENABLE(CONTEXT_MENUS) && PLATFORM(WIN)
+#if ENABLE(CONTEXT_MENUS) && !PLATFORM(MAC)
     WebContextMenuProxy* activeContextMenu() const { return m_activeContextMenu.get(); }
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.h
@@ -31,7 +31,7 @@
 #include "WebContextMenuItemGlib.h"
 #include "WebContextMenuProxy.h"
 #include <WebCore/IntPoint.h>
-#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GMenu GMenu;
@@ -52,7 +52,6 @@ public:
 
     void populate(const Vector<WebContextMenuItemGlib>&);
     GtkWidget* gtkWidget() const { return m_menu; }
-    const FrameInfoData& frameInfo() const { return m_frameInfo; }
     static const char* widgetDismissedSignal;
 
 private:
@@ -67,9 +66,8 @@ private:
 
     GtkWidget* m_webView;
     GtkWidget* m_menu;
-    HashMap<unsigned long, void*> m_signalHandlers;
+    HashSet<GRefPtr<GAction>> m_actions;
     GRefPtr<GSimpleActionGroup> m_actionGroup { adoptGRef(g_simple_action_group_new()) };
-    const FrameInfoData m_frameInfo;
 };
 
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -27,7 +27,6 @@
 
 #if PLATFORM(MAC)
 
-#include "FrameInfoData.h"
 #include "WebContextMenuProxy.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakObjCPtr.h>
@@ -120,7 +119,6 @@ private:
 #if ENABLE(VIDEO)
     RetainPtr<WKCaptionStyleMenuController> m_captionStyleMenuController;
 #endif
-    const FrameInfoData m_frameInfo;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -238,9 +238,8 @@ namespace WebKit {
 using namespace WebCore;
 
 WebContextMenuProxyMac::WebContextMenuProxyMac(NSView *webView, WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
-    : WebContextMenuProxy(page, WTF::move(context), userData)
+    : WebContextMenuProxy(page, WTF::move(frameInfo), WTF::move(context), userData)
     , m_webView(webView)
-    , m_frameInfo(WTF::move(frameInfo))
 {
 }
 

--- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
@@ -103,8 +103,7 @@ void WebContextMenuProxyWin::showContextMenuWithItems(Vector<Ref<WebContextMenuI
 }
 
 WebContextMenuProxyWin::WebContextMenuProxyWin(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
-    : WebContextMenuProxy(page, WTF::move(context), userData)
-    , m_frameInfo(WTF::move(frameInfo))
+    : WebContextMenuProxy(page, WTF::move(frameInfo), WTF::move(context), userData)
 {
     m_menu = createMenu(m_context);
 }

--- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
@@ -44,14 +44,11 @@ public:
     }
     ~WebContextMenuProxyWin();
 
-    FrameInfoData frameInfo() { return m_frameInfo; }
-
 private:
     WebContextMenuProxyWin(WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
 
     HMENU m_menu;
-    FrameInfoData m_frameInfo;
 };
 
 

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.cpp
@@ -31,8 +31,8 @@
 namespace WebKit {
 using namespace WebCore;
 
-WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
-    : WebContextMenuProxy(page, WTF::move(context), userData)
+WebContextMenuProxyWPE::WebContextMenuProxyWPE(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
+    : WebContextMenuProxy(page, WTF::move(frameInfo), WTF::move(context), userData)
 {
 }
 

--- a/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
+++ b/Source/WebKit/UIProcess/wpe/WebContextMenuProxyWPE.h
@@ -33,13 +33,13 @@ namespace WebKit {
 
 class WebContextMenuProxyWPE final : public WebContextMenuProxy {
 public:
-    static auto create(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
+    static auto create(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
     {
-        return adoptRef(*new WebContextMenuProxyWPE(page, WTF::move(context), userData));
+        return adoptRef(*new WebContextMenuProxyWPE(page, WTF::move(frameInfo), WTF::move(context), userData));
     }
 
 private:
-    WebContextMenuProxyWPE(WebPageProxy&, ContextMenuContextData&&, const UserData&);
+    WebContextMenuProxyWPE(WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
 };
 

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -336,7 +336,8 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitAutoconfigProxyResolver.h'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitFormDataInputStream.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitFormDataInputStream.h'),
-      os.path.join('Source', 'WebKit', 'NetworkProcess', 'soup', 'WebKitDirectoryInputStream.h')],
+      os.path.join('Source', 'WebKit', 'NetworkProcess', 'soup', 'WebKitDirectoryInputStream.h'),
+      os.path.join('Source', 'WebKit', 'Shared', 'glib', 'WebKitContextMenuGAction.cpp')],
      ["-readability/naming",
       "-readability/enum_casing"]),
     ([


### PR DESCRIPTION
#### b819cf0c1a0a562ffc05692b9f77a078ee344014
<pre>
[GTK] Add WebKitContextMenuGAction to use as GAction for WebContextMenuItemGlib instead of GSimpleAction
<a href="https://bugs.webkit.org/show_bug.cgi?id=304330">https://bugs.webkit.org/show_bug.cgi?id=304330</a>

Reviewed by Adrian Perez de Castro.

Using our GAction implementation simplifies the code and will make it
easier to expose context menu API in WPE.

Canonical link: <a href="https://commits.webkit.org/305267@main">https://commits.webkit.org/305267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e699c9d39094f01908d692b0ce0f130359ecab09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146042 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86365 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137322 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5602 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10021 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114245 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7788 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64745 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10067 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37938 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73635 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->