### PR TITLE
[run-benchmark] Fix crashes when using --driver=webdriver

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ class BenchmarkRunner(object):
     def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform,
                  browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None,
                  diagnose_dir=None, generate_pgo_profiles=False, profile_output_dir=None, trace_type=None,
-                 profiling_interval=None, browser_args=None):
+                 profiling_interval=None, browser_args=None, http_server_type=None):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
         if 'options' not in self._plan:
             self._plan['options'] = {}

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
@@ -43,17 +43,21 @@ class LinuxChromeDriver(LinuxBrowserDriver):
         self._default_browser_arguments += ['--homepage', url]
         super().launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         from selenium import webdriver
         from selenium.webdriver.chrome.options import Options
+        from selenium.webdriver.chrome.service import Service
         options = Options()
         for option_switch in self._default_browser_arguments:
             options.add_argument(option_switch)
         if browser_build_path:
             binary_path = os.path.join(browser_build_path, 'chromium-browser')
             options.binary_location = binary_path
+        elif browser_path:
+            options.binary_location = browser_path
         driver_executable = self.webdriver_binary_path
-        driver = webdriver.Chrome(chrome_options=options, executable_path=driver_executable)
+        service = Service(executable_path=driver_executable)
+        driver = webdriver.Chrome(service=service, options=options)
         super().launch_webdriver(url, driver)
         return driver
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
@@ -44,7 +44,7 @@ class CogBrowserDriver(LinuxBrowserDriver):
         self._default_browser_arguments.append(url)
         super(CogBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))
 
     def prepare_env(self, config):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_epiphany_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_epiphany_driver.py
@@ -37,5 +37,5 @@ class EpiphanyBrowserDriver(LinuxBrowserDriver):
                                    url]
         super(EpiphanyBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_firefox_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_firefox_driver.py
@@ -40,14 +40,18 @@ class LinuxFirefoxDriver(LinuxBrowserDriver):
                                    url]
         super(LinuxFirefoxDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         from selenium import webdriver
         from selenium.webdriver.firefox.options import Options
+        from selenium.webdriver.firefox.service import Service
         options = Options()
         if browser_build_path:
             binary_path = os.path.join(browser_build_path, 'firefox-bin')
             options.binary_location = binary_path
+        elif browser_path:
+            options.binary_location = browser_path
         driver_executable = self.webdriver_binary_path
-        driver = webdriver.Firefox(firefox_options=options, executable_path=driver_executable)
+        service = Service(executable_path=driver_executable, service_args=["--profile-root", self._temp_profiledir])
+        driver = webdriver.Firefox(service=service, options=options)
         super(LinuxFirefoxDriver, self).launch_webdriver(url, driver)
         return driver

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
@@ -42,5 +42,5 @@ class GTKMiniBrowserDriver(LinuxBrowserDriver):
         self._default_browser_arguments.append(url)
         super(GTKMiniBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -44,7 +44,7 @@ class WPEMiniBrowserBaseDriver(LinuxBrowserDriver):
         self._default_browser_arguments.append(url)
         super().launch_url(url, options, browser_build_path, browser_path)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))
 
     def prepare_env(self, config):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_servo_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_servo_driver.py
@@ -31,5 +31,5 @@ class ServoBrowserDriver(LinuxBrowserDriver):
     browser_name = 'servo'
     process_search_list = ['servo']
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
@@ -17,22 +17,25 @@ class OSXChromeDriverBase(OSXBrowserDriver):
     def launch_url(self, url, options, browser_build_path, browser_path):
         self._launch_process(build_dir=browser_build_path, app_name=self.app_name, url=url, args=self.launch_args_with_url(url))
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         from selenium import webdriver
-        chrome_options = self._create_chrome_options(browser_build_path)
+        chrome_options = self._create_chrome_options(browser_build_path, browser_path)
         driver_executable = self.webdriver_binary_path
         driver = webdriver.Chrome(chrome_options=chrome_options, executable_path=driver_executable)
         self._launch_webdriver(url=url, driver=driver)
         return driver
 
-    def _create_chrome_options(self, browser_build_path):
+    def _create_chrome_options(self, browser_build_path, browser_path):
         from selenium.webdriver.chrome.options import Options
         chrome_options = Options()
         chrome_options.add_argument("--disable-web-security")
         chrome_options.add_argument("--user-data-dir")
         chrome_options.add_argument("--disable-extensions")
         chrome_options.add_argument(self._window_size_arg())
-        self._set_chrome_binary_location(chrome_options, browser_build_path)
+        if browser_build_path:
+            self._set_chrome_binary_location(chrome_options, browser_build_path)
+        elif browser_path:
+            chrome_options.binary_location = browser_path
         return chrome_options
 
     def _window_size_arg(self):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_firefox_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_firefox_driver.py
@@ -34,13 +34,18 @@ class OSXFirefoxDriverBase(OSXBrowserDriver):
         args_with_url.append(url)
         self._launch_process(build_dir=browser_build_path, app_name=self.app_name, url=url, args=args_with_url)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         from selenium import webdriver
         from selenium.webdriver.firefox.options import Options
+        from selenium.webdriver.firefox.service import Service
         firefox_options = Options()
-        self._set_firefox_binary_location(options, browser_build_path)
+        if browser_build_path:
+            self._set_firefox_binary_location(firefox_options, browser_build_path)
+        elif browser_path:
+            firefox_options.binary_location = browser_path
         driver_executable = self.webdriver_binary_path
-        driver = webdriver.Firefox(firefox_options=firefox_options, executable_path=driver_executable)
+        service = Service(executable_path=driver_executable, service_args=["--profile-root", self._profile_directory])
+        driver = webdriver.Firefox(service=service, options=firefox_options)
         self._launch_webdriver(url=url, driver=driver)
         return driver
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -104,7 +104,7 @@ class OSXSafariDriver(OSXBrowserDriver):
 
         subprocess.Popen(['open', '-a', safari_app_path, url], env=env)
 
-    def launch_driver(self, url, options, browser_build_path):
+    def launch_driver(self, url, options, browser_build_path, browser_path):
         from selenium import webdriver
         driver = webdriver.Safari(quiet=False)
         self._launch_webdriver(url=url, driver=driver)


### PR DESCRIPTION
#### 52cb4ab5e9c3373a6b1f2e7f8928d923e39a3223
<pre>
[run-benchmark] Fix crashes when using --driver=webdriver
<a href="https://bugs.webkit.org/show_bug.cgi?id=304414">https://bugs.webkit.org/show_bug.cgi?id=304414</a>

Reviewed by NOBODY (OOPS!).

The WebDriver benchmark runner was crashing due to two issues:

1. BenchmarkRunner.__init__() did not accept http_server_type parameter,
   causing &quot;takes from 10 to 20 positional arguments but 21 were given&quot;.

2. launch_driver() methods did not accept browser_path parameter,
   causing &quot;takes 4 positional arguments but 5 were given&quot;.

The WebDriver benchmark runner now passes browser_path to launch_driver(),
matching the existing launch_url() signature. This allows specifying a custom
browser binary path when using the WebDriver runner.

This patch also fixes a regression from <a href="https://commits.webkit.org/245441@main">245441@main</a> where osx_firefox_driver.py
was passing the wrong options object to _set_firefox_binary_location(),
causing custom browser builds to not work correctly.

Additionally, this modifies Firefox drivers to pass the profile directory to the
WebDriver Service, ensuring Firefox launches with the correct profile settings
that suppress the default browser check and privacy notice.
To do so, update drivers to use the modern Selenium 4 API (Service) instead of
deprecated executable_path and firefox_options/chrome_options parameters.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__): Accept http_server_type parameter for interface
compatibility with WebServerBenchmarkRunner.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py:
(LinuxChromeDriver.launch_driver): Add browser_path parameter and use Service class.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py:
(CogBrowserDriver.launch_driver): Add browser_path parameter.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_epiphany_driver.py:
(EpiphanyBrowserDriver.launch_driver): Add browser_path parameter.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_firefox_driver.py:
(LinuxFirefoxDriver.launch_driver): Add browser_path parameter, use Service class,
and pass profile directory via service_args.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py:
(GTKMiniBrowserDriver.launch_driver): Add browser_path parameter.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py:
(WPEMiniBrowserBaseDriver.launch_driver): Add browser_path parameter.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_servo_driver.py:
(ServoBrowserDriver.launch_driver): Add browser_path parameter.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py:
(OSXChromeDriverBase.launch_driver): Add browser_path parameter.
(OSXChromeDriverBase._create_chrome_options): Handle browser_path.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_firefox_driver.py:
(OSXFirefoxDriverBase.launch_driver): Add browser_path parameter, fix bug passing
wrong options object, use Service class, and pass profile directory via service_args.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver.launch_driver): Add browser_path parameter for interface
compatibility (Safari WebDriver does not support custom browser paths).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52cb4ab5e9c3373a6b1f2e7f8928d923e39a3223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9335 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8500 "Hash 52cb4ab5 for PR 55632 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104219 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/74836 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85052 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135646 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6450 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8355 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/8500 "Hash 52cb4ab5 for PR 55632 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112902 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6380 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118438 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8386 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36495 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->