### PR TITLE
[GTK][WPE] Make sure we just use the triggerMemoryPressureEvent with information from the UIProcess for the MemoryPressureHandler

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -85,11 +85,16 @@ void MemoryPressureHandler::setMemoryFootprintPollIntervalForTesting(Seconds pol
 
 void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
 {
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    UNUSED_PARAM(use);
+    m_measurementTimer = nullptr;
+#else
     if (use) {
         m_measurementTimer = makeUnique<RunLoop::Timer>(RunLoop::mainSingleton(), "MemoryPressureHandler::MeasurementTimer"_s, this, &MemoryPressureHandler::measurementTimerFired);
         m_measurementTimer->startRepeating(m_configuration.pollInterval);
     } else
         m_measurementTimer = nullptr;
+#endif
 }
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### eee74bee8940afe9737f3846d039b0d58fa84105
<pre>
[GTK][WPE] Make sure we just use the triggerMemoryPressureEvent with information from the UIProcess for the MemoryPressureHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=304428">https://bugs.webkit.org/show_bug.cgi?id=304428</a>

Reviewed by NOBODY (OOPS!).

We are using the m_measurementTimer and the triggerMemoryPressureEvent signaled by
MemoryPressureMonitor at the same time, this is not correct because both have the same
goal and the one in the timer uses a suboptimal implementation to check memory usage
that causes stops in the main loop of the WebProcess. We want to first use just the one
in the MemoryPressureMonitor and later verify how to unify and make it more similar to
other platforms.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee74bee8940afe9737f3846d039b0d58fa84105

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104240 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/74867 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122153 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85073 "Found 2 new API test failures: WPE/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4134 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4631 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128285 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146784 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134812 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40921 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112580 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphenate-character-002.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-010.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-inline-010.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-punctuation-001.html imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html imported/w3c/web-platform-tests/quirks/line-height-in-list-item.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7030 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112924 "Found 2 new API test failures: WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, WebKitGTK/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6401 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62354 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8415 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36514 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167591 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71974 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43720 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->