### PR TITLE
Digital Credentials: ignore unknown digital credential types

### DIFF
--- a/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt
+++ b/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-protocol-1"
+CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-protocol-2"
+CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-before"
+CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-after"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https.html
+++ b/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credential API: Console Message Tests</title>
+<script src="/js-test-resources/js-test.js"></script>
+<body onload="setup().then(generateConsoleMessages)"></body>
+<script>
+    async function setup() {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+    }
+
+    async function generateConsoleMessages() {
+        try {
+            await navigator.credentials.get({
+                digital: {
+                    requests: [
+                        { protocol: "unknown-protocol-1", data: {} },
+                        { protocol: "unknown-protocol-2", data: {} },
+                    ],
+                },
+                mediation: "required",
+            });
+        } catch {}
+
+        try {
+            await navigator.credentials.get({
+                digital: {
+                    requests: [
+                        { protocol: "unknown-before", data: {} },
+                        {
+                            protocol: "org-iso-mdoc",
+                            data: {
+                                deviceRequest:
+                                    "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+                                encryptionInfo:
+                                    "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+                            },
+                        },
+                        { protocol: "unknown-after", data: {} },
+                    ],
+                },
+                mediation: "required",
+            });
+        } catch {}
+    }
+</script>

--- a/LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Valid protocol is accepted and processed
+PASS Unknown protocols are filtered out - all unknown protocols result in TypeError
+PASS Single unknown protocol is filtered out and results in TypeError
+PASS Mixed known and unknown protocols - unknown ones are silently filtered out
+PASS Multiple valid and unknown protocols - unknown ones are filtered out, valid ones processed
+PASS Empty protocol string is treated as unknown protocol
+PASS Protocol matching is case sensitive
+PASS Protocol with extra characters is treated as unknown
+

--- a/LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https.html
+++ b/LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credential API: Protocol Filtering Tests</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    promise_setup(async () => {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+        assert_equals(document.visibilityState, "visible", "should be visible");
+    });
+
+    const validMDocRequest = {
+        protocol: "org-iso-mdoc",
+        data: {
+            deviceRequest:
+                "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+            encryptionInfo:
+                "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+        },
+    };
+
+    const unknownProtocolRequest1 = {
+        protocol: "unknown-protocol-1",
+        data: { someField: "someValue" },
+    };
+
+    const unknownProtocolRequest2 = {
+        protocol: "unknown-protocol-2",
+        data: { anotherField: "anotherValue" },
+    };
+
+    // test passing just the valid protocol to ensure it works as expected
+    promise_test(async (t) => {
+        try {
+            await navigator.credentials.get({
+                digital: {
+                    requests: [validMDocRequest],
+                },
+                mediation: "required",
+            });
+            assert_unreached(
+                "Should not reach here in test environment - no credentials available"
+            );
+        } catch (error) {
+            // Expect some other error, but NOT TypeError which would indicate valid protocol wasn't recognized
+            assert_not_equals(
+                error.name,
+                "TypeError",
+                `Should not get TypeError when valid protocol is used: ${error.message}`
+            );
+        }
+    }, "Valid protocol is accepted and processed");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.credentials.get({
+                digital: {
+                    requests: [
+                        unknownProtocolRequest1,
+                        unknownProtocolRequest2,
+                    ],
+                },
+                mediation: "required",
+            }),
+            "Two unknown protocols should result in TypeError due to empty validated requests"
+        );
+    }, "Unknown protocols are filtered out - all unknown protocols result in TypeError");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.credentials.get({
+                digital: {
+                    requests: [unknownProtocolRequest1],
+                },
+                mediation: "required",
+            }),
+            "Single unknown protocol should result in TypeError due to empty validated requests"
+        );
+    }, "Single unknown protocol is filtered out and results in TypeError");
+
+    promise_test(async (t) => {
+        try {
+            await navigator.credentials.get({
+                digital: {
+                    requests: [
+                        unknownProtocolRequest1,
+                        validMDocRequest,
+                        unknownProtocolRequest2,
+                    ],
+                },
+                mediation: "required",
+            });
+            assert_unreached(
+                "Should not reach here in test environment - no credentials available"
+            );
+        } catch (error) {
+            // Expect some other error, but NOT TypeError which would indicate unknown protocols weren't filtered
+            assert_not_equals(
+                error.name,
+                "TypeError",
+                `Should not get TypeError when mixing known and unknown protocols - unknown should be filtered out: ${error.message}`
+            );
+        }
+    }, "Mixed known and unknown protocols - unknown ones are silently filtered out");
+
+    promise_test(async (t) => {
+        const validMDocRequest2 = {
+            protocol: "org-iso-mdoc",
+            data: {
+                deviceRequest:
+                    "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+                encryptionInfo:
+                    "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+            },
+        };
+
+        try {
+            await navigator.credentials.get({
+                digital: {
+                    requests: [
+                        unknownProtocolRequest1,
+                        validMDocRequest,
+                        unknownProtocolRequest2,
+                        validMDocRequest2,
+                        { protocol: "yet-another-unknown", data: {} },
+                    ],
+                },
+                mediation: "required",
+            });
+            assert_unreached(
+                "Should not reach here in test environment - no credentials available"
+            );
+        } catch (error) {
+            assert_not_equals(
+                error.name,
+                "TypeError",
+                "Should not get TypeError when valid protocols are present - unknown should be filtered out: " + error.message
+            );
+        }
+    }, "Multiple valid and unknown protocols - unknown ones are filtered out, valid ones processed");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.credentials.get({
+                digital: {
+                    requests: [{ protocol: "", data: {} }],
+                },
+                mediation: "required",
+            }),
+            "Empty protocol string should result in TypeError"
+        );
+    }, "Empty protocol string is treated as unknown protocol");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.credentials.get({
+                digital: {
+                    requests: [{ protocol: "ORG-ISO-MDOC", data: {} }],
+                },
+            }),
+            "Protocol matching should be case sensitive"
+        );
+    }, "Protocol matching is case sensitive");
+
+    promise_test(async (t) => {
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.credentials.get({
+                digital: {
+                    requests: [{ protocol: "org-iso-mdoc-extra", data: {} }],
+                },
+                mediation: "required",
+            }),
+            "Protocol with extra characters should be treated as unknown"
+        );
+    }, "Protocol with extra characters is treated as unknown");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html
@@ -246,4 +246,16 @@
       );
     }
   }, "Throws TypeError when request data is not JSON stringifiable.");
+
+  promise_test(async (t) => {
+    const options = {
+      password: document.createElement("form"),
+    };
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.create(options),
+      "Should throw for invalid form element"
+    );
+  }, "Throws when form element does not contain password.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
@@ -29,7 +29,7 @@
   });
 
   promise_test(async (t) => {
-    const invalidData = [null, undefined, "", 123, true, false];
+    const invalidData = [null, "", 123, true, false];
     for (const data of invalidData) {
       const options = makeGetOptions({ data });
       await test_driver.bless("user activation");

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
@@ -15,24 +15,6 @@
  * @typedef {GetProtocol | CreateProtocol} Protocol
  */
 
-/** @type {GetProtocol[]} */
-const GET_PROTOCOLS = /** @type {const} */ ([
-  "openid4vp-v1-unsigned",
-  "openid4vp-v1-signed",
-  "openid4vp-v1-multisigned",
-  "org-iso-mdoc",
-]);
-
-/** @type {CreateProtocol[]} */
-const CREATE_PROTOCOLS = /** @type {const} */ (["openid4vci"]);
-
-const SUPPORTED_GET_PROTOCOL = GET_PROTOCOLS.find((protocol) =>
-  DigitalCredential.userAgentAllowsProtocol(protocol)
-);
-const SUPPORTED_CREATE_PROTOCOL = CREATE_PROTOCOLS.find((protocol) =>
-  DigitalCredential.userAgentAllowsProtocol(protocol)
-);
-
 /** @type {Record<Protocol, object | MobileDocumentRequest>} */
 const CANONICAL_REQUEST_OBJECTS = {
   openid4vci: {
@@ -174,8 +156,9 @@ function makeCredentialOptionsFromConfig(config, mapping) {
  * @returns {CredentialRequestOptions}
  */
 export function makeGetOptions(config = {}) {
+  /** @type {MakeGetOptionsConfig} */
   const configWithDefaults = {
-    protocol: SUPPORTED_GET_PROTOCOL,
+    protocol: ["openid4vp-v1-unsigned", "org-iso-mdoc"],
     ...config,
   };
 
@@ -191,8 +174,9 @@ export function makeGetOptions(config = {}) {
  * @returns {CredentialCreationOptions}
  */
 export function makeCreateOptions(config = {}) {
+  /** @type {MakeCreateOptionsConfig} */
   const configWithDefaults = {
-    protocol: SUPPORTED_CREATE_PROTOCOL,
+    protocol: "openid4vci",
     ...config,
   };
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4569,6 +4569,7 @@ webkit.org/b/98927 fast/dom/DeviceMotion/ [ Skip ]
 webkit.org/b/98927 fast/dom/DeviceOrientation/ [ Skip ]
 
 # The Digital Credentials API is not supported in GTK and WPE ports.
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 

--- a/LayoutTests/platform/ios-18/TestExpectations
+++ b/LayoutTests/platform/ios-18/TestExpectations
@@ -110,6 +110,7 @@ imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-im
 
 # Digital Credentials supported added in iOS 26
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 
 # -- The above has different, expected behavior on iOS 26 than iOS 18 --

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8140,7 +8140,6 @@ http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-
 http/tests/workers/service/basic-install-event-sw-fetch-third-party.html [ Failure ]
 http/wpt/webcodecs/videoFrame-negative-timestamp.html [ Failure ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-nesting-parent-containing-hover.html [ Failure ]
-imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html [ Failure ]
 imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/interesttarget.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/uievents/mouse/mousemove_after_mouseover_target_removed.html [ Failure ]
 platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html [ Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -3,16 +3,16 @@
 PASS Type conversion happens on the data member of the DigitalCredentialGetRequest object.
 PASS Calling navigator.credentials.get() without a digital member same origin.
 PASS navigator.credentials.get() API rejects if there are no credential request.
-PASS navigator.credentials.get() API rejects if there are no credential request for same-origin iframe.
+FAIL navigator.credentials.get() API rejects if there are no credential request for same-origin iframe. promise_rejects_js: function "function() { throw e; }" threw object "NotAllowedError: The document is not focused." ("NotAllowedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 PASS navigator.credentials.get() API rejects if there are no credential request in cross-origin iframe.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller in same-origin iframe.
 PASS navigator.credentials.get() promise is rejected if called with an aborted signal in cross-origin iframe.
 PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get().
 PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe.
-FAIL Mediation is implicitly required and hence ignored. Request is aborted regardless. promise_rejects_js: function "function() { throw e; }" threw object "InvalidStateError: A credential picker operation is already in progress." ("InvalidStateError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS Mediation is implicitly required and hence ignored. Request is aborted regardless.
 PASS Throws TypeError when request data is not JSON stringifiable.
 PASS `requests` field is required in the options object.
 

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -32,6 +32,7 @@ imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworke
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https.html [ Skip ]
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https.html [ Skip ]
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 
 # -- The above has different, expected behavior on Tahoe than Sequoia --

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -115,6 +115,7 @@ imported/w3c/web-platform-tests/webxr/layers [ Skip ]
 imported/w3c/web-platform-tests/webxr/light-estimation [ Skip ]
 
 # The Digital Credentials API is not supported on visionOS.
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -99,6 +99,7 @@ fast/shadow-dom/pointerlockelement-in-slot.html [ Skip ]
 pointer-lock [ Skip ]
 
 # WEB_AUTHN is disabled
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1271,6 +1271,7 @@ imported/w3c/web-platform-tests/css/css-position/hypothetical-box-scroll-parent.
 webkit.org/b/254518 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html [ Crash Failure Pass ]
 
 # The Digital Credentials API is not supported on WPE port.
+http/tests/digital-credentials/ [ Skip ]
 http/wpt/identity/ [ Skip ]
 imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequest.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequest.h
@@ -26,8 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/IdentityCredentialProtocol.h>
-
+#include <wtf/text/WTFString.h>
 namespace JSC {
 class JSObject;
 }
@@ -35,7 +34,7 @@ class JSObject;
 namespace WebCore {
 
 struct DigitalCredentialRequest {
-    IdentityCredentialProtocol protocol;
+    String protocol;
     JSC::Strong<JSC::JSObject> data;
 };
 

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequest.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequest.idl
@@ -24,6 +24,6 @@
  */
 
 dictionary DigitalCredentialRequest {
-    required IdentityCredentialProtocol protocol;
+    required DOMString protocol;
     required object data;
 };


### PR DESCRIPTION
#### b2e1c1159b0077c428d7f5c9e1db7fb062207639
<pre>
Digital Credentials: ignore unknown digital credential types
<a href="https://rdar.apple.com/166673454">rdar://166673454</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304158">https://bugs.webkit.org/show_bug.cgi?id=304158</a>

Reviewed by Anne van Kesteren.

WebKit relied on the IdentityCredentialProtocol.idl enum to prevent requests with unknown protocols being processed.
However, this prevented unknown protocols from being ignored gracefully, as required by this spec change:
<a href="https://github.com/w3c-fedid/digital-credentials/pull/372">https://github.com/w3c-fedid/digital-credentials/pull/372</a>

We now gracefully ignore unknown protocols by filtering them out, rather than throwing an error.
We also now show a console warning, so developers are aware of ignored protocols.

Includes upstream web platform test commit:
<a href="https://github.com/web-platform-tests/wpt/commit/2d00123f9d72e0c18fa3110aec3893931b00c83b">https://github.com/web-platform-tests/wpt/commit/2d00123f9d72e0c18fa3110aec3893931b00c83b</a>

Tests: http/tests/digital-credentials/digital-credential-console-messages.https.html
       http/wpt/identity/digital-credential-protocol-filtering.https.html

* LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt: Added.
* LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https.html: Added.
* LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/digital-credential-protocol-filtering.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-18/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt:
* LayoutTests/platform/mac-sequoia/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::convertProtocolString):
(WebCore::jsToCredentialRequest):
(WebCore::DigitalCredential::convertObjectsToDigitalPresentationRequests):
* Source/WebCore/Modules/identity/DigitalCredentialRequest.h:
* Source/WebCore/Modules/identity/DigitalCredentialRequest.idl:

Canonical link: <a href="https://commits.webkit.org/305257@main">https://commits.webkit.org/305257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22fef8b480ea1e2e09e2ebd733253a63165e4589

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49309 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/99f3e227-7810-487d-817a-bf80e93ac191) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2534c4a4-487c-4c98-aa7e-4f361e86e26c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8207 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b1d83ea-2443-4c39-b689-e6027ce79871) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5571 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42384 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7757 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64718 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10040 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9770 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->