### PR TITLE
Refactor ownership of the provisional LocalFrame from WebKit to WebCore

### DIFF
--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -30,8 +30,9 @@
 #include "AutoplayPolicy.h"
 #include "Document.h"
 #include "FrameDestructionObserverInlines.h"
-#include "HTMLFrameOwnerElement.h"
 #include "FrameInlines.h"
+#include "HTMLFrameOwnerElement.h"
+#include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "NodeInlines.h"
 #include "RemoteDOMWindow.h"
@@ -204,6 +205,17 @@ const SecurityOrigin& RemoteFrame::frameDocumentSecurityOriginOrOpaque() const
 AutoplayPolicy RemoteFrame::autoplayPolicy() const
 {
     return m_autoplayPolicy;
+}
+
+RefPtr<LocalFrame> RemoteFrame::takeProvisionalLocalFrame()
+{
+    return std::exchange(m_provisionalLocalFrame, nullptr);
+}
+
+void RemoteFrame::setProvisionalFrame(LocalFrame* provisionalLocalFrame)
+{
+    ASSERT(!m_provisionalLocalFrame);
+    m_provisionalLocalFrame = provisionalLocalFrame;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class IntPoint;
+class LocalFrame;
 class RemoteDOMWindow;
 class RemoteFrameClient;
 class RemoteFrameView;
@@ -86,6 +87,10 @@ public:
     void reportMixedContentViolation(bool blocked, const URL& target) const final;
     const SecurityOrigin& frameDocumentSecurityOriginOrOpaque() const;
 
+    LocalFrame* provisionalLocalFrame() { return m_provisionalLocalFrame.get(); }
+    WEBCORE_EXPORT RefPtr<LocalFrame> takeProvisionalLocalFrame();
+    WEBCORE_EXPORT void setProvisionalFrame(LocalFrame*);
+
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);
 
@@ -115,6 +120,7 @@ private:
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
     AutoplayPolicy m_autoplayPolicy;
     bool m_preventsParentFromBeingComplete { true };
+    RefPtr<LocalFrame> m_provisionalLocalFrame;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -462,8 +462,8 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
         return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(protectedThis), makeInvalidator());
     };
     auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, parameters.scrollingMode, *parent, Ref { remoteFrame->frameTreeSyncData() }) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.effectiveReferrerPolicy, nullptr, Ref { remoteFrame->frameTreeSyncData() });
-    ASSERT(!m_provisionalFrame);
-    m_provisionalFrame = localFrame.ptr();
+    ASSERT(!remoteFrame->provisionalLocalFrame());
+    remoteFrame->setProvisionalFrame(localFrame.ptr());
     m_frameIDBeforeProvisionalNavigation = parameters.frameIDBeforeProvisionalNavigation;
     localFrame->init();
     localFrame->protectedDocument()->setURL(URL { aboutBlankURL() });
@@ -476,7 +476,11 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
 
 void WebFrame::destroyProvisionalFrame()
 {
-    if (RefPtr frame = std::exchange(m_provisionalFrame, nullptr)) {
+    RefPtr remoteFrame = coreRemoteFrame();
+    if (!remoteFrame)
+        return;
+
+    if (RefPtr frame = remoteFrame->takeProvisionalLocalFrame()) {
         if (auto* client = dynamicDowncast<WebLocalFrameLoaderClient>(frame->loader().client()))
             client->takeFrameInvalidator().release();
         frame->loader().detachFromParent();
@@ -487,12 +491,12 @@ void WebFrame::destroyProvisionalFrame()
 
 void WebFrame::commitProvisionalFrame()
 {
-    RefPtr localFrame = std::exchange(m_provisionalFrame, nullptr);
-    if (!localFrame)
+    RefPtr remoteFrame = coreRemoteFrame();
+    if (!remoteFrame)
         return;
 
-    RefPtr remoteFrame = coreRemoteFrame();
-    if (!remoteFrame) {
+    RefPtr localFrame = remoteFrame->takeProvisionalLocalFrame();
+    if (!localFrame) {
         ASSERT_NOT_REACHED();
         return;
     }
@@ -536,6 +540,12 @@ void WebFrame::commitProvisionalFrame()
 
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
+}
+
+WebCore::LocalFrame* WebFrame::provisionalFrame()
+{
+    RefPtr remoteFrame = coreRemoteFrame();
+    return remoteFrame ? remoteFrame->provisionalLocalFrame() : nullptr;
 }
 
 void WebFrame::removeFromTree()

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -130,7 +130,7 @@ public:
     void commitProvisionalFrame();
     void destroyProvisionalFrame();
     void loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHostingContextIdentifier>);
-    WebCore::LocalFrame* provisionalFrame() { return m_provisionalFrame.get(); }
+    WebCore::LocalFrame* provisionalFrame();
 
     Awaitable<std::optional<FrameInfoData>> getFrameInfo();
     FrameInfoData info(WithCertificateInfo = WithCertificateInfo::No) const;
@@ -297,7 +297,6 @@ private:
 
     WeakPtr<WebCore::Frame> m_coreFrame;
     WeakPtr<WebPage> m_page;
-    RefPtr<WebCore::LocalFrame> m_provisionalFrame;
 
     struct PolicyCheck {
         ForNavigationAction forNavigationAction { ForNavigationAction::No };


### PR DESCRIPTION
#### 393654ae88276dfe5efa368c37751aa3b0bba1f7
<pre>
Refactor ownership of the provisional LocalFrame from WebKit to WebCore
<a href="https://rdar.apple.com/166813534">rdar://166813534</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304429">https://bugs.webkit.org/show_bug.cgi?id=304429</a>

Reviewed by NOBODY (OOPS!).

While committing a frame load in WebCore, the FrameTree is consulted for various operations.

With site isolation on, while committing a frame load that is transitioning from remote to local,
the FrameTree has some things wrong because it hasn&apos;t been updated quite yet.

If WebCore knew about the provisional LocalFrame that was about to be committed, it could get
these things right.

Instead of fixing known site isolation bugs in this patch, let&apos;s make it a 100% refactor,
with bug fixes coming up later.

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::setProvisionalFrame):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::provisionalFrame const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::destroyProvisionalFrame):
(WebKit::WebFrame::commitProvisionalFrame):
(WebKit::WebFrame::provisionalFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebFrame::provisionalFrame): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/393654ae88276dfe5efa368c37751aa3b0bba1f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144096 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89355 "Failed to checkout and rebase branch from PR 55642") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9549a3c0-40e5-4d81-a2eb-9dfedde16a75) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104289 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/89355 "Failed to checkout and rebase branch from PR 55642") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fcd784ad-236c-4b92-99d1-41f13c6b8d4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6861 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85125 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4174 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4687 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8423 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112626 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112973 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6442 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62410 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8471 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->