### PR TITLE
[libpas] Parallelize test runner

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -201,7 +201,7 @@ typedef enum pas_mte_tag_constraint pas_mte_tag_constraint;
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint pas_mte_exclude_tag(pas_mte_tag_constraint base, uint8_t tag_value_to_exclude)
 {
-    return (pas_mte_tag_constraint)(base & ~(1 << tag_value_to_exclude));
+    return (pas_mte_tag_constraint)((unsigned)base & ~(1u << tag_value_to_exclude));
 }
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint

--- a/Source/bmalloc/libpas/src/test/PGMTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTests.cpp
@@ -30,7 +30,10 @@
 
 #include "TestHarness.h"
 
+#if defined(PAS_BMALLOC)
 #include "bmalloc/BPlatform.h"
+#endif
+
 #include "bmalloc_heap.h"
 #include "iso_heap.h"
 #include "iso_heap_config.h"

--- a/Source/bmalloc/libpas/test-impl.sh
+++ b/Source/bmalloc/libpas/test-impl.sh
@@ -26,13 +26,13 @@
 
 case $variants in
     all|testing)
-        DYLD_LIBRARY_PATH=build-$sdk-testing/$configdir build-$sdk-testing/$configdir/test_pas
+        DYLD_LIBRARY_PATH=build-$sdk-testing/$configdir build-$sdk-testing/$configdir/test_pas $testArgs
         ;;
 esac
 
 case $variants in
     all|default)
-        DYLD_LIBRARY_PATH=build-$sdk-default/$configdir build-$sdk-default/$configdir/test_pas
+        DYLD_LIBRARY_PATH=build-$sdk-default/$configdir build-$sdk-default/$configdir/test_pas $testArgs
         ;;
 esac
 


### PR DESCRIPTION
#### b0355af434c640539b97fb2d342fd96d9cc1f1b9
<pre>
[libpas] Parallelize test runner
<a href="https://bugs.webkit.org/show_bug.cgi?id=304285">https://bugs.webkit.org/show_bug.cgi?id=304285</a>
<a href="https://rdar.apple.com/164655522">rdar://164655522</a>

Reviewed by Keith Miller.

With this patch, TestHarness.cpp will launch up to NCPUs/2 test
processes at once by default. This is friendlier than NCPUs for
contended cases like CI runners, while still being a big speedup
for desk usage.
This default can be overridden via the PasTestConcurrency envvar.

On my M3 Macbook Pro, this reduces the wall-clock time of `./test.sh`
from ~16m to a bit under ~5m, using `PasTestConcurrency=8`.

Canonical link: <a href="https://commits.webkit.org/305304@main">https://commits.webkit.org/305304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2be87f7f4d76cacbb9876cb83fd49c9982690270

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138049 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26aa70ec-2ca2-4891-b9ab-abb5d9966383) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105577 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e31b43b7-892e-4047-89c6-4771d73da2de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8300 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86426 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfa48414-3989-4ba6-b550-d60fd09f5620) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5670 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6402 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130013 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148831 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136608 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113975 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29047 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7849 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120055 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10142 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169321 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9873 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44155 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->