### PR TITLE
[GTK] imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html is crashing in a Skia codepath

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2745,8 +2745,8 @@ imported/w3c/web-platform-tests/webrtc/protocol/pt-no-bundle.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-codecs.html [ Failure ]
 
 # The 'Can demux two video tracks with the same payload type on an unbundled connection' test times
-# out, the metadataToBeLoaded promise never resolves. The skia crash seems to be a consequence of the timeout.
-webkit.org/b/286481 imported/w3c/web-platform-tests/webrtc/protocol/rtp-demuxing.html [ Crash ]
+# out, the metadataToBeLoaded promise never resolves.
+webkit.org/b/286481 imported/w3c/web-platform-tests/webrtc/protocol/rtp-demuxing.html [ Failure ]
 
 # webrtcbin expects mid in its offer/answer SDP, this is not spec compliant, it's an optional field.
 imported/w3c/web-platform-tests/webrtc/protocol/missing-fields.html [ Failure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -105,9 +105,6 @@ webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 webkit.org/b/303924 webrtc/peer-connection-audio-mute2.html [ Failure ]
 webkit.org/b/303925 webrtc/audio-replace-track.html [ Failure ]
 
-# Skia-related
-webkit.org/b/304134 imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html [ Pass Crash ]
-
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 # Legacy Expectations sections below

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
@@ -46,7 +46,8 @@ CoordinatedImageBackingStore::~CoordinatedImageBackingStore() = default;
 
 bool CoordinatedImageBackingStore::isSameNativeImage(const NativeImage& nativeImage)
 {
-    return nativeImage.uniqueID() == downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image().uniqueID();
+    auto* image = downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image();
+    return image && nativeImage.uniqueID() == image->uniqueID();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -38,14 +38,14 @@ public:
     CoordinatedPlatformLayerBufferNativeImage(Ref<NativeImage>&&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferNativeImage();
 
-    const NativeImage& image() const { return m_image.get(); }
+    const NativeImage* image() const { return m_image.get(); }
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
     bool tryEnsureBuffer(TextureMapper&);
 
-    const Ref<NativeImage> m_image;
+    RefPtr<NativeImage> m_image;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
 };
 


### PR DESCRIPTION
#### 02d6be0a697de0b2e7a1c5868b2e6eebe50cfb8a
<pre>
[GTK] imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html is crashing in a Skia codepath
<a href="https://bugs.webkit.org/show_bug.cgi?id=304134">https://bugs.webkit.org/show_bug.cgi?id=304134</a>

Reviewed by Adrian Perez de Castro.

When using Skia with GPU acceleration, NativeImages backed by textures must be
destroyed on the same thread where the Skia GrDirectContext was created, not on
the compositor thread. Releasing GPU resources on the wrong thread corrupts
Skia&apos;s GrResourceCache, leading to bounds check failures and crashes.

This patch ensures that in ~CoordinatedPlatformLayerBufferNativeImage(), if the
image is texture-backed, its destruction is dispatched to the main thread.

This also fixes crashes/assertions in:
- http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
- http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
- imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html

Covered by existing tests.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp:
(WebCore::CoordinatedImageBackingStore::isSameNativeImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::~CoordinatedPlatformLayerBufferNativeImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h:

Canonical link: <a href="https://commits.webkit.org/304897@main">https://commits.webkit.org/304897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00bb1a561c5ecd4d7314e580d94ccbb3495cad07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4459 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113180 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6662 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62812 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8744 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36791 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72310 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->