### PR TITLE
[JSC] Error.isError(WebAssembly.Exception) should be `false`

### DIFF
--- a/JSTests/wasm/stress/exception-thrown-out-of-wasm-integration-error-is-error.js
+++ b/JSTests/wasm/stress/exception-thrown-out-of-wasm-integration-error-is-error.js
@@ -1,0 +1,39 @@
+import Builder from '../Builder.js'
+import * as assert from '../assert.js'
+
+{
+    const b = new Builder();
+    b.Type().End()
+        .Function().End()
+        .Exception().Signature({ params: [] }).End()
+        .Export().Function("call")
+            .Exception("foo", 0)
+        .End()
+        .Code()
+            .Function("call", { params: [], ret: "i32" })
+            .Throw(0)
+            .I32Const(1)
+            .End()
+        .End()
+
+    const bin = b.WebAssembly().get();
+    const module = new WebAssembly.Module(bin);
+    const instance = new WebAssembly.Instance(module);
+
+    let hasCaught = false;
+    try {
+        instance.exports.call();
+    } catch (e) {
+        hasCaught = true;
+        assert.instanceof(e, WebAssembly.Exception, 'must be an instance of WebAssembly.Exception');
+        // By the current (22 November 2025) spec semantics, `WebAssembly.Exception` does not have `[[ErrorData]]` in ECMA262 concept.
+        // This means `Error.isError(<a instance of WebAssembly.Exception>)` should be `false`.
+        //
+        // - https://webassembly.github.io/spec/js-api/#exceptions
+        // - https://github.com/WebAssembly/spec/issues/1914
+        // - https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-properties-of-error-instances
+        assert.eq(Error.isError(e), false, 'Error.isError(WebAssembly.Exception) should be false');
+    }
+
+    assert.truthy(hasCaught, 'expected assertion was not called');
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -45,7 +45,7 @@ const ClassInfo JSWebAssemblyException::s_info = { "WebAssembly.Exception"_s, &B
 
 Structure* JSWebAssemblyException::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
-    return Structure::create(vm, globalObject, prototype, TypeInfo(ErrorInstanceType, StructureFlags), info());
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
 JSWebAssemblyException::JSWebAssemblyException(VM& vm, Structure* structure, Ref<const Wasm::Tag>&& tag, FixedVector<uint64_t>&& payload)


### PR DESCRIPTION
#### 6376164b58fe81dd7d23f6c9e5722fc31572c7fd
<pre>
[JSC] Error.isError(WebAssembly.Exception) should be `false`
<a href="https://bugs.webkit.org/show_bug.cgi?id=304410">https://bugs.webkit.org/show_bug.cgi?id=304410</a>

Reviewed by Yusuke Suzuki and Sosuke Suzuki.

According to the spec discussion, the current `WebAssembly.Exception` does not have `[[ErrorData]]` semantically.
So `Error.isError(WebAssembly.Exception)` should be `false`.

- <a href="https://github.com/WebAssembly/spec/issues/1914">https://github.com/WebAssembly/spec/issues/1914</a>
- <a href="https://webassembly.github.io/spec/js-api/#exceptions">https://webassembly.github.io/spec/js-api/#exceptions</a>

Test: JSTests/wasm/stress/exception-thrown-out-of-wasm-integration-error-is-error.js
* JSTests/wasm/stress/exception-thrown-out-of-wasm-integration-error-is-error.js: Added.
(import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.catch):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp:
(JSC::JSWebAssemblyException::createStructure):

Canonical link: <a href="https://commits.webkit.org/304917@main">https://commits.webkit.org/304917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c602cb58dd2cbf1af43765d91f78d06e9935136c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104212 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6442 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4103 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4594 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128248 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146746 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134775 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8330 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6372 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118432 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62317 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8378 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36489 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167554 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71937 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43712 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->