### PR TITLE
[JSC] Wasm: fix exceptions with inlining between SIMD and non-SIMD functions

### DIFF
--- a/JSTests/wasm/stress/simd-inline-exceptions.js
+++ b/JSTests/wasm/stress/simd-inline-exceptions.js
@@ -1,0 +1,109 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// Test case 1: SIMD function inlined into non-SIMD function that catches exception
+// The SIMD function throws an exception which should be caught by the caller
+async function testSIMDInlinedIntoNonSIMD() {
+    const wat = `
+    (module
+        (tag $exn)
+        (global $simd_result (mut v128) (v128.const i32x4 0 0 0 0))
+        (global $simd_input (mut v128) (v128.const i32x4 1 2 3 4))
+        (func $simd_throw (export "simd_throw") (result i32)
+            (global.get $simd_input)
+
+            ;; Throw with v128 on the nested expression stack
+            (if
+                (i32.const 1)
+                (then
+                    (throw $exn)
+                )
+            )
+
+            (global.set $simd_result)
+            (i32.const 0)
+        )
+        (func (export "caller") (result i32)
+            ;; Non-SIMD function that calls SIMD function and catches exception
+            ;; Put some values on the stack before the try block
+            (i32.const 10)
+            (i32.const 20)
+
+            (try (result i32)
+                (do
+                    (call $simd_throw)
+                )
+                (catch $exn
+                    (i32.const 42)
+                )
+            )
+
+            ;; After catching exception, stack should have: 10, 20, 42
+            ;; Add them all together: 10 + 20 + 42 = 72
+            (i32.add)
+            (i32.add)
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, { exceptions: true, simd: true });
+    const { caller } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        const result = caller();
+        assert.eq(result, 72, "Test case 1: Exception should be caught and return 10 + 20 + 42 = 72");
+    }
+}
+
+// Test case 2: Non-SIMD function inlined into SIMD function that catches exception
+// The non-SIMD function throws an exception which should be caught by the SIMD caller
+async function testNonSIMDInlinedIntoSIMD() {
+    const wat = `
+    (module
+        (tag $exn)
+        (global $simd_input (mut v128) (v128.const i32x4 1 2 3 4))
+        (func $non_simd_throw (export "non_simd_throw") (result i32)
+            (local $x i32)
+            ;; Throw inside an if block
+            (if
+                (i32.const 1)
+                (then
+                    (throw $exn)
+                )
+            )
+            (i32.const 0)
+        )
+        (func (export "simd_caller") (result i32)
+            (local $tmp i32)
+            ;; SIMD function that calls non-SIMD function and catches exception
+            (global.get $simd_input)
+
+            (try (result i32)
+                (do
+                    (call $non_simd_throw)
+                )
+                (catch $exn
+                    (i32.const 99)
+                )
+            )
+
+            (local.set $tmp)
+            (i32x4.extract_lane 3)
+            (local.get $tmp)
+            (i32.add)
+        )
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, { exceptions: true, simd: true });
+    const { simd_caller } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        const result = simd_caller();
+        assert.eq(result, 103, "Test case 2: Exception should be caught, return 99 + lane 3 (4) = 103");
+    }
+}
+
+assert.asyncTest(testSIMDInlinedIntoNonSIMD());
+assert.asyncTest(testNonSIMDInlinedIntoSIMD());

--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -57,11 +57,6 @@ void MacroAssembler::probeDebug(Function<void(Probe::Context&)> func)
     probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)));
 }
 
-void MacroAssembler::probeDebugSIMD(Function<void(Probe::Context&)> func)
-{
-    probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)), Probe::SavedFPWidth::SaveVectors);
-}
-
 } // namespace JSC
 
 namespace WTF {

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -112,17 +112,10 @@ namespace JSC {
 
 namespace Probe {
 
-enum class SavedFPWidth {
-    SaveVectors,
-    DontSaveVectors
-};
-
 class Context;
 typedef void (SYSV_ABI *Function)(Context&);
 
 } // namespace Probe
-
-using Probe::SavedFPWidth;
 
 namespace Printer {
 
@@ -2475,11 +2468,10 @@ public:
     //
     // Note: this version of probe() should be implemented by the target specific
     // MacroAssembler.
-    void probe(Probe::Function, void* arg, SavedFPWidth = SavedFPWidth::DontSaveVectors);
+    void probe(Probe::Function, void* arg);
 
     // This leaks memory. Must not be used for production.
     JS_EXPORT_PRIVATE void probeDebug(Function<void(Probe::Context&)>);
-    JS_EXPORT_PRIVATE void probeDebugSIMD(Function<void(Probe::Context&)>);
 
     // Let's you print from your JIT generated code.
     // See comments in MacroAssemblerPrinter.h for examples of how to use this.

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -65,8 +65,6 @@ namespace JSC {
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampoline, void, ());
 JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampoline);
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampolineSIMD, void, ());
-JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampolineSIMD);
 
 using namespace ARM64Registers;
 
@@ -123,42 +121,42 @@ using namespace ARM64Registers;
 #define PROBE_CPU_NZCV_OFFSET (PROBE_FIRST_GPREG_OFFSET + (33 * GPREG_SIZE))
 #define PROBE_CPU_FPSR_OFFSET (PROBE_FIRST_GPREG_OFFSET + (34 * GPREG_SIZE))
 
-#define PROBE_FIRST_FPREG_OFFSET (PROBE_FIRST_GPREG_OFFSET + (35 * GPREG_SIZE))
+#define PROBE_FIRST_VECTOR_OFFSET (PROBE_FIRST_GPREG_OFFSET + (35 * GPREG_SIZE))
 
-#define FPREG_SIZE 8
-#define PROBE_CPU_Q0_OFFSET (PROBE_FIRST_FPREG_OFFSET + (0 * FPREG_SIZE))
-#define PROBE_CPU_Q1_OFFSET (PROBE_FIRST_FPREG_OFFSET + (1 * FPREG_SIZE))
-#define PROBE_CPU_Q2_OFFSET (PROBE_FIRST_FPREG_OFFSET + (2 * FPREG_SIZE))
-#define PROBE_CPU_Q3_OFFSET (PROBE_FIRST_FPREG_OFFSET + (3 * FPREG_SIZE))
-#define PROBE_CPU_Q4_OFFSET (PROBE_FIRST_FPREG_OFFSET + (4 * FPREG_SIZE))
-#define PROBE_CPU_Q5_OFFSET (PROBE_FIRST_FPREG_OFFSET + (5 * FPREG_SIZE))
-#define PROBE_CPU_Q6_OFFSET (PROBE_FIRST_FPREG_OFFSET + (6 * FPREG_SIZE))
-#define PROBE_CPU_Q7_OFFSET (PROBE_FIRST_FPREG_OFFSET + (7 * FPREG_SIZE))
-#define PROBE_CPU_Q8_OFFSET (PROBE_FIRST_FPREG_OFFSET + (8 * FPREG_SIZE))
-#define PROBE_CPU_Q9_OFFSET (PROBE_FIRST_FPREG_OFFSET + (9 * FPREG_SIZE))
-#define PROBE_CPU_Q10_OFFSET (PROBE_FIRST_FPREG_OFFSET + (10 * FPREG_SIZE))
-#define PROBE_CPU_Q11_OFFSET (PROBE_FIRST_FPREG_OFFSET + (11 * FPREG_SIZE))
-#define PROBE_CPU_Q12_OFFSET (PROBE_FIRST_FPREG_OFFSET + (12 * FPREG_SIZE))
-#define PROBE_CPU_Q13_OFFSET (PROBE_FIRST_FPREG_OFFSET + (13 * FPREG_SIZE))
-#define PROBE_CPU_Q14_OFFSET (PROBE_FIRST_FPREG_OFFSET + (14 * FPREG_SIZE))
-#define PROBE_CPU_Q15_OFFSET (PROBE_FIRST_FPREG_OFFSET + (15 * FPREG_SIZE))
-#define PROBE_CPU_Q16_OFFSET (PROBE_FIRST_FPREG_OFFSET + (16 * FPREG_SIZE))
-#define PROBE_CPU_Q17_OFFSET (PROBE_FIRST_FPREG_OFFSET + (17 * FPREG_SIZE))
-#define PROBE_CPU_Q18_OFFSET (PROBE_FIRST_FPREG_OFFSET + (18 * FPREG_SIZE))
-#define PROBE_CPU_Q19_OFFSET (PROBE_FIRST_FPREG_OFFSET + (19 * FPREG_SIZE))
-#define PROBE_CPU_Q20_OFFSET (PROBE_FIRST_FPREG_OFFSET + (20 * FPREG_SIZE))
-#define PROBE_CPU_Q21_OFFSET (PROBE_FIRST_FPREG_OFFSET + (21 * FPREG_SIZE))
-#define PROBE_CPU_Q22_OFFSET (PROBE_FIRST_FPREG_OFFSET + (22 * FPREG_SIZE))
-#define PROBE_CPU_Q23_OFFSET (PROBE_FIRST_FPREG_OFFSET + (23 * FPREG_SIZE))
-#define PROBE_CPU_Q24_OFFSET (PROBE_FIRST_FPREG_OFFSET + (24 * FPREG_SIZE))
-#define PROBE_CPU_Q25_OFFSET (PROBE_FIRST_FPREG_OFFSET + (25 * FPREG_SIZE))
-#define PROBE_CPU_Q26_OFFSET (PROBE_FIRST_FPREG_OFFSET + (26 * FPREG_SIZE))
-#define PROBE_CPU_Q27_OFFSET (PROBE_FIRST_FPREG_OFFSET + (27 * FPREG_SIZE))
-#define PROBE_CPU_Q28_OFFSET (PROBE_FIRST_FPREG_OFFSET + (28 * FPREG_SIZE))
-#define PROBE_CPU_Q29_OFFSET (PROBE_FIRST_FPREG_OFFSET + (29 * FPREG_SIZE))
-#define PROBE_CPU_Q30_OFFSET (PROBE_FIRST_FPREG_OFFSET + (30 * FPREG_SIZE))
-#define PROBE_CPU_Q31_OFFSET (PROBE_FIRST_FPREG_OFFSET + (31 * FPREG_SIZE))
-#define PROBE_SIZE (PROBE_FIRST_FPREG_OFFSET + (32 * 2 * FPREG_SIZE))
+#define VECTOR_SIZE 16
+#define PROBE_CPU_Q0_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (0 * VECTOR_SIZE))
+#define PROBE_CPU_Q1_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (1 * VECTOR_SIZE))
+#define PROBE_CPU_Q2_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (2 * VECTOR_SIZE))
+#define PROBE_CPU_Q3_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (3 * VECTOR_SIZE))
+#define PROBE_CPU_Q4_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (4 * VECTOR_SIZE))
+#define PROBE_CPU_Q5_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (5 * VECTOR_SIZE))
+#define PROBE_CPU_Q6_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (6 * VECTOR_SIZE))
+#define PROBE_CPU_Q7_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (7 * VECTOR_SIZE))
+#define PROBE_CPU_Q8_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (8 * VECTOR_SIZE))
+#define PROBE_CPU_Q9_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (9 * VECTOR_SIZE))
+#define PROBE_CPU_Q10_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (10 * VECTOR_SIZE))
+#define PROBE_CPU_Q11_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (11 * VECTOR_SIZE))
+#define PROBE_CPU_Q12_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (12 * VECTOR_SIZE))
+#define PROBE_CPU_Q13_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (13 * VECTOR_SIZE))
+#define PROBE_CPU_Q14_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (14 * VECTOR_SIZE))
+#define PROBE_CPU_Q15_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (15 * VECTOR_SIZE))
+#define PROBE_CPU_Q16_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (16 * VECTOR_SIZE))
+#define PROBE_CPU_Q17_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (17 * VECTOR_SIZE))
+#define PROBE_CPU_Q18_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (18 * VECTOR_SIZE))
+#define PROBE_CPU_Q19_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (19 * VECTOR_SIZE))
+#define PROBE_CPU_Q20_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (20 * VECTOR_SIZE))
+#define PROBE_CPU_Q21_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (21 * VECTOR_SIZE))
+#define PROBE_CPU_Q22_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (22 * VECTOR_SIZE))
+#define PROBE_CPU_Q23_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (23 * VECTOR_SIZE))
+#define PROBE_CPU_Q24_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (24 * VECTOR_SIZE))
+#define PROBE_CPU_Q25_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (25 * VECTOR_SIZE))
+#define PROBE_CPU_Q26_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (26 * VECTOR_SIZE))
+#define PROBE_CPU_Q27_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (27 * VECTOR_SIZE))
+#define PROBE_CPU_Q28_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (28 * VECTOR_SIZE))
+#define PROBE_CPU_Q29_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (29 * VECTOR_SIZE))
+#define PROBE_CPU_Q30_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (30 * VECTOR_SIZE))
+#define PROBE_CPU_Q31_OFFSET (PROBE_FIRST_VECTOR_OFFSET + (31 * VECTOR_SIZE))
+#define PROBE_SIZE (PROBE_FIRST_VECTOR_OFFSET + (32 * VECTOR_SIZE))
 
 #define SAVED_PROBE_RETURN_PC_OFFSET        (PROBE_SIZE + (0 * GPREG_SIZE))
 #define PROBE_SIZE_PLUS_EXTRAS              (PROBE_SIZE + (3 * GPREG_SIZE))
@@ -213,39 +211,39 @@ static_assert(PROBE_OFFSETOF(cpu.sprs[ARM64Registers::fpsr]) == PROBE_CPU_FPSR_O
 
 static_assert(!(PROBE_CPU_Q0_OFFSET & 0x7), "Probe::State::cpu.fprs[q0]'s offset should be 8 byte aligned");
 
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q0]) == PROBE_CPU_Q0_OFFSET, "Probe::State::cpu.fprs[q0]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q1]) == PROBE_CPU_Q1_OFFSET, "Probe::State::cpu.fprs[q1]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q2]) == PROBE_CPU_Q2_OFFSET, "Probe::State::cpu.fprs[q2]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q3]) == PROBE_CPU_Q3_OFFSET, "Probe::State::cpu.fprs[q3]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q4]) == PROBE_CPU_Q4_OFFSET, "Probe::State::cpu.fprs[q4]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q5]) == PROBE_CPU_Q5_OFFSET, "Probe::State::cpu.fprs[q5]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q6]) == PROBE_CPU_Q6_OFFSET, "Probe::State::cpu.fprs[q6]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q7]) == PROBE_CPU_Q7_OFFSET, "Probe::State::cpu.fprs[q7]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q8]) == PROBE_CPU_Q8_OFFSET, "Probe::State::cpu.fprs[q8]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q9]) == PROBE_CPU_Q9_OFFSET, "Probe::State::cpu.fprs[q9]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q10]) == PROBE_CPU_Q10_OFFSET, "Probe::State::cpu.fprs[q10]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q11]) == PROBE_CPU_Q11_OFFSET, "Probe::State::cpu.fprs[q11]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q12]) == PROBE_CPU_Q12_OFFSET, "Probe::State::cpu.fprs[q12]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q13]) == PROBE_CPU_Q13_OFFSET, "Probe::State::cpu.fprs[q13]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q14]) == PROBE_CPU_Q14_OFFSET, "Probe::State::cpu.fprs[q14]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q15]) == PROBE_CPU_Q15_OFFSET, "Probe::State::cpu.fprs[q15]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q0]) == PROBE_CPU_Q0_OFFSET, "Probe::State::cpu.fprs[q0]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q1]) == PROBE_CPU_Q1_OFFSET, "Probe::State::cpu.fprs[q1]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q2]) == PROBE_CPU_Q2_OFFSET, "Probe::State::cpu.fprs[q2]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q3]) == PROBE_CPU_Q3_OFFSET, "Probe::State::cpu.fprs[q3]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q4]) == PROBE_CPU_Q4_OFFSET, "Probe::State::cpu.fprs[q4]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q5]) == PROBE_CPU_Q5_OFFSET, "Probe::State::cpu.fprs[q5]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q6]) == PROBE_CPU_Q6_OFFSET, "Probe::State::cpu.fprs[q6]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q7]) == PROBE_CPU_Q7_OFFSET, "Probe::State::cpu.fprs[q7]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q8]) == PROBE_CPU_Q8_OFFSET, "Probe::State::cpu.fprs[q8]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q9]) == PROBE_CPU_Q9_OFFSET, "Probe::State::cpu.fprs[q9]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q10]) == PROBE_CPU_Q10_OFFSET, "Probe::State::cpu.fprs[q10]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q11]) == PROBE_CPU_Q11_OFFSET, "Probe::State::cpu.fprs[q11]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q12]) == PROBE_CPU_Q12_OFFSET, "Probe::State::cpu.fprs[q12]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q13]) == PROBE_CPU_Q13_OFFSET, "Probe::State::cpu.fprs[q13]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q14]) == PROBE_CPU_Q14_OFFSET, "Probe::State::cpu.fprs[q14]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q15]) == PROBE_CPU_Q15_OFFSET, "Probe::State::cpu.fprs[q15]'s offset matches ctiMasmProbeTrampoline");
 
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q16]) == PROBE_CPU_Q16_OFFSET, "Probe::State::cpu.fprs[q16]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q17]) == PROBE_CPU_Q17_OFFSET, "Probe::State::cpu.fprs[q17]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q18]) == PROBE_CPU_Q18_OFFSET, "Probe::State::cpu.fprs[q18]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q19]) == PROBE_CPU_Q19_OFFSET, "Probe::State::cpu.fprs[q19]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q20]) == PROBE_CPU_Q20_OFFSET, "Probe::State::cpu.fprs[q20]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q21]) == PROBE_CPU_Q21_OFFSET, "Probe::State::cpu.fprs[q21]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q22]) == PROBE_CPU_Q22_OFFSET, "Probe::State::cpu.fprs[q22]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q23]) == PROBE_CPU_Q23_OFFSET, "Probe::State::cpu.fprs[q23]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q24]) == PROBE_CPU_Q24_OFFSET, "Probe::State::cpu.fprs[q24]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q25]) == PROBE_CPU_Q25_OFFSET, "Probe::State::cpu.fprs[q25]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q26]) == PROBE_CPU_Q26_OFFSET, "Probe::State::cpu.fprs[q26]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q27]) == PROBE_CPU_Q27_OFFSET, "Probe::State::cpu.fprs[q27]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q28]) == PROBE_CPU_Q28_OFFSET, "Probe::State::cpu.fprs[q28]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q29]) == PROBE_CPU_Q29_OFFSET, "Probe::State::cpu.fprs[q29]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q30]) == PROBE_CPU_Q30_OFFSET, "Probe::State::cpu.fprs[q30]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF(cpu.fprs.fprs[ARM64Registers::q31]) == PROBE_CPU_Q31_OFFSET, "Probe::State::cpu.fprs[q31]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q16]) == PROBE_CPU_Q16_OFFSET, "Probe::State::cpu.fprs[q16]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q17]) == PROBE_CPU_Q17_OFFSET, "Probe::State::cpu.fprs[q17]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q18]) == PROBE_CPU_Q18_OFFSET, "Probe::State::cpu.fprs[q18]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q19]) == PROBE_CPU_Q19_OFFSET, "Probe::State::cpu.fprs[q19]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q20]) == PROBE_CPU_Q20_OFFSET, "Probe::State::cpu.fprs[q20]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q21]) == PROBE_CPU_Q21_OFFSET, "Probe::State::cpu.fprs[q21]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q22]) == PROBE_CPU_Q22_OFFSET, "Probe::State::cpu.fprs[q22]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q23]) == PROBE_CPU_Q23_OFFSET, "Probe::State::cpu.fprs[q23]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q24]) == PROBE_CPU_Q24_OFFSET, "Probe::State::cpu.fprs[q24]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q25]) == PROBE_CPU_Q25_OFFSET, "Probe::State::cpu.fprs[q25]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q26]) == PROBE_CPU_Q26_OFFSET, "Probe::State::cpu.fprs[q26]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q27]) == PROBE_CPU_Q27_OFFSET, "Probe::State::cpu.fprs[q27]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q28]) == PROBE_CPU_Q28_OFFSET, "Probe::State::cpu.fprs[q28]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q29]) == PROBE_CPU_Q29_OFFSET, "Probe::State::cpu.fprs[q29]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q30]) == PROBE_CPU_Q30_OFFSET, "Probe::State::cpu.fprs[q30]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF(cpu.fprs.vectors[ARM64Registers::q31]) == PROBE_CPU_Q31_OFFSET, "Probe::State::cpu.fprs[q31]'s offset matches ctiMasmProbeTrampoline");
 
 static_assert(sizeof(Probe::State) == PROBE_SIZE, "Probe::State's size matches ctiMasmProbeTrampoline");
 
@@ -255,9 +253,7 @@ static_assert(!(PROBE_SIZE_PLUS_EXTRAS & 0xf), "PROBE_SIZE_PLUS_EXTRAS should be
 
 #undef PROBE_OFFSETOF
 
-#define FPR_OFFSET(fpr) (PROBE_CPU_##fpr##_OFFSET - PROBE_CPU_Q0_OFFSET)
-
-#define VECTOR_OFFSET(fpr) (2 * (PROBE_CPU_##fpr##_OFFSET - PROBE_CPU_Q0_OFFSET))
+#define VECTOR_OFFSET(fpr) (PROBE_CPU_##fpr##_OFFSET - PROBE_CPU_Q0_OFFSET)
 
 struct IncomingProbeRecord {
     UCPURegister x24;
@@ -391,22 +387,22 @@ __asm__(
     "stp       x0, x1, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_NZCV_OFFSET) "]" "\n" // Store nzcv and fpsr (preloaded into x0 and x1 above).
 
     "add       x9, sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_Q0_OFFSET) "\n"
-    "stp       d0, d1, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q0)) "]" "\n"
-    "stp       d2, d3, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q2)) "]" "\n"
-    "stp       d4, d5, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q4)) "]" "\n"
-    "stp       d6, d7, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q6)) "]" "\n"
-    "stp       d8, d9, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q8)) "]" "\n"
-    "stp       d10, d11, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q10)) "]" "\n"
-    "stp       d12, d13, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q12)) "]" "\n"
-    "stp       d14, d15, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q14)) "]" "\n"
-    "stp       d16, d17, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q16)) "]" "\n"
-    "stp       d18, d19, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q18)) "]" "\n"
-    "stp       d20, d21, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q20)) "]" "\n"
-    "stp       d22, d23, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q22)) "]" "\n"
-    "stp       d24, d25, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q24)) "]" "\n"
-    "stp       d26, d27, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q26)) "]" "\n"
-    "stp       d28, d29, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q28)) "]" "\n"
-    "stp       d30, d31, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q30)) "]" "\n"
+    "stp       q0,   q1, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q0)) "]" "\n"
+    "stp       q2,   q3, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q2)) "]" "\n"
+    "stp       q4,   q5, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q4)) "]" "\n"
+    "stp       q6,   q7, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q6)) "]" "\n"
+    "stp       q8,   q9, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q8)) "]" "\n"
+    "stp       q10, q11, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q10)) "]" "\n"
+    "stp       q12, q13, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q12)) "]" "\n"
+    "stp       q14, q15, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q14)) "]" "\n"
+    "stp       q16, q17, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q16)) "]" "\n"
+    "stp       q18, q19, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q18)) "]" "\n"
+    "stp       q20, q21, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q20)) "]" "\n"
+    "stp       q22, q23, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q22)) "]" "\n"
+    "stp       q24, q25, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q24)) "]" "\n"
+    "stp       q26, q27, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q26)) "]" "\n"
+    "stp       q28, q29, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q28)) "]" "\n"
+    "stp       q30, q31, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q30)) "]" "\n"
 
     "mov       x27, sp" "\n" // Save the Probe::State* in a callee saved register.
 
@@ -467,22 +463,22 @@ __asm__(
     // See https://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html.
 
     "add       x9, sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_Q0_OFFSET) "\n"
-    "ldp       d0, d1, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q0)) "]" "\n"
-    "ldp       d2, d3, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q2)) "]" "\n"
-    "ldp       d4, d5, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q4)) "]" "\n"
-    "ldp       d6, d7, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q6)) "]" "\n"
-    "ldp       d8, d9, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q8)) "]" "\n"
-    "ldp       d10, d11, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q10)) "]" "\n"
-    "ldp       d12, d13, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q12)) "]" "\n"
-    "ldp       d14, d15, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q14)) "]" "\n"
-    "ldp       d16, d17, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q16)) "]" "\n"
-    "ldp       d18, d19, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q18)) "]" "\n"
-    "ldp       d20, d21, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q20)) "]" "\n"
-    "ldp       d22, d23, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q22)) "]" "\n"
-    "ldp       d24, d25, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q24)) "]" "\n"
-    "ldp       d26, d27, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q26)) "]" "\n"
-    "ldp       d28, d29, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q28)) "]" "\n"
-    "ldp       d30, d31, [x9, #" STRINGIZE_VALUE_OF(FPR_OFFSET(Q30)) "]" "\n"
+    "ldp       q0,   q1, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q0)) "]" "\n"
+    "ldp       q2,   q3, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q2)) "]" "\n"
+    "ldp       q4,   q5, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q4)) "]" "\n"
+    "ldp       q6,   q7, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q6)) "]" "\n"
+    "ldp       q8,   q9, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q8)) "]" "\n"
+    "ldp       q10, q11, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q10)) "]" "\n"
+    "ldp       q12, q13, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q12)) "]" "\n"
+    "ldp       q14, q15, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q14)) "]" "\n"
+    "ldp       q16, q17, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q16)) "]" "\n"
+    "ldp       q18, q19, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q18)) "]" "\n"
+    "ldp       q20, q21, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q20)) "]" "\n"
+    "ldp       q22, q23, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q22)) "]" "\n"
+    "ldp       q24, q25, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q24)) "]" "\n"
+    "ldp       q26, q27, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q26)) "]" "\n"
+    "ldp       q28, q29, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q28)) "]" "\n"
+    "ldp       q30, q31, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q30)) "]" "\n"
 
     "ldp       x0, x1, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X0_OFFSET) "]" "\n"
     "ldp       x2, x3, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "]" "\n"
@@ -583,270 +579,14 @@ __asm__(
     ".previous" "\n"
 );
 
-// And now, the slower version that saves the full width of FP registers:
-__asm__(
-    ".text" "\n"
-    ".balign 16" "\n"
-    ".globl " SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) "\n"
-    HIDE_SYMBOL(ctiMasmProbeTrampolineSIMD) "\n"
-    SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) ":" "\n"
-
-    // MacroAssemblerARM64::probe() has already generated code to store some values in an
-    // IncomingProbeRecord. sp points to the IncomingProbeRecord.
-    //
-    // Incoming register values:
-    //     x24: probe function
-    //     x25: probe arg
-    //     x26: scratch, was ctiMasmProbeTrampoline
-    //     x30: return address
-
-    "str       x27, [sp, #" STRINGIZE_VALUE_OF(IN_X27_OFFSET) "]" "\n"
-    "mov       x26, sp" "\n"
-    "sub       x27, sp, #" STRINGIZE_VALUE_OF(PROBE_SIZE_PLUS_EXTRAS + OUT_SIZE) "\n"
-    "bic       sp, x27, #0xf" "\n" // The ARM EABI specifies that the stack needs to be 16 byte aligned.
-
-    "stp       x24, x25, [sp, #" STRINGIZE_VALUE_OF(PROBE_PROBE_FUNCTION_OFFSET) "]" "\n" // Store the probe handler function and arg (preloaded into x24 and x25
-
-    "stp       x0, x1, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X0_OFFSET) "]" "\n"
-    "mrs       x0, nzcv" "\n" // Preload nzcv.
-    "stp       x2, x3, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "]" "\n"
-    "stp       x4, x5, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X4_OFFSET) "]" "\n"
-    "mrs       x1, fpsr" "\n" // Preload fpsr.
-    "stp       x6, x7, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X6_OFFSET) "]" "\n"
-    "stp       x8, x9, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X8_OFFSET) "]" "\n"
-
-    "ldp       x2, x3, [x26, #" STRINGIZE_VALUE_OF(IN_X24_OFFSET) "]" "\n" // Preload saved x24 and x25.
-    "ldp       x4, x5, [x26, #" STRINGIZE_VALUE_OF(IN_X26_OFFSET) "]" "\n" // Preload saved x26 and lr.
-    "ldr       x27, [x26, #" STRINGIZE_VALUE_OF(IN_X27_OFFSET) "]" "\n"
-
-    "add       x26, x26, #" STRINGIZE_VALUE_OF(IN_SIZE) "\n" // Compute the sp before the probe.
-
-    "stp       x10, x11, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X10_OFFSET) "]" "\n"
-    "stp       x12, x13, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X12_OFFSET) "]" "\n"
-    "stp       x14, x15, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X14_OFFSET) "]" "\n"
-    "stp       x16, x17, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X16_OFFSET) "]" "\n"
-    "stp       x18, x19, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X18_OFFSET) "]" "\n"
-    "stp       x20, x21, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X20_OFFSET) "]" "\n"
-    "stp       x22, x23, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X22_OFFSET) "]" "\n"
-    "stp       x2,  x3,  [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X24_OFFSET) "]" "\n" // Store saved r24 and r25 (preloaded into x2 and x3 above).
-    "stp       x4,  x27, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X26_OFFSET) "]" "\n" // Store saved r26 (preloaded into x4) and r27.
-    "stp       x28, x29, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X28_OFFSET) "]" "\n"
-    "stp       x5,  x26, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_LR_OFFSET) "]" "\n" // Save values lr and sp (original sp value computed into x26 above).
-
-    "add       x30, x30, #" STRINGIZE_VALUE_OF(2 * GPREG_SIZE) "\n" // The PC after the probe is at 2 instructions past the return point.
-#if CPU(ARM64E)
-    "movz      x27, #" STRINGIZE_VALUE_OF(JIT_PROBE_PC_PTR_TAG) "\n"
-    "pacib     x30, x27" "\n"
-#endif
-    "str       x30, [sp, #" STRINGIZE_VALUE_OF(SAVED_PROBE_RETURN_PC_OFFSET) "]" "\n" // Save a duplicate copy of return pc (in lr).
-    "str       x30, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "]" "\n"
-
-    "stp       x0, x1, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_NZCV_OFFSET) "]" "\n" // Store nzcv and fpsr (preloaded into x0 and x1 above).
-
-    "add       x9, sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_Q0_OFFSET) "\n"
-    "stp       q0,   q1, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q0)) "]" "\n"
-    "stp       q2,   q3, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q2)) "]" "\n"
-    "stp       q4,   q5, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q4)) "]" "\n"
-    "stp       q6,   q7, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q6)) "]" "\n"
-    "stp       q8,   q9, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q8)) "]" "\n"
-    "stp       q10, q11, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q10)) "]" "\n"
-    "stp       q12, q13, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q12)) "]" "\n"
-    "stp       q14, q15, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q14)) "]" "\n"
-    "stp       q16, q17, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q16)) "]" "\n"
-    "stp       q18, q19, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q18)) "]" "\n"
-    "stp       q20, q21, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q20)) "]" "\n"
-    "stp       q22, q23, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q22)) "]" "\n"
-    "stp       q24, q25, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q24)) "]" "\n"
-    "stp       q26, q27, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q26)) "]" "\n"
-    "stp       q28, q29, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q28)) "]" "\n"
-    "stp       q30, q31, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q30)) "]" "\n"
-
-    "mov       x27, sp" "\n" // Save the Probe::State* in a callee saved register.
-
-    // Note: we haven't changed the value of fp. Hence, it is still pointing to the frame of
-    // the caller of the probe (which is what we want in order to play nice with debuggers e.g. lldb).
-    "mov       x0, sp" "\n" // Set the Probe::State* arg.
-    "bl      " SYMBOL_STRING(executeJSCJITProbe) "\n"
-
-    // Make sure the Probe::State is entirely below the result stack pointer so
-    // that register values are still preserved when we call the initializeStack
-    // function.
-    "ldr       x1, [x27, #" STRINGIZE_VALUE_OF(PROBE_CPU_SP_OFFSET) "]" "\n" // Result sp.
-    "add       x2, x27, #" STRINGIZE_VALUE_OF(PROBE_SIZE_PLUS_EXTRAS + OUT_SIZE) "\n" // End of Probe::State + buffer.
-    "cmp       x1, x2" "\n"
-    "bge     " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafeSIMD) "\n"
-
-    // Allocate a safe place on the stack below the result stack pointer to stash the Probe::State.
-    "sub       x1, x1, #" STRINGIZE_VALUE_OF(PROBE_SIZE_PLUS_EXTRAS + OUT_SIZE) "\n"
-    "bic       x1, x1, #0xf" "\n" // The ARM EABI specifies that the stack needs to be 16 byte aligned.
-    "mov       sp, x1" "\n" // Set the new sp to protect that memory from interrupts before we copy the Probe::State.
-
-    // Copy the Probe::State to the safe place.
-    // Note: we have to copy from low address to higher address because we're moving the
-    // Probe::State to a lower address.
-    "mov       x5, x27" "\n"
-    "mov       x6, x1" "\n"
-    "add       x7, x27, #" STRINGIZE_VALUE_OF(PROBE_SIZE_PLUS_EXTRAS) "\n"
-
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoopSIMD) ":" "\n"
-    "ldp       x3, x4, [x5], #16" "\n"
-    "stp       x3, x4, [x6], #16" "\n"
-    "cmp       x5, x7" "\n"
-    "blt     " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoopSIMD) "\n"
-
-    "mov       x27, x1" "\n"
-
-    // Call initializeStackFunction if present.
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafeSIMD) ":" "\n"
-    "ldr       x2, [x27, #" STRINGIZE_VALUE_OF(PROBE_INIT_STACK_FUNCTION_OFFSET) "]" "\n"
-    "cbz       x2, " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegistersSIMD) "\n"
-
-    "mov       x0, x27" "\n" // Set the Probe::State* arg.
-#if CPU(ARM64E)
-    "movz      lr, #" STRINGIZE_VALUE_OF(JIT_PROBE_STACK_INITIALIZATION_FUNCTION_PTR_TAG) "\n"
-    "blrab     x2, lr" "\n" // Call the initializeStackFunction (loaded into x2 above).all the probe handler.
-#else
-    "blr       x2" "\n" // Call the initializeStackFunction (loaded into x2 above).
-#endif
-
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegistersSIMD) ":" "\n"
-
-    "mov       sp, x27" "\n"
-
-    // To enable probes to modify register state, we copy all registers
-    // out of the Probe::State before returning. That is except for x18.
-    // x18 is "reserved for the platform. Conforming software should not make use of it."
-    // Hence, the JITs would not be using it, and the probe should also not be modifying it.
-    // See https://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html.
-
-    "add       x9, sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_Q0_OFFSET) "\n"
-    "ldp       q0,   q1, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q0)) "]" "\n"
-    "ldp       q2,   q3, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q2)) "]" "\n"
-    "ldp       q4,   q5, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q4)) "]" "\n"
-    "ldp       q6,   q7, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q6)) "]" "\n"
-    "ldp       q8,   q9, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q8)) "]" "\n"
-    "ldp       q10, q11, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q10)) "]" "\n"
-    "ldp       q12, q13, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q12)) "]" "\n"
-    "ldp       q14, q15, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q14)) "]" "\n"
-    "ldp       q16, q17, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q16)) "]" "\n"
-    "ldp       q18, q19, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q18)) "]" "\n"
-    "ldp       q20, q21, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q20)) "]" "\n"
-    "ldp       q22, q23, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q22)) "]" "\n"
-    "ldp       q24, q25, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q24)) "]" "\n"
-    "ldp       q26, q27, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q26)) "]" "\n"
-    "ldp       q28, q29, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q28)) "]" "\n"
-    "ldp       q30, q31, [x9, #" STRINGIZE_VALUE_OF(VECTOR_OFFSET(Q30)) "]" "\n"
-
-    "ldp       x0, x1, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X0_OFFSET) "]" "\n"
-    "ldp       x2, x3, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "]" "\n"
-    "ldp       x4, x5, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X4_OFFSET) "]" "\n"
-    "ldp       x6, x7, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X6_OFFSET) "]" "\n"
-    "ldp       x8, x9, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X8_OFFSET) "]" "\n"
-    "ldp       x10, x11, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X10_OFFSET) "]" "\n"
-    "ldp       x12, x13, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X12_OFFSET) "]" "\n"
-    "ldp       x14, x15, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X14_OFFSET) "]" "\n"
-    "ldp       x16, x17, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X16_OFFSET) "]" "\n"
-    // x18 should not be modified by the probe. See comment above for details.
-    "ldp       x19, x20, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X19_OFFSET) "]" "\n"
-    "ldp       x21, x22, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X21_OFFSET) "]" "\n"
-    "ldp       x23, x24, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X23_OFFSET) "]" "\n"
-    "ldp       x25, x26, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X25_OFFSET) "]" "\n"
-
-    // Remaining registers to restore are: fpsr, nzcv, x27, x28, fp, lr, sp, and pc.
-
-    // The only way to set the pc on ARM64 (from user space) is via an indirect branch
-    // or a ret, which means we'll need a free register to do so. For our purposes, lr
-    // happens to be available in applications of the probe where we may want to
-    // continue executing at a different location (i.e. change the pc) after the probe
-    // returns. So, the ARM64 probe implementation will allow the probe handler to
-    // either modify lr or pc, but not both in the same probe invocation. The probe
-    // mechanism ensures that we never try to modify both lr and pc with a RELEASE_ASSERT
-    // in Probe::executeJSCJITProbe().
-
-    // Determine if the probe handler changed the pc.
-    "ldr       x30, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_SP_OFFSET) "]" "\n" // preload the target sp.
-    "ldr       x27, [sp, #" STRINGIZE_VALUE_OF(SAVED_PROBE_RETURN_PC_OFFSET) "]" "\n"
-    "ldr       x28, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "]" "\n"
-    "cmp       x27, x28" "\n"
-    "bne     " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineEndSIMD) "\n"
-
-     // We didn't change the PC. So, let's prepare for setting a potentially new lr value.
-
-     // 1. Make room for the LRRestorationRecord. The probe site will pop this off later.
-    "sub       x30, x30, #" STRINGIZE_VALUE_OF(LR_RESTORATION_SIZE) "\n"
-     // 2. Store the lp value to restore at the probe return site.
-    "ldr       x27, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_LR_OFFSET) "]" "\n"
-    "str       x27, [x30, #" STRINGIZE_VALUE_OF(LR_RESTORATION_LR_OFFSET) "]" "\n"
-     // 3. Force the return ramp to return to the probe return site.
-    "ldr       x27, [sp, #" STRINGIZE_VALUE_OF(SAVED_PROBE_RETURN_PC_OFFSET) "]" "\n"
-#if CPU(ARM64E)
-    "movz      x28, #" STRINGIZE_VALUE_OF(JIT_PROBE_PC_PTR_TAG) "\n"
-    "autib     x27, x28" "\n"
-    "mov       x28, x27" "\n"
-    "xpaci     x28" "\n"
-    "cmp       x28, x27" "\n"
-    "beq     " LOCAL_LABEL_STRING(ctiMasmProbeTrampolinePCAuthDoneSIMD) "\n"
-    "brk       #" STRINGIZE_VALUE_OF(WTF_FATAL_CRASH_CODE) "\n"
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolinePCAuthDoneSIMD) ":" "\n"
-#endif
-    "sub       x27, x27, #" STRINGIZE_VALUE_OF(2 * GPREG_SIZE) "\n" // The return point PC is at 2 instructions before the end of the probe.
-#if CPU(ARM64E)
-    "movz      x28, #" STRINGIZE_VALUE_OF(JIT_PROBE_PC_PTR_TAG) "\n"
-    "pacib     x27, x28" "\n"
-#endif
-    "str       x27, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "]" "\n"
-
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineEndSIMD) ":" "\n"
-
-    // Fill in the OutgoingProbeRecord.
-    "sub       x30, x30, #" STRINGIZE_VALUE_OF(OUT_SIZE) "\n"
-
-    "ldp       x27, x28, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_NZCV_OFFSET) "]" "\n"
-    "stp       x27, x28, [x30, #" STRINGIZE_VALUE_OF(OUT_NZCV_OFFSET) "]" "\n"
-    "ldp       x27, x28, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_X27_OFFSET) "]" "\n"
-    "stp       x27, x28, [x30, #" STRINGIZE_VALUE_OF(OUT_X27_OFFSET) "]" "\n"
-    "ldr       x28, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "]" "\n" // Set up the outgoing record so that we'll jump to the new PC.
-#if CPU(ARM64E)
-    "movz      x27, #" STRINGIZE_VALUE_OF(JIT_PROBE_PC_PTR_TAG) "\n"
-    "autib     x28, x27" "\n"
-    "mov       x27, x28" "\n"
-    "xpaci     x27" "\n"
-    "cmp       x27, x28" "\n"
-    "beq     " LOCAL_LABEL_STRING(ctiMasmProbeTrampolinePCAuthDone2SIMD) "\n"
-    "brk       #" STRINGIZE_VALUE_OF(WTF_FATAL_CRASH_CODE) "\n"
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolinePCAuthDone2SIMD) ":" "\n"
-    "add       x27, x30, #48" "\n" // Compute sp at return point.
-    "pacib     x28, x27" "\n"
-#endif
-    "ldr       x27, [sp, #" STRINGIZE_VALUE_OF(PROBE_CPU_FP_OFFSET) "]" "\n"
-    "stp       x27, x28, [x30, #" STRINGIZE_VALUE_OF(OUT_FP_OFFSET) "]" "\n"
-    "mov       sp, x30" "\n"
-
-    // Restore the remaining registers and pop the OutgoingProbeRecord.
-    "ldp       x27, x28, [sp], #" STRINGIZE_VALUE_OF(2 * GPREG_SIZE) "\n"
-    "msr       nzcv, x27" "\n"
-    "msr       fpsr, x28" "\n"
-    "ldp       x27, x28, [sp], #" STRINGIZE_VALUE_OF(2 * GPREG_SIZE) "\n"
-    "ldp       x29, x30, [sp], #" STRINGIZE_VALUE_OF(2 * GPREG_SIZE) "\n"
-#if CPU(ARM64E)
-    "retab" "\n"
-#else
-    "ret" "\n"
-#endif
-    ".previous" "\n"
-);
-
-void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth savedFPWidth)
+void MacroAssembler::probe(Probe::Function function, void* arg)
 {
     JIT_COMMENT(*this, "Probe start");
     sub64(TrustedImm32(sizeof(IncomingProbeRecord)), sp);
 
     storePair64(x24, x25, sp, TrustedImm32(offsetof(IncomingProbeRecord, x24)));
     storePair64(x26, x30, sp, TrustedImm32(offsetof(IncomingProbeRecord, x26))); // Note: x30 is lr.
-    if (savedFPWidth == SavedFPWidth::SaveVectors)
-        move(TrustedImmPtr(tagCFunction<OperationPtrTag>(ctiMasmProbeTrampolineSIMD)), x26);
-    else
-        move(TrustedImmPtr(tagCFunction<OperationPtrTag>(ctiMasmProbeTrampoline)), x26);
+    move(TrustedImmPtr(tagCFunction<OperationPtrTag>(ctiMasmProbeTrampoline)), x26);
 #if CPU(ARM64E)
     assertIsTaggedWith<JITProbePtrTag>(function);
 #endif

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp
@@ -369,7 +369,7 @@ __asm__(
     ".previous" "\n"
 );
 
-void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth)
+void MacroAssembler::probe(Probe::Function function, void* arg)
 {
     sub32(TrustedImm32(sizeof(IncomingRecord)), sp);
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
@@ -499,7 +499,7 @@ __asm__(
 
     "ret" "\n");
 
-void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth)
+void MacroAssembler::probe(Probe::Function function, void* arg)
 {
     sub64(TrustedImm32(sizeof(IncomingProbeRecord)), sp);
     store64(ra, Address(sp, offsetof(IncomingProbeRecord, x1)));

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
@@ -40,10 +40,6 @@ namespace JSC {
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampoline, void, ());
 JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampoline);
-#if CPU(X86_64)
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampolineSIMD, void, ());
-JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampolineSIMD);
-#endif
 
 // The following are offsets for Probe::State fields accessed by the ctiMasmProbeTrampoline stub.
 
@@ -78,46 +74,27 @@ JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampolineSIMD);
 #define PROBE_CPU_EFLAGS_OFFSET (PROBE_FIRST_SPR_OFFSET + (1 * PTR_SIZE))
 #define PROBE_FIRST_XMM_OFFSET (PROBE_FIRST_SPR_OFFSET + (2 * PTR_SIZE))
 
-#define XMM_SIZE 8
-#define PROBE_CPU_XMM0_OFFSET (PROBE_FIRST_XMM_OFFSET + (0 * XMM_SIZE))
-#define PROBE_CPU_XMM1_OFFSET (PROBE_FIRST_XMM_OFFSET + (1 * XMM_SIZE))
-#define PROBE_CPU_XMM2_OFFSET (PROBE_FIRST_XMM_OFFSET + (2 * XMM_SIZE))
-#define PROBE_CPU_XMM3_OFFSET (PROBE_FIRST_XMM_OFFSET + (3 * XMM_SIZE))
-#define PROBE_CPU_XMM4_OFFSET (PROBE_FIRST_XMM_OFFSET + (4 * XMM_SIZE))
-#define PROBE_CPU_XMM5_OFFSET (PROBE_FIRST_XMM_OFFSET + (5 * XMM_SIZE))
-#define PROBE_CPU_XMM6_OFFSET (PROBE_FIRST_XMM_OFFSET + (6 * XMM_SIZE))
-#define PROBE_CPU_XMM7_OFFSET (PROBE_FIRST_XMM_OFFSET + (7 * XMM_SIZE))
-
-#define PROBE_CPU_XMM8_OFFSET (PROBE_FIRST_XMM_OFFSET + (8 * XMM_SIZE))
-#define PROBE_CPU_XMM9_OFFSET (PROBE_FIRST_XMM_OFFSET + (9 * XMM_SIZE))
-#define PROBE_CPU_XMM10_OFFSET (PROBE_FIRST_XMM_OFFSET + (10 * XMM_SIZE))
-#define PROBE_CPU_XMM11_OFFSET (PROBE_FIRST_XMM_OFFSET + (11 * XMM_SIZE))
-#define PROBE_CPU_XMM12_OFFSET (PROBE_FIRST_XMM_OFFSET + (12 * XMM_SIZE))
-#define PROBE_CPU_XMM13_OFFSET (PROBE_FIRST_XMM_OFFSET + (13 * XMM_SIZE))
-#define PROBE_CPU_XMM14_OFFSET (PROBE_FIRST_XMM_OFFSET + (14 * XMM_SIZE))
-#define PROBE_CPU_XMM15_OFFSET (PROBE_FIRST_XMM_OFFSET + (15 * XMM_SIZE))
+#define XMM_VECTOR_SIZE 16
 
 // For the case when we want to save 128 bits for each XMM register, the layout is different.
-#define PROBE_CPU_XMM0_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (0 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM1_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (1 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM2_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (2 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM3_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (3 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM4_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (4 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM5_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (5 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM6_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (6 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM7_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (7 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM8_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (8 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM9_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (9 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM10_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (10 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM11_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (11 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM12_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (12 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM13_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (13 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM14_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (14 * 2 * XMM_SIZE))
-#define PROBE_CPU_XMM15_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (15 * 2 * XMM_SIZE))
-// We save extra room for XMM registers in case we save vectors, but normally
-// we the doubles together. This is to match ARM64, where we store pair in the
-// non-vector case.
-#define PROBE_SIZE (PROBE_FIRST_XMM_OFFSET + 16 * 2 * XMM_SIZE)
+#define PROBE_CPU_XMM0_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (0 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM1_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (1 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM2_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (2 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM3_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (3 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM4_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (4 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM5_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (5 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM6_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (6 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM7_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (7 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM8_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (8 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM9_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (9 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM10_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (10 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM11_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (11 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM12_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (12 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM13_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (13 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM14_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (14 * XMM_VECTOR_SIZE))
+#define PROBE_CPU_XMM15_VECTOR_OFFSET (PROBE_FIRST_XMM_OFFSET + (15 * XMM_VECTOR_SIZE))
+
+#define PROBE_SIZE (PROBE_FIRST_XMM_OFFSET + 16 * XMM_VECTOR_SIZE)
 
 // The outgoing record to be popped off the stack at the end consists of:
 // eflags, eax, ecx, ebp, eip.
@@ -143,7 +120,6 @@ static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::edi) == PROBE_CPU_EDI_O
 static_assert(PROBE_OFFSETOF_REG(cpu.sprs, X86Registers::eip) == PROBE_CPU_EIP_OFFSET, "Probe::State::cpu.gprs[eip]'s offset matches ctiMasmProbeTrampoline");
 static_assert(PROBE_OFFSETOF_REG(cpu.sprs, X86Registers::eflags) == PROBE_CPU_EFLAGS_OFFSET, "Probe::State::cpu.sprs[eflags]'s offset matches ctiMasmProbeTrampoline");
 
-#if CPU(X86_64)
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r8) == PROBE_CPU_R8_OFFSET, "Probe::State::cpu.gprs[r8]'s offset matches ctiMasmProbeTrampoline");
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r9) == PROBE_CPU_R9_OFFSET, "Probe::State::cpu.gprs[r9]'s offset matches ctiMasmProbeTrampoline");
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r10) == PROBE_CPU_R10_OFFSET, "Probe::State::cpu.gprs[r10]'s offset matches ctiMasmProbeTrampoline");
@@ -152,240 +128,36 @@ static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r12) == PROBE_CPU_R12_O
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r13) == PROBE_CPU_R13_OFFSET, "Probe::State::cpu.gprs[r13]'s offset matches ctiMasmProbeTrampoline");
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r14) == PROBE_CPU_R14_OFFSET, "Probe::State::cpu.gprs[r14]'s offset matches ctiMasmProbeTrampoline");
 static_assert(PROBE_OFFSETOF_REG(cpu.gprs, X86Registers::r15) == PROBE_CPU_R15_OFFSET, "Probe::State::cpu.gprs[r15]'s offset matches ctiMasmProbeTrampoline");
-#endif // CPU(X86_64)
 
-static_assert(!(PROBE_CPU_XMM0_OFFSET & 0x7), "Probe::State::cpu.fprs[xmm0]'s offset should be 8 byte aligned");
+static_assert(!(PROBE_CPU_XMM0_VECTOR_OFFSET & 0xf), "Probe::State::cpu.fprs[xmm0]'s offset should be 16 byte aligned");
 
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm0) == PROBE_CPU_XMM0_OFFSET, "Probe::State::cpu.fprs[xmm0]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm1) == PROBE_CPU_XMM1_OFFSET, "Probe::State::cpu.fprs[xmm1]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm2) == PROBE_CPU_XMM2_OFFSET, "Probe::State::cpu.fprs[xmm2]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm3) == PROBE_CPU_XMM3_OFFSET, "Probe::State::cpu.fprs[xmm3]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm4) == PROBE_CPU_XMM4_OFFSET, "Probe::State::cpu.fprs[xmm4]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm5) == PROBE_CPU_XMM5_OFFSET, "Probe::State::cpu.fprs[xmm5]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm6) == PROBE_CPU_XMM6_OFFSET, "Probe::State::cpu.fprs[xmm6]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm7) == PROBE_CPU_XMM7_OFFSET, "Probe::State::cpu.fprs[xmm7]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm0) == PROBE_CPU_XMM0_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm0]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm1) == PROBE_CPU_XMM1_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm1]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm2) == PROBE_CPU_XMM2_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm2]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm3) == PROBE_CPU_XMM3_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm3]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm4) == PROBE_CPU_XMM4_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm4]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm5) == PROBE_CPU_XMM5_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm5]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm6) == PROBE_CPU_XMM6_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm6]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm7) == PROBE_CPU_XMM7_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm7]'s offset matches ctiMasmProbeTrampoline");
 
-#if CPU(X86_64)
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm8) == PROBE_CPU_XMM8_OFFSET, "Probe::State::cpu.fprs[xmm8]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm9) == PROBE_CPU_XMM9_OFFSET, "Probe::State::cpu.fprs[xmm9]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm10) == PROBE_CPU_XMM10_OFFSET, "Probe::State::cpu.fprs[xmm10]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm11) == PROBE_CPU_XMM11_OFFSET, "Probe::State::cpu.fprs[xmm11]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm12) == PROBE_CPU_XMM12_OFFSET, "Probe::State::cpu.fprs[xmm12]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm13) == PROBE_CPU_XMM13_OFFSET, "Probe::State::cpu.fprs[xmm13]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm14) == PROBE_CPU_XMM14_OFFSET, "Probe::State::cpu.fprs[xmm14]'s offset matches ctiMasmProbeTrampoline");
-static_assert(PROBE_OFFSETOF_REG(cpu.fprs.fprs, X86Registers::xmm15) == PROBE_CPU_XMM15_OFFSET, "Probe::State::cpu.fprs[xmm15]'s offset matches ctiMasmProbeTrampoline");
-#endif // CPU(X86_64)
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm8) == PROBE_CPU_XMM8_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm8]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm9) == PROBE_CPU_XMM9_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm9]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm10) == PROBE_CPU_XMM10_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm10]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm11) == PROBE_CPU_XMM11_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm11]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm12) == PROBE_CPU_XMM12_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm12]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm13) == PROBE_CPU_XMM13_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm13]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm14) == PROBE_CPU_XMM14_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm14]'s offset matches ctiMasmProbeTrampoline");
+static_assert(PROBE_OFFSETOF_REG(cpu.fprs.vectors, X86Registers::xmm15) == PROBE_CPU_XMM15_VECTOR_OFFSET, "Probe::State::cpu.fprs[xmm15]'s offset matches ctiMasmProbeTrampoline");
 
 static_assert(sizeof(Probe::State) == PROBE_SIZE, "Probe::State::size's matches ctiMasmProbeTrampoline");
 
 #undef PROBE_OFFSETOF
 
-#if CPU(X86_64)
 __asm__(
     ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
     HIDE_SYMBOL(ctiMasmProbeTrampoline) "\n"
     SYMBOL_STRING(ctiMasmProbeTrampoline) ":" "\n"
-
-    "pushq %rbp" "\n"
-    "movq  %rsp, %rbp" "\n"
-
-    "pushfq" "\n"
-
-    // MacroAssemblerX86_64::probe() has already generated code to store some values.
-    // Together with the rbp and rflags pushed above, the top of stack now looks like this:
-    //     rbp[-1 * ptrSize]: rflags
-    //     rbp[0 * ptrSize]: rbp / previousCallFrame
-    //     rbp[1 * ptrSize]: return address / saved rip
-    //     rbp[2 * ptrSize]: saved rbx
-    //     rbp[3 * ptrSize]: saved rdx
-    //     rbp[4 * ptrSize]: saved rax
-    //
-    // Incoming registers contain:
-    //     rdx: probe function
-    //     rbx: probe arg
-    //     rax: scratch (was ctiMasmProbeTrampoline)
-
-    "subq $" STRINGIZE_VALUE_OF(PROBE_SIZE + OUT_SIZE) ", %rsp" "\n"
-
-    // The X86_64 ABI specifies that the worse case stack alignment requirement is 32 bytes.
-    "andq $~0x1f, %rsp" "\n"
-    // Since sp points to the Probe::State, we've ensured that it's protected from interrupts before we initialize it.
-
-    "movq %rdx, " STRINGIZE_VALUE_OF(PROBE_PROBE_FUNCTION_OFFSET) "(%rsp)" "\n"
-    "movq %rbx, " STRINGIZE_VALUE_OF(PROBE_ARG_OFFSET) "(%rsp)" "\n"
-    "movq %rsi, " STRINGIZE_VALUE_OF(PROBE_CPU_ESI_OFFSET) "(%rsp)" "\n"
-    "movq %rdi, " STRINGIZE_VALUE_OF(PROBE_CPU_EDI_OFFSET) "(%rsp)" "\n"
-
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_ECX_OFFSET) "(%rsp)" "\n"
-
-    "movq -1 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EFLAGS_OFFSET) "(%rsp)" "\n"
-    "movq 0 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EBP_OFFSET) "(%rsp)" "\n"
-    "movq 1 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EIP_OFFSET) "(%rsp)" "\n"
-    "movq 2 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EBX_OFFSET) "(%rsp)" "\n"
-    "movq 3 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EDX_OFFSET) "(%rsp)" "\n"
-    "movq 4 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rbp), %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_EAX_OFFSET) "(%rsp)" "\n"
-
-    "movq %rbp, %rcx" "\n"
-    "addq $" STRINGIZE_VALUE_OF(6 * PTR_SIZE) ", %rcx" "\n"
-    "movq %rcx, " STRINGIZE_VALUE_OF(PROBE_CPU_ESP_OFFSET) "(%rsp)" "\n"
-
-    "movq %r8, " STRINGIZE_VALUE_OF(PROBE_CPU_R8_OFFSET) "(%rsp)" "\n"
-    "movq %r9, " STRINGIZE_VALUE_OF(PROBE_CPU_R9_OFFSET) "(%rsp)" "\n"
-    "movq %r10, " STRINGIZE_VALUE_OF(PROBE_CPU_R10_OFFSET) "(%rsp)" "\n"
-    "movq %r11, " STRINGIZE_VALUE_OF(PROBE_CPU_R11_OFFSET) "(%rsp)" "\n"
-    "movq %r12, " STRINGIZE_VALUE_OF(PROBE_CPU_R12_OFFSET) "(%rsp)" "\n"
-    "movq %r13, " STRINGIZE_VALUE_OF(PROBE_CPU_R13_OFFSET) "(%rsp)" "\n"
-    "movq %r14, " STRINGIZE_VALUE_OF(PROBE_CPU_R14_OFFSET) "(%rsp)" "\n"
-    "movq %r15, " STRINGIZE_VALUE_OF(PROBE_CPU_R15_OFFSET) "(%rsp)" "\n"
-
-    "movq %xmm0, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM0_OFFSET) "(%rsp)" "\n"
-    "movq %xmm1, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM1_OFFSET) "(%rsp)" "\n"
-    "movq %xmm2, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM2_OFFSET) "(%rsp)" "\n"
-    "movq %xmm3, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM3_OFFSET) "(%rsp)" "\n"
-    "movq %xmm4, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM4_OFFSET) "(%rsp)" "\n"
-    "movq %xmm5, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM5_OFFSET) "(%rsp)" "\n"
-    "movq %xmm6, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM6_OFFSET) "(%rsp)" "\n"
-    "movq %xmm7, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM7_OFFSET) "(%rsp)" "\n"
-    "movq %xmm8, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM8_OFFSET) "(%rsp)" "\n"
-    "movq %xmm9, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM9_OFFSET) "(%rsp)" "\n"
-    "movq %xmm10, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM10_OFFSET) "(%rsp)" "\n"
-    "movq %xmm11, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM11_OFFSET) "(%rsp)" "\n"
-    "movq %xmm12, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM12_OFFSET) "(%rsp)" "\n"
-    "movq %xmm13, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM13_OFFSET) "(%rsp)" "\n"
-    "movq %xmm14, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM14_OFFSET) "(%rsp)" "\n"
-    "movq %xmm15, " STRINGIZE_VALUE_OF(PROBE_CPU_XMM15_OFFSET) "(%rsp)" "\n"
-
-    "movq %rsp, %rdi" "\n" // the Probe::State* arg.
-    "call " SYMBOL_STRING(executeJSCJITProbe) "\n"
-
-    // Make sure the Probe::State is entirely below the result stack pointer so
-    // that register values are still preserved when we call the initializeStack
-    // function.
-    "movq %rsp, %rbp" "\n"
-    "movq $" STRINGIZE_VALUE_OF(PROBE_SIZE + OUT_SIZE) ", %rcx" "\n"
-    "movq %rsp, %rax" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_ESP_OFFSET) "(%rbp), %rdx" "\n"
-    "addq %rcx, %rax" "\n"
-    "cmpq %rax, %rdx" "\n"
-    "jge " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) "\n"
-
-    // Allocate a safe place on the stack below the result stack pointer to stash the Probe::State.
-    "subq %rcx, %rdx" "\n"
-    "andq $~0x1f, %rdx" "\n" // Keep the stack pointer 32 bytes aligned.
-    "xorq %rax, %rax" "\n"
-    "movq %rdx, %rsp" "\n"
-
-    "movq $" STRINGIZE_VALUE_OF(PROBE_SIZE) ", %rcx" "\n"
-
-    // Copy the Probe::State to the safe place.
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) ":" "\n"
-    "movq (%rbp, %rax), %rdx" "\n"
-    "movq %rdx, (%rsp, %rax)" "\n"
-    "addq $" STRINGIZE_VALUE_OF(PTR_SIZE) ", %rax" "\n"
-    "cmpq %rax, %rcx" "\n"
-    "jg " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) "\n"
-
-    "movq %rsp, %rbp" "\n"
-
-    // Call initializeStackFunction if present.
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) ":" "\n"
-    "xorq %rcx, %rcx" "\n"
-    "addq " STRINGIZE_VALUE_OF(PROBE_INIT_STACK_FUNCTION_OFFSET) "(%rbp), %rcx" "\n"
-    "je " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) "\n"
-
-    "movq %rbp, %rdi" "\n" // the Probe::State* arg.
-    "call *%rcx" "\n"
-
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) ":" "\n"
-
-    // To enable probes to modify register state, we copy all registers
-    // out of the Probe::State before returning.
-
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EDX_OFFSET) "(%rbp), %rdx" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EBX_OFFSET) "(%rbp), %rbx" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_ESI_OFFSET) "(%rbp), %rsi" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EDI_OFFSET) "(%rbp), %rdi" "\n"
-
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R8_OFFSET) "(%rbp), %r8" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R9_OFFSET) "(%rbp), %r9" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R10_OFFSET) "(%rbp), %r10" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R11_OFFSET) "(%rbp), %r11" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R12_OFFSET) "(%rbp), %r12" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R13_OFFSET) "(%rbp), %r13" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R14_OFFSET) "(%rbp), %r14" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_R15_OFFSET) "(%rbp), %r15" "\n"
-
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM0_OFFSET) "(%rbp), %xmm0" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM1_OFFSET) "(%rbp), %xmm1" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM2_OFFSET) "(%rbp), %xmm2" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM3_OFFSET) "(%rbp), %xmm3" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM4_OFFSET) "(%rbp), %xmm4" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM5_OFFSET) "(%rbp), %xmm5" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM6_OFFSET) "(%rbp), %xmm6" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM7_OFFSET) "(%rbp), %xmm7" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM8_OFFSET) "(%rbp), %xmm8" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM9_OFFSET) "(%rbp), %xmm9" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM10_OFFSET) "(%rbp), %xmm10" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM11_OFFSET) "(%rbp), %xmm11" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM12_OFFSET) "(%rbp), %xmm12" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM13_OFFSET) "(%rbp), %xmm13" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM14_OFFSET) "(%rbp), %xmm14" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_XMM15_OFFSET) "(%rbp), %xmm15" "\n"
-
-    // There are 6 more registers left to restore:
-    //     rax, rcx, rbp, rsp, rip, and rflags.
-
-    // The restoration process at ctiMasmProbeTrampolineEnd below works by popping
-    // 5 words off the stack into rflags, rax, rcx, rbp, and rip. These 5 words need
-    // to be pushed on top of the final esp value so that just by popping the 5 words,
-    // we'll get the esp that the probe wants to set. Let's call this area (for storing
-    // these 5 words) the restore area.
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_ESP_OFFSET) "(%rbp), %rcx" "\n"
-    "subq $5 * " STRINGIZE_VALUE_OF(PTR_SIZE) ", %rcx" "\n"
-
-    // rcx now points to the restore area.
-
-    // Copy remaining restore values from the Probe::State to the restore area.
-    // Note: We already ensured above that the Probe::State is in a safe location before
-    // calling the initializeStackFunction. The initializeStackFunction is not allowed to
-    // change the stack pointer again.
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EFLAGS_OFFSET) "(%rbp), %rax" "\n"
-    "movq %rax, 0 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rcx)" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EAX_OFFSET) "(%rbp), %rax" "\n"
-    "movq %rax, 1 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rcx)" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_ECX_OFFSET) "(%rbp), %rax" "\n"
-    "movq %rax, 2 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rcx)" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EBP_OFFSET) "(%rbp), %rax" "\n"
-    "movq %rax, 3 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rcx)" "\n"
-    "movq " STRINGIZE_VALUE_OF(PROBE_CPU_EIP_OFFSET) "(%rbp), %rax" "\n"
-    "movq %rax, 4 * " STRINGIZE_VALUE_OF(PTR_SIZE) "(%rcx)" "\n"
-    "movq %rcx, %rsp" "\n"
-
-    // Do the remaining restoration by popping off the restore area.
-    "popfq" "\n"
-    "popq %rax" "\n"
-    "popq %rcx" "\n"
-    "popq %rbp" "\n"
-    "ret" "\n"
-#if !COMPILER(MSVC)
-    ".previous" "\n"
-#endif
-);
-
-// And now, the slower version that saves the full width of vectors in xmm registers.
-
-__asm__(
-    ".text" "\n"
-    ".globl " SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) "\n"
-    HIDE_SYMBOL(ctiMasmProbeTrampolineSIMD) "\n"
-    SYMBOL_STRING(ctiMasmProbeTrampolineSIMD) ":" "\n"
 
     "pushq %rbp" "\n"
     "movq  %rsp, %rbp" "\n"
@@ -474,7 +246,7 @@ __asm__(
     "movq " STRINGIZE_VALUE_OF(PROBE_CPU_ESP_OFFSET) "(%rbp), %rdx" "\n"
     "addq %rcx, %rax" "\n"
     "cmpq %rax, %rdx" "\n"
-    "jge " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafeSIMD) "\n"
+    "jge " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) "\n"
 
     // Allocate a safe place on the stack below the result stack pointer to stash the Probe::State.
     "subq %rcx, %rdx" "\n"
@@ -485,25 +257,25 @@ __asm__(
     "movq $" STRINGIZE_VALUE_OF(PROBE_SIZE) ", %rcx" "\n"
 
     // Copy the Probe::State to the safe place.
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoopSIMD) ":" "\n"
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) ":" "\n"
     "movq (%rbp, %rax), %rdx" "\n"
     "movq %rdx, (%rsp, %rax)" "\n"
     "addq $" STRINGIZE_VALUE_OF(PTR_SIZE) ", %rax" "\n"
     "cmpq %rax, %rcx" "\n"
-    "jg " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoopSIMD) "\n"
+    "jg " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) "\n"
 
     "movq %rsp, %rbp" "\n"
 
     // Call initializeStackFunction if present.
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafeSIMD) ":" "\n"
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) ":" "\n"
     "xorq %rcx, %rcx" "\n"
     "addq " STRINGIZE_VALUE_OF(PROBE_INIT_STACK_FUNCTION_OFFSET) "(%rbp), %rcx" "\n"
-    "je " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegistersSIMD) "\n"
+    "je " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) "\n"
 
     "movq %rbp, %rdi" "\n" // the Probe::State* arg.
     "call *%rcx" "\n"
 
-    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegistersSIMD) ":" "\n"
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) ":" "\n"
 
     // To enable probes to modify register state, we copy all registers
     // out of the Probe::State before returning.
@@ -578,7 +350,6 @@ __asm__(
     ".previous" "\n"
 #endif
 );
-#endif // CPU(X86_64)
 
 // What code is emitted for the probe?
 // ==================================
@@ -619,23 +390,14 @@ __asm__(
 // position before we push the Probe::State frame. The saved rip will point to
 // the address of the instruction immediately following the probe.
 
-void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth savedFPWidth)
+void MacroAssembler::probe(Probe::Function function, void* arg)
 {
-#if CPU(X86_64)
     // Extra push so that the total number of pushes pad out to 32-bytes, and the
     // stack pointer remains 32 byte aligned as required by the ABI.
     push(RegisterID::eax);
-#endif
     push(RegisterID::eax);
 
-#if CPU(X86_64)
-    if (savedFPWidth == SavedFPWidth::SaveVectors)
-        move(TrustedImmPtr(reinterpret_cast<void*>(ctiMasmProbeTrampolineSIMD)), RegisterID::eax);
-    else
-#else
-    UNUSED_PARAM(savedFPWidth);
-#endif
-        move(TrustedImmPtr(reinterpret_cast<void*>(ctiMasmProbeTrampoline)), RegisterID::eax);
+    move(TrustedImmPtr(reinterpret_cast<void*>(ctiMasmProbeTrampoline)), RegisterID::eax);
 
     push(RegisterID::edx);
     move(TrustedImmPtr(reinterpret_cast<void*>(function)), RegisterID::edx);

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -276,7 +276,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
         debugInfo->kind = exit.m_kind;
         debugInfo->exitIndex = osrExitIndex;
         debugInfo->bytecodeIndex = exit.m_codeOrigin.bytecodeIndex();
-        jit.probe(tagCFunction<JITProbePtrTag>(operationDebugPrintSpeculationFailure), debugInfo, SavedFPWidth::DontSaveVectors);
+        jit.probe(tagCFunction<JITProbePtrTag>(operationDebugPrintSpeculationFailure), debugInfo);
     }
 
     // Perform speculation recovery. This only comes into play when an operation

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -158,7 +158,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         debugInfo->kind = exit.m_kind;
         debugInfo->exitIndex = exitID;
         debugInfo->bytecodeIndex = exit.m_codeOrigin.bytecodeIndex();
-        jit.probe(tagCFunction<JITProbePtrTag>(operationDebugPrintSpeculationFailure), debugInfo, SavedFPWidth::DontSaveVectors);
+        jit.probe(tagCFunction<JITProbePtrTag>(operationDebugPrintSpeculationFailure), debugInfo);
     }
 
     // The first thing we need to do is restablish our frame in the case of an exception.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -96,9 +96,7 @@ void BBQPlan::work()
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
     const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
 
-    bool usesSIMD = m_moduleInformation->usesSIMD(m_functionIndex);
-    SavedFPWidth savedFPWidth = usesSIMD ? SavedFPWidth::SaveVectors : SavedFPWidth::DontSaveVectors;
-    Ref<BBQCallee> callee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), savedFPWidth);
+    Ref<BBQCallee> callee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
     std::unique_ptr<InternalFunction> function = compileFunction(m_functionIndex, callee.get(), context, unlinkedWasmToWasmCalls);
 
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -350,9 +350,9 @@ class BBQCallee final : public OptimizingJITCallee {
 public:
     static constexpr unsigned extraOSRValuesForLoopIndex = 1;
 
-    static Ref<BBQCallee> create(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, SavedFPWidth savedFPWidth)
+    static Ref<BBQCallee> create(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     {
-        return adoptRef(*new BBQCallee(index, WTFMove(name), savedFPWidth));
+        return adoptRef(*new BBQCallee(index, WTFMove(name)));
     }
     ~BBQCallee();
 
@@ -372,7 +372,6 @@ public:
     const Vector<CodeLocationLabel<WasmEntryPtrTag>>& loopEntrypoints() { return m_loopEntrypoints; }
 
     unsigned osrEntryScratchBufferSize() const { return m_osrEntryScratchBufferSize; }
-    SavedFPWidth savedFPWidth() const { return m_savedFPWidth; }
 
     void setEntrypoint(Wasm::Entrypoint&& entrypoint, Vector<UnlinkedWasmToWasmCall>&& unlinkedCalls, StackMaps&& stackmaps, Vector<UnlinkedHandlerInfo>&& exceptionHandlers, Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>&& exceptionHandlerLocations, Vector<CodeLocationLabel<WasmEntryPtrTag>>&& loopEntrypoints, std::optional<CodeLocationLabel<WasmEntryPtrTag>> sharedLoopEntrypoint, unsigned osrEntryScratchBufferSize)
     {
@@ -402,9 +401,8 @@ public:
     }
 
 private:
-    BBQCallee(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, SavedFPWidth savedFPWidth)
+    BBQCallee(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name)
         : OptimizingJITCallee(Wasm::CompilationMode::BBQMode, index, WTFMove(name))
-        , m_savedFPWidth(savedFPWidth)
     {
     }
 
@@ -417,7 +415,6 @@ private:
     unsigned m_osrEntryScratchBufferSize { 0 };
     unsigned m_stackCheckSize { 0 };
     bool m_didStartCompilingOSREntryCallee { false };
-    SavedFPWidth m_savedFPWidth { SavedFPWidth::DontSaveVectors };
     Vector<UniqueRef<EmbeddedFixedVector<CodeLocationLabel<JSSwitchPtrTag>>>> m_switchJumpTables;
 };
 #endif

--- a/Source/JavaScriptCore/wasm/WasmContext.cpp
+++ b/Source/JavaScriptCore/wasm/WasmContext.cpp
@@ -30,7 +30,7 @@
 
 namespace JSC { namespace Wasm {
 
-uint64_t* Context::scratchBufferForSize(size_t size)
+Context::ScratchBufferEntry* Context::scratchBufferForSize(size_t size)
 {
     if (!size)
         return nullptr;
@@ -39,7 +39,7 @@ uint64_t* Context::scratchBufferForSize(size_t size)
     if (size > m_sizeOfLastScratchBuffer) {
         m_sizeOfLastScratchBuffer = size * 2;
 
-        auto newBuffer = makeUniqueArray<uint64_t>(m_sizeOfLastScratchBuffer);
+        auto newBuffer = makeUniqueArray<ScratchBufferEntry>(m_sizeOfLastScratchBuffer);
         RELEASE_ASSERT(newBuffer);
         m_scratchBuffers.append(WTFMove(newBuffer));
     }

--- a/Source/JavaScriptCore/wasm/WasmContext.h
+++ b/Source/JavaScriptCore/wasm/WasmContext.h
@@ -35,15 +35,14 @@
 namespace JSC { namespace Wasm {
 
 struct Context {
-    uint64_t* scratchBufferForSize(size_t numberOfSlots);
+    struct alignas(16) ScratchBufferEntry {
+        uint8_t data[16]; // Large enough for any type (including v128_t)
+    };
 
-    ALWAYS_INLINE static constexpr size_t scratchBufferSlotsPerValue(SavedFPWidth savedFPWidth)
-    {
-        return savedFPWidth == SavedFPWidth::SaveVectors ? 2 : 1;
-    }
+    ScratchBufferEntry* scratchBufferForSize(size_t numberOfSlots);
 
 private:
-    Vector<UniqueArray<uint64_t>> m_scratchBuffers;
+    Vector<UniqueArray<ScratchBufferEntry>> m_scratchBuffers;
     size_t m_sizeOfLastScratchBuffer { 0 };
     Lock m_scratchBufferLock;
 };

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -63,7 +63,7 @@ JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, void, (void*, C
 JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* sp, CallFrame*, JSWebAssemblyInstance*));
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, SavedFPWidth);
+void loadValuesIntoBuffer(Probe::Context&, const StackMap&, Wasm::Context::ScratchBufferEntry*);
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (CallFrame*, JSWebAssemblyInstance*));
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)


### PR DESCRIPTION
#### c410d58148a69bd4a4c5093c2820d5a988de0420
<pre>
[JSC] Wasm: fix exceptions with inlining between SIMD and non-SIMD functions
<a href="https://rdar.apple.com/163013486">rdar://163013486</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301380">https://bugs.webkit.org/show_bug.cgi?id=301380</a>

Reviewed by Yusuke Suzuki.

Currently, OSR and exception scratch buffer entries are sized dependent
on whether the function uses SIMD or not. When OMG inlines a function,
the caller and callee make independent choices about the size of
the scratch buffer entry for the catch entry points and throw/call
patchpoints. This is not correct when the catch site and throw/call site
disagree since the buffer will be misinterpreted.

Let&apos;s fix this and simplify things by just having a single size for
scratch buffer entries large enough to fit vectors. As a consequence,
also combine the SIMD and non-SIMD probe code that always saves/restores
vector-width FPRs.

Test: JSTests/wasm/stress/simd-inline-exceptions.js
* JSTests/wasm/stress/simd-inline-exceptions.js: Added.
(async testSIMDInlinedIntoNonSIMD):
(async testNonSIMDInlinedIntoSIMD):
* Source/JavaScriptCore/assembler/MacroAssembler.cpp:
(JSC::MacroAssembler::probeDebugSIMD): Deleted.
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
(JSC::MacroAssembler::probe):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.cpp:
(JSC::MacroAssembler::probe):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp:
(JSC::MacroAssembler::probe):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp:
(JSC::MacroAssembler::probe):
* Source/JavaScriptCore/assembler/ProbeContext.h:
(JSC::Probe::CPUState::fpr):
(JSC::Probe::CPUState::fpr const):
(JSC::Probe::Context::fpr):
(): Deleted.
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoopOSREntrypoint):
(JSC::Wasm::BBQJITImpl::BBQJIT::makeStackMap):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitLoopTierUpCheckAndOSREntryData):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmContext.cpp:
(JSC::Wasm::Context::scratchBufferForSize):
* Source/JavaScriptCore/wasm/WasmContext.h:
(JSC::Wasm::Context::scratchBufferSlotsPerValue): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::buildEntryBufferForLoopOSR):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::buildEntryBufferForCatch):
(JSC::Wasm::buildEntryBufferForCatchSIMD): Deleted.
(JSC::Wasm::buildEntryBufferForCatchNoSIMD): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::insertEntrySwitch):
(JSC::Wasm::OMGIRGenerator::addArguments):
(JSC::Wasm::OMGIRGenerator::loadFromScratchBuffer):
(JSC::Wasm::OMGIRGenerator::addLoop):
(JSC::Wasm::prepareForTailCallImpl):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::insertEntrySwitch):
(JSC::Wasm::OMGIRGenerator::addArguments):
(JSC::Wasm::prepareForTailCallImpl):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::loadValuesIntoBuffer):
(JSC::Wasm::doOSREntry):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:

Originally-landed-as: 301765.112@safari-7623-branch (bd8fd327ea0b). <a href="https://rdar.apple.com/166338130">rdar://166338130</a>
Canonical link: <a href="https://commits.webkit.org/304684@main">https://commits.webkit.org/304684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9ac05f3674cc92aed81a972fd5ac12f0354bec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104148 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84978 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b689f4e-98d7-4be2-ac96-c711c1c5cae1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6381 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4041 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4511 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128165 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146662 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134692 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112498 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112830 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6303 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118356 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62234 "Build is in progress. Recent messages:") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8295 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36414 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71854 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43698 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->