### PR TITLE
[threaded-animations] scroll-driven animations cause continuous page rendering updates while the page is idle

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A threaded scroll-driven animation should not yield rendering updates.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+</style>
+
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    window.internals?.setSpeculativeTilingDelayDisabledForTesting(true);
+
+    const target = createDiv(t);
+    const timeline = new ScrollTimeline({ source : document.documentElement });
+    const animation = target.animate({ opacity: [0, 1] }, { timeline });
+
+    await threadedAnimationsCommit();
+
+    window.internals?.startTrackingRenderingUpdates();
+
+    // Wait for the equivalent of 10 rendering frames.
+    const numberOfFrames = 10;
+    const frameDuration = 1000 / 60;
+    await new Promise(resolve => setTimeout(resolve, numberOfFrames * frameDuration));
+
+    // Check we got not even half of those.
+    assert_less_than(window.internals?.renderingUpdateCount(), numberOfFrames / 2);
+}, "A threaded scroll-driven animation should not yield rendering updates.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -158,10 +158,12 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
     for (const auto& effect : copyToVector(sortedEffects())) {
         auto keyframeRecomputationReason = effect->recomputeKeyframesIfNecessary(previousLastStyleChangeEventStyle, unanimatedStyle, resolutionContext);
 
+        auto wasOrWasAboutToRunAccelerated = effect->isRunningAccelerated() || effect->isAboutToRunAccelerated();
+
         Ref animation = *effect->animation();
         impact.add(animation->resolve(targetStyle, resolutionContext));
 
-        if (effect->isRunningAccelerated() || effect->isAboutToRunAccelerated())
+        if (!wasOrWasAboutToRunAccelerated && (effect->isRunningAccelerated() || effect->isAboutToRunAccelerated()))
             impact.add(AnimationImpact::RequiresRecomposite);
 
         if (effect->triggersStackingContext())


### PR DESCRIPTION
#### 43a3c1193c42e20ce68c491a8a229b27e05e8569
<pre>
[threaded-animations] scroll-driven animations cause continuous page rendering updates while the page is idle
<a href="https://bugs.webkit.org/show_bug.cgi?id=304412">https://bugs.webkit.org/show_bug.cgi?id=304412</a>
<a href="https://rdar.apple.com/166792409">rdar://166792409</a>

Reviewed by Simon Fraser.

If you have &quot;Threaded Scroll-driven Animations&quot; and have a page loaded with a scroll-driven animation,
you&apos;ll see page rendering updates happening continuously resulting in remote layer tree transactions
being uploaded to the remote layer tree even when the page appears completely idle.

This was due to the `AnimationImpact::RequiresRecomposite` bit being set when applying keyframe effects
when an effect was marked as accelerated. We should only set that bit if the acceleration state changed
to being accelerated.

The new test would fail on iOS prior to this change.

Test: webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates.html

* LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-scroll-driven-animation-rendering-updates.html: Added.
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):

Canonical link: <a href="https://commits.webkit.org/304731@main">https://commits.webkit.org/304731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da3b7d36221ed7fb68c0c17924c1753546632b73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144054 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e6ae969-0341-4871-8420-a44bf547613b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a30b78a-8cd7-4d0c-a636-f3526a337b4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85084 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4142 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4645 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146798 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112591 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112935 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6407 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118477 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21025 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36532 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8147 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->