### PR TITLE
Re-land [Swift in WebKit] Enable module verification for bmalloc (part 2)

### DIFF
--- a/Source/WTF/Scripts/modules-verifier/GenerateModuleVerifierInputsTask.py
+++ b/Source/WTF/Scripts/modules-verifier/GenerateModuleVerifierInputsTask.py
@@ -22,10 +22,15 @@ def _module_verifier_target_set_combinations(
     languages_and_standards = [
         (language, language.supported_standards(standards)) for language in languages
     ]
-    for architecture in targets:
+
+    for target in targets:
+        # FIXME: Support Catalyst targets.
+        if target.suffix is not None and "macabi" in target.suffix:
+            continue
+
         for language, supported_standards in languages_and_standards:
             for standard in supported_standards:
-                result.append(ModuleVerifierTargetSet(architecture, language, standard))
+                result.append(ModuleVerifierTargetSet(target, language, standard))
 
     return result
 

--- a/Source/WTF/Scripts/modules-verifier/ModuleVerifierLanguage.py
+++ b/Source/WTF/Scripts/modules-verifier/ModuleVerifierLanguage.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 
 class LanguageStandard(Enum):
+    C_99 = "c99"
+    GNU_99 = "gnu99"
     C_11 = "c11"
     GNU_11 = "gnu11"
     C_17 = "c17"
@@ -11,7 +13,7 @@ class LanguageStandard(Enum):
 
     @classmethod
     def c_standards(cls: type["LanguageStandard"]) -> set["LanguageStandard"]:
-        return {cls.C_11, cls.GNU_11, cls.C_17, cls.GNU_17, cls.C_23, cls.GNU_23}
+        return {cls.C_99, cls.GNU_99, cls.C_11, cls.GNU_11, cls.C_17, cls.GNU_17, cls.C_23, cls.GNU_23}
 
     C_PLUS_PLUS_17 = "c++17"
     GNU_PLUS_PLUS_17 = "gnu++17"

--- a/Source/WTF/Scripts/modules-verifier/library-modules-verifier.py
+++ b/Source/WTF/Scripts/modules-verifier/library-modules-verifier.py
@@ -60,9 +60,6 @@ if __name__ == "__main__":
 
     arguments = parse_command_arguments()
 
-    assert arguments.tapi_filelist.is_file()
-    assert arguments.relative_to.is_dir()
-
     with open(arguments.tapi_filelist, "r") as tapi_filelist:
         filelist_data: FileList = json.load(tapi_filelist)
 

--- a/Source/bmalloc/Configurations/bmalloc.xcconfig
+++ b/Source/bmalloc/Configurations/bmalloc.xcconfig
@@ -95,7 +95,7 @@ MODULES_FOLDER_PATH = $(MODULES_FOLDER_PATH_$(WK_BMALLOC_HAS_SWIFT_MODULE));
 MODULES_FOLDER_PATH_YES = swift;
 
 OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_$(WK_BMALLOC_HAS_SWIFT_MODULE));
-OTHER_SWIFT_FLAGS_YES = -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature MemberImportVisibility -enable-upcoming-feature ExistentialAny -enable-upcoming-feature InferIsolatedConformances -enable-upcoming-feature NonisolatedNonsendingByDefault;
+OTHER_SWIFT_FLAGS_YES = -Xcc -std=c++2b -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature MemberImportVisibility -enable-upcoming-feature ExistentialAny -enable-upcoming-feature InferIsolatedConformances -enable-upcoming-feature NonisolatedNonsendingByDefault;
 
 SWIFT_OBJC_INTEROP_MODE = $(SWIFT_OBJC_INTEROP_MODE_$(WK_BMALLOC_HAS_SWIFT_MODULE));
 SWIFT_OBJC_INTEROP_MODE_YES = objcxx;
@@ -109,8 +109,8 @@ SWIFT_ACTIVE_COMPILATION_CONDITIONS_YES = BMALLOC_SWIFT_CXX_INTEROP;
 SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 SWIFT_STRICT_CONCURRENCY = complete;
 
-ENABLE_WK_LIBRARY_MODULE_VERIFIER = NO;
-MODULE_VERIFIER_SUPPORTED_LANGUAGES = c++ objective-c++;
-MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = c++23;
+ENABLE_WK_LIBRARY_MODULE_VERIFIER = $(WK_BMALLOC_HAS_SWIFT_MODULE);
+MODULE_VERIFIER_SUPPORTED_LANGUAGES = c objective-c c++ objective-c++;
+MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = gnu99 c++2b;
 
-OTHER_MODULE_VERIFIER_FLAGS = -- -I$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH) -iframework $(WK_PRIVATE_SDK_DIR)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks -Wsystem-headers-in-module=bmalloc;
+OTHER_MODULE_VERIFIER_FLAGS = -- -isystem $(DSTROOT)$(BMALLOC_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH) -I$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH) -I$(WK_ADDITIONAL_SDKS)$(WK_LIBRARY_HEADERS_FOLDER_PATH) -isystem "$(WK_PRIVATE_SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" -iframework $(WK_PRIVATE_SDK_DIR)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks -Wsystem-headers-in-module=bmalloc;

--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -1,50 +1,27 @@
 module bmalloc [system] {
     config_macros OS_UNFAIR_LOCK_INLINE
 
-    // List of "semi-public" bmalloc headers. What does "semi-public" mean? These are
-    // the headers which, in practice, are included by WTF headers. WTF headers are
-    // exported as part of the WebKit SPI, and therefore these headers need to be
-    // buildable as a clang module.
-    explicit module bmalloc_cpp {
-        requires cplusplus20
-        header "Algorithm.h"
-        header "BAssert.h"
-        header "BCompiler.h"
-        header "BInline.h"
-        header "BPlatform.h"
-        header "BVMTags.h"
-        header "CompactAllocationMode.h"
-        header "Gigacage.h"
-        header "GigacageConfig.h"
-        header "GigacageKind.h"
-        header "IsoHeap.h"
-        header "IsoHeapInlines.h"
-        header "Logging.h"
-        header "Sizes.h"
-        header "TZoneHeap.h"
-        header "TZoneHeapInlines.h"
+    explicit module pas_simple_free_heap_declarations_def {
+        private textual header "pas_simple_free_heap_declarations.def"
     }
-    // The following header contains only plain C definitions so
-    // we declare this in a submodule which doesn't require cplusplus11
-    explicit module bexport {
-        header "BExport.h"
+
+    explicit module pas_segregated_page_config_kind_def {
+        private textual header "pas_segregated_page_config_kind.def"
     }
-    // The following also do not need cplusplus11 and also need
-    // to be colocated in one module since any headers including
-    // most of these will end up requiring the definitions from
-    // the others. Specifically, we don't want lots of downstream
-    // files to need to explicitly include pas_utils_prefix.h,
-    // yet many of these other files define things in terms of
-    // the contents of that file.
-    explicit module pas {
-        header "pas_allocation_mode.h"
-        header "pas_config.h"
-        header "pas_config_prefix.h"
-        header "pas_lock.h"
-        header "pas_platform.h"
-        header "pas_thread.h"
-        header "pas_utils.h"
-        header "pas_utils_prefix.h"
+
+    explicit module pas_bitfit_page_config_kind_def {
+        private textual header "pas_bitfit_page_config_kind.def"
     }
-    export *
+
+    explicit module pas_heap_config_kind_def {
+        private textual header "pas_heap_config_kind.def"
+    }
+
+    explicit module Core {
+        umbrella "."
+
+        explicit module * {
+            export *
+        }
+    }
 }


### PR DESCRIPTION
#### 378bb0cfd99ac2932c1391433c38019e7447832b
<pre>
Re-land [Swift in WebKit] Enable module verification for bmalloc (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304367">https://bugs.webkit.org/show_bug.cgi?id=304367</a>
<a href="https://rdar.apple.com/166743946">rdar://166743946</a>

Reviewed by Aditya Keerthi.

This effectively re-lands 304592@main, but only a part of it (the verification and module map fixing part).

* Source/WTF/Scripts/modules-verifier/GenerateModuleVerifierInputsTask.py:
* Source/WTF/Scripts/modules-verifier/ModuleVerifierLanguage.py:
(LanguageStandard):
(LanguageStandard.c_standards):
* Source/WTF/Scripts/modules-verifier/library-modules-verifier.py:
* Source/bmalloc/Configurations/bmalloc.xcconfig:
* Source/bmalloc/Configurations/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/304692@main">https://commits.webkit.org/304692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e798bd36505ad33b6ea76393265c92048ea629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144003 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a59d36be-60db-4f46-b17f-16b2735823ca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/757b1e47-d376-4fb7-9969-ab46d57baeca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85046 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c42a244-7bfb-4d31-b094-10b46300ec0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4104 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128249 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134776 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112552 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6373 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118433 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8379 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36490 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8097 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71938 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43713 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->