### PR TITLE
[run-benchmark][AutoInstall] Fix support for chromedriver and geckodriver

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -149,11 +149,12 @@ class Package(object):
             else:
                 raise OSError('{} has an unrecognized package format'.format(self.path))
 
-    def __init__(self, import_name, version=None, pypi_name=None, slow_install=False, wheel=None, aliases=None, implicit_deps=None):
+    def __init__(self, import_name, version=None, pypi_name=None, custom_install=False, slow_install=False, wheel=None, aliases=None, implicit_deps=None):
         self.name = import_name
         self.version = version
         self._archives = []
         self.pypi_name = pypi_name or self.name
+        self.custom_install = custom_install
         self.slow_install = slow_install
         self.wheel = wheel
         self.aliases = aliases or []
@@ -164,6 +165,7 @@ class Package(object):
                 "import_name={self.name!r}, "
                 "version={self.version!r}, "
                 "pypi_name={self.pypi_name!r}, "
+                "custom_install={self.custom_install!r}, "
                 "slow_install={self.slow_install!r}, "
                 "wheel={self.wheel!r}, "
                 "aliases={self.aliases!r}, "
@@ -176,6 +178,9 @@ class Package(object):
         if not AutoInstall.directory:
             raise ValueError('No AutoInstall directory, Package cannot resolve location')
         return os.path.join(AutoInstall.directory, *self.name.split('.'))
+
+    def do_custom_install(self, unpack_location):
+        pass
 
     def do_post_install(self, archive_path):
         pass
@@ -410,7 +415,12 @@ class Package(object):
                             element.endswith('.dist-info') for element in to_be_moved
                         )
                     ):
-                        raise OSError('Cannot install {}, could not find setup.py'.format(self.name))
+                        if self.custom_install:
+                            # Binary-only package installation, bypassing Python-specific setup.py logic
+                            self.do_custom_install(temp_location)
+                            to_be_moved = []
+                        else:
+                            raise OSError('Cannot install {}, could not find setup.py'.format(self.name))
                     for file in to_be_moved:
                         target = os.path.join(AutoInstall.directory, file)
                         if os.path.isdir(target):

--- a/Tools/Scripts/webkitpy/autoinstalled/chromedriver.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/chromedriver.py
@@ -20,47 +20,58 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import platform
 import requests
+import shutil
 
 from webkitscmpy import Package, Version
 
 
 class ChromeDriverPackage(Package):
-    URL = 'https://chromedriver.storage.googleapis.com/'
+    URL = 'https://storage.googleapis.com/chrome-for-testing-public/'
+    VERSIONS_URL = 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json'
 
     def __init__(self, version=None):
-        super(ChromeDriverPackage, self).__init__('chromedriver', version=version)
+        super(ChromeDriverPackage, self).__init__('chromedriver', version=version, custom_install=True)
+        self._platform = None
 
     def archives(self):
-        if self.version is not None:
+        if self.version is None:
             try:
-                response = requests.get(self.URL + 'LATEST_RELEASE')
+                response = requests.get(self.VERSIONS_URL)
             except requests.RequestException:
                 return []
 
             if response.status_code != 200:
                 return []
-            version = Version.from_string(response.text.rstrip())
+            version = Version.from_string(response.json()['channels']['Stable']['version'])
         else:
             version = self.version
 
         os_name = platform.system()
+        machine = platform.machine()
         if os_name == 'Linux':
-            os = 'linux{}'.format('64' if platform.machine()[-2:] == '64' else '')
+            self._platform = 'linux64'
         elif os_name == 'Darwin':
-            os = 'mac64'
+            self._platform = 'mac-arm64' if machine == 'arm64' else 'mac-x64'
         else:
             return []
 
         return [Package.Archive(
             self.name,
-            link='{}{}/chromedriver_{}.zip'.format(self.URL, version, os),
+            link='{}{}/{}/chromedriver-{}.zip'.format(self.URL, version, self._platform, self._platform),
             version=version,
             extension='zip',
         )]
 
+    def do_custom_install(self, unpack_location):
+        # The chromedriver binary is inside a chromedriver-{platform} subdirectory
+        source = os.path.join(unpack_location, 'chromedriver-{}'.format(self._platform), self.name)
+        shutil.copy(source, self.location)
+        os.chmod(self.location, 0o755)
 
-package = ChromeDriverPackage(version=Version(86, 0, 4240, 22))
+
+package = ChromeDriverPackage(version=Version(143, 0, 7499, 42))
 package.install()
 executable = package.location

--- a/Tools/Scripts/webkitpy/autoinstalled/geckodriver.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/geckodriver.py
@@ -20,8 +20,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import platform
 import requests
+import shutil
 
 from webkitscmpy import Package, Version
 
@@ -30,7 +32,7 @@ class GeckoDriverPackage(Package):
     URL = 'https://api.github.com/repos/mozilla/geckodriver/releases'
 
     def __init__(self, version=None):
-        super(GeckoDriverPackage, self).__init__('geckodriver', version=version)
+        super(GeckoDriverPackage, self).__init__('geckodriver', version=version, custom_install=True)
 
     def archives(self):
         try:
@@ -43,9 +45,9 @@ class GeckoDriverPackage(Package):
 
         os_name = platform.system()
         if os_name == 'Darwin':
-            os = 'macos'
+            os_tag = 'macos'
         else:
-            os = '{}{}'.format(os_name, platform.machine()[-2:])
+            os_tag = '{}{}'.format(os_name.lower(), platform.machine()[-2:])
 
         archives = []
         for candidate in reversed(response.json()):
@@ -58,7 +60,7 @@ class GeckoDriverPackage(Package):
                 url = asset.get('browser_download_url')
                 if not url:
                     continue
-                if os not in url:
+                if os_tag not in url:
                     continue
 
                 extension = 'zip' if url.endswith('.zip') else 'tar.gz'
@@ -79,7 +81,13 @@ class GeckoDriverPackage(Package):
 
         return archives
 
+    def do_custom_install(self, unpack_location):
+        # The geckodriver binary is directly in the archive root
+        source = os.path.join(unpack_location, self.name)
+        shutil.copy(source, self.location)
+        os.chmod(self.location, 0o755)
 
-package = GeckoDriverPackage(version=Version(0, 27, 0))
+
+package = GeckoDriverPackage(version=Version(0, 36, 0))
 package.install()
 executable = package.location


### PR DESCRIPTION
#### 0f241d9413c39cab6f0b90d3544e29247f9a4c57
<pre>
[run-benchmark][AutoInstall] Fix support for chromedriver and geckodriver
<a href="https://bugs.webkit.org/show_bug.cgi?id=304416">https://bugs.webkit.org/show_bug.cgi?id=304416</a>

Reviewed by NOBODY (OOPS!).

The autoinstall system was redesigned for Python packages only and expects
setup.py or wheel files. This caused failures when installing binary-only
packages like chromedriver and geckodriver which contain just an executable.

This patch adds a custom_install flag and do_custom_install() hook to Package,
allowing subclasses to handle binary-only archives without requiring intrusive
changes to the main install() logic.

Updates chromedriver to use Chrome for Testing (CfT) URLs since the legacy
chromedriver.storage.googleapis.com endpoint only has versions up to 114.
The new CfT endpoint provides chromedriver for Chrome 115+.

Updates geckodriver to version 0.36.0, required by Selenium 4 for the
--websocket-port option (minimum version 0.30.0). Also fixes the download URL
by lowercasing the OS name (e.g. &quot;Linux64&quot; -&gt; &quot;linux64&quot;) to match the
artifact naming convention on GitHub releases.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.__init__): Add custom_install parameter.
(Package.__repr__): Include custom_install in representation.
(Package.do_custom_install): New hook method for binary-only package installation.
(Package.install): Call do_custom_install() when custom_install is True and no
setup.py is found.

* Tools/Scripts/webkitpy/autoinstalled/chromedriver.py:
(ChromeDriverPackage.__init__): Set custom_install=True.
(ChromeDriverPackage.archives): Use Chrome for Testing URLs and track platform.
(ChromeDriverPackage.do_custom_install): Copy binary from chromedriver-{platform}
subdirectory.
Update version to 143.0.7499.42.

* Tools/Scripts/webkitpy/autoinstalled/geckodriver.py:
(GeckoDriverPackage.__init__): Set custom_install=True.
(GeckoDriverPackage.archives): Fix OS name to lowercase for URL matching.
(GeckoDriverPackage.do_custom_install): Copy binary from archive root.
Update version to 0.36.0.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f241d9413c39cab6f0b90d3544e29247f9a4c57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104220 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/74893 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85053 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135650 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4113 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8342 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40906 "Found 1 new test failure: fast/html/a-tooltip-null.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112560 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/135729 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112904 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6382 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8390 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->