### PR TITLE
RuleFeatureSet should collect features from a selector only once

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <queue>
 #include <wtf/Assertions.h>
+#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -1019,26 +1020,26 @@ bool isElementBackedPseudoElement(CSSSelector::PseudoElement pseudoElement)
     }
 }
 
+static bool shouldSkipForEqualMode(const CSSSelector& simpleSelector, ComplexSelectorsEqualMode mode)
+{
+    if (mode == ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements)
+        return simpleSelector.matchesPseudoElement() && !isElementBackedPseudoElement(simpleSelector.pseudoElement());
+    return false;
+};
+
 bool complexSelectorsEqual(const CSSSelector& complexA, const CSSSelector& complexB, ComplexSelectorsEqualMode mode)
 {
     auto aRelation = CSSSelector::Relation::Subselector;
     auto bRelation = CSSSelector::Relation::Subselector;
 
     for (auto a = &complexA, b = &complexB; a || b; a = a->precedingInComplexSelector(), b = b->precedingInComplexSelector()) {
-        if (mode == ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements) {
-            auto canSkipPseudoElement = [](const CSSSelector& simpleSelector) {
-                if (!simpleSelector.matchesPseudoElement())
-                    return false;
-                return !isElementBackedPseudoElement(simpleSelector.pseudoElement());
-            };
-            if (a && canSkipPseudoElement(*a)) {
-                aRelation = a->relation();
-                a = a->precedingInComplexSelector();
-            }
-            if (b && canSkipPseudoElement(*b)) {
-                bRelation = b->relation();
-                b = b->precedingInComplexSelector();
-            }
+        if (a && shouldSkipForEqualMode(*a, mode)) {
+            aRelation = a->relation();
+            a = a->precedingInComplexSelector();
+        }
+        if (b && shouldSkipForEqualMode(*b, mode)) {
+            bRelation = b->relation();
+            b = b->precedingInComplexSelector();
         }
         if (!a || !b)
             return a == b;
@@ -1050,6 +1051,53 @@ bool complexSelectorsEqual(const CSSSelector& complexA, const CSSSelector& compl
         bRelation = b->relation();
     }
     return true;
+}
+
+static void addSimpleSelector(Hasher& hasher, const CSSSelector& simpleSelector)
+{
+    // This hash does try to include every possible thing in a selector.
+    add(hasher, simpleSelector.match());
+
+    switch (simpleSelector.match()) {
+    case CSSSelector::Match::Tag:
+        add(hasher, simpleSelector.tagQName());
+        break;
+    case CSSSelector::Match::PseudoClass:
+        add(hasher, simpleSelector.pseudoClass());
+        break;
+    case CSSSelector::Match::PseudoElement:
+        add(hasher, simpleSelector.pseudoElement());
+        break;
+    case CSSSelector::Match::Exact:
+    case CSSSelector::Match::Set:
+    case CSSSelector::Match::List:
+    case CSSSelector::Match::Hyphen:
+    case CSSSelector::Match::Begin:
+    case CSSSelector::Match::End:
+    case CSSSelector::Match::Contain:
+        add(hasher, simpleSelector.attribute());
+        add(hasher, simpleSelector.value());
+        break;
+    default:
+        add(hasher, simpleSelector.value());
+        break;
+    }
+    if (simpleSelector.selectorList())
+        add(hasher, *simpleSelector.selectorList());
+}
+
+void addComplexSelector(Hasher& hasher, const CSSSelector& complexSelector, ComplexSelectorsEqualMode mode)
+{
+    auto relationToRight = CSSSelector::Relation::Subselector;
+    for (auto simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+        if (shouldSkipForEqualMode(*simpleSelector, mode)) {
+            relationToRight = simpleSelector->relation();
+            continue;
+        }
+        add(hasher, relationToRight);
+        addSimpleSelector(hasher, *simpleSelector);
+        relationToRight = simpleSelector->relation();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -288,6 +288,8 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
 enum class ComplexSelectorsEqualMode : bool { Full, IgnoreNonElementBackedPseudoElements };
 bool complexSelectorsEqual(const CSSSelector&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
 
+void addComplexSelector(Hasher&, const CSSSelector&, ComplexSelectorsEqualMode = ComplexSelectorsEqualMode::Full);
+
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 
 inline const QualifiedName& CSSSelector::attribute() const

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -278,4 +278,11 @@ bool CSSSelectorList::operator==(const CSSSelectorList& other) const
     return true;
 }
 
+void add(Hasher& hasher, const CSSSelectorList& list)
+{
+    for (auto& selector : list)
+        addComplexSelector(hasher, selector);
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -127,4 +127,6 @@ private:
     UniqueArray<CSSSelector> m_selectorArray;
 };
 
+void add(Hasher&, const CSSSelectorList&);
+
 } // namespace WebCore

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -136,10 +136,11 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
     RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, { });
-    addRule(WTFMove(ruleData), 0, 0, 0);
+    // This path is used when building invalidation RuleSets, no need to collect features (nullptr CollectionContext).
+    addRule(WTFMove(ruleData), 0, 0, 0, nullptr);
 }
 
-void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier)
+void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerIdentifier, ContainerQueryIdentifier containerQueryIdentifier, ScopeRuleIdentifier scopeRuleIdentifier, RuleFeatureSet::CollectionContext* featureCollectionContext)
 {
     ASSERT(ruleData.position() == m_ruleCount);
 
@@ -170,7 +171,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 
-    m_features.collectFeatures(ruleData, scopeRules);
+    if (featureCollectionContext)
+        m_features.collectFeatures(*featureCollectionContext, ruleData, scopeRules);
 
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -147,7 +147,7 @@ private:
     using ContainerQueryIdentifier = unsigned;
     using ScopeRuleIdentifier = unsigned;
 
-    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier);
+    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier, RuleFeatureSet::CollectionContext*);
 
     struct ResolverMutatingRule {
         Ref<StyleRuleBase> rule;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -304,7 +304,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
         RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_usedRuleTypes);
         m_mediaQueryCollector.addRuleIfNeeded(ruleData);
-        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
+        m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier, &m_featureCollectionContext);
         ++selectorListIndex;
     }
 }

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -96,6 +96,8 @@ private:
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };
+
+    RuleFeatureSet::CollectionContext m_featureCollectionContext;
 };
 
 }


### PR DESCRIPTION
#### 8e1eba971f76d1095cec337ae98d5f30143d4d69
<pre>
RuleFeatureSet should collect features from a selector only once
<a href="https://bugs.webkit.org/show_bug.cgi?id=304391">https://bugs.webkit.org/show_bug.cgi?id=304391</a>
<a href="https://rdar.apple.com/166770565">rdar://166770565</a>

Reviewed by Alan Baradlay.

Duplicate selectors are common. We should only collect features from them once.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::shouldSkipForEqualMode):
(WebCore::complexSelectorsEqual):
(WebCore::addSimpleSelector):
(WebCore::addComplexSelector):

Add hashing support.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::add):

Add hashing support.

* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::SelectorDeduplicationKey::SelectorDeduplicationKey):

Compute and cache the selector hash for fast rehashing.

(WebCore::Style::SelectorDeduplicationKey::operator== const):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::collectPseudoElementFeatures):

Separate pseudo-element feature collection as regular collection path treats otherwise identical selectors
with or without pseudo element as equivalent.

(WebCore::Style::equalIgnoringPseudoElement): Deleted.
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::SelectorDeduplicationKey::hash const):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Only enter recursive feature collection for selectors we haven&apos;t seen before.

Remove the existing deduplication code based on searching feature vectors on append.
That was inefficient with complex selectors that were added to many vectors.

* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):

Pass a temporary context that contains the deduplication HashSet.

* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/304734@main">https://commits.webkit.org/304734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e3457d6f8454205f8cd13f08448d758b767121

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a32b66c5-b9fe-4c5d-8485-1a07df9d011b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8462 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7a2767dc-df13-4d7c-912b-b38f0b6a6837) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85016 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1034d5af-80f1-4efb-93cd-88192c2e96b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4074 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146716 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6342 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62287 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8348 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36464 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->