### PR TITLE
[JSC] Implement `String.prototype.concat` in C++

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-concat-2-args.js
+++ b/JSTests/microbenchmarks/string-prototype-concat-2-args.js
@@ -2,6 +2,6 @@ const str = "a".repeat(10);
 const arg1 = "b".repeat(10);
 const arg2 = "c".repeat(10);
 
-for (let i = 0; i < 1e6; i++) {
+for (let i = 0; i < 1e5; i++) {
   str.concat(arg1, arg2);
 }

--- a/JSTests/microbenchmarks/string-prototype-concat-5-args.js
+++ b/JSTests/microbenchmarks/string-prototype-concat-5-args.js
@@ -1,0 +1,10 @@
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+const arg3 = "d".repeat(10);
+const arg4 = "e".repeat(10);
+const arg5 = "f".repeat(10);
+
+for (let i = 0; i < 1e5; i++) {
+  str.concat(arg1, arg2, arg3, arg4, arg5);
+}

--- a/JSTests/stress/string-prototype-concat-jit-object-arg.js
+++ b/JSTests/stress/string-prototype-concat-jit-object-arg.js
@@ -1,0 +1,8 @@
+function test() {
+  "".concat({});
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+  test();
+}

--- a/JSTests/stress/string-prototype-concat-jit-object-this.js
+++ b/JSTests/stress/string-prototype-concat-jit-object-this.js
@@ -1,0 +1,8 @@
+function test() {
+  String.prototype.concat.call({}, "str");
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+  test();
+}

--- a/JSTests/stress/string-prototype-concat-no-args.js
+++ b/JSTests/stress/string-prototype-concat-no-args.js
@@ -1,0 +1,16 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a) {
+  return String.prototype.concat.call(a);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+
+for (let i = 0; i < testLoopCount; i++) {
+  const result = concat(str);
+  shouldBe(result, str);
+}

--- a/JSTests/stress/string-prototype-concat-this-null.js
+++ b/JSTests/stress/string-prototype-concat-this-null.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+let errorCount = 0;
+let thisShouldBeNull = false;
+for (let i = 0; i < testLoopCount; i++) {
+  if (i === testLoopCount / 2) {
+    thisShouldBeNull = true;
+  }
+  try {
+    concat(thisShouldBeNull ? null : str, arg1, arg2);
+  } catch {
+    errorCount++;
+  }
+}
+
+shouldBe(errorCount, testLoopCount / 2);

--- a/JSTests/stress/string-prototype-concat-this-undefined.js
+++ b/JSTests/stress/string-prototype-concat-this-undefined.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+let errorCount = 0;
+let thisShouldBeNull = false;
+for (let i = 0; i < testLoopCount; i++) {
+  if (i === testLoopCount / 2) {
+    thisShouldBeNull = true;
+  }
+  try {
+    concat(thisShouldBeNull ? undefined : str, arg1, arg2);
+  } catch {
+    errorCount++;
+  }
+}
+
+shouldBe(errorCount, testLoopCount / 2);

--- a/JSTests/stress/string-prototype-concat.js
+++ b/JSTests/stress/string-prototype-concat.js
@@ -1,0 +1,18 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function concat(a, b, c) {
+  return String.prototype.concat.call(a, b, c);
+}
+noInline(concat);
+
+const str = "a".repeat(10);
+const arg1 = "b".repeat(10);
+const arg2 = "c".repeat(10);
+
+for (let i = 0; i < testLoopCount; i++) {
+  const result = concat(str, arg1, arg2);
+  shouldBe(result, `${str}${arg1}${arg2}`);
+}

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -341,32 +341,6 @@ function split(separator, limit)
 }
 
 @linkTimeConstant
-function stringConcatSlowPath()
-{
-    "use strict";
-
-    var result = @toString(this);
-    for (var i = 0, length = @argumentCount(); i < length; ++i)
-        result += @toString(arguments[i]);
-    return result;
-}
-
-function concat(arg /* ... */)
-{
-    "use strict";
-
-    if (@isUndefinedOrNull(this))
-        @throwTypeError("String.prototype.concat requires that |this| not be null or undefined");
-
-    if (@argumentCount() === 1)
-        return @toString(this) + @toString(arg);
-    if (@argumentCount() === 2)
-        return @toString(this) + @toString(arg) + @toString(arguments[1]);
-
-    return @tailCallForwardArguments(@stringConcatSlowPath, this);
-}
-
-@linkTimeConstant
 function createHTML(func, string, tag, attribute, value)
 {
     "use strict";

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3129,6 +3129,45 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeConcatIntrinsic: {
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisNode = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            addToGraph(Check, Edge(thisNode, StringUse));
+
+            unsigned numArguments = argumentCountIncludingThis - 1;
+
+            if (!numArguments) {
+                setResult(addToGraph(ToString, thisNode));
+                return CallOptimizationResult::Inlined;
+            }
+
+            constexpr unsigned maxStrCatArguments = 3;
+            Node* operands[AdjacencyList::Size] = { };
+            unsigned indexInOperands = 0;
+
+            operands[indexInOperands++] = thisNode;
+
+            for (unsigned i = 0; i < numArguments; ++i) {
+                if (indexInOperands == maxStrCatArguments) {
+                    operands[0] = addToGraph(StrCat, operands[0], operands[1], operands[2]);
+                    for (unsigned j = 1; j < AdjacencyList::Size; ++j)
+                        operands[j] = nullptr;
+                    indexInOperands = 1;
+                }
+                ASSERT(indexInOperands < AdjacencyList::Size);
+                ASSERT(indexInOperands < maxStrCatArguments);
+                Node* arg = get(virtualRegisterForArgumentIncludingThis(i + 1, registerOffset));
+                addToGraph(Check, Edge(arg, StringUse));
+                operands[indexInOperands++] = arg;
+            }
+
+            setResult(addToGraph(StrCat, operands[0], operands[1], operands[2]));
+            return CallOptimizationResult::Inlined;
+        }
+
         case Clz32Intrinsic: {
             insertChecks();
             if (argumentCountIncludingThis == 1)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12300,7 +12300,7 @@ void SpeculativeJIT::speculateOther(Edge edge)
 {
     if (!needsTypeCheck(edge, SpecOther))
         return;
-    
+
     JSValueOperand operand(this, edge, ManualOperandSpeculation);
     speculateOther(edge, operand.jsValueRegs());
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -24507,6 +24507,15 @@ IGNORE_CLANG_WARNINGS_END
         typeCheck(jsValueValue(value), edge, SpecOther, isNotOther(value));
     }
 
+    void speculateNotOther(Edge edge)
+    {
+        if (!m_interpreter.needsTypeCheck(edge))
+            return;
+
+        LValue value = lowJSValue(edge, ManualOperandSpeculation);
+        typeCheck(jsValueValue(value), edge, ~SpecOther, isOther(value));
+    }
+
     void speculateMisc(Edge edge)
     {
         if (!m_interpreter.needsTypeCheck(edge))

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -115,6 +115,7 @@ namespace JSC {
     macro(ReflectGetPrototypeOfIntrinsic) \
     macro(ReflectOwnKeysIntrinsic) \
     macro(StringConstructorIntrinsic) \
+    macro(StringPrototypeConcatIntrinsic) \
     macro(StringPrototypeAtIntrinsic) \
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \


### PR DESCRIPTION
#### fe7e0f57289e2d77bdd02ee5732bf5c23edf29c1
<pre>
[JSC] Implement `String.prototype.concat` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=303680">https://bugs.webkit.org/show_bug.cgi?id=303680</a>

Reviewed by Yusuke Suzuki.

This patch reverts 304551@main to reland 304079@main .

The change from the original patch adds a new Check node to verify that all arguments
are StringUse. According to the spec, String#concat accepts all primitive values (except symbols),
but we don&apos;t currently have the appropriate UseKind. So we use `StringUse` for now.

And `NotOtherUse` is no longer used so remove it from the original patch.

------
(original commit message)

This patch implements `String.prototype.concat` in C++ with the following changes:

- Adds a new use kind `NotOtherUse` to implement the `RequireObjectCoercible`
  abstract operation[1] using a `Check` node.
- Handles `String#concat` in DFG/FTL using the existing `StrCat` DFG node.
  `StrCat` is already used for template literals and well optimized.

[1]: <a href="https://tc39.es/ecma262/#sec-requireobjectcoercible">https://tc39.es/ecma262/#sec-requireobjectcoercible</a>

                                        TipOfTree                  Patched

string-prototype-concat-2-args        1.5717+-0.1456     ^      0.4188+-0.0543        ^ definitely 3.7526x faster
string-prototype-concat-5-args        2.4512+-0.0797     ^      0.5042+-0.1257        ^ definitely 4.8621x faster

* JSTests/microbenchmarks/string-prototype-concat-2-args.js:
* JSTests/microbenchmarks/string-prototype-concat-5-args.js: Added.
* JSTests/stress/string-prototype-concat-jit-object-arg.js: Added.
(test):
* JSTests/stress/string-prototype-concat-jit-object-this.js: Added.
(test):
* JSTests/stress/string-prototype-concat-no-args.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat-this-null.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat-this-undefined.js: Added.
(shouldBe):
(concat):
* JSTests/stress/string-prototype-concat.js: Added.
(shouldBe):
(concat):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.stringConcatSlowPath): Deleted.
(concat): Deleted.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/304820@main">https://commits.webkit.org/304820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db79567401f5eba486e05a6d79aa708786f1937b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8531 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/74852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6478 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4137 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4633 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128287 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146786 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134814 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6413 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36527 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167593 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71976 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43721 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->