### PR TITLE
[iOS] WirelessPlaybackMediaPlayerEnabled can't be enabled at runtime

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -10041,8 +10041,7 @@ WirelessPlaybackMediaPlayerEnabled:
   category: media
   humanReadableName: "Wireless Playback Media Player"
   humanReadableDescription: "Enable wireless playback via MediaPlayerPrivateWirelessPlayback"
-  webcoreBinding: DeprecatedGlobalSettings
-  condition: ENABLE(REMOTE_PLAYBACK_MEDIA_PLAYER)
+  condition: ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
   defaultValue:
     WebCore:
       default: false

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -124,11 +124,6 @@ public:
     static bool modelDocumentEnabled() { return singleton().m_modelDocumentEnabled; }
 #endif
 
-#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    static void setWirelessPlaybackMediaPlayerEnabled(bool isEnabled) { singleton().m_wirelessPlaybackMediaPlayerEnabled = isEnabled; }
-    static bool isWirelessPlaybackMediaPlayerEnabled() { return singleton().m_wirelessPlaybackMediaPlayerEnabled; }
-#endif
-
 private:
     WEBCORE_EXPORT static DeprecatedGlobalSettings& singleton();
     DeprecatedGlobalSettings() = default;
@@ -184,10 +179,6 @@ private:
 
 #if ENABLE(MODEL_ELEMENT)
     bool m_modelDocumentEnabled { false };
-#endif
-
-#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    bool m_wirelessPlaybackMediaPlayerEnabled { false };
 #endif
 
     friend class NeverDestroyed<DeprecatedGlobalSettings>;

--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -110,4 +110,22 @@ void MediaStrategy::enableRemoteRenderer(MediaPlayerMediaEngineIdentifier type, 
 }
 #endif
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+void MediaStrategy::setWirelessPlaybackMediaPlayerEnabled(bool enabled)
+{
+    if (m_wirelessPlaybackMediaPlayerEnabled == enabled)
+        return;
+
+    m_wirelessPlaybackMediaPlayerEnabled = enabled;
+#if ENABLE(VIDEO)
+    MediaPlayer::resetMediaEngines();
+#endif
 }
+
+bool MediaStrategy::wirelessPlaybackMediaPlayerEnabled() const
+{
+    return m_wirelessPlaybackMediaPlayerEnabled;
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -78,11 +78,21 @@ public:
     virtual bool enableWebMMediaPlayer() const { return true; }
     virtual bool isWebMediaStrategy() const { return false; }
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    void setWirelessPlaybackMediaPlayerEnabled(bool);
+    bool wirelessPlaybackMediaPlayerEnabled() const;
+#endif
+
 protected:
     MediaStrategy();
     virtual ~MediaStrategy();
     bool m_mockMediaSourceEnabled { false };
     WTF::BitSet<16> m_remoteRenderersEnabled;
+
+private:
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    bool m_wirelessPlaybackMediaPlayerEnabled { false };
+#endif
 };
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -72,9 +72,11 @@ private:
     Vector<Ref<MediaDeviceRoute>> m_activeRoutes;
 };
 
-WEBCORE_EXPORT void setMockMediaDeviceRouteControllerEnabled(bool);
-WEBCORE_EXPORT bool mockMediaDeviceRouteControllerEnabled();
-
 } // namespace WebCore
 
 #endif // HAVE(AVROUTING_FRAMEWORK)
+
+namespace WebCore {
+WEBCORE_EXPORT void setMockMediaDeviceRouteControllerEnabled(bool);
+WEBCORE_EXPORT bool mockMediaDeviceRouteControllerEnabled();
+}

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -28,6 +28,8 @@
 
 #if HAVE(AVROUTING_FRAMEWORK)
 
+#import "MediaStrategy.h"
+#import "PlatformStrategies.h"
 #import <WebKitAdditions/MediaDeviceRouteControllerAdditions.mm>
 
 #import <pal/ios/AVRoutingSoftLink.h>
@@ -90,6 +92,12 @@ bool MediaDeviceRouteController::deactivateRoute(WebMediaDevicePlatformRoute *pl
     return true;
 }
 
+} // namespace WebCore
+
+#endif // HAVE(AVROUTING_FRAMEWORK)
+
+namespace WebCore {
+
 static bool& mockMediaDeviceRouteControllerEnabledValue()
 {
     static bool mockMediaDeviceRouteControllerEnabled;
@@ -98,7 +106,13 @@ static bool& mockMediaDeviceRouteControllerEnabledValue()
 
 void setMockMediaDeviceRouteControllerEnabled(bool isEnabled)
 {
+    if (mockMediaDeviceRouteControllerEnabledValue() == isEnabled)
+        return;
+
     mockMediaDeviceRouteControllerEnabledValue() = isEnabled;
+#if ENABLE(VIDEO)
+    platformStrategies()->mediaStrategy()->resetMediaEngines();
+#endif
 }
 bool mockMediaDeviceRouteControllerEnabled()
 {
@@ -106,5 +120,3 @@ bool mockMediaDeviceRouteControllerEnabled()
 }
 
 } // namespace WebCore
-
-#endif // HAVE(AVROUTING_FRAMEWORK)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -367,7 +367,7 @@ static void buildMediaEnginesVector() WTF_REQUIRES_LOCK(mediaEngineVectorLock)
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    if (DeprecatedGlobalSettings::isWirelessPlaybackMediaPlayerEnabled()) {
+    if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy()->wirelessPlaybackMediaPlayerEnabled()) {
         if (registerRemoteEngine && !mockMediaDeviceRouteControllerEnabled())
             registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::WirelessPlayback);
         else

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -431,6 +431,7 @@
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+#import "MediaDeviceRouteController.h"
 #import "MockMediaDeviceRouteController.h"
 #endif
 
@@ -743,6 +744,13 @@ void Internals::resetToConsistentState(Page& page)
 
 #if ENABLE(DAMAGE_TRACKING)
     page.chrome().client().resetDamageHistoryForTesting();
+#endif
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+#if HAVE(AVROUTING_FRAMEWORK)
+    MediaDeviceRouteController::singleton().setClient(nullptr);
+#endif
+    setMockMediaDeviceRouteControllerEnabled(false);
 #endif
 }
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1500,5 +1500,5 @@ enum ContentsFormat {
     undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
     undefined resetNavigationRateLimiter(DOMWindow window);
 
-    [Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER] readonly attribute MockMediaDeviceRouteController mockMediaDeviceRouteController;
+    [Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER, EnabledBySetting=WirelessPlaybackMediaPlayerEnabled] readonly attribute MockMediaDeviceRouteController mockMediaDeviceRouteController;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    EnabledBySetting=WirelessPlaybackMediaPlayerEnabled,
     LegacyNoInterfaceObject,
 ] interface MockMediaDeviceRoute {
 };

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.idl
@@ -25,12 +25,13 @@
 
 [
     Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    EnabledBySetting=WirelessPlaybackMediaPlayerEnabled,
     LegacyNoInterfaceObject,
 ] interface MockMediaDeviceRouteController {
     attribute boolean enabled;
 
     MockMediaDeviceRoute createMockMediaDeviceRoute();
-    
+
     boolean activateRoute(MockMediaDeviceRoute route);
     boolean deactivateRoute(MockMediaDeviceRoute route);
 };

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.mm
@@ -51,7 +51,9 @@ bool MockMediaDeviceRouteController::enabled() const
 
 void MockMediaDeviceRouteController::setEnabled(bool enabled)
 {
+#if HAVE(AVROUTING_FRAMEWORK)
     MediaDeviceRouteController::singleton().setClient(enabled ? &MediaSessionHelper::sharedHelper() : nullptr);
+#endif
     setMockMediaDeviceRouteControllerEnabled(enabled);
 }
 
@@ -62,12 +64,22 @@ Ref<MockMediaDeviceRoute> MockMediaDeviceRouteController::createMockMediaDeviceR
 
 bool MockMediaDeviceRouteController::activateRoute(const MockMediaDeviceRoute& route)
 {
+#if HAVE(AVROUTING_FRAMEWORK)
     return MediaDeviceRouteController::singleton().activateRoute(route.platformRoute());
+#else
+    UNUSED_PARAM(route);
+    return false;
+#endif
 }
 
 bool MockMediaDeviceRouteController::deactivateRoute(const MockMediaDeviceRoute& route)
 {
+#if HAVE(AVROUTING_FRAMEWORK)
     return MediaDeviceRouteController::singleton().deactivateRoute(route.platformRoute());
+#else
+    UNUSED_PARAM(route);
+    return false;
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4921,6 +4921,10 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
         settings.setTrackConfigurationEnabled(true);
     }
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    platformStrategies()->mediaStrategy()->setWirelessPlaybackMediaPlayerEnabled(store.getBoolValueForKey(WebPreferencesKey::wirelessPlaybackMediaPlayerEnabledKey()));
+#endif
+
 #if ENABLE(PDF_PLUGIN)
     for (Ref pluginView : m_pluginViews)
         pluginView->didChangeSettings();


### PR DESCRIPTION
#### 2db7bcd445af5bfc302b39a462e604b08045ec5d
<pre>
[iOS] WirelessPlaybackMediaPlayerEnabled can&apos;t be enabled at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=304360">https://bugs.webkit.org/show_bug.cgi?id=304360</a>
<a href="https://rdar.apple.com/166734272">rdar://166734272</a>

Reviewed by Jean-Yves Avenard.

Fixed a bug where the wrong condition was specified in the definition of
WirelessPlaybackMediaPlayerEnabled. While here:
1. Moved the WebCore runtime setting from DeprecatedGlobalSettings to MediaStrategy.
2. Called MediaStrategy::resetMediaEngines() when WirelessPlaybackMediaPlayerEnabled or
   MockMediaDeviceRouteControllerEnabled changes.
3. Disabled MockMediaDeviceRouteControllerEnabled and cleared MediaDeviceRouteController&apos;s client
   in Internals::resetToConsistentState.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setWirelessPlaybackMediaPlayerEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::isWirelessPlaybackMediaPlayerEnabled): Deleted.
* Source/WebCore/platform/MediaStrategy.cpp:
(WebCore::MediaStrategy::setWirelessPlaybackMediaPlayerEnabled):
(WebCore::MediaStrategy::wirelessPlaybackMediaPlayerEnabled const):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm:
(WebCore::setMockMediaDeviceRouteControllerEnabled):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRouteController.idl:
* Source/WebCore/testing/MockMediaDeviceRouteController.mm:
(WebCore::MockMediaDeviceRouteController::setEnabled):
(WebCore::MockMediaDeviceRouteController::activateRoute):
(WebCore::MockMediaDeviceRouteController::deactivateRoute):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/304788@main">https://commits.webkit.org/304788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca6e2a2e5dbb77c248c4081a2beaa902ad98dd4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89185 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84984 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19f41a04-72b6-459f-8f62-5006c3ef81c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6390 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4048 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4521 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146672 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134702 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6314 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62244 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8305 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167481 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71864 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43700 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->