### PR TITLE
REGRESSION(304573@main): [GTK][WPE] API test expectations don't work anymore because the default webkitpy port name has changed

### DIFF
--- a/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
@@ -53,7 +53,7 @@ class ExpectationsTest(unittest.TestCase):
             "test1_two": {
                 "expected": {
                     "all": {"status": ["FAIL"], "bug": "1234"},
-                    "gtk-wk2": {"status": ["PASS"]}
+                    "gtk": {"status": ["PASS"]}
                 }
             }
         }
@@ -77,7 +77,7 @@ class ExpectationsTest(unittest.TestCase):
         "expected": {"all": {"status": ["SKIP"], "bug": "1234"}}
     },
     "imported/w3c/webdriver/tests/test2.py": {
-        "expected": {"gtk-wk2": {"status": ["SKIP"], "bug": "1234"}}
+        "expected": {"gtk": {"status": ["SKIP"], "bug": "1234"}}
     },
     "imported/w3c/webdriver/tests/test3.py": {
         "expected": {"all": {"status": ["SKIP"], "bug": "1234"}},
@@ -101,7 +101,7 @@ class ExpectationsTest(unittest.TestCase):
     "TestCookieManager": {
         "subtests": {
             "/webkit2/WebKitCookieManager/persistent-storage": {
-                "expected": {"gtk-wk2": {"status": ["FAIL", "PASS"], "bug": "1234"}}
+                "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "1234"}}
             }
         }
     },
@@ -111,7 +111,7 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all": {"status": ["CRASH", "PASS"], "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"wpe-wk2": {"status": ["FAIL", "TIMEOUT"], "bug": "1234"}}
+                "expected": {"wpe": {"status": ["FAIL", "TIMEOUT"], "bug": "1234"}}
             }
         }
     }
@@ -132,8 +132,8 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all@Debug": {"status": ["CRASH"], "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"gtk-wk2@Release": {"status": ["FAIL"], "bug": "1234"},
-                             "gtk-wk2@Debug": {"status": ["CRASH"], "bug": "1234"}}
+                "expected": {"gtk@Release": {"status": ["FAIL"], "bug": "1234"},
+                             "gtk@Debug": {"status": ["CRASH"], "bug": "1234"}}
             }
         }
     },
@@ -150,10 +150,10 @@ class ExpectationsTest(unittest.TestCase):
     },
     "TestWebViewEditor": {
         "expected": {"all@Release": {"status": ["SKIP"]},
-                     "wpe-wk2@Debug": {"status": ["SKIP"]}},
+                     "wpe@Debug": {"status": ["SKIP"]}},
         "subtests": {
             "/webkit2/WebKitWebView/editable/editable": {
-                "expected": {"gtk-wk2": {"status": ["FAIL"], "bug": "1234"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "1234"}}
             }
         }
     }
@@ -165,7 +165,7 @@ class ExpectationsTest(unittest.TestCase):
         "expected": {"all": {"slow": true}},
         "subtests": {
             "/webkit2/WebKitCookieManager/persistent-storage": {
-                "expected": {"wpe-wk2": {"status": ["FAIL"], "slow": false, "bug": "1234"}}
+                "expected": {"wpe": {"status": ["FAIL"], "slow": false, "bug": "1234"}}
             }
         }
     },
@@ -175,7 +175,7 @@ class ExpectationsTest(unittest.TestCase):
                 "expected": {"all": {"status": ["FAIL"], "slow": true, "bug": "1234"}}
             },
             "WebKit.WKConnection": {
-                "expected": {"gtk-wk2": {"status": ["CRASH"], "bug": "1234"}}
+                "expected": {"gtk": {"status": ["CRASH"], "bug": "1234"}}
             }
         }
     }

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -64,6 +64,12 @@ class GLibPort(Port):
             multiplier *= 2
         return multiplier * default_timeout
 
+    @classmethod
+    def determine_full_port_name(cls, host, options, port_name):
+        """Return a fully-specified port name that can be used to construct objects."""
+        # gtk and wpe ports don't add a -wk2 suffix on the default port name because they don't support -wk1
+        return port_name
+
     def _built_executables_path(self, *path):
         return self._build_path(*(('bin',) + path))
 


### PR DESCRIPTION
#### 1f24c9f3fd2ce620af13e2d48e07076c440107bc
<pre>
REGRESSION(304573@main): [GTK][WPE] API test expectations don&apos;t work anymore because the default webkitpy port name has changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=304332">https://bugs.webkit.org/show_bug.cgi?id=304332</a>

Unreviewed partial revert fix.

304573@main changed the webkitpy port name from gtk and wpe to gtk-wk2
and wpe-wk2 and that has caused that the API Test Expectations don&apos;t
match anymore.

This recovers back the previous webkitpy names for GTK and WPE because this
port names are used on several parts of the webkitpy code and not only on
the API test expectation file.

If there is really a desire to change the default webkitpy port name in this
case, then a more careful approach and some discussion is needed.

* Tools/Scripts/webkitpy/common/test_expectations_unittest.py:
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort):
(GLibPort.determine_full_port_name):

Canonical link: <a href="https://commits.webkit.org/304594@main">https://commits.webkit.org/304594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8990356b93710e384026f25dd809363772f9757

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143786 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139026 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/84877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135428 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4382 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146534 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8120 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/40708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8136 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/112744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/6204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8168 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->