### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE with Timer.cpp

### DIFF
--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -357,18 +357,16 @@ inline void TimerBase::checkConsistency() const
         checkHeapIndex();
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void TimerBase::heapDecreaseKey()
 {
     ASSERT(static_cast<bool>(nextFireTime()));
     RefPtr item = m_heapItemWithBitfields.pointer();
     ASSERT(item);
     checkHeapIndex();
-    auto* heapData = item->timerHeap().mutableSpan().data();
-    std::push_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + item->heapIndex() + 1), TimerHeapLessThanFunction());
+    auto heapData = item->timerHeap().mutableSpan();
+    std::push_heap(TimerHeapIterator(heapData.data()), TimerHeapIterator(heapData.subspan(item->heapIndex() + 1).data()), TimerHeapLessThanFunction());
     checkHeapIndex();
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 inline void TimerBase::heapDelete()
 {
@@ -420,7 +418,6 @@ inline void TimerBase::heapPop()
     item->time = fireTime;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void TimerBase::heapPopMin()
 {
     RefPtr item = m_heapItemWithBitfields.pointer();
@@ -428,8 +425,8 @@ void TimerBase::heapPopMin()
     ASSERT(item == item->timerHeap().first());
     checkHeapIndex();
     auto& heap = item->timerHeap();
-    auto* heapData = heap.mutableSpan().data();
-    std::pop_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + heap.size()), TimerHeapLessThanFunction());
+    auto heapData = heap.mutableSpan();
+    std::pop_heap(TimerHeapIterator(heapData.data()), TimerHeapIterator(heapData.subspan(heap.size()).data()), TimerHeapLessThanFunction());
     checkHeapIndex();
     ASSERT(item == item->timerHeap().last());
 }
@@ -438,11 +435,10 @@ void TimerBase::heapDeleteNullMin(ThreadTimerHeap& heap)
 {
     RELEASE_ASSERT(!heap.first()->hasTimer());
     heap.first()->time = -MonotonicTime::infinity();
-    auto* heapData = heap.mutableSpan().data();
-    std::pop_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + heap.size()), TimerHeapLessThanFunction());
+    auto heapData = heap.mutableSpan();
+    std::pop_heap(TimerHeapIterator(heapData.data()), TimerHeapIterator(heapData.subspan(heap.size()).data()), TimerHeapLessThanFunction());
     heap.removeLast();
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static inline bool parentHeapPropertyHolds(const TimerBase* current, const ThreadTimerHeap& heap, unsigned currentIndex)
 {


### PR DESCRIPTION
#### 50a29164ea909747f8ce661de1029ba2a2835538
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE with Timer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=304382">https://bugs.webkit.org/show_bug.cgi?id=304382</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::heapDecreaseKey):
(WebCore::TimerBase::heapPopMin):
(WebCore::TimerBase::heapDeleteNullMin):

Canonical link: <a href="https://commits.webkit.org/304708@main">https://commits.webkit.org/304708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5cc0dbdd73109516202a1f16f626b255da9c0f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143942 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104166 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84997 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4549f7ee-e412-4546-be9e-411791d093e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6397 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4056 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4536 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8272 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112508 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112849 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6324 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118380 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36437 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71879 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8112 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->