### PR TITLE
Use NO_UNIQUE_ADDRESS macro instead of [[no_unique_address]] attribute

### DIFF
--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -70,7 +70,7 @@ protected:
 
 private:
     mutable unsigned m_refCount { 1 };
-    [[no_unique_address]] RefCountDebugger m_refCountDebugger;
+    NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 
 template<typename T> class RefCounted : public RefCountedBase {

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -85,7 +85,7 @@ protected:
 
 private:
     mutable std::atomic<unsigned> m_refCount { 1 };
-    [[no_unique_address]] RefCountDebugger m_refCountDebugger;
+    NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 
 template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCounted : public ThreadSafeRefCountedBase {

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -87,7 +87,7 @@ protected:
 
 private:
     mutable std::atomic<unsigned> m_refCount { 1 };
-    [[no_unique_address]] RefCountDebugger m_refCountDebugger;
+    NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 
 template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCountedWithSuppressingSaferCPPChecking : public ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase {


### PR DESCRIPTION
#### 62df643698ea0e6a23866901e87ac3c201d44b72
<pre>
Use NO_UNIQUE_ADDRESS macro instead of [[no_unique_address]] attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=304415">https://bugs.webkit.org/show_bug.cgi?id=304415</a>
<a href="https://rdar.apple.com/problem/166795977">rdar://problem/166795977</a>

Reviewed by Ross Kirsling and Darin Adler.

Windows builds with clang-cl fail to recognize [[no_unique_address]]
even when compiling with C++23. WebKit already has a NO_UNIQUE_ADDRESS
macro in Compiler.h that properly detects compiler support for this
attribute and falls back to empty definition when unavailable.

Replace direct use of [[no_unique_address]] with the NO_UNIQUE_ADDRESS
macro in RefCounted base classes to fix Windows builds while maintaining
the attribute on platforms that support it.

* Source/WTF/wtf/RefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:

Canonical link: <a href="https://commits.webkit.org/304697@main">https://commits.webkit.org/304697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66bba171584a37844e997580f49014d57604b60e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144011 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9259f7ff-b6d5-40ff-a938-e1cb6609d9c5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104222 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8711f02-fd87-47cb-800f-41f3308db5ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85055 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bc9cf809-51ea-48c6-8489-0daf57e9bde5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4112 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4603 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128257 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146755 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134784 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112903 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6383 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118443 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8387 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36500 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167563 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71946 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43714 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->