### PR TITLE
SubFrameSOAuthorizationSession should post new message to parent when authorization cancels with a UserCanceled error

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -177,7 +177,7 @@ void PopUpSOAuthorizationSession::close(WKWebView *webView)
         return;
     }
     m_secretWebView = nullptr;
-    WTFLogAlways("SecretWebView is cleaned.");
+    AUTHORIZATIONSESSION_RELEASE_LOG("SecretWebView is cleaned.");
 }
 
 void PopUpSOAuthorizationSession::initSecretWebView()
@@ -195,7 +195,7 @@ void PopUpSOAuthorizationSession::initSecretWebView()
     [m_secretWebView setNavigationDelegate:m_secretDelegate.get()];
 
     RELEASE_ASSERT(!m_secretWebView->_page->protectedPreferences()->isExtensibleSSOEnabled());
-    WTFLogAlways("SecretWebView is created.");
+    AUTHORIZATIONSESSION_RELEASE_LOG("SecretWebView is created.");
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -69,7 +69,8 @@ public:
     void shouldStart();
 
     // The following should only be called by SOAuthorizationDelegate methods.
-    void fallBackToWebPath();
+    enum class UserCancel : bool { No, Yes };
+    void fallBackToWebPath(UserCancel = UserCancel::No);
     void abort();
     // Only responses that meet all of the following requirements will be processed:
     // 1) it has the same origin as the request;
@@ -103,6 +104,7 @@ protected:
 private:
     virtual void shouldStartInternal() = 0;
     virtual void fallBackToWebPathInternal() = 0;
+    virtual void userCancel() { fallBackToWebPathInternal(); }
     virtual void abortInternal() = 0;
     virtual void completeInternal(const WebCore::ResourceResponse&, NSData *) = 0;
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -274,7 +274,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
     [m_soAuthorization beginAuthorizationWithURL:retainPtr(nsRequest.get().URL).get() httpHeaders:retainPtr(nsRequest.get().allHTTPHeaderFields).get() httpBody:retainPtr(nsRequest.get().HTTPBody).get()];
 }
 
-void SOAuthorizationSession::fallBackToWebPath()
+void SOAuthorizationSession::fallBackToWebPath(UserCancel userCancel)
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPath");
 
@@ -285,7 +285,10 @@ void SOAuthorizationSession::fallBackToWebPath()
     }
 
     becomeCompleted();
-    fallBackToWebPathInternal();
+    if (userCancel == UserCancel::Yes)
+        this->userCancel();
+    else
+        fallBackToWebPathInternal();
 }
 
 void SOAuthorizationSession::abort()

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -53,6 +53,7 @@ private:
     // SOAuthorizationSession
     void fallBackToWebPathInternal() final;
     void abortInternal() final;
+    void userCancel() final;
     void completeInternal(const WebCore::ResourceResponse&, NSData *) final;
 
     // NavigationSOAuthorizationSession

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -50,6 +50,7 @@ namespace {
 
 constexpr auto soAuthorizationPostDidStartMessageToParent = "<script>parent.postMessage('SOAuthorizationDidStart', '*');</script>"_s;
 constexpr auto soAuthorizationPostDidCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidCancel', '*');</script>"_s;
+constexpr auto soAuthorizationPostDidUserCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidUserCancel', '*');</script>"_s;
 
 } // namespace
 
@@ -77,6 +78,14 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
     appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidCancelMessageToParent.span8()));
+    appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
+}
+
+void SubFrameSOAuthorizationSession::userCancel()
+{
+    AUTHORIZATIONSESSION_RELEASE_LOG("userCancel: navigationAction=%p", navigationAction());
+    ASSERT(navigationAction());
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidUserCancelMessageToParent.span8()));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
@@ -146,6 +146,14 @@
         ASSERT_NOT_REACHED();
         return;
     }
+
+    NSString *authenticationErrorDomain = @"AKAuthenticationError"; // AKAppleIDAuthenticationErrorDomain
+    constexpr NSInteger userCanceled = -7003; // AKAuthenticationErrorUserCanceled
+    if ([error.domain isEqualToString:authenticationErrorDomain] && error.code == userCanceled) {
+        WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: User cancelled");
+        return session->fallBackToWebPath(WebKit::SOAuthorizationSession::UserCancel::Yes);
+    }
+
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: Falling back to web path.");
     session->fallBackToWebPath();
 }


### PR DESCRIPTION
#### 66ebed132bc6cf2fdc1503bdd439cc565b059f2a
<pre>
SubFrameSOAuthorizationSession should post new message to parent when authorization cancels with a UserCanceled error
<a href="https://bugs.webkit.org/show_bug.cgi?id=304350">https://bugs.webkit.org/show_bug.cgi?id=304350</a>
<a href="https://rdar.apple.com/164667729">rdar://164667729</a>

Reviewed by Brent Fulgham.

We want a new message to be posted when the user cancels the authentication to distinguish it from other errors.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::close):
(WebKit::PopUpSOAuthorizationSession::initSecretWebView):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
(WebKit::SOAuthorizationSession::userCancel):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::fallBackToWebPath):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::userCancel):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm:
(-[WKSOAuthorizationDelegate authorization:didCompleteWithError:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, UserCancel)):

Canonical link: <a href="https://commits.webkit.org/304723@main">https://commits.webkit.org/304723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f61af27ff6e03bf7e3cdecfb79aba7ad73db821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143835 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59714734-2114-4f76-935d-49f47e491af9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104067 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4fb3214a-26be-41fc-aede-bde39d4de26f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b7632cf-5b01-4449-b724-43d7b372967f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3979 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146582 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112766 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6233 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62154 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21022 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->