### PR TITLE
AX: Force accessibility/text-stitching-inside-links.html to perform text stitching within the link, fixing it after 304507@main broke it

### DIFF
--- a/LayoutTests/accessibility/text-stitching-inside-links-expected.txt
+++ b/LayoutTests/accessibility/text-stitching-inside-links-expected.txt
@@ -13,6 +13,8 @@ This test ensures we stitch text inside links.
 
 {AXRole: AXStaticText AXValue: $550.00}
 
+{AXRole: AXButton}
+
 {AXRole: AXLink}
 
 {AXRole: AXStaticText AXValue: 10% OFF}
@@ -25,6 +27,8 @@ This test ensures we stitch text inside links.
 
 {AXRole: AXStaticText AXValue: $550.00}
 
+{AXRole: AXButton}
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
@@ -33,4 +37,4 @@ Foobar 9000
 Category Name
 $430.10 (BIGGEST PRICE DROP YET)
 $550.00
-
+Upvote product

--- a/LayoutTests/accessibility/text-stitching-inside-links.html
+++ b/LayoutTests/accessibility/text-stitching-inside-links.html
@@ -15,6 +15,9 @@
         <div id="new-price-div"><span>$</span><span>430</span><span>.10</span></div>
         <div>$550.00</div>
     </div>
+    <!-- Add this button so iOS doesn't consider the containing link an atomic accessibility element via -[WebAccessibilityObjectWrapperIOS containsUnnaturallySegmentedChildren].
+         If it were an accessibility element, the text within the link wouldn't be exposed, preventing us from actually testing its stitching behavior. -->
+    <button>Upvote product</button>
 </a>
 
 <script>
@@ -31,6 +34,12 @@ if (window.accessibilityController) {
     span.innerText = " (BIGGEST PRICE DROP YET)";
     document.getElementById("new-price-div").appendChild(span);
 
+    // FIXME: This forced layout shouldn't be necessary, but there seems to be a bug where the page won't layout and
+    // update rendering naturally only when the <button> is present in the link. For now, force a layout to ensure
+    // text stitching gets updated with the rendering.
+    document.body.offsetWidth;
+
+    var newTraversalOutput;
     setTimeout(async function() {
         await waitFor(() => {
             newTraversalOutput = dumpAXSearchTraversal(webArea, { excludeRoles: ["group"] });

--- a/LayoutTests/platform/ios/accessibility/text-stitching-inside-links-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/text-stitching-inside-links-expected.txt
@@ -11,6 +11,8 @@ This test ensures we stitch text inside links.
 
 {StaticText AXLabel: $550.00}
 
+{Button}
+
 {StaticText AXLabel: 10% OFF}
 
 {StaticText AXLabel: Foobar 9000}
@@ -21,6 +23,8 @@ This test ensures we stitch text inside links.
 
 {StaticText AXLabel: $550.00}
 
+{Button}
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
@@ -29,4 +33,4 @@ Foobar 9000
 Category Name
 $430.10 (BIGGEST PRICE DROP YET)
 $550.00
-
+Upvote product


### PR DESCRIPTION
#### 68b23a5f79478273df9c7fc0b4f2709fc9b044e1
<pre>
AX: Force accessibility/text-stitching-inside-links.html to perform text stitching within the link, fixing it after 304507@main broke it
<a href="https://bugs.webkit.org/show_bug.cgi?id=304354">https://bugs.webkit.org/show_bug.cgi?id=304354</a>
<a href="https://rdar.apple.com/166728489">rdar://166728489</a>

Reviewed by Joshua Hoffman.

In <a href="https://commits.webkit.org/304507@main">https://commits.webkit.org/304507@main</a>, we made links atomic accessibility elements in more scenarios, but that broke
the ability to test stitching within links as accessibility/text-stitching-inside-links.html relied on. Add a button
to the link in this test to ensure it is exposed in the accessibility as its descendants, allowing us to exercise the
text stitching logic.

* LayoutTests/accessibility/text-stitching-inside-links-expected.txt:
* LayoutTests/accessibility/text-stitching-inside-links.html:
* LayoutTests/platform/ios/accessibility/text-stitching-inside-links-expected.txt:

Canonical link: <a href="https://commits.webkit.org/304784@main">https://commits.webkit.org/304784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4ea3d5337e2fd035d8240c0664c7976156675c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143842 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89102 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84914 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6326 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3986 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4438 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146589 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112429 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6239 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62161 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8222 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36356 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->