### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for CanvasObserver

### DIFF
--- a/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
+++ b/Source/WTF/wtf/AbstractCanMakeCheckedPtr.h
@@ -45,4 +45,12 @@ protected:
 
 } // namespace WTF
 
+#define OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(BaseClass) \
+    uint32_t checkedPtrCount() const final { return BaseClass::checkedPtrCount(); } \
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return BaseClass::checkedPtrCountWithoutThreadCheck(); } \
+    void incrementCheckedPtrCount() const final { BaseClass::incrementCheckedPtrCount(); } \
+    void decrementCheckedPtrCount() const final { BaseClass::decrementCheckedPtrCount(); } \
+    void setDidBeginCheckedPtrDeletion() final { BaseClass::setDidBeginCheckedPtrDeletion(); } \
+    using __unused_for_semicolon_canmakecheckedptr = int
+
 using WTF::AbstractCanMakeCheckedPtr;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -41,6 +41,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CanvasCaptureMediaStreamTrack);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CanvasCaptureMediaStreamTrack::Source);
 
 Ref<CanvasCaptureMediaStreamTrack> CanvasCaptureMediaStreamTrack::create(Document& document, Ref<HTMLCanvasElement>&& canvas, std::optional<double>&& frameRequestRate)
 {

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -30,6 +30,8 @@
 #include "CanvasObserver.h"
 #include "MediaStreamTrack.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakPtr.h>
 
@@ -52,7 +54,9 @@ public:
     RefPtr<MediaStreamTrack> clone() final;
 
 private:
-    class Source final : public RealtimeMediaSource, private CanvasObserver, private CanvasDisplayBufferObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop> {
+    class Source final : public RealtimeMediaSource, private CanvasObserver, private CanvasDisplayBufferObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr<Source> {
+        WTF_MAKE_TZONE_ALLOCATED(Source);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Source);
     public:
         static Ref<Source> create(HTMLCanvasElement&, std::optional<double>&& frameRequestRate);
         
@@ -61,6 +65,9 @@ private:
         RefPtr<VideoFrame> grabFrame();
 
         WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
+
+        // CanvasObserver.
+        OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeThreadSafeCheckedPtr);
 
     private:
         Source(HTMLCanvasElement&, std::optional<double>&&);

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -34,6 +34,7 @@
 #include "PlatformXR.h"
 #include "WebXRLayer.h"
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -53,10 +54,10 @@ class WebXRViewport;
 struct XRWebGLLayerInit;
 template<typename> class ExceptionOr;
 
-class WebXRWebGLLayer : public WebXRLayer, private CanvasObserver {
+class WebXRWebGLLayer : public WebXRLayer, private CanvasObserver, public CanMakeCheckedPtr<WebXRWebGLLayer> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRWebGLLayer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebXRWebGLLayer);
 public:
-
     using WebXRRenderingContext = Variant<
         RefPtr<WebGLRenderingContext>,
         RefPtr<WebGL2RenderingContext>
@@ -71,6 +72,9 @@ public:
     const WebGLFramebuffer* framebuffer() const;
     unsigned framebufferWidth() const;
     unsigned framebufferHeight() const;
+
+    // CanvasObserver.
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
     ExceptionOr<RefPtr<WebXRViewport>> getViewport(WebXRView&);
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -159,8 +159,8 @@ bool CanvasBase::hasObserver(CanvasObserver& observer) const
 
 void CanvasBase::notifyObserversCanvasChanged(const FloatRect& rect)
 {
-    for (auto& observer : m_observers)
-        observer.canvasChanged(*this, rect);
+    for (CheckedRef observer : m_observers)
+        observer->canvasChanged(*this, rect);
 }
 
 void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
@@ -182,16 +182,16 @@ void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostPr
 
 void CanvasBase::notifyObserversCanvasResized()
 {
-    for (auto& observer : m_observers)
-        observer.canvasResized(*this);
+    for (CheckedRef observer : m_observers)
+        observer->canvasResized(*this);
 }
 
 void CanvasBase::notifyObserversCanvasDestroyed()
 {
     ASSERT(!m_didNotifyObserversCanvasDestroyed);
 
-    for (auto& observer : std::exchange(m_observers, WeakHashSet<CanvasObserver>()))
-        observer.canvasDestroyed(*this);
+    for (CheckedRef observer : std::exchange(m_observers, WeakHashSet<CanvasObserver>()))
+        observer->canvasDestroyed(*this);
 
 #if ASSERT_ENABLED
     m_didNotifyObserversCanvasDestroyed = true;
@@ -217,8 +217,8 @@ void CanvasBase::notifyObserversCanvasDisplayBufferPrepared()
 HashSet<Element*> CanvasBase::cssCanvasClients() const
 {
     HashSet<Element*> cssCanvasClients;
-    for (auto& observer : m_observers) {
-        RefPtr image = dynamicDowncast<StyleCanvasImage>(observer);
+    for (CheckedRef observer : m_observers) {
+        RefPtr image = dynamicDowncast<StyleCanvasImage>(observer.get());
         if (!image)
             continue;
 

--- a/Source/WebCore/html/CanvasObserver.h
+++ b/Source/WebCore/html/CanvasObserver.h
@@ -25,23 +25,18 @@
 
 #pragma once
 
+#include <wtf/AbstractCanMakeCheckedPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CanvasObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CanvasObserver> : std::true_type { };
-}
 
 namespace WebCore {
 
 class CanvasBase;
 class FloatRect;
 
-class CanvasObserver : public CanMakeWeakPtr<CanvasObserver> {
+class CanvasObserver : public CanMakeWeakPtr<CanvasObserver>, public AbstractCanMakeCheckedPtr {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CanvasObserver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CanvasObserver);
 public:
     virtual ~CanvasObserver() = default;
 

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -70,6 +70,9 @@ public:
     void discardAgent();
     virtual bool enabled() const;
 
+    // CanvasObserver.
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
+
     // CanvasBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<void> enable();
     Inspector::Protocol::ErrorStringOr<void> disable();

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -32,8 +32,11 @@
 #include "InspectorInstrumentation.h"
 #include "RenderElement.h"
 #include "RenderObjectInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleCanvasImage);
 
 StyleCanvasImage::StyleCanvasImage(String&& name)
     : StyleGeneratedImage { Type::CanvasImage, StyleCanvasImage::isFixedSize }

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -29,6 +29,8 @@
 #include "CanvasObserver.h"
 #include "HTMLCanvasElement.h"
 #include "StyleGeneratedImage.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -36,7 +38,9 @@ namespace WebCore {
 
 class Document;
 
-class StyleCanvasImage final : public StyleGeneratedImage, public CanvasObserver {
+class StyleCanvasImage final : public StyleGeneratedImage, public CanvasObserver, public CanMakeCheckedPtr<StyleCanvasImage> {
+    WTF_MAKE_TZONE_ALLOCATED(StyleCanvasImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleCanvasImage);
 public:
     static Ref<StyleCanvasImage> create(String name)
     {
@@ -48,6 +52,8 @@ public:
     bool equals(const StyleCanvasImage&) const;
     
     static constexpr bool isFixedSize = true;
+
+    OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
 private:
     explicit StyleCanvasImage(String&&);


### PR DESCRIPTION
#### 06d3158c0390cafb37a05885a7f98541aab675d2
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for CanvasObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=304392">https://bugs.webkit.org/show_bug.cgi?id=304392</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/AbstractCanMakeCheckedPtr.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::notifyObserversCanvasChanged):
(WebCore::CanvasBase::notifyObserversCanvasResized):
(WebCore::CanvasBase::notifyObserversCanvasDestroyed):
(WebCore:: const):
* Source/WebCore/html/CanvasObserver.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
* Source/WebCore/rendering/style/StyleCanvasImage.h:

Canonical link: <a href="https://commits.webkit.org/304726@main">https://commits.webkit.org/304726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a713426194b7381f15c29d8e119ec243511b3709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136362 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b384a14-3a87-4f28-8606-aa01dbe756db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccb5535f-4468-46f6-a0ba-e15f3baee371) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85108 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f0d7437-ec22-43aa-881a-2665d955e4ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6498 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4158 "Found 1 new API test failure: TestWebKitAPI.MessagePort.MessageToClosedPort (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4665 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128319 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146818 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134846 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8401 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112611 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28678 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6428 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118492 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8449 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36547 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167625 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72008 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43727 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->