### PR TITLE
Use better colors for selected legacy attachments in inactive windows

### DIFF
--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -58,9 +58,6 @@ constexpr CGFloat attachmentTitleBackgroundPadding = 3;
 constexpr CGFloat attachmentTitleMaximumWidth = 100 - (attachmentTitleBackgroundPadding * 2);
 constexpr CFIndex attachmentTitleMaximumLineCount = 2;
 
-constexpr auto attachmentTitleInactiveBackgroundColor = SRGBA<uint8_t> { 204, 204, 204 };
-constexpr auto attachmentTitleInactiveTextColor = SRGBA<uint8_t> { 100, 100, 100 };
-
 constexpr CGFloat attachmentSubtitleFontSize = 10;
 constexpr int attachmentSubtitleWidthIncrement = 10;
 constexpr auto attachmentSubtitleTextColor = SRGBA<uint8_t> { 82, 145, 214 };
@@ -81,15 +78,9 @@ constexpr CGFloat attachmentMargin = 3;
 
 static Color titleTextColorForAttachment(const RenderAttachment& attachment, AttachmentLayoutStyle style)
 {
-    Color result = RenderTheme::singleton().systemColor(CSSValueCanvastext, attachment.styleColorOptions());
-    
-    if (style == AttachmentLayoutStyle::Selected) {
-        if (attachment.frame().selection().isFocusedAndActive())
-            result = RenderTheme::singleton().systemColor(CSSValueAppleSystemAlternateSelectedText, attachment.styleColorOptions());
-        else
-            result = attachmentTitleInactiveTextColor;
-    }
-    return result;
+    if (style == AttachmentLayoutStyle::Selected && attachment.frame().selection().isFocusedAndActive())
+        return RenderTheme::singleton().systemColor(CSSValueAppleSystemAlternateSelectedText, attachment.styleColorOptions());
+    return RenderTheme::singleton().systemColor(CSSValueCanvastext, attachment.styleColorOptions());
 }
 
 void AttachmentLayout::layOutTitle(const RenderAttachment& attachment)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -23,6 +23,7 @@
 
 #if PLATFORM(MAC)
 
+#import "AttachmentLayout.h"
 #import "BitmapImage.h"
 #import "CSSPropertyNames.h"
 #import "CSSValueKeywords.h"
@@ -1906,11 +1907,7 @@ static void paintAttachmentTitleBackground(const RenderAttachment& attachment, G
         return line.backgroundRect;
     });
 
-    Color backgroundColor;
-    if (attachment.frame().checkedSelection()->isFocusedAndActive())
-        backgroundColor = colorFromCocoaColor([NSColor selectedContentBackgroundColor]);
-    else
-        backgroundColor = attachmentTitleInactiveBackgroundColor;
+    Color backgroundColor = colorFromCocoaColor(attachment.frame().checkedSelection()->isFocusedAndActive() ? [NSColor selectedContentBackgroundColor] : [NSColor unemphasizedSelectedContentBackgroundColor]);
 
     backgroundColor = attachment.checkedStyle()->colorByApplyingColorFilter(backgroundColor);
     context.setFillColor(backgroundColor);


### PR DESCRIPTION
#### cad1baf8d489506f5b9a2793fd18309655d75b0c
<pre>
Use better colors for selected legacy attachments in inactive windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=304379">https://bugs.webkit.org/show_bug.cgi?id=304379</a>
<a href="https://rdar.apple.com/132956951">rdar://132956951</a>

Reviewed by Cameron McCormack.

The legacy attachment used hard-coded inactive-window colors, which made
the title text hard to read, especially in dark mode.
Instead we now use standard system colors, which match surrounding text
and adapt to the current system appearance.

No new tests, it&apos;s only changing colors.

* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::titleTextColorForAttachment):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::paintAttachmentTitleBackground):

Canonical link: <a href="https://commits.webkit.org/304703@main">https://commits.webkit.org/304703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deb10f7be7a9e948e2ba747332432aada13e5e16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143931 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7a3bcb4-4d5d-4e7d-b659-ac9e09d31068) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6724 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122063 "Found 1 new API test failure: TestWebKitAPI.MessagePort.MessageToClosedPort (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa8d77e9-55a3-42db-8f69-61a4b4b59296) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6389 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4050 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4525 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146676 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6315 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118368 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8309 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36425 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71868 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8248 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->