### PR TITLE
REBASELINE [ iOS] multiple css tests are failing with image diff after update to C

### DIFF
--- a/LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html
+++ b/LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-61; totalPixels=0-68170" />
+    <meta name="fuzzy" content="maxDifference=0-61; totalPixels=0-70000" />
     <style>
         body {
             margin: 0;

--- a/LayoutTests/css3/blending/background-blend-mode-body-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-body-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=130500-215000" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=130500-230000" />
 <style>
 body {
 	background-image: linear-gradient(green, green);

--- a/LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=234000-254000" />
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=234000-270000" />
 <style>
 body {
 	background-image: linear-gradient(transparent, transparent 10%, green 10%, green 90%, transparent 90%, transparent);

--- a/LayoutTests/fast/gradients/linear-two-hints-angle.html
+++ b/LayoutTests/fast/gradients/linear-two-hints-angle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=12300-13200" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=12300-13400" />
     <style>
     	div {
             width: 200px;

--- a/LayoutTests/imported/mozilla/svg/text-scale-02.svg
+++ b/LayoutTests/imported/mozilla/svg/text-scale-02.svg
@@ -3,7 +3,7 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <svg xmlns="http://www.w3.org/2000/svg">
-  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=67000-115000" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=67000-116000" />
   <style>
     @font-face {
       font-family: Ahem;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1b.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1c.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-3.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-3-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'no-repeat space' and 'space no-repeat' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-5300">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-5550">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-4-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'repeat space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7908">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 96px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-5-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space repeat' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7960">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8350">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-001.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Background Clip Follows Rounded Corner</title>
-<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-22547">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-27000">
 <link rel="match" href="reference/background-rounded-image-clip.html">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-001.html
@@ -5,7 +5,7 @@
 <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
 <meta name="assert" content="Tests that analogous missing components logic works.">
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-17000">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-18000">
 <link rel="match" href="gradient-analogous-missing-components-001-ref.html">
 <style>
     .test {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html
@@ -7,7 +7,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#gradients">
     <meta name="assert" content="Correct placement and rendering of gradients inside elements with borders.">
     <link rel="match" href="gradients-with-border-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-11000">
+    <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-11500">
     <style>
         .test {
             width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
 <meta name="assert" content="A color stop with two positions create a hard transition">
 <link rel="match" href="reference/100x100-blue-green.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4050">
 <style>
 #target {
   width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-round-zero-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-round-zero-size.html
@@ -7,7 +7,7 @@
 <link rel="author" title="Mozilla" href="https://mozilla.org">
 <link rel="match" href="clip-path-round-zero-size-ref.html">
 <!-- Allow differences of antialised pixels along rounded edges -->
-<meta name="fuzzy" content="maxDifference=0-64;totalPixels=0-100">
+<meta name="fuzzy" content="maxDifference=0-75;totalPixels=0-100">
 <style>
 #target {
   margin: 50px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1500" />
 <title>'box-decoration-break: slice' and 'mask-image'</title>
 <meta name="flags" content="ahem">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
@@ -11,7 +11,7 @@
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float with
                                 shape-margin applied."/>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9600"/>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-9650"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8461,22 +8461,4 @@ webkit.org/b/304079 [ Debug ] http/tests/ipc/ipc-fetch-task-message-crash.html [
 
 webkit.org/b/303650 fast/lists/marker-before-empty-inline.html [ ImageOnlyFailure ]
 
-# webkit.org/b/304268 REBASELINE [ iOS] multiple css tests are failing with image diff after update to C
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1a.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1b.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1c.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-3.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-round-zero-size.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html [ ImageOnlyFailure ]
-
-
 webkit.org/b/304298 accessibility/text-stitching-inside-links.html [ Failure ]


### PR DESCRIPTION
#### b9e2bf404bd35693eec5e6f52d9b09d710c354dd
<pre>
REBASELINE [ iOS] multiple css tests are failing with image diff after update to C
<a href="https://bugs.webkit.org/show_bug.cgi?id=304268">https://bugs.webkit.org/show_bug.cgi?id=304268</a>
<a href="https://rdar.apple.com/166641336">rdar://166641336</a>

Unreviewed fuzzy adjustments.

* LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html:
* LayoutTests/css3/blending/background-blend-mode-body-image.html:
* LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html:
* LayoutTests/fast/gradients/linear-two-hints-angle.html:
* LayoutTests/imported/mozilla/svg/text-scale-02.svg:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-3.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-round-zero-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-inline-sliced-1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/304621@main">https://commits.webkit.org/304621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b1d22f42d4b89bf50128623d0aae170bdce46df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/136157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/8513 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/143866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/9187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/8358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/143866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/139103 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/9187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/143866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/9187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/4461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/9187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146612 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/8197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/146612 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/8213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/8358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146612 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20971 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/8245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/47437 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/7962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/8184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/8037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->