### PR TITLE
Reduce unsafeness in WebCore/Modules/webdatabase

### DIFF
--- a/Source/WebCore/Modules/webdatabase/Database.h
+++ b/Source/WebCore/Modules/webdatabase/Database.h
@@ -166,7 +166,7 @@ private:
     bool m_opened { false };
     bool m_new { false };
 
-    UniqueRef<SQLiteDatabase> m_sqliteDatabase;
+    const UniqueRef<SQLiteDatabase> m_sqliteDatabase;
 
     const Ref<DatabaseAuthorizer> m_databaseAuthorizer;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -81,7 +81,7 @@ private:
     // ActiveDOMObject.
     void stop() override;
 
-    RefPtr<DatabaseThread> m_databaseThread;
+    const RefPtr<DatabaseThread> m_databaseThread;
     bool m_hasOpenDatabases { false }; // This never changes back to false, even after the database thread is closed.
     bool m_hasRequestedTermination { false };
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
@@ -75,7 +75,7 @@ void DatabaseTask::performTask()
 
     LOG(StorageAPI, "Performing %s %p\n", debugTaskName().characters(), this);
 
-    m_database.resetAuthorizer();
+    database()->resetAuthorizer();
 
     doPerformTask();
 
@@ -99,7 +99,7 @@ DatabaseOpenTask::DatabaseOpenTask(Database& database, bool setVersionInNewDatab
 
 void DatabaseOpenTask::doPerformTask()
 {
-    m_result = crossThreadCopy(database().performOpenAndVerify(m_setVersionInNewDatabase));
+    m_result = crossThreadCopy(database()->performOpenAndVerify(m_setVersionInNewDatabase));
 }
 
 #if !LOG_DISABLED
@@ -121,7 +121,7 @@ DatabaseCloseTask::DatabaseCloseTask(Database& database, DatabaseTaskSynchronize
 
 void DatabaseCloseTask::doPerformTask()
 {
-    database().performClose();
+    database()->performClose();
 }
 
 #if !LOG_DISABLED
@@ -184,7 +184,7 @@ DatabaseTableNamesTask::DatabaseTableNamesTask(Database& database, DatabaseTaskS
 void DatabaseTableNamesTask::doPerformTask()
 {
     // FIXME: Why no need for an isolatedCopy here?
-    m_result = database().performGetTableNames();
+    m_result = database()->performGetTableNames();
 }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.h
@@ -33,6 +33,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -74,7 +75,7 @@ public:
 
     void performTask();
 
-    Database& database() const { return m_database; }
+    Ref<Database> database() const { return m_database.get().releaseNonNull(); }
 
 #if ASSERT_ENABLED
     bool hasSynchronizer() const { return m_synchronizer; }
@@ -87,7 +88,7 @@ protected:
 private:
     virtual void doPerformTask() = 0;
 
-    Database& m_database;
+    ThreadSafeWeakPtr<Database> m_database;
     DatabaseTaskSynchronizer* m_synchronizer;
 
 #if !LOG_DISABLED
@@ -140,7 +141,7 @@ private:
     ASCIILiteral debugTaskName() const final;
 #endif
 
-    RefPtr<SQLTransaction> m_transaction;
+    const RefPtr<SQLTransaction> m_transaction;
     bool m_didPerformTask;
 };
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseThread.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseThread.h
@@ -43,7 +43,7 @@ class DatabaseTaskSynchronizer;
 class Document;
 class SQLTransactionCoordinator;
 
-class DatabaseThread : public ThreadSafeRefCounted<DatabaseThread> {
+class DatabaseThread : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DatabaseThread> {
 public:
     static Ref<DatabaseThread> create() { return adoptRef(*new DatabaseThread); }
     ~DatabaseThread();
@@ -69,7 +69,7 @@ private:
     void databaseThread();
 
     Lock m_threadCreationMutex;
-    RefPtr<Thread> m_thread;
+    const RefPtr<Thread> m_thread;
     RefPtr<DatabaseThread> m_selfRef;
 
     MessageQueue<DatabaseTask> m_queue;

--- a/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
+++ b/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
@@ -52,7 +52,7 @@ ExceptionOr<RefPtr<Database>> LocalDOMWindowWebDatabase::openDatabase(LocalDOMWi
     if (document->canAccessResource(ScriptExecutionContext::ResourceType::WebSQL) != ScriptExecutionContext::HasResourceAccess::Yes)
         return Exception { ExceptionCode::SecurityError };
 
-    auto result = manager.openDatabase(*window.document(), name, version, displayName, estimatedSize, WTFMove(creationCallback));
+    auto result = manager.openDatabase(*document, name, version, displayName, estimatedSize, WTF::move(creationCallback));
     if (result.hasException()) {
         // FIXME: To preserve our past behavior, this discards the error string in the exception.
         // At a later time we may decide that we want to use the error strings, and if so we can just return the exception as is.

--- a/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
@@ -204,9 +204,9 @@ bool SQLStatement::performCallback(SQLTransaction& transaction)
     // Call the appropriate statement callback and track if it resulted in an error,
     // because then we need to jump to the transaction error callback.
 
-    if (m_error) {
+    if (RefPtr error = m_error) {
         if (auto errorCallback = m_statementErrorCallbackWrapper.unwrap()) {
-            auto result = errorCallback->invoke(transaction, *m_error);
+            auto result = errorCallback->invoke(transaction, *error);
 
             // The spec says:
             // "If the error callback returns false, then move on to the next statement..."
@@ -227,7 +227,7 @@ bool SQLStatement::performCallback(SQLTransaction& transaction)
     if (auto callback = m_statementCallbackWrapper.unwrap()) {
         ASSERT(m_resultSet);
 
-        auto result = callback->invoke(transaction, *m_resultSet);
+        auto result = callback->invoke(transaction, Ref { *m_resultSet }.get());
         return result.type() == CallbackResultType::ExceptionThrown;
     }
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.h
@@ -56,7 +56,7 @@ public:
     virtual void handleCommitFailedAfterPostflight(SQLTransaction&) = 0;
 };
 
-class SQLTransaction : public ThreadSafeRefCounted<SQLTransaction>, public SQLTransactionStateMachine<SQLTransaction> {
+class SQLTransaction : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SQLTransaction>, public SQLTransactionStateMachine<SQLTransaction> {
 public:
     static Ref<SQLTransaction> create(Ref<Database>&&, RefPtr<SQLTransactionCallback>&&, RefPtr<VoidCallback>&& successCallback, RefPtr<SQLTransactionErrorCallback>&&, RefPtr<SQLTransactionWrapper>&&, bool readOnly);
     ~SQLTransaction();

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.h
@@ -31,6 +31,7 @@
 #include "SQLTransactionStateMachine.h"
 #include <memory>
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -71,7 +72,9 @@ private:
 
     NO_RETURN_DUE_TO_ASSERT void unreachableState();
 
-    SQLTransaction& m_frontend;
+    Ref<SQLTransaction> frontend() { return m_frontend.get().releaseNonNull(); }
+
+    ThreadSafeWeakPtr<SQLTransaction> m_frontend;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -4,8 +4,6 @@ Modules/mediastream/libwebrtc/LibWebRTCObservers.h
 Modules/notifications/NotificationResourcesLoader.h
 Modules/push-api/PushManager.h
 Modules/storage/StorageManager.cpp
-Modules/webdatabase/DatabaseTask.h
-Modules/webdatabase/SQLTransactionBackend.h
 [ Mac ] inspector/InspectorFrontendHost.cpp
 [ Mac ] inspector/InspectorFrontendHost.h
 [ iOS ] page/ios/ContentChangeObserver.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -14,11 +14,8 @@ Modules/webaudio/DefaultAudioDestinationNode.cpp
 Modules/webaudio/IIRFilterNode.cpp
 Modules/webaudio/MediaStreamAudioDestinationNode.cpp
 Modules/webaudio/WaveShaperNode.cpp
-Modules/webdatabase/ChangeVersionWrapper.cpp
 Modules/webdatabase/Database.cpp
-Modules/webdatabase/DatabaseContext.cpp
 Modules/webdatabase/DatabaseManager.cpp
-Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
 Modules/webdatabase/SQLTransaction.cpp
 StyleBuilderGenerated.cpp
 StyleExtractorGenerated.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -64,14 +64,8 @@ Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioInternalData.h
 Modules/webcodecs/WebCodecsVideoFrame.cpp
 Modules/webdatabase/Database.cpp
-Modules/webdatabase/DatabaseContext.cpp
 Modules/webdatabase/DatabaseManager.cpp
-Modules/webdatabase/DatabaseTask.cpp
-Modules/webdatabase/DatabaseThread.cpp
-Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
-Modules/webdatabase/SQLStatement.cpp
 Modules/webdatabase/SQLTransaction.cpp
-Modules/webdatabase/SQLTransactionBackend.cpp
 Modules/webtransport/WebTransport.cpp
 StyleChangedAnimatablePropertiesGenerated.cpp
 [ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -31,7 +31,6 @@ Modules/webauthn/AuthenticatorAssertionResponse.cpp
 Modules/webauthn/AuthenticatorAttestationResponse.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/PublicKeyCredential.cpp
-Modules/webdatabase/Database.cpp
 Modules/webdatabase/DatabaseManager.cpp
 accessibility/AXObjectCache.cpp
 [ iOS ] accessibility/AccessibilityNodeObject.cpp


### PR DESCRIPTION
#### b744bdbd6b54dfda0ffb565f6a91e72769b09e5e
<pre>
Reduce unsafeness in WebCore/Modules/webdatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=304403">https://bugs.webkit.org/show_bug.cgi?id=304403</a>

Reviewed by Ryosuke Niwa.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304746@main">https://commits.webkit.org/304746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0112325f5dfff1c8c10a153a4d78cfad6d7513f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136437 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144149 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5eb32fb7-163f-4432-b13e-b683c7a126d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ecd9c0e3-d6ff-4889-870a-8da79c7b4f46) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0490a34b-0a58-4abf-96e6-eb4d959d2b9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6555 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4217 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4741 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41020 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8493 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7121 "Found 1 new test failure: inspector/unit-tests/iterableweakset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113017 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6491 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118555 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21032 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8524 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36607 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->