### PR TITLE
Reduce unsafeness in WebCore/css/query

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -3,7 +3,6 @@ bindings/js/JSLazyEventListener.cpp
 css/CSSToLengthConversionData.h
 css/SelectorChecker.h
 css/SelectorFilter.h
-css/query/MediaQueryEvaluator.h
 dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -80,7 +80,6 @@ css/SelectorCheckerTestFunctions.h
 css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
 css/parser/SizesAttributeParser.cpp
-css/query/MediaQueryFeatures.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/typedom/InlineStylePropertyMap.cpp
 dom/Attr.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -15,7 +15,6 @@ css/SelectorChecker.cpp
 css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
 css/StyleRuleImport.cpp
-css/query/ContainerQueryFeatures.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
 dom/CollectionIndexCacheInlines.h
 dom/CustomElementReactionQueue.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -240,7 +240,6 @@ css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
-css/query/MediaQueryFeatures.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
 css/typedom/CSSStyleValue.cpp
 css/typedom/CSSStyleValueFactory.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -67,7 +67,6 @@ css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
 css/StyleProperties.cpp
 css/StyleRuleImport.cpp
-css/query/MediaQueryFeatures.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/values/CSSValueAggregates.h
 cssjit/SelectorCompiler.cpp

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -86,10 +86,10 @@ struct WidthFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto& renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+        CheckedRef renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
 
-        auto width = unscaledSizeForPrincipleBox(renderStyle.width(), renderer.contentBoxWidth(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        auto width = unscaledSizeForPrincipleBox(renderStyle->width(), renderer.contentBoxWidth(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
         return evaluateLengthFeature(feature, width, conversionData);
     }
 };
@@ -104,10 +104,10 @@ struct HeightFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto& renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+        CheckedRef renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
 
-        auto height = unscaledSizeForPrincipleBox(renderStyle.height(), renderer.contentBoxHeight(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        auto height = unscaledSizeForPrincipleBox(renderStyle->height(), renderer.contentBoxHeight(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
         return evaluateLengthFeature(feature, height, conversionData);
     }
 };
@@ -122,10 +122,10 @@ struct InlineSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto& renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+        CheckedRef renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
 
-        auto logicalWidth = unscaledSizeForPrincipleBox(renderStyle.logicalWidth(), renderer.contentBoxLogicalWidth(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        auto logicalWidth = unscaledSizeForPrincipleBox(renderStyle->logicalWidth(), renderer.contentBoxLogicalWidth(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
         return evaluateLengthFeature(feature, logicalWidth, conversionData);
     }
 };
@@ -140,10 +140,10 @@ struct BlockSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        auto& renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle.useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
+        CheckedRef renderStyle = renderer.style();
+        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
 
-        auto logicalHeight = unscaledSizeForPrincipleBox(renderStyle.logicalHeight(), renderer.contentBoxLogicalHeight(), usesSVGZoomRulesForLength, renderStyle.usedZoom());
+        auto logicalHeight = unscaledSizeForPrincipleBox(renderStyle->logicalHeight(), renderer.contentBoxLogicalHeight(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
         return evaluateLengthFeature(feature, logicalHeight, conversionData);
     }
 };
@@ -187,16 +187,15 @@ struct StyleFeatureSchema : public FeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        if (!context.conversionData.style() || !context.conversionData.parentStyle())
+        CheckedPtr style = context.conversionData.style();
+        if (!style || !context.conversionData.parentStyle())
             return EvaluationResult::False;
 
-        auto& style = *context.conversionData.style();
-
-        RefPtr customPropertyValue = style.customPropertyValue(feature.name);
+        RefPtr customPropertyValue = style->customPropertyValue(feature.name);
         if (!feature.rightComparison)
             return toEvaluationResult(customPropertyValue && !customPropertyValue->isGuaranteedInvalid());
 
-        auto resolvedFeatureValue = [&]() -> RefPtr<const Style::CustomProperty> {
+        auto resolvedFeatureValue = [&] -> RefPtr<const Style::CustomProperty> {
             auto featureValue = dynamicDowncast<CSSCustomPropertyValue>(feature.rightComparison->value);
             ASSERT(featureValue);
 
@@ -208,7 +207,7 @@ struct StyleFeatureSchema : public FeatureSchema {
                 context.conversionData.elementForContainerUnitResolution()
             };
 
-            auto dummyStyle = RenderStyle::clone(style);
+            auto dummyStyle = RenderStyle::clone(*style);
             auto dummyMatchResult = Style::MatchResult::create();
 
             auto styleBuilder = Style::Builder { dummyStyle, WTF::move(builderContext), dummyMatchResult };

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -76,13 +76,17 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::True;
 
         RefPtr document = m_document.get();
-        if (!document || !m_rootElementStyle)
+        if (!document)
+            return m_staticMediaConditionResult;
+
+        CheckedPtr rootElementStyle = m_rootElementStyle;
+        if (!rootElementStyle)
             return m_staticMediaConditionResult;
 
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
+        FeatureEvaluationContext context { *document, { *rootElementStyle, rootElementStyle.get(), nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,7 +50,7 @@ public:
 private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
-    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
+    CheckedPtr<const RenderStyle> m_rootElementStyle;
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -196,11 +196,11 @@ private:
 
 static float deviceScaleFactor(const FeatureEvaluationContext& context)
 {
-    auto& frame = *context.document->frame();
-    auto mediaType = frame.view()->mediaType();
+    Ref frame = *context.document->frame();
+    auto mediaType = frame->protectedView()->mediaType();
     
     if (mediaType == screenAtom())
-        return frame.page() ? frame.page()->deviceScaleFactor() : 1;
+        return frame->page() ? frame->page()->deviceScaleFactor() : 1;
 
     if (mediaType == printAtom()) {
         // The resolution of images while printing should not depend on the dpi

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -194,8 +194,8 @@ private:
 
     std::unique_ptr<Style::CustomFunctionRegistry> m_customFunctionRegistry;
 
-    MQ::MediaQueryEvaluator m_mediaQueryEvaluator;
     std::unique_ptr<RenderStyle> m_rootDefaultStyle;
+    MQ::MediaQueryEvaluator m_mediaQueryEvaluator;
 
     InspectorCSSOMWrappers m_inspectorCSSOMWrappers;
 


### PR DESCRIPTION
#### 89ad6512372ce162a068b05dda1b90e7b9e54d94
<pre>
Reduce unsafeness in WebCore/css/query
<a href="https://bugs.webkit.org/show_bug.cgi?id=304399">https://bugs.webkit.org/show_bug.cgi?id=304399</a>
<a href="https://rdar.apple.com/167168414">rdar://167168414</a>

Reviewed by Chris Dumez.

Now that MediaQueryEvaluator holds m_rootElementStyle in a CheckedPtr,
we have to change the member order in StyleResolver such that
m_mediaQueryEvaluator gets deleted before m_rootDefaultStyle. Otherwise
the MediaQueryEvaluator destructor will throw.

Thanks to Claude AI for the fix.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305863@main">https://commits.webkit.org/305863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80eb3a447d08a9004c51fa74641607ef833e94d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92455 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0b43ff1-8b54-4190-b4e5-14f38ddc8306) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106719 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77693 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bdd619c-5987-4992-875a-59487b3b4376) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87581 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fe4de93-7ef9-4ae4-9ac1-7a5ca295ebb9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6774 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/821 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115117 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 36 flakes 17 failures; Uploaded test results; 7 flakes 7 failures; Compiled WebKit; 2 flakes 5 failures; Passed layout tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115427 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9786 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66442 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21540 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11490 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->