### PR TITLE
TrackInfo and derivative should be a class, not a struct.

### DIFF
--- a/Source/WebCore/platform/MediaSamplesBlock.h
+++ b/Source/WebCore/platform/MediaSamplesBlock.h
@@ -81,7 +81,7 @@ public:
     }
     MediaTime presentationEndTime() const { return presentationTime() + duration(); }
     bool isSync() const { return size() ? (first().flags & MediaSample::IsSync) : false; }
-    TrackID trackID() const { return m_info ? m_info->trackID : -1; }
+    TrackID trackID() const { return m_info ? m_info->trackID() : -1; }
     bool isVideo() const { return m_info && m_info->isVideo(); }
     bool isAudio() const { return m_info && m_info->isAudio(); }
     TrackInfo::TrackType type() const { return m_info ? m_info->type() : TrackInfo::TrackType::Unknown; }

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/DataView.h>
+#include <WebCore/FloatSize.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/PlatformVideoColorSpace.h>
 #include <WebCore/SharedBuffer.h>
@@ -175,7 +176,7 @@ struct AV1CodecConfigurationRecord {
 
 struct MediaCapabilitiesInfo;
 struct VideoConfiguration;
-struct VideoInfo;
+class VideoInfo;
 
 WEBCORE_EXPORT std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView codecString);
 WEBCORE_EXPORT String createAV1CodecParametersString(const AV1CodecConfigurationRecord&);
@@ -186,7 +187,7 @@ WEBCORE_EXPORT bool validateAV1PerLevelConstraints(const AV1CodecConfigurationRe
 std::optional<AV1CodecConfigurationRecord> parseAV1DecoderConfigurationRecord(std::span<const uint8_t>);
 std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<const uint8_t>);
 WEBCORE_EXPORT PlatformVideoColorSpace createPlatformVideoColorSpaceFromAV1CodecConfigurationRecord(const AV1CodecConfigurationRecord&);
-WEBCORE_EXPORT RefPtr<VideoInfo> createVideoInfoFromAV1Stream(std::span<const uint8_t>);
+WEBCORE_EXPORT RefPtr<VideoInfo> createVideoInfoFromAV1Stream(std::span<const uint8_t>, std::optional<FloatSize> = std::nullopt);
 
 template<typename E>
 std::optional<E> parseEnumFromStringView(StringView stringView)

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-struct AudioInfo;
+class AudioInfo;
 
 class AudioTrackPrivate : public TrackPrivateBase {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioTrackPrivate);

--- a/Source/WebCore/platform/graphics/MediaSampleConverter.h
+++ b/Source/WebCore/platform/graphics/MediaSampleConverter.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class MediaSample;
 class MediaSamplesBlock;
-struct TrackInfo;
+class TrackInfo;
 
 class MediaSampleConverter final {
     WTF_MAKE_TZONE_ALLOCATED(MediaSampleConverter);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -59,7 +59,7 @@ namespace WebCore {
 class MediaSourcePrivate;
 class SharedBuffer;
 class TrackBuffer;
-struct TrackInfo;
+class TrackInfo;
 class TimeRanges;
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-struct VideoInfo;
+class VideoInfo;
 
 class VideoTrackPrivate : public TrackPrivateBase {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(VideoTrackPrivate);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -75,7 +75,7 @@ class AudioTrackPrivateMediaSourceAVFObjC;
 class VideoTrackPrivateMediaSourceAVFObjC;
 class SharedBuffer;
 
-struct TrackInfo;
+class TrackInfo;
 
 class SourceBufferPrivateAVFObjC final
     : public SourceBufferPrivate

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -109,9 +109,9 @@ std::optional<MediaTime> AudioTrackPrivateWebM::discardPadding() const
 String AudioTrackPrivateWebM::codec() const
 {
     if (m_formatDescription) {
-        if (!m_formatDescription->codecString.isEmpty())
-            return m_formatDescription->codecString;
-        return String::fromLatin1(m_formatDescription->codecName.string().data());
+        if (!m_formatDescription->codecString().isEmpty())
+            return m_formatDescription->codecString();
+        return String::fromLatin1(m_formatDescription->codecName().string().data());
     }
 
     if (!m_track.codec_id.is_present())
@@ -134,7 +134,7 @@ String AudioTrackPrivateWebM::codec() const
 uint32_t AudioTrackPrivateWebM::sampleRate() const
 {
     if (m_formatDescription)
-        return m_formatDescription->rate;
+        return m_formatDescription->rate();
 
     if (!m_track.audio.is_present())
         return 0;
@@ -149,7 +149,7 @@ uint32_t AudioTrackPrivateWebM::sampleRate() const
 uint32_t AudioTrackPrivateWebM::numberOfChannels() const
 {
     if (m_formatDescription)
-        return m_formatDescription->channels;
+        return m_formatDescription->channels();
 
     if (!m_track.audio.is_present())
         return 0;

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-struct AudioInfo;
+class AudioInfo;
 
 class AudioTrackPrivateWebM final : public AudioTrackPrivate {
     WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateWebM);

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-struct VideoInfo;
+class VideoInfo;
 
 WEBCORE_EXPORT RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t>);
 

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
@@ -111,13 +111,15 @@ RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
     auto dimensions = PAL::CMVideoFormatDescriptionGetDimensions(rawDescription);
     auto presentationDimensions = PAL::CMVideoFormatDescriptionGetPresentationDimensions(rawDescription, true, true);
 
-    Ref info = VideoInfo::create();
-    info->codecName = kCMVideoCodecType_H264;
-    info->size = { static_cast<float>(dimensions.width), static_cast<float>(dimensions.height) };
-    info->displaySize = { static_cast<float>(presentationDimensions.width), static_cast<float>(presentationDimensions.height) };
-    info->extensionAtoms = { 1 , { computeBoxType(kCMVideoCodecType_H264), SharedBuffer::create(avcc) } };
-
-    return info;
+    return VideoInfo::create({
+        {
+            .codecName = kCMVideoCodecType_H264
+        }, {
+            .size = { static_cast<float>(dimensions.width), static_cast<float>(dimensions.height) },
+            .displaySize = { static_cast<float>(presentationDimensions.width), static_cast<float>(presentationDimensions.height) },
+            .extensionAtoms = { 1 , { computeBoxType(kCMVideoCodecType_H264), SharedBuffer::create(avcc) } },
+        }
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -45,7 +45,7 @@ class ContentType;
 class MediaSampleAVFObjC;
 class SharedBuffer;
 struct MediaSourceConfiguration;
-struct TrackInfo;
+class TrackInfo;
 
 class WEBCORE_EXPORT SourceBufferParser : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SourceBufferParser, WTF::DestructionThread::Main> {
 public:

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -53,7 +53,7 @@ class WebmParser;
 namespace WebCore {
 
 class PacketDurationParser;
-struct TrackInfo;
+class TrackInfo;
 template<typename> class ExceptionOr;
 
 class WebMParser
@@ -153,7 +153,7 @@ public:
         void setFormatDescription(Ref<TrackInfo>&& description)
         {
             m_formatDescription = WTFMove(description);
-            m_formatDescription->trackID = track().track_uid.value();
+            m_formatDescription->setTrackID(track().track_uid.value());
         }
 
         WebMParser& parser() const { return m_parser; }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 struct MediaCapabilitiesInfo;
 struct VideoConfiguration;
-struct VideoInfo;
+class VideoInfo;
 
 WEBCORE_EXPORT bool shouldEnableVP9Decoder();
 WEBCORE_EXPORT bool shouldEnableSWVP9Decoder();

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -531,14 +531,18 @@ static Ref<VideoInfo> createVideoInfoFromVPCodecConfigurationRecord(const VPCode
     // FIXME: Convert existing struct to an ISOBox and replace the writing code below
     // with a subclass of ISOFullBox.
 
-    auto videoInfo = VideoInfo::create();
-    videoInfo->size = size;
-    videoInfo->displaySize = displaySize;
-    videoInfo->codecName = record.codecName == "vp09"_s ? 'vp09' : 'vp08';
-    videoInfo->extensionAtoms = { 1, { computeBoxType(videoInfo->codecName), SharedBuffer::create(vpcCFromVPCodecConfigurationRecord(record)) } };
-    videoInfo->colorSpace = colorSpaceFromVPCodecConfigurationRecord(record);
-    videoInfo->codecString = createVPCodecParametersString(record);
-    return videoInfo;
+    FourCC codecName = record.codecName == "vp09"_s ? 'vp09' : 'vp08';
+    return VideoInfo::create({
+        {
+            .codecName = codecName,
+            .codecString = createVPCodecParametersString(record)
+        }, {
+            .size = size,
+            .displaySize = displaySize,
+            .colorSpace = colorSpaceFromVPCodecConfigurationRecord(record),
+            .extensionAtoms = { 1, { computeBoxType(codecName), SharedBuffer::create(vpcCFromVPCodecConfigurationRecord(record)) } },
+        }
+    });
 }
 
 Ref<VideoInfo> createVideoInfoFromVP9HeaderParser(const vp9_parser::Vp9HeaderParser& parser, const webm::Video& video)

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -99,9 +99,9 @@ int VideoTrackPrivateWebM::trackIndex() const
 String VideoTrackPrivateWebM::codec() const
 {
     if (m_formatDescription) {
-        if (!m_formatDescription->codecString.isEmpty())
-            return m_formatDescription->codecString;
-        return String::fromLatin1(m_formatDescription->codecName.string().data());
+        if (!m_formatDescription->codecString().isEmpty())
+            return m_formatDescription->codecString();
+        return String::fromLatin1(m_formatDescription->codecName().string().data());
     }
 
     if (!m_track.codec_id.is_present())
@@ -124,7 +124,7 @@ String VideoTrackPrivateWebM::codec() const
 uint32_t VideoTrackPrivateWebM::width() const
 {
     if (m_formatDescription)
-        return m_formatDescription->size.width();
+        return m_formatDescription->size().width();
 
     if (!m_track.video.is_present())
         return 0;
@@ -142,7 +142,7 @@ uint32_t VideoTrackPrivateWebM::width() const
 uint32_t VideoTrackPrivateWebM::height() const
 {
     if (m_formatDescription)
-        return m_formatDescription->size.height();
+        return m_formatDescription->size().height();
 
     if (!m_track.video.is_present())
         return 0;
@@ -177,7 +177,7 @@ double VideoTrackPrivateWebM::framerate() const
 PlatformVideoColorSpace VideoTrackPrivateWebM::colorSpace() const
 {
     if (m_formatDescription)
-        return m_formatDescription->colorSpace;
+        return m_formatDescription->colorSpace();
     return { };
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-struct VideoInfo;
+class VideoInfo;
 
 class VideoTrackPrivateWebM final : public VideoTrackPrivate {
     WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateWebM);

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -35,7 +35,7 @@ struct AudioStreamBasicDescription;
 
 namespace WebCore {
 
-struct AudioInfo;
+class AudioInfo;
 class SharedBuffer;
 
 WEBCORE_EXPORT bool isVorbisDecoderAvailable();

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -108,14 +108,17 @@ static RefPtr<AudioInfo> createAudioInfoForFormat(OSType formatID, Vector<uint8_
         return nullptr;
     }
 
-    auto audioInfo = AudioInfo::create();
-    audioInfo->codecName = formatID;
-    audioInfo->rate = asbd.mSampleRate;
-    audioInfo->channels = asbd.mChannelsPerFrame;
-    audioInfo->framesPerPacket = asbd.mFramesPerPacket;
-    audioInfo->bitDepth = 16;
-    audioInfo->cookieData = SharedBuffer::create(WTFMove(magicCookie));
-    return audioInfo;
+    return AudioInfo::create({
+        {
+            .codecName = formatID
+        }, {
+            .rate = static_cast<uint32_t>(asbd.mSampleRate),
+            .channels = asbd.mChannelsPerFrame,
+            .framesPerPacket = asbd.mFramesPerPacket,
+            .bitDepth = 16,
+            .cookieData = SharedBuffer::create(WTFMove(magicCookie))
+        }
+    });
 }
 
 #endif // ENABLE(VORBIS) || ENABLE(OPUS)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -52,8 +52,8 @@ struct MediaRecorderPrivateOptions;
 class MediaSample;
 class PlatformAudioData;
 class VideoFrame;
-struct AudioInfo;
-struct VideoInfo;
+class AudioInfo;
+class VideoInfo;
 
 class MediaRecorderPrivateEncoder final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateEncoder, WTF::DestructionThread::Main> {
 public:

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -40,8 +40,8 @@ struct CGAffineTransform;
 namespace WebCore {
 
 class MediaSamplesBlock;
-struct AudioInfo;
-struct VideoInfo;
+class AudioInfo;
+class VideoInfo;
 
 class MediaRecorderPrivateWriterListener : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateWriterListener> {
 public:

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -103,15 +103,15 @@ public:
 
     std::optional<uint8_t> addAudioTrack(const AudioInfo& info)
     {
-        auto trackIndex = m_segment.AddAudioTrack(info.rate, info.channels, 0);
+        auto trackIndex = m_segment.AddAudioTrack(info.rate(), info.channels(), 0);
         if (!trackIndex)
             return { };
         auto* audioTrack = downcast<mkvmuxer::AudioTrack>(m_segment.GetTrackByNumber(trackIndex));
         ASSERT(audioTrack);
         audioTrack->set_bit_depth(32u);
-        audioTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName));
-        ASSERT(info.codecName == kAudioFormatOpus || info.codecName == kAudioFormatLinearPCM);
-        if (info.codecName == kAudioFormatOpus) {
+        audioTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName()));
+        ASSERT(info.codecName() == kAudioFormatOpus || info.codecName() == kAudioFormatLinearPCM);
+        if (info.codecName() == kAudioFormatOpus) {
             auto description = audioStreamDescriptionFromAudioInfo(info);
             auto opusHeader = createOpusPrivateData(description.streamDescription());
             audioTrack->SetCodecPrivate(opusHeader.span().data(), opusHeader.size());
@@ -121,14 +121,14 @@ public:
 
     std::optional<uint8_t> addVideoTrack(const VideoInfo& info)
     {
-        auto trackIndex = m_segment.AddVideoTrack(info.size.width(), info.size.height(), 0);
+        auto trackIndex = m_segment.AddVideoTrack(info.size().width(), info.size().height(), 0);
         if (!trackIndex)
             return { };
         auto* videoTrack = downcast<mkvmuxer::VideoTrack>(m_segment.GetTrackByNumber(trackIndex));
         ASSERT(videoTrack);
-        videoTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName));
-        if (info.extensionAtoms.size()) {
-            Ref atomData = info.extensionAtoms[0].second;
+        videoTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName()));
+        if (info.extensionAtoms().size()) {
+            Ref atomData = info.extensionAtoms()[0].second;
             videoTrack->SetCodecPrivate(atomData->span().data(), atomData->span().size());
         }
         return trackIndex;

--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
@@ -55,9 +55,9 @@ static RetainPtr<CMVideoFormatDescriptionRef> computeAV1InputFormat(std::span<co
     if (!videoInfo)
         return { };
 
-    if (width && videoInfo->size.width() != width)
+    if (width && videoInfo->size().width() != width)
         return { };
-    if (height && videoInfo->size.height() != height)
+    if (height && videoInfo->size().height() != height)
         return { };
 
     return createFormatDescriptionFromTrackInfo(*videoInfo);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8890,46 +8890,66 @@ enum class WebCore::EncryptionBoxType : uint8_t {
     TransportStreamEncryptionInitData
 };
 
+#if ENABLE(ENCRYPTED_MEDIA)
+using WebCore::TrackInfoEncryptionData = std::pair<WebCore::EncryptionBoxType, Ref<WebCore::SharedBuffer>>;
+using WebCore::TrackInfoEncryptionInitData = WebCore::TrackInfoAtomData;
+
 header: <WebCore/TrackInfo.h>
-[CustomHeader, RefCounted, DisableMissingMemberCheck] struct WebCore::AudioInfo {
+[CustomHeader] struct WebCore::EncryptionDataCollection {
+    WebCore::TrackInfoEncryptionData encryptionData;
+    WebCore::FourCC encryptionOriginalFormat;
+    Vector<WebCore::TrackInfoEncryptionInitData> encryptionInitDatas;
+};
+#endif
+
+header: <WebCore/TrackInfo.h>
+[CustomHeader] struct WebCore::TrackInfoData {
     WebCore::FourCC codecName;
     String codecString;
-    WebCore::TrackID trackID;
+    TrackID trackID;
+
 #if ENABLE(ENCRYPTED_MEDIA)
-    std::optional<std::pair<WebCore::EncryptionBoxType, Ref<WebCore::SharedBuffer>>> encryptionData;
-    std::optional<WebCore::FourCC> encryptionOriginalFormat;
-    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> encryptionInitDatas;
+    std::optional<WebCore::EncryptionDataCollection> encryptionData;
 #endif
-    [NotSerialized] WebCore::TrackInfoTrackType m_type;
+};
+
+header: <WebCore/TrackInfo.h>
+[CustomHeader] struct WebCore::AudioSpecificInfoData {
     uint32_t rate;
     uint32_t channels;
     uint32_t framesPerPacket;
     uint8_t bitDepth;
+
     RefPtr<WebCore::SharedBuffer> cookieData;
+};
+using WebCore::AudioInfoData = std::pair<WebCore::TrackInfoData, WebCore::AudioSpecificInfoData>;
+
+header: <WebCore/TrackInfo.h>
+[CustomHeader, RefCounted] class WebCore::AudioInfo {
+    WebCore::AudioInfoData toAudioInfoData();
 };
 
 header: <WebCore/TrackInfo.h>
-[CustomHeader, RefCounted, DisableMissingMemberCheck] struct WebCore::VideoInfo {
-    WebCore::FourCC codecName;
-    String codecString;
-    WebCore::TrackID trackID;
-#if ENABLE(ENCRYPTED_MEDIA)
-    std::optional<std::pair<WebCore::EncryptionBoxType, Ref<WebCore::SharedBuffer>>> encryptionData;
-    std::optional<WebCore::FourCC> encryptionOriginalFormat;
-    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> encryptionInitDatas;
-#endif
-    [NotSerialized] WebCore::TrackInfoTrackType m_type;
+[CustomHeader] struct WebCore::VideoSpecificInfoData {
     WebCore::FloatSize size;
     WebCore::FloatSize displaySize;
     uint8_t bitDepth;
     WebCore::PlatformVideoColorSpace colorSpace;
+    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> extensionAtoms;
+
 #if PLATFORM(VISION)
     std::optional<WebCore::ImmersiveVideoMetadata> immersiveVideoMetadata;
 #endif
-    Vector<std::pair<WebCore::FourCC, Ref<WebCore::SharedBuffer>>> extensionAtoms;
 };
 
-[RefCounted, CreateUsing=fromVariant] struct WebCore::TrackInfo {
+using WebCore::VideoInfoData = std::pair<WebCore::TrackInfoData, WebCore::VideoSpecificInfoData>;
+
+header: <WebCore/TrackInfo.h>
+[CustomHeader, RefCounted] class WebCore::VideoInfo {
+    WebCore::VideoInfoData toVideoInfoData();
+};
+
+[RefCounted, CreateUsing=fromVariant] class WebCore::TrackInfo {
     Variant<Ref<WebCore::AudioInfo>, Ref<WebCore::VideoInfo>> toVariant();
 };
 


### PR DESCRIPTION
#### 740232e86f953e5363c619c318901fe848125733
<pre>
TrackInfo and derivative should be a class, not a struct.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304329">https://bugs.webkit.org/show_bug.cgi?id=304329</a>
<a href="https://rdar.apple.com/166697941">rdar://166697941</a>

Reviewed by Youenn Fablet.

We make TrackInfo a class with immutable members.

Covered by existing tests.
* Source/WebCore/platform/MediaSamplesBlock.h:
(WebCore::MediaSamplesBlock::trackID const):
* Source/WebCore/platform/TrackInfo.h:
(WebCore::TrackInfo::operator== const):
(WebCore::TrackInfo::codecName const):
(WebCore::TrackInfo::codecString const):
(WebCore::TrackInfo::trackID const):
(WebCore::TrackInfo::setTrackID):
(WebCore::TrackInfo::encryptionData const):
(WebCore::TrackInfo::encryptionOriginalFormat const):
(WebCore::TrackInfo::encryptionInitDatas const):
(WebCore::TrackInfo::TrackInfo):
(WebCore::VideoInfo::create):
(WebCore::VideoInfo::size const):
(WebCore::VideoInfo::displaySize const):
(WebCore::VideoInfo::bitDepth const):
(WebCore::VideoInfo::colorSpace const):
(WebCore::VideoInfo::extensionAtoms const):
(WebCore::VideoInfo::immersiveVideoMetadata const):
(WebCore::VideoInfo::toVideoInfoData const):
(WebCore::VideoInfo::VideoInfo):
(WebCore::AudioInfo::create):
(WebCore::AudioInfo::rate const):
(WebCore::AudioInfo::channels const):
(WebCore::AudioInfo::framesPerPacket const):
(WebCore::AudioInfo::bitDepth const):
(WebCore::AudioInfo::cookieData const):
(WebCore::AudioInfo::toAudioInfoData const):
(WebCore::AudioInfo::AudioInfo):
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::createVideoInfoFromAV1CodecConfigurationRecord):
(WebCore::createVideoInfoFromAV1Stream):
* Source/WebCore/platform/graphics/AV1Utilities.h:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
* Source/WebCore/platform/graphics/MediaSampleConverter.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::codec const):
(WebCore::AudioTrackPrivateWebM::sampleRate const):
(WebCore::AudioTrackPrivateWebM::numberOfChannels const):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::audioStreamDescriptionFromAudioInfo):
(WebCore::getEncryptionData):
(WebCore::createAudioFormatDescription):
(WebCore::createFormatDescriptionFromTrackInfo):
(WebCore::createAudioInfoFromFormatDescription):
(WebCore::createVideoInfoFromFormatDescription):
(WebCore::toCMSampleBuffer):
(WebCore::samplesBlockFromCMSampleBuffer):
(WebCore::PacketDurationParser::PacketDurationParser):
(WebCore::setEncryptionInfo): Deleted.
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromAVCC):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
(WebCore::SourceBufferParserWebM::returnSamples):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::TrackData::setFormatDescription):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromVPCodecConfigurationRecord):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::codec const):
(WebCore::VideoTrackPrivateWebM::width const):
(WebCore::VideoTrackPrivateWebM::height const):
(WebCore::VideoTrackPrivateWebM::colorSpace const):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::createAudioInfoForFormat):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::processVideoEncoderActiveConfiguration):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addVideoTrack):
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(computeAV1InputFormat):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304673@main">https://commits.webkit.org/304673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319984448679efc8111ac6ea8a526a3bf3bd371c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143947 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104170 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80f6c401-0d07-4641-9172-5be56bb631e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4059 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4541 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128195 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146693 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40848 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112511 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-text/hyphens/hyphenate-character-002.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-010.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-inline-010.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-punctuation-001.html imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html imported/w3c/web-platform-tests/quirks/line-height-in-list-item.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112852 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6329 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118385 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8325 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36442 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8117 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->