### PR TITLE
WebAVSampleBufferListenerClient : com.apple.WebCore:  WTF::ThreadSafeWeakPtrControlBlock::strongRef const

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <CoreMedia/CMTime.h>
-#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -38,7 +38,7 @@ OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 
 namespace WebCore {
 
-class WebAVSampleBufferListenerClient : public AbstractRefCountedAndCanMakeWeakPtr<WebAVSampleBufferListenerClient> {
+class WebAVSampleBufferListenerClient : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
 public:
     virtual ~WebAVSampleBufferListenerClient() = default;
     virtual void videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *) { }

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -62,7 +62,7 @@ static bool isSampleBufferVideoRenderer(id object)
 }
 
 @interface WebAVSampleBufferListenerPrivate : NSObject {
-    WeakPtr<WebCore::WebAVSampleBufferListenerClient> _client WTF_GUARDED_BY_CAPABILITY(mainThread);
+    ThreadSafeWeakPtr<WebCore::WebAVSampleBufferListenerClient> _client WTF_GUARDED_BY_CAPABILITY(mainThread);
     Vector<RetainPtr<WebSampleBufferVideoRendering>> _videoRenderers;
     Vector<RetainPtr<AVSampleBufferAudioRenderer>> _audioRenderers;
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -35,7 +35,6 @@
 #include <WebCore/SourceBufferParserWebM.h>
 #include <WebCore/TimeRanges.h>
 #include <WebCore/VideoFrameMetadata.h>
-#include "WebAVSampleBufferListener.h"
 #include "WebMResourceClient.h"
 #include <wtf/HashFunctions.h>
 #include <wtf/LoggerHelper.h>
@@ -73,7 +72,6 @@ class VideoTrackPrivateWebM;
 class MediaPlayerPrivateWebM
     : public MediaPlayerPrivateInterface
     , public WebMResourceClientParent
-    , public WebAVSampleBufferListenerClient
     , private LoggerHelper
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayerPrivateWebM, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlayerPrivateWebM);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -61,7 +61,6 @@
 #import <wtf/NativePromise.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
-#import <wtf/WeakPtr.h>
 #import <wtf/WorkQueue.h>
 
 #pragma mark - Soft Linking
@@ -208,7 +207,7 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 
     m_renderer->setPreferences(options.videoRendererPreferences | VideoRendererPreference::PrefersDecompressionSession);
 
-    m_renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }](PlatformMediaError error) {
+    m_renderer->notifyWhenErrorOccurs([weakThis = ThreadSafeWeakPtr { *this }](PlatformMediaError error) {
         ensureOnMainThread([weakThis, error] {
             if (RefPtr protectedThis = weakThis.get()) {
                 protectedThis->m_errored = true;
@@ -222,21 +221,21 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
         });
     });
 
-    m_renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }] {
+    m_renderer->notifyFirstFrameAvailable([weakThis = ThreadSafeWeakPtr { *this }] {
         ensureOnMainThread([weakThis] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setHasAvailableVideoFrame(true);
         });
     });
 
-    m_renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }] {
+    m_renderer->notifyWhenRequiresFlushToResume([weakThis = ThreadSafeWeakPtr { *this }] {
         ensureOnMainThread([weakThis] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setLayerRequiresFlush();
         });
     });
 
-    m_renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }] {
+    m_renderer->notifyRenderingModeChanged([weakThis = ThreadSafeWeakPtr { *this }] {
         ensureOnMainThread([weakThis] {
             if (RefPtr protectedThis = weakThis.get()) {
                 if (RefPtr player = protectedThis->m_player.get())
@@ -245,14 +244,14 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
         });
     });
 
-    m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+    m_renderer->notifySizeChanged([weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&, FloatSize size) {
         ensureOnMainThread([weakThis, size] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setNaturalSize(size);
         });
     });
 
-    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
+    m_renderer->notifyEffectiveRateChanged([weakThis = ThreadSafeWeakPtr { *this }](double) {
         ensureOnMainThread([weakThis] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->effectiveRateChanged();
@@ -261,7 +260,7 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 
     m_renderer->setPreferences(VideoRendererPreference::PrefersDecompressionSession);
 
-    m_renderer->notifyVideoLayerSizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
+    m_renderer->notifyVideoLayerSizeChanged([weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&, FloatSize size) {
         ensureOnMainThread([weakThis, size] {
             if (RefPtr protectedThis = weakThis.get()) {
                 if (RefPtr player = protectedThis->m_player.get())
@@ -1168,7 +1167,7 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
             m_readyForMoreSamplesMap[trackId] = true;
             characteristicsChanged();
         }
-        m_renderer->notifyTrackNeedsReenqueuing(trackIdentifier, [weakThis = WeakPtr { *this }, trackId](TrackIdentifier, const MediaTime&) {
+        m_renderer->notifyTrackNeedsReenqueuing(trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, trackId](TrackIdentifier, const MediaTime&) {
             ensureOnMainThread([weakThis, trackId] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->reenqueSamples(trackId, NeedsFlush::No);
@@ -1359,7 +1358,7 @@ void MediaPlayerPrivateWebM::clearTracks()
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = true;
-    m_renderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
+    m_renderer->notifyWhenHasAvailableVideoFrame([weakThis = ThreadSafeWeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
         ensureOnMainThread([weakThis, presentationTime, displayTime] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -70,8 +70,7 @@ public:
     static Ref<VideoMediaSampleRenderer> create(WebSampleBufferVideoRendering *renderer, const Logger& logger, uint64_t logIdentifier) { return adoptRef(*new VideoMediaSampleRenderer(renderer, logger, logIdentifier)); }
     ~VideoMediaSampleRenderer();
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     using Preferences = VideoRendererPreferences;
     bool prefersDecompressionSession() const;


### PR DESCRIPTION
#### da9dd87407211e7b41a3293d480941740b747721
<pre>
WebAVSampleBufferListenerClient : com.apple.WebCore:  WTF::ThreadSafeWeakPtrControlBlock::strongRef const
<a href="https://bugs.webkit.org/show_bug.cgi?id=304390">https://bugs.webkit.org/show_bug.cgi?id=304390</a>
<a href="https://rdar.apple.com/166770286">rdar://166770286</a>

Reviewed by Youenn Fablet and Gerald Squelart.

VideoMediaSampleRenderer was a WebAVSampleBufferListenerClient and ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.
As such, WebAVSampleBufferListener using a WeakPtr wasn&apos;t safe.
We make the WebAVSampleBufferListener a AbstractThreadSafeRefCountedAndCanMakeWeakPtr instead.
AudioVideoRendererAVFObjC as such also has to be used with a ThreadSafeWeakPtr.

remove WebAVSampleBufferListenerClient inheritance from MediaPlayerPrivateWebM. It was
no longer required since it adopted AudioVideoRenderer.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::requestMediaDataWhenReady):
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
(WebCore::AudioVideoRendererAVFObjC::performTaskAtTime):
(WebCore::AudioVideoRendererAVFObjC::setTimeObserver):
(WebCore::AudioVideoRendererAVFObjC::setVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::configureHasAvailableVideoFrameCallbackIfNeeded):
(WebCore::AudioVideoRendererAVFObjC::sizeWillChangeAtTime):
(WebCore::AudioVideoRendererAVFObjC::stageVideoRenderer):
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h:
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm: Remove use of WeakPtr, must use ThreadSafeWeakPtr
(WebCore::MediaPlayerPrivateWebM::load):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:

Canonical link: <a href="https://commits.webkit.org/304736@main">https://commits.webkit.org/304736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a4b7b904ac7be8a16e5c91e3c2dfefe8457fd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143997 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/82d18fce-16f4-451c-b0f0-71393fb23b1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104207 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85040 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ae89273-0d03-4e16-8a16-31de1be5fa5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4098 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146741 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112546 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6368 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62312 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8373 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36485 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->