### PR TITLE
Avoid scheduling rendering updates for SVG animations on elements

### DIFF
--- a/LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates-expected.txt
+++ b/LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates-expected.txt
@@ -1,0 +1,10 @@
+Test that SVG animations on hidden elements do not trigger rendering updates.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS updateCount <= 5 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates.html
+++ b/LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <style>
+        #container {
+            width: 100px;
+            height: 100px;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="container" hidden>
+        <svg viewBox="0 0 100 100" width="100" height="100">
+            <circle cx="50" cy="50" fill="none" r="35" stroke="currentColor"
+                stroke-dasharray="164.93361431346415 56.97787143782138" stroke-width="6">
+                <animateTransform attributeName="transform" type="rotate" repeatCount="indefinite" dur="1s"
+                    values="0 50 50;90 50 50;180 50 50;360 50 50" keyTimes="0;0.40;0.65;1"></animateTransform>
+            </circle>
+        </svg>
+    </div>
+    <div id="console"></div>
+    <script>
+        window.jsTestIsAsync = true;
+
+        let updateCount = 0;
+
+        function sleepFor(duration) {
+            return new Promise(resolve => setTimeout(resolve, duration));
+        }
+
+        async function waitForRenderingUpdateCountToSettle() {
+            let renderingUpdateCount = 0;
+            do {
+                renderingUpdateCount = internals.renderingUpdateCount();
+                // Wait slightly more than 2 frames at 60fps (~33.33ms) to ensure
+                // any pending rendering updates have completed.
+                await sleepFor(34);
+            } while (internals.renderingUpdateCount() != renderingUpdateCount);
+
+            internals.startTrackingRenderingUpdates();
+        }
+
+        window.addEventListener('load', async () => {
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+
+            description('Test that SVG animations on hidden elements do not trigger rendering updates.');
+
+            internals.setSpeculativeTilingDelayDisabledForTesting(true);
+            
+            await waitForRenderingUpdateCountToSettle();
+
+            await sleepFor(250);
+
+            updateCount = internals.renderingUpdateCount();
+
+            shouldBeTrue('updateCount <= 5');
+
+            finishJSTest();
+        }, false);
+    </script>
+</body>
+
+</html>

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -155,9 +155,10 @@ void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)
             return;
         }
 
-        if (CheckedPtr renderer = this->renderer())
+        if (CheckedPtr renderer = this->renderer()) {
             renderer->setNeedsTransformUpdate();
-        updateSVGRendererForElementChange();
+            updateSVGRendererForElementChange();
+        }
         return;
     }
 


### PR DESCRIPTION
#### b70eabc441428cc812dd279f5f2df22b237bc523
<pre>
Avoid scheduling rendering updates for SVG animations on elements
without renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=298217">https://bugs.webkit.org/show_bug.cgi?id=298217</a>
<a href="https://rdar.apple.com/159647563">rdar://159647563</a>

Reviewed by Antoine Quint.

When SVG elements with SMIL animations (like animateTransform) are
inside containers with hidden attribute, the legacy SVG engine was
scheduling full page rendering updates every animation frame despite
the elements having no renderer.

Now when animations run on elements without renderers, we skip
scheduling rendering updates entirely.

* LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates-expected.txt: Added.
* LayoutTests/svg/animations/animateTransform-hidden-no-rendering-updates.html: Added.
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/304744@main">https://commits.webkit.org/304744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcc831e50506ed50cb2d4479bfc46940c5a279ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144106 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a557c01c-7e6b-4dc6-9639-4b2943aa8f41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104294 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00232f2d-0ff4-4f6e-bca4-1178333a7e3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6870 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122208 "Found 1 new API test failure: TestWebKitAPI.InWindowFullscreen.IFrameDocument (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b38fd90c-0fdb-4fb5-9ee2-ebd448b65a85) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6517 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4178 "Found 1 new API test failure: TestWebKitAPI.FormValidation.PresentingFormValidationUIWithoutViewControllerDoesNotCrash (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4697 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146850 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8433 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112630 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112977 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6453 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62420 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36569 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->