### PR TITLE
Use more efficient network traffic attribution API

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#include <mach/message.h>
 #include <optional>
 #include <wtf/BitSet.h>
 #include <wtf/Forward.h>
@@ -152,6 +153,11 @@ WTF_EXPORT_PRIVATE void setApplicationBundleIdentifierOverride(const String&);
 WTF_EXPORT_PRIVATE String applicationBundleIdentifier();
 WTF_EXPORT_PRIVATE void clearApplicationBundleIdentifierTestingOverride();
 
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);
+WTF_EXPORT_PRIVATE std::optional<audit_token_t> applicationAuditToken();
+#endif
+
 namespace CocoaApplication {
 
 WTF_EXPORT_PRIVATE bool isAppleApplication();
@@ -226,5 +232,10 @@ using WTF::setApplicationBundleIdentifier;
 using WTF::setApplicationBundleIdentifierOverride;
 using WTF::setProcessIsExtension;
 using WTF::setSDKAlignedBehaviors;
+
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+using WTF::applicationAuditToken;
+using WTF::setApplicationAuditToken;
+#endif
 
 #endif // PLATFORM(COCOA)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -359,6 +359,22 @@ void clearApplicationBundleIdentifierTestingOverride()
 #endif
 }
 
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+
+static std::optional<audit_token_t> applicationAuditTokenStorage;
+
+void setApplicationAuditToken(audit_token_t token)
+{
+    applicationAuditTokenStorage = token;
+}
+
+std::optional<audit_token_t> applicationAuditToken()
+{
+    return applicationAuditTokenStorage;
+}
+
+#endif
+
 static bool applicationBundleIsEqualTo(const String& bundleIdentifierString)
 {
     return applicationBundleIdentifier() == bundleIdentifierString;

--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -40,7 +40,7 @@ symbols = [
 request = "rdar://157890562"
 symbols = [
     # Only used for benchmarking, see 293525@main.
-    "nw_parameters_set_source_application_by_bundle_id",
+    "nw_parameters_set_source_application",
 ]
 
 [[temporary-usage]]

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -122,9 +122,13 @@ void DNSResolveQueueCFNet::performDNSLookup(const String& hostname, Ref<Completi
     RetainPtr context = adoptCF(nw_context_create("WebKit DNS Lookup"));
     RetainPtr parameters = adoptCF(nw_parameters_create());
 
-    auto bundleID = applicationBundleIdentifier();
-    if (!bundleID.isEmpty())
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+    if (auto auditToken = applicationAuditToken())
+        nw_parameters_set_source_application(parameters.get(), auditToken.value());
+#else
+    if (auto bundleID = applicationBundleIdentifier(); !bundleID.isEmpty())
         nw_parameters_set_source_application_by_bundle_id(parameters.get(), bundleID.ascii().data());
+#endif
 
     nw_context_set_privacy_level(context.get(), nw_context_privacy_level_silent);
     nw_parameters_set_context(parameters.get(), context.get());

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -66,6 +66,10 @@
 #import <pal/spi/mac/HIServicesSPI.h>
 #endif
 
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+#import <wtf/darwin/XPCObjectPtr.h>
+#endif
+
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 #if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
@@ -109,6 +113,14 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
     [[NSFileManager defaultManager] changeCurrentDirectoryPath:retainPtr([[NSBundle mainBundle] bundlePath]).get()];
 
     setApplicationBundleIdentifier(parameters.clientBundleIdentifier);
+
+#if USE(SOURCE_APPLICATION_AUDIT_DATA)
+    if (XPCObjectPtr connection = parameters.connectionIdentifier.xpcConnection) {
+        audit_token_t auditToken { };
+        xpc_connection_get_audit_token(connection.get(), &auditToken);
+        setApplicationAuditToken(auditToken);
+    }
+#endif
 
 #if PLATFORM(MAC)
     disableDowngradeToLayoutManager();


### PR DESCRIPTION
#### 734443e9bf87d41a60ec716323d7247dbe7b8fe2
<pre>
Use more efficient network traffic attribution API
<a href="https://bugs.webkit.org/show_bug.cgi?id=304376">https://bugs.webkit.org/show_bug.cgi?id=304376</a>
<a href="https://rdar.apple.com/166751326">rdar://166751326</a>

Reviewed by Brady Eidson.

In 293525@main we made prefetchDNS use nw_parameters_set_source_application_by_bundle_id_internal to
attribute the DNS request to the host application. It turns out that this is a pretty inefficient
API (it blocks on a sync XPC message for ~10 ms which then goes and enumerates all apps by bundle ID
on the system). Fix this by using nw_parameters_set_source_application instead, which doesn&apos;t seem
to suffer from the same issue.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::setApplicationAuditToken):
(WTF::applicationAuditToken):
* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::performDNSLookup):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::platformInitialize):

Canonical link: <a href="https://commits.webkit.org/304682@main">https://commits.webkit.org/304682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60dab2f1a82ac56d4cecc52d384577d2e7c605b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104165 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84996 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/922d765b-674d-458a-ac5f-54448032ed80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4057 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4538 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128192 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146690 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134719 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8274 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6325 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118382 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8322 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36439 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167498 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71881 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43703 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->