### PR TITLE
Use EnumSet in LFC code

### DIFF
--- a/Source/WebCore/layout/floats/PlacedFloats.h
+++ b/Source/WebCore/layout/floats/PlacedFloats.h
@@ -28,7 +28,7 @@
 #include <WebCore/LayoutBoxGeometry.h>
 #include <WebCore/LayoutElementBox.h>
 #include <WebCore/LayoutShape.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -102,11 +102,11 @@ public:
 private:
     CheckedRef<const ElementBox> m_blockFormattingContextRoot;
     List m_list;
-    enum class PositionType {
-        Start = 1 << 0,
-        End  = 1 << 1
+    enum class PositionType : bool {
+        Start,
+        End
     };
-    OptionSet<PositionType> m_positionTypes;
+    EnumSet<PositionType> m_positionTypes;
     WritingMode m_writingMode;
 };
 

--- a/Source/WebCore/layout/formattingContexts/FormattingConstraints.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingConstraints.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/LayoutUnit.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 namespace Layout {
@@ -50,22 +50,22 @@ struct ConstraintsForInFlowContent {
     LayoutUnit logicalTop() const { return m_logicalTop; }
 
     enum BaseTypeFlag : uint8_t {
-        GenericContent = 1 << 0,
-        InlineContent  = 1 << 1,
-        TableContent   = 1 << 2,
-        FlexContent    = 1 << 3
+        GenericContent,
+        InlineContent,
+        TableContent,
+        FlexContent
     };
     bool isConstraintsForInlineContent() const { return baseTypeFlags().contains(InlineContent); }
     bool isConstraintsForTableContent() const { return baseTypeFlags().contains(TableContent); }
     bool isConstraintsForFlexContent() const { return baseTypeFlags().contains(FlexContent); }
 
 protected:
-    ConstraintsForInFlowContent(HorizontalConstraints, LayoutUnit logicalTop, OptionSet<BaseTypeFlag>);
+    ConstraintsForInFlowContent(HorizontalConstraints, LayoutUnit logicalTop, EnumSet<BaseTypeFlag>);
 
 private:
-    OptionSet<BaseTypeFlag> baseTypeFlags() const { return OptionSet<BaseTypeFlag>::fromRaw(m_baseTypeFlags); }
+    EnumSet<BaseTypeFlag> baseTypeFlags() const { return EnumSet<BaseTypeFlag>::fromRaw(m_baseTypeFlags); }
 
-    unsigned m_baseTypeFlags : 3; // OptionSet<BaseTypeFlag>
+    unsigned m_baseTypeFlags : 4; // EnumSet<BaseTypeFlag>
     HorizontalConstraints m_horizontal;
     LayoutUnit m_logicalTop;
 };
@@ -77,7 +77,7 @@ struct ConstraintsForOutOfFlowContent {
     LayoutUnit borderAndPaddingConstraints;
 };
 
-inline ConstraintsForInFlowContent::ConstraintsForInFlowContent(HorizontalConstraints horizontal, LayoutUnit logicalTop, OptionSet<BaseTypeFlag> baseTypeFlags)
+inline ConstraintsForInFlowContent::ConstraintsForInFlowContent(HorizontalConstraints horizontal, LayoutUnit logicalTop, EnumSet<BaseTypeFlag> baseTypeFlags)
     : m_baseTypeFlags(baseTypeFlags.toRaw())
     , m_horizontal(horizontal)
     , m_logicalTop(logicalTop)

--- a/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
@@ -43,11 +43,11 @@ public:
         bool shouldDiscardOverflow { false };
         bool isLegacy { true };
     };
-    enum class TextBoxTrimSide : uint8_t {
-        Start = 1 << 0,
-        End   = 1 << 1
+    enum class TextBoxTrimSide : bool {
+        Start,
+        End
     };
-    using TextBoxTrim = OptionSet<TextBoxTrimSide>;
+    using TextBoxTrim = EnumSet<TextBoxTrimSide>;
 
     struct LineGrid {
         LayoutSize layoutOffset;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -855,7 +855,7 @@ InlineContentBreaker::OverflowingTextContent InlineContentBreaker::processOverfl
     return { overflowingRunIndex };
 }
 
-OptionSet<InlineContentBreaker::WordBreakRule> InlineContentBreaker::wordBreakBehavior(const RenderStyle& style, bool hasWrapOpportunityAtPreviousPosition) const
+EnumSet<InlineContentBreaker::WordBreakRule> InlineContentBreaker::wordBreakBehavior(const RenderStyle& style, bool hasWrapOpportunityAtPreviousPosition) const
 {
     // Disregard any prohibition against line breaks mandated by the word-break property.
     // The different wrapping opportunities must not be prioritized.
@@ -867,7 +867,7 @@ OptionSet<InlineContentBreaker::WordBreakRule> InlineContentBreaker::wordBreakBe
     if (style.wordBreak() == WordBreak::BreakAll)
         return { WordBreakRule::AtArbitraryPositionWithinWords };
 
-    auto includeHyphenationIfAllowed = [&](std::optional<InlineContentBreaker::WordBreakRule> wordBreakRule) -> OptionSet<InlineContentBreaker::WordBreakRule> {
+    auto includeHyphenationIfAllowed = [&](std::optional<InlineContentBreaker::WordBreakRule> wordBreakRule) -> EnumSet<InlineContentBreaker::WordBreakRule> {
         auto hyphenationIsAllowed = !n_hyphenationIsDisabled && style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.computedLocale()));
         if (hyphenationIsAllowed) {
             if (wordBreakRule)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
@@ -185,12 +185,12 @@ private:
     std::optional<OverflowingTextContent::BreakingPosition> tryBreakingNextOverflowingRuns(const LineStatus&, const ContinuousContent::RunList&, size_t overflowingRunIndex, InlineLayoutUnit nonOverflowingContentWidth) const;
     std::optional<OverflowingTextContent::BreakingPosition> tryHyphenationAcrossOverflowingInlineTextItems(const LineStatus&, const ContinuousContent::RunList&, size_t overflowingRunIndex) const;
 
-    enum class WordBreakRule {
-        AtArbitraryPositionWithinWords = 1 << 0,
-        AtArbitraryPosition            = 1 << 1,
-        AtHyphenationOpportunities     = 1 << 2
+    enum class WordBreakRule : uint8_t {
+        AtArbitraryPositionWithinWords,
+        AtArbitraryPosition,
+        AtHyphenationOpportunities
     };
-    OptionSet<WordBreakRule> wordBreakBehavior(const RenderStyle&, bool hasWrapOpportunityAtPreviousPosition) const;
+    EnumSet<WordBreakRule> wordBreakBehavior(const RenderStyle&, bool hasWrapOpportunityAtPreviousPosition) const;
     bool isMinimumInIntrinsicWidthMode() const { return m_isMinimumInIntrinsicWidthMode; }
 
 private:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -35,7 +35,7 @@
 #include <WebCore/StylePrimitiveNumericTypes+Evaluation.h>
 #include <WebCore/StyleTextBoxEdge.h>
 #include <WebCore/StyleWebKitLineBoxContain.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 namespace Layout {
@@ -97,12 +97,12 @@ public:
     bool isLineBreakBox() const { return m_type == Type::LineBreakBox; }
 
     enum class Type : uint8_t {
-        InlineBox             = 1 << 0,
-        LineSpanningInlineBox = 1 << 1,
-        RootInlineBox         = 1 << 2,
-        AtomicInlineBox       = 1 << 3,
-        LineBreakBox          = 1 << 4,
-        GenericInlineLevelBox = 1 << 5
+        InlineBox,
+        LineSpanningInlineBox,
+        RootInlineBox,
+        AtomicInlineBox,
+        LineBreakBox,
+        GenericInlineLevelBox
     };
     Type type() const { return m_type; }
 
@@ -112,11 +112,11 @@ public:
     bool isLastBox() const { return m_isLastWithinLayoutBox; }
 
 private:
-    enum class PositionWithinLayoutBox {
-        First = 1 << 0,
-        Last  = 1 << 1
+    enum class PositionWithinLayoutBox : bool {
+        First,
+        Last
     };
-    InlineLevelBox(const Box&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutSize, Type, OptionSet<PositionWithinLayoutBox> = { PositionWithinLayoutBox::First, PositionWithinLayoutBox::Last });
+    InlineLevelBox(const Box&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutSize, Type, EnumSet<PositionWithinLayoutBox> = { PositionWithinLayoutBox::First, PositionWithinLayoutBox::Last });
 
     friend class InlineDisplayLineBuilder;
     friend class LineBox;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -46,7 +46,7 @@ template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment 
     );
 }
 
-inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const RenderStyle& style, InlineLayoutUnit logicalLeft, InlineLayoutSize logicalSize, Type type, OptionSet<PositionWithinLayoutBox> positionWithinLayoutBox)
+inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const RenderStyle& style, InlineLayoutUnit logicalLeft, InlineLayoutSize logicalSize, Type type, EnumSet<PositionWithinLayoutBox> positionWithinLayoutBox)
     : m_layoutBox(layoutBox)
     , m_logicalRect({ }, logicalLeft, logicalSize.width(), logicalSize.height())
     , m_hasContent(layoutBox.isRubyBase() && layoutBox.associatedRubyAnnotationBox()) // Normally we set inline box's has-content state as we come across child content, but ruby annotations are not visible to inline layout.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -121,7 +121,7 @@ private:
     bool m_hasContent { false };
     bool m_isFirstFormattedLine { true };
     InlineRect m_logicalRect;
-    OptionSet<InlineLevelBox::Type> m_boxTypes;
+    EnumSet<InlineLevelBox::Type> m_boxTypes;
 
     FontBaseline m_baselineType { FontBaseline::Alphabetic };
     InlineLevelBox m_rootInlineBox;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -30,7 +30,7 @@
 #include <WebCore/LayoutBox.h>
 #include <WebCore/TextFlags.h>
 #include <unicode/ubidi.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 namespace InlineDisplay {
@@ -85,11 +85,11 @@ struct Box {
         BlockLevelBox,
     };
     struct Expansion;
-    enum class PositionWithinInlineLevelBox : uint8_t {
-        First = 1 << 0,
-        Last  = 1 << 1
+    enum class PositionWithinInlineLevelBox : bool {
+        First,
+        Last
     };
-    Box(size_t lineIndex, Type, const Layout::Box&, UBiDiLevel, const FloatRect&, const FloatRect& inkOverflow, bool isFirstFormattedLine, Expansion, std::optional<Text> = std::nullopt, bool hasContent = true, bool isFullyTruncated = false, OptionSet<PositionWithinInlineLevelBox> = { });
+    Box(size_t lineIndex, Type, const Layout::Box&, UBiDiLevel, const FloatRect&, const FloatRect& inkOverflow, bool isFirstFormattedLine, Expansion, std::optional<Text> = std::nullopt, bool hasContent = true, bool isFullyTruncated = false, EnumSet<PositionWithinInlineLevelBox> = { });
     ~Box();
 
     bool isText() const { return m_type == Type::Text || isWordSeparator(); }
@@ -196,7 +196,7 @@ private:
     Text m_text;
 };
 
-inline Box::Box(size_t lineIndex, Type type, const Layout::Box& layoutBox, UBiDiLevel bidiLevel, const FloatRect& physicalRect, const FloatRect& inkOverflow, bool isFirstFormattedLine, Expansion expansion, std::optional<Text> text, bool hasContent, bool isFullyTruncated, OptionSet<PositionWithinInlineLevelBox> positionWithinInlineLevelBox)
+inline Box::Box(size_t lineIndex, Type type, const Layout::Box& layoutBox, UBiDiLevel bidiLevel, const FloatRect& physicalRect, const FloatRect& inkOverflow, bool isFirstFormattedLine, Expansion expansion, std::optional<Text> text, bool hasContent, bool isFullyTruncated, EnumSet<PositionWithinInlineLevelBox> positionWithinInlineLevelBox)
     : m_layoutBox(layoutBox)
     , m_unflippedVisualRect(physicalRect)
     , m_inkOverflow(inkOverflow)

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -76,9 +76,9 @@ static inline LayoutUnit paddingLineRight(const Layout::BoxGeometry& boxGeometry
     return writingMode.isBidiLTR() ? boxGeometry.paddingEnd() : boxGeometry.paddingStart();
 }
 
-static inline OptionSet<InlineDisplay::Box::PositionWithinInlineLevelBox> isFirstLastBox(const InlineLevelBox& inlineBox)
+static inline EnumSet<InlineDisplay::Box::PositionWithinInlineLevelBox> isFirstLastBox(const InlineLevelBox& inlineBox)
 {
-    auto positionWithinInlineLevelBox = OptionSet<InlineDisplay::Box::PositionWithinInlineLevelBox> { };
+    auto positionWithinInlineLevelBox = EnumSet<InlineDisplay::Box::PositionWithinInlineLevelBox> { };
     if (inlineBox.isFirstBox())
         positionWithinInlineLevelBox.add(InlineDisplay::Box::PositionWithinInlineLevelBox::First);
     if (inlineBox.isLastBox())

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h
@@ -27,7 +27,7 @@
 
 #include <WebCore/InlineDisplayContent.h>
 #include <WebCore/InlineLineTypes.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 namespace Layout {
@@ -42,14 +42,14 @@ public:
     ~InlineDamage();
 
     enum class Reason : uint8_t {
-        Append                 = 1 << 0,
-        Insert                 = 1 << 1,
-        Remove                 = 1 << 2,
-        ContentChange          = 1 << 3,
-        StyleChange            = 1 << 4,
-        Pagination             = 1 << 5
+        Append,
+        Insert,
+        Remove,
+        ContentChange,
+        StyleChange,
+        Pagination,
     };
-    OptionSet<Reason> reasons() const { return m_damageReasons; }
+    EnumSet<Reason> reasons() const { return m_damageReasons; }
 
     // FIXME: Add support for damage range with multiple, different damage types.
     struct LayoutPosition {
@@ -78,7 +78,7 @@ private:
     void setTrailingDisplayBoxes(TrailingDisplayBoxList&& trailingDisplayBoxes) { m_trailingDisplayBoxes = WTFMove(trailingDisplayBoxes); }
     void setInlineItemListDirty() { m_isInlineItemListDirty = true; }
 
-    OptionSet<Reason> m_damageReasons;
+    EnumSet<Reason> m_damageReasons;
     bool m_isInlineItemListDirty { false };
     std::optional<LayoutPosition> m_layoutStartPosition;
     TrailingDisplayBoxList m_trailingDisplayBoxes;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -279,7 +279,7 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
             textRenderer->setHasStrongDirectionalityContent(*hasStrongDirectionalityContent);
         }
 
-        auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
+        auto contentCharacteristic = EnumSet<Layout::InlineTextBox::ContentCharacteristic> { };
         if (canUseSimpleFontCodePath)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpleFontCodepath);
         if (textRenderer->shouldUseSimpleGlyphOverflowCodePath())
@@ -300,7 +300,7 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
     if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderElement)) {
-        OptionSet<Layout::ElementBox::ListMarkerAttribute> listMarkerAttributes;
+        EnumSet<Layout::ElementBox::ListMarkerAttribute> listMarkerAttributes;
         if (listMarkerRenderer->isImage())
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
         if (!listMarkerRenderer->isInside())
@@ -366,7 +366,7 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
     if (!shouldUpdateContentCharacteristic)
         return;
 
-    auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
+    auto contentCharacteristic = EnumSet<Layout::InlineTextBox::ContentCharacteristic> { };
     // These may only change when content changes.
     if (inlineTextBox.canUseSimpleFontCodePath())
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpleFontCodepath);
@@ -385,7 +385,7 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
 
 static void updateListMarkerAttributes(const RenderListMarker& listMarkerRenderer, Layout::ElementBox& layoutBox)
 {
-    auto listMarkerAttributes = OptionSet<Layout::ElementBox::ListMarkerAttribute> { };
+    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
     if (listMarkerRenderer.isImage())
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
     if (!listMarkerRenderer.isInside())
@@ -429,7 +429,7 @@ void BoxTreeUpdater::updateContent(const RenderText& textRenderer)
         return combineTextRenderer && combineTextRenderer->isCombined();
     }();
     auto text = style.textSecurity() == TextSecurity::None ? (isCombinedText ? textRenderer.originalText() : String { textRenderer.text() }) : RenderBlock::updateSecurityDiscCharacters(style, isCombinedText ? textRenderer.originalText() : String { textRenderer.text() });
-    auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
+    auto contentCharacteristic = EnumSet<Layout::InlineTextBox::ContentCharacteristic> { };
     if (textRenderer.canUseSimpleFontCodePath())
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpleFontCodepath);
     if (textRenderer.canUseSimpleFontCodePath() && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style.fontCascade(), style.collapseWhiteSpace(), &inlineTextBox.firstLineStyle()))

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -46,40 +46,32 @@
 #include "StyleContentAlignmentData.h"
 #include "StyleSelfAlignmentData.h"
 #include <pal/Logging.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 namespace LayoutIntegration {
 
-enum class FlexAvoidanceReason : uint32_t {
-    FeatureIsDisabled                   = 1U << 0,
-    FlexBoxHasNonFixedHeightInMainAxis  = 1U << 1,
-    FlexBoxNeedsBaseline                = 1U << 2,
-    FlexBoxIsOutOfFlow                  = 1U << 3,
-    FlexIsVertical                      = 1U << 4,
-    FlexWithNonInitialMinMaxHeight      = 1U << 5,
-    NoFlexLayoutIsNeeded                = 1U << 6,
-    FlexBoxHasUnsupportedOverflow       = 1U << 7,
-    // Unused                           = 1U << 8,
-    // Unused                           = 1U << 9,
-    // Unused                           = 1U << 10,
-    // Unused                           = 1U << 11,
-    FlexBoxHasUnsupportedTypeOfRenderer = 1U << 12,
-    FlexBoxHasMarginTrim                = 1U << 13,
-    FlexBoxHasOutOfFlowChild            = 1U << 14,
-    FlexBoxHasSVGChild                  = 1U << 15,
-    FlexBoxHasNestedFlex                = 1U << 16,
-    // Unused                           = 1U << 17,
-    // Unused                           = 1U << 18,
-    FlexItemHasNonFixedHeight           = 1U << 19,
-    FlexItemHasIntrinsicFlexBasis       = 1U << 20,
-    // Unused                           = 1U << 21,
-    // Unused                           = 1U << 22,
-    FlexItemHasContainsSize             = 1U << 23,
-    FlexItemHasUnsupportedOverflow      = 1U << 24,
-    FlexItemHasAspectRatio              = 1U << 25,
-    FlexItemHasBaselineAlign            = 1U << 26,
-    EndOfReasons                        = 1U << 27
+enum class FlexAvoidanceReason : uint8_t {
+    FeatureIsDisabled,
+    FlexBoxHasNonFixedHeightInMainAxis,
+    FlexBoxNeedsBaseline,
+    FlexBoxIsOutOfFlow,
+    FlexIsVertical,
+    FlexWithNonInitialMinMaxHeight,
+    NoFlexLayoutIsNeeded,
+    FlexBoxHasUnsupportedOverflow,
+    FlexBoxHasUnsupportedTypeOfRenderer,
+    FlexBoxHasMarginTrim,
+    FlexBoxHasOutOfFlowChild,
+    FlexBoxHasSVGChild,
+    FlexBoxHasNestedFlex,
+    FlexItemHasNonFixedHeight,
+    FlexItemHasIntrinsicFlexBasis,
+    FlexItemHasContainsSize,
+    FlexItemHasUnsupportedOverflow,
+    FlexItemHasAspectRatio,
+    FlexItemHasBaselineAlign,
+    EndOfReasons,
 };
 
 enum class IncludeReasons : bool {
@@ -106,9 +98,9 @@ static inline bool mayHaveScrollbarOrScrollableOverflow(const RenderStyle& style
     return !style.isOverflowVisible() || !style.scrollbarGutter().isAuto();
 }
 
-static OptionSet<FlexAvoidanceReason> canUseForFlexLayoutWithReason(const RenderFlexibleBox& flexBox, IncludeReasons includeReasons)
+static EnumSet<FlexAvoidanceReason> canUseForFlexLayoutWithReason(const RenderFlexibleBox& flexBox, IncludeReasons includeReasons)
 {
-    auto reasons = OptionSet<FlexAvoidanceReason> { };
+    auto reasons = EnumSet<FlexAvoidanceReason> { };
 
     if (!flexBox.document().settings().flexFormattingContextIntegrationEnabled())
         ADD_REASON_AND_RETURN_IF_NEEDED(FeatureIsDisabled, reasons, includeReasons);
@@ -305,7 +297,7 @@ static void printReason(FlexAvoidanceReason reason, TextStream& stream)
     }
 }
 
-static void printReasons(OptionSet<FlexAvoidanceReason> reasons, TextStream& stream)
+static void printReasons(EnumSet<FlexAvoidanceReason> reasons, TextStream& stream)
 {
     stream << " ";
     for (auto reason : reasons) {

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -44,47 +44,46 @@ enum class ReasonCollectionMode : bool {
     All
 };
 
-enum class GridAvoidanceReason : uint64_t {
-    GridHasNonFixedWidth                        = 1LLU << 0,
-    GridHasNonFixedHeight                       = 1LLU << 1,
-    GridHasVerticalWritingMode                  = 1LLU << 2,
-    GridHasMarginTrim                           = 1LLU << 3,
-    // Unused                                   = 1LLU << 4,
-    GridNeedsBaseline                           = 1LLU << 5,
-    GridHasOutOfFlowChild                       = 1LLU << 6,
-    GridHasNonVisibleOverflow                   = 1LLU << 7,
-    GridHasUnsupportedRenderer                  = 1LLU << 8,
-    GridIsEmpty                                 = 1LLU << 9,
-    GridHasNonInitialMinWidth                   = 1LLU << 10,
-    GridHasNonInitialMaxWidth                   = 1LLU << 11,
-    GridHasNonInitialMinHeight                  = 1LLU << 12,
-    GridHasNonInitialMaxHeight                  = 1LLU << 13,
-    GridHasNonZeroMinWidth                      = 1LLU << 14,
-    GridHasGridTemplateAreas                    = 1LLU << 15,
-    GridHasColumnAutoFlow                       = 1LLU << 16,
-    GridHasNonFixedGaps                         = 1LLU << 17,
-    GridIsOutOfFlow                             = 1LLU << 18,
-    GridHasContainsSize                         = 1LLU << 19,
-    GridHasUnsupportedGridTemplateColumns       = 1LLU << 20,
-    GridHasUnsupportedGridTemplateRows          = 1LLU << 21,
-    GridItemHasNonFixedWidth                    = 1LLU << 22,
-    GridItemHasNonFixedHeight                   = 1LLU << 23,
-    GridItemHasNonInitialMaxWidth               = 1LLU << 24,
-    GridItemHasNonZeroMinHeight                 = 1LLU << 25,
-    GridItemHasNonInitialMaxHeight              = 1LLU << 26,
-    GridItemHasBorder                           = 1LLU << 27,
-    GridItemHasPadding                          = 1LLU << 28,
-    GridItemHasMargin                           = 1LLU << 29,
-    GridItemHasVerticalWritingMode              = 1LLU << 30,
-    GridItemHasAspectRatio                      = 1LLU << 31,
-    GridItemHasUnsupportedInlineAxisAlignment   = 1LLU << 32,
-    GridItemHasUnsupportedBlockAxisAlignment    = 1LLU << 33,
-    GridItemHasNonVisibleOverflow               = 1LLU << 34,
-    GridItemHasContainsSize                     = 1LLU << 35,
-    GridItemHasUnsupportedColumnPlacement       = 1LLU << 36,
-    GridItemHasUnsupportedRowPlacement          = 1LLU << 37,
-    NotAGrid                                    = 1LLU << 38,
-    GridFormattingContextIntegrationDisabled    = 1LLU << 39,
+enum class GridAvoidanceReason : uint8_t {
+    GridHasNonFixedWidth,
+    GridHasNonFixedHeight,
+    GridHasVerticalWritingMode,
+    GridHasMarginTrim,
+    GridNeedsBaseline,
+    GridHasOutOfFlowChild,
+    GridHasNonVisibleOverflow,
+    GridHasUnsupportedRenderer,
+    GridIsEmpty,
+    GridHasNonInitialMinWidth,
+    GridHasNonInitialMaxWidth,
+    GridHasNonInitialMinHeight,
+    GridHasNonInitialMaxHeight,
+    GridHasNonZeroMinWidth,
+    GridHasGridTemplateAreas,
+    GridHasColumnAutoFlow,
+    GridHasNonFixedGaps,
+    GridIsOutOfFlow,
+    GridHasContainsSize,
+    GridHasUnsupportedGridTemplateColumns,
+    GridHasUnsupportedGridTemplateRows,
+    GridItemHasNonFixedWidth,
+    GridItemHasNonFixedHeight,
+    GridItemHasNonInitialMaxWidth,
+    GridItemHasNonZeroMinHeight,
+    GridItemHasNonInitialMaxHeight,
+    GridItemHasBorder,
+    GridItemHasPadding,
+    GridItemHasMargin,
+    GridItemHasVerticalWritingMode,
+    GridItemHasAspectRatio,
+    GridItemHasUnsupportedInlineAxisAlignment,
+    GridItemHasUnsupportedBlockAxisAlignment,
+    GridItemHasNonVisibleOverflow,
+    GridItemHasContainsSize,
+    GridItemHasUnsupportedColumnPlacement,
+    GridItemHasUnsupportedRowPlacement,
+    NotAGrid,
+    GridFormattingContextIntegrationDisabled,
 };
 
 #ifndef NDEBUG
@@ -142,9 +141,9 @@ static std::optional<GridAvoidanceReason> hasValidRowEnd(const Style::GridPositi
     );
 }
 
-static OptionSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid, ReasonCollectionMode reasonCollectionMode)
+static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid, ReasonCollectionMode reasonCollectionMode)
 {
-    auto reasons = OptionSet<GridAvoidanceReason> { };
+    auto reasons = EnumSet<GridAvoidanceReason> { };
 
     if (!renderGrid.document().settings().gridFormattingContextIntegrationEnabled())
         ADD_REASON_AND_RETURN_IF_NEEDED(GridFormattingContextIntegrationDisabled, reasons, reasonCollectionMode);
@@ -555,7 +554,7 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     }
 }
 
-static void printReasons(OptionSet<GridAvoidanceReason> reasons, TextStream& stream)
+static void printReasons(EnumSet<GridAvoidanceReason> reasons, TextStream& stream)
 {
     stream << " ";
     for (auto reason : reasons) {

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Box);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Box::BoxRareData);
 
 
-Box::Box(ElementAttributes&& elementAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag> baseTypeFlags)
+Box::Box(ElementAttributes&& elementAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, EnumSet<BaseTypeFlag> baseTypeFlags)
     : m_nodeType(elementAttributes.nodeType)
     , m_isAnonymous(static_cast<bool>(elementAttributes.isAnonymous))
     , m_baseTypeFlags(baseTypeFlags.toRaw())

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -73,9 +73,9 @@ public:
     };
 
     enum BaseTypeFlag : uint8_t {
-        InlineTextBoxFlag          = 1 << 0,
-        ElementBoxFlag             = 1 << 1,
-        InitialContainingBlockFlag = 1 << 2,
+        InlineTextBoxFlag,
+        ElementBoxFlag,
+        InitialContainingBlockFlag,
     };
 
     virtual ~Box();
@@ -210,7 +210,7 @@ public:
     UniqueRef<Box> removeFromParent();
 
 protected:
-    Box(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag>);
+    Box(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle, EnumSet<BaseTypeFlag>);
 
 private:
     friend class ElementBox;
@@ -234,7 +234,7 @@ private:
     BoxRareData& ensureRareData();
     void removeRareData();
     
-    OptionSet<BaseTypeFlag> baseTypeFlags() const { return OptionSet<BaseTypeFlag>::fromRaw(m_baseTypeFlags); }
+    EnumSet<BaseTypeFlag> baseTypeFlags() const { return EnumSet<BaseTypeFlag>::fromRaw(m_baseTypeFlags); }
 
     typedef HashMap<const Box*, std::unique_ptr<BoxRareData>> RareDataMap;
 
@@ -243,7 +243,7 @@ private:
     NodeType m_nodeType : 4;
     bool m_isAnonymous : 1;
 
-    unsigned m_baseTypeFlags : 4; // OptionSet<BaseTypeFlag>
+    unsigned m_baseTypeFlags : 4; // EnumSet<BaseTypeFlag>
     bool m_hasRareData : 1 { false };
     bool m_isInlineIntegrationRoot : 1 { false };
     bool m_isAnonymousTextIndentCandidateForIntegration : 1 { false }; // Either first anonymous block box child or simple anonymous block container (e.g flex item).

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -35,12 +35,12 @@ namespace Layout {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ElementBox);
 
-ElementBox::ElementBox(ElementAttributes&& attributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag> baseTypeFlags)
+ElementBox::ElementBox(ElementAttributes&& attributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, EnumSet<BaseTypeFlag> baseTypeFlags)
     : Box(WTFMove(attributes), WTFMove(style), WTFMove(firstLineStyle), baseTypeFlags | ElementBoxFlag)
 {
 }
 
-ElementBox::ElementBox(ElementAttributes&& attributes, OptionSet<ListMarkerAttribute> listMarkerAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle)
+ElementBox::ElementBox(ElementAttributes&& attributes, EnumSet<ListMarkerAttribute> listMarkerAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle)
     : Box(WTFMove(attributes), WTFMove(style), WTFMove(firstLineStyle), ElementBoxFlag)
     , m_replacedData(makeUnique<ReplacedData>())
 {

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -41,13 +41,13 @@ class ElementBox : public Box {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ElementBox);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ElementBox);
 public:
-    ElementBox(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr, OptionSet<BaseTypeFlag> = { ElementBoxFlag });
+    ElementBox(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr, EnumSet<BaseTypeFlag> = { ElementBoxFlag });
 
-    enum class ListMarkerAttribute : uint8_t {
-        Image = 1 << 0,
-        Outside = 1 << 1,
+    enum class ListMarkerAttribute : bool {
+        Image,
+        Outside,
     };
-    ElementBox(ElementAttributes&&, OptionSet<ListMarkerAttribute>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
+    ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
 
     struct ReplacedAttributes {
         LayoutSize intrinsicSize;
@@ -90,7 +90,7 @@ public:
     LayoutUnit intrinsicRatio() const;
     bool hasAspectRatio() const;
 
-    void setListMarkerAttributes(OptionSet<ListMarkerAttribute> listMarkerAttributes) { m_replacedData->listMarkerAttributes = listMarkerAttributes; }
+    void setListMarkerAttributes(EnumSet<ListMarkerAttribute> listMarkerAttributes) { m_replacedData->listMarkerAttributes = listMarkerAttributes; }
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
     bool isListMarkerOutside() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Outside); }
@@ -110,7 +110,7 @@ private:
     struct ReplacedData {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ReplacedData);
 
-        OptionSet<ListMarkerAttribute> listMarkerAttributes;
+        EnumSet<ListMarkerAttribute> listMarkerAttributes;
         std::pair<int, int> layoutBounds;
 
         std::optional<LayoutSize> intrinsicSize;

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.cpp
@@ -35,7 +35,7 @@ namespace Layout {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(InlineTextBox);
 
-InlineTextBox::InlineTextBox(String content, bool isCombined, OptionSet<ContentCharacteristic> contentCharacteristicSet, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle)
+InlineTextBox::InlineTextBox(String content, bool isCombined, EnumSet<ContentCharacteristic> contentCharacteristicSet, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle)
 : Box({ NodeType::Text, IsAnonymous::Yes }, WTFMove(style), WTFMove(firstLineStyle), Box::InlineTextBoxFlag)
     , m_content(content)
     , m_isCombined(isCombined)

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
@@ -38,13 +38,13 @@ class InlineTextBox : public Box {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InlineTextBox);
 public:
     enum class ContentCharacteristic : uint8_t {
-        CanUseSimplifiedContentMeasuring         = 1 << 0,
-        CanUseSimpleFontCodepath                 = 1 << 1,
-        ShouldUseSimpleGlyphOverflowCodePath     = 1 << 2,
-        HasPositionDependentContentWidth         = 1 << 3,
-        HasStrongDirectionalityContent           = 1 << 4
+        CanUseSimplifiedContentMeasuring,
+        CanUseSimpleFontCodepath,
+        ShouldUseSimpleGlyphOverflowCodePath,
+        HasPositionDependentContentWidth,
+        HasStrongDirectionalityContent
     };
-    InlineTextBox(String, bool isCombined, OptionSet<ContentCharacteristic>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
+    InlineTextBox(String, bool isCombined, EnumSet<ContentCharacteristic>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
     virtual ~InlineTextBox() = default;
 
     const String& content() const { return m_content; }
@@ -56,16 +56,16 @@ public:
     bool hasPositionDependentContentWidth() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasPositionDependentContentWidth); }
     bool hasStrongDirectionalityContent() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasStrongDirectionalityContent); }
 
-    void setContent(String newContent, OptionSet<ContentCharacteristic>);
-    void setContentCharacteristic(OptionSet<ContentCharacteristic> contentCharacteristicSet) { m_contentCharacteristicSet = contentCharacteristicSet; }
+    void setContent(String newContent, EnumSet<ContentCharacteristic>);
+    void setContentCharacteristic(EnumSet<ContentCharacteristic> contentCharacteristicSet) { m_contentCharacteristicSet = contentCharacteristicSet; }
 
 private:
     String m_content;
     bool m_isCombined { false };
-    OptionSet<ContentCharacteristic> m_contentCharacteristicSet;
+    EnumSet<ContentCharacteristic> m_contentCharacteristicSet;
 };
 
-inline void InlineTextBox::setContent(String newContent, OptionSet<ContentCharacteristic> contentCharacteristicSet)
+inline void InlineTextBox::setContent(String newContent, EnumSet<ContentCharacteristic> contentCharacteristicSet)
 {
     m_content = newContent;
     m_contentCharacteristicSet = contentCharacteristicSet;

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<Box> TreeBuilder::createReplacedBox(Box::ElementAttributes eleme
 
 std::unique_ptr<Box> TreeBuilder::createTextBox(String text, bool isCombined, bool canUseSimplifiedTextMeasuring, bool canUseSimpleFontCodePath, bool hasPositionDependentContentWidth, bool hasStrongDirectionalityContent, RenderStyle&& style)
 {
-    auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
+    auto contentCharacteristic = EnumSet<Layout::InlineTextBox::ContentCharacteristic> { };
     if (canUseSimpleFontCodePath)
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpleFontCodepath);
     if (canUseSimplifiedTextMeasuring)


### PR DESCRIPTION
#### 90e3d5543d67805a08c04684f839c50310d2cc60
<pre>
Use EnumSet in LFC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304396">https://bugs.webkit.org/show_bug.cgi?id=304396</a>
<a href="https://rdar.apple.com/166776334">rdar://166776334</a>

Reviewed by Alan Baradlay.

* Source/WebCore/layout/floats/PlacedFloats.h:
* Source/WebCore/layout/formattingContexts/FormattingConstraints.h:
(WebCore::Layout::ConstraintsForInFlowContent::baseTypeFlags const):
(WebCore::Layout::ConstraintsForInFlowContent::ConstraintsForInFlowContent):
* Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
(WebCore::Layout::InlineContentBreaker::wordBreakBehavior const):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::InlineLevelBox):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
(WebCore::Layout::InlineLevelBox::InlineLevelBox):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::Box):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::isFirstLastBox):
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h:
(WebCore::Layout::InlineDamage::reasons const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::updateContentCharacteristic):
(WebCore::LayoutIntegration::updateListMarkerAttributes):
(WebCore::LayoutIntegration::BoxTreeUpdater::updateContent):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForFlexLayoutWithReason):
(WebCore::LayoutIntegration::printReasons):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReasons):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::Box):
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::baseTypeFlags const):
* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
(WebCore::Layout::ElementBox::ElementBox):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::ElementBox):
(WebCore::Layout::ElementBox::setListMarkerAttributes):
* Source/WebCore/layout/layouttree/LayoutInlineTextBox.cpp:
(WebCore::Layout::InlineTextBox::InlineTextBox):
* Source/WebCore/layout/layouttree/LayoutInlineTextBox.h:
(WebCore::Layout::InlineTextBox::setContentCharacteristic):
(WebCore::Layout::InlineTextBox::setContent):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::createTextBox):

Canonical link: <a href="https://commits.webkit.org/304679@main">https://commits.webkit.org/304679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1893d57f812f8be388d8a6113a356e22191fe48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143992 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d2137fd-eb33-41e2-beca-c8ee6fdc3eaf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa76b853-0cfd-43c7-9870-1cbd74274e50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/17877a77-bd07-4a93-a820-4720ce351315) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6433 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4094 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4584 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146736 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40886 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6363 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118422 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8368 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36479 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->