### PR TITLE
[threaded-animations] Threaded time-based animations should opt into a higher frame rate on iOS

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -58,6 +58,8 @@ private:
     void setPreferredFramesPerSecond(IPC::Connection&, WebCore::FramesPerSecond) override;
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;
+    void scheduleDisplayLinkAndSetFrameRate();
+    void pauseDisplayLinkIfNeeded();
 
     void didRefreshDisplay() override;
 


### PR DESCRIPTION
#### 2876fe9c22e0f13d2cbd960a781737f77862f4a1
<pre>
[threaded-animations] Threaded time-based animations should opt into a higher frame rate on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=304358">https://bugs.webkit.org/show_bug.cgi?id=304358</a>
<a href="https://rdar.apple.com/166731485">rdar://166731485</a>

Reviewed by Simon Fraser.

On iOS, the `CADisplayLink` that schedules display refresh callbacks that will trigger page rendering
updates as well as monotonic animation updates is owned by `RemoteLayerTreeDrawingAreaProxyIOS`. That
display link only ever opts into a higher frame rate than the default 60fps if &quot;Prefer Page Rendering
Updates near 60fps&quot; is disabled, whereas it&apos;s enabled by default.

This means that threaded time-based animations only ever run at 120Hz on Pro Motion displays if that
flag is disabled. Meanwhile, in the legacy code path, the CA animations we create opt into a higher
frame rate.

In order to retain high frame rate animations with threaded time-based animations, we now account for
whether `scheduleDisplayRefreshCallbacksForMonotonicAnimations()` has been called. However, to ensure
that we do not trigger page rendering updates at a higher frame rate if &quot;Prefer Page Rendering Updates
near 60fps&quot; is disabled (again, its default value), we now use `DisplayUpdate` to only call
`RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()` on frames that match the expected frame rate for
such updates.

To make the code a bit clearer and modular, we&apos;ve also refactored the scheduling and pausing of callbacks
to two new methods: `scheduleDisplayLinkAndSetFrameRate()` and `pauseDisplayLinkIfNeeded()`. Both account
for the type of callbacks currently scheduled (page rendering and animation updates) as well as accounting
for &quot;Prefer Page Rendering Updates near 60fps&quot; setting and the preferred frames per second set by the Web
process, which may be lower than 60fps for low-power mode.

Manual testing included:

1. a page continuously scheduling page rendering updates with `requestAnimationFrame()` is getting callbacks
   at 60fps with &quot;Prefer Page Rendering Updates near 60fps&quot; enabled and at 120fps with &quot;Prefer Page
   Rendering Updates near 60fps&quot; disabled.
2. a page continuously scheduling page rendering updates with `requestAnimationFrame()` is getting callbacks
   at 60fps while a threaded time-based animation was getting updates at 120fps if &quot;Prefer Page Rendering
   Updates near 60fps&quot; was enabled, and at 120fps with &quot;Prefer Page Rendering Updates near 60fps&quot; disabled.

In both cases, low-power mode was also enabled to verify that callbacks ran at around 30fps and that threaded
monotonic animations were also updated around 30fps. An earlier version of this patch which failed to account
for the preferred frames per second set for low-power mode had regressed a couple of tests which proved valuable
to verify the correct behavior:

- fast/animation/request-animation-frame-throttling-aggressiveThermalMitigation.html
- fast/animation/request-animation-frame-throttling-lowPowerMode.html

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
(-[WKDisplayLinkHandler displayLinkFired:]):
(-[WKDisplayLinkHandler timerFired]):
(-[WKDisplayLinkHandler setPreferredFramesPerSecond:]):
(-[WKDisplayLinkHandler setWantsHighFrameRate:]):
(-[WKDisplayLinkHandler updateFrameRate]):
(-[WKDisplayLinkHandler isDisplayRefreshRelevantForPreferredUpdateFrequency]):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayLinkAndSetFrameRate):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayLinkIfNeeded):

Canonical link: <a href="https://commits.webkit.org/304907@main">https://commits.webkit.org/304907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b15c8287067a731cc579301a11643360d1db8f0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48139 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/144588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89825 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9058 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/144588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/7249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/144588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/5176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/116216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/147345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8895 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/147345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8913 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/147345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/6814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63079 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21095 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8943 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8664 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/72509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->