### PR TITLE
Make CSSRule and children TZone-allocated

### DIFF
--- a/Source/WebCore/css/CSSConditionRule.cpp
+++ b/Source/WebCore/css/CSSConditionRule.cpp
@@ -30,7 +30,11 @@
 #include "config.h"
 #include "CSSConditionRule.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSConditionRule);
 
 CSSConditionRule::CSSConditionRule(StyleRuleGroup& group, CSSStyleSheet* parent)
     : CSSGroupingRule(group, parent)

--- a/Source/WebCore/css/CSSConditionRule.h
+++ b/Source/WebCore/css/CSSConditionRule.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class CSSConditionRule : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSConditionRule);
 public:
     virtual String conditionText() const = 0;
 

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -31,8 +31,11 @@
 #include "GenericMediaQuerySerialization.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSContainerRule);
 
 CSSContainerRule::CSSContainerRule(StyleRuleContainer& rule, CSSStyleSheet* parent)
     : CSSConditionRule(rule, parent)

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleContainer;
 
 class CSSContainerRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSContainerRule);
 public:
     static Ref<CSSContainerRule> create(StyleRuleContainer&, CSSStyleSheet* parent);
 

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -37,8 +37,11 @@
 #include "StylePropertiesInlines.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSCounterStyleRule);
 
 StyleRuleCounterStyle::StyleRuleCounterStyle(const AtomString& name, CSSCounterStyleDescriptors&& descriptors)
     : StyleRuleBase(StyleRuleType::CounterStyle)

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -66,6 +66,7 @@ private:
 };
 
 class CSSCounterStyleRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSCounterStyleRule);
 public:
     static Ref<CSSCounterStyleRule> create(StyleRuleCounterStyle&, CSSStyleSheet*);
     virtual ~CSSCounterStyleRule();

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -29,8 +29,11 @@
 #include "StyleRule.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFaceRule);
 
 CSSFontFaceRule::CSSFontFaceRule(StyleRuleFontFace& fontFaceRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -29,6 +29,7 @@ class CSSFontFaceDescriptors;
 class StyleRuleFontFace;
 
 class CSSFontFaceRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFaceRule);
 public:
     static Ref<CSSFontFaceRule> create(StyleRuleFontFace& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFaceRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -27,8 +27,12 @@
 #include "CSSFontFeatureValuesRule.h"
 
 #include "CSSMarkup.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFeatureValuesRule);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontFeatureValuesBlockRule);
 
 CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& fontFeatureValuesRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class CSSFontFeatureValuesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFeatureValuesRule);
 public:
     static Ref<CSSFontFeatureValuesRule> create(StyleRuleFontFeatureValues& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesRule(rule, sheet)); }
     virtual ~CSSFontFeatureValuesRule() = default;
@@ -68,6 +69,7 @@ private:
 };
 
 class CSSFontFeatureValuesBlockRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontFeatureValuesBlockRule);
 public:
     static Ref<CSSFontFeatureValuesBlockRule> create(StyleRuleFontFeatureValuesBlock& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesBlockRule(rule, sheet)); }
     virtual ~CSSFontFeatureValuesBlockRule() = default;

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -34,8 +34,11 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFontPaletteValuesRule);
 
 CSSFontPaletteValuesRule::CSSFontPaletteValuesRule(StyleRuleFontPaletteValues& fontPaletteValuesRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.h
@@ -34,6 +34,7 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleFontPaletteValues;
 
 class CSSFontPaletteValuesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFontPaletteValuesRule);
 public:
     static Ref<CSSFontPaletteValuesRule> create(StyleRuleFontPaletteValues& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontPaletteValuesRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSFunctionDeclarations.cpp
+++ b/Source/WebCore/css/CSSFunctionDeclarations.cpp
@@ -31,8 +31,11 @@
 #include "MutableStyleProperties.h"
 #include "StylePropertiesInlines.h"
 #include "StyleRuleFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFunctionDeclarations);
 
 CSSFunctionDeclarations::CSSFunctionDeclarations(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSFunctionDeclarations.h
+++ b/Source/WebCore/css/CSSFunctionDeclarations.h
@@ -33,6 +33,7 @@ class CSSFunctionDescriptors;
 class StyleRuleFunctionDeclarations;
 
 class CSSFunctionDeclarations final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFunctionDeclarations);
 public:
     static Ref<CSSFunctionDeclarations> create(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFunctionDeclarations(rule, sheet)); };
 

--- a/Source/WebCore/css/CSSFunctionRule.cpp
+++ b/Source/WebCore/css/CSSFunctionRule.cpp
@@ -28,8 +28,11 @@
 
 #include "CSSMarkup.h"
 #include "StyleRuleFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFunctionRule);
 
 Ref<CSSFunctionRule> CSSFunctionRule::create(StyleRuleFunction& rule, CSSStyleSheet* parent)
 {

--- a/Source/WebCore/css/CSSFunctionRule.h
+++ b/Source/WebCore/css/CSSFunctionRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleFunction;
 
 class CSSFunctionRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSFunctionRule);
 public:
     static Ref<CSSFunctionRule> create(StyleRuleFunction&, CSSStyleSheet* parent);
 

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -37,8 +37,11 @@
 #include "StylePropertiesInlines.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSGroupingRule);
 
 CSSGroupingRule::CSSGroupingRule(StyleRuleGroup& groupRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -32,6 +32,7 @@ class CSSRuleList;
 class StyleRuleGroup;
 
 class CSSGroupingRule : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSGroupingRule);
 public:
     virtual ~CSSGroupingRule();
 

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -32,8 +32,11 @@
 #include "StyleRuleImport.h"
 #include "StyleSheetContents.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSImportRule);
 
 CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -34,6 +34,7 @@ using MediaQueryList = Vector<MediaQuery>;
 }
 
 class CSSImportRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSImportRule);
 public:
     static Ref<CSSImportRule> create(StyleRuleImport& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSImportRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
@@ -27,8 +27,11 @@
 #include "CSSInternalBaseAppearanceRule.h"
 
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSInternalBaseAppearanceRule);
 
 CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
     : CSSGroupingRule(rule, parent)

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleInternalBaseAppearance;
 
 class CSSInternalBaseAppearanceRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSInternalBaseAppearanceRule);
 public:
     static Ref<CSSInternalBaseAppearanceRule> create(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
     {

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -35,8 +35,11 @@
 #include "StylePropertiesInlines.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSKeyframeRule);
 
 void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
 {

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -76,6 +76,7 @@ private:
 };
 
 class CSSKeyframeRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSKeyframeRule);
 public:
     virtual ~CSSKeyframeRule();
 

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -33,8 +33,11 @@
 #include "CSSStyleSheet.h"
 #include "Document.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSKeyframesRule);
 
 StyleRuleKeyframes::StyleRuleKeyframes(const AtomString& name)
     : StyleRuleBase(StyleRuleType::Keyframes)

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -66,6 +66,7 @@ private:
 };
 
 class CSSKeyframesRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSKeyframesRule);
 public:
     static Ref<CSSKeyframesRule> create(StyleRuleKeyframes& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSKeyframesRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -34,8 +34,11 @@
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSLayerBlockRule);
 
 CSSLayerBlockRule::CSSLayerBlockRule(StyleRuleLayer& rule, CSSStyleSheet* parent)
     : CSSGroupingRule(rule, parent)

--- a/Source/WebCore/css/CSSLayerBlockRule.h
+++ b/Source/WebCore/css/CSSLayerBlockRule.h
@@ -39,6 +39,7 @@ class StyleRuleLayer;
 using CascadeLayerName = Vector<AtomString>;
 
 class CSSLayerBlockRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSLayerBlockRule);
 public:
     static Ref<CSSLayerBlockRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
 

--- a/Source/WebCore/css/CSSLayerStatementRule.cpp
+++ b/Source/WebCore/css/CSSLayerStatementRule.cpp
@@ -34,8 +34,11 @@
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSLayerStatementRule);
 
 CSSLayerStatementRule::CSSLayerStatementRule(StyleRuleLayer& rule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSLayerStatementRule.h
+++ b/Source/WebCore/css/CSSLayerStatementRule.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class StyleRuleLayer;
 
 class CSSLayerStatementRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSLayerStatementRule);
 public:
     static Ref<CSSLayerStatementRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
     virtual ~CSSLayerStatementRule();

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -28,8 +28,11 @@
 #include "MediaQueryParser.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSMediaRule);
 
 CSSMediaRule::CSSMediaRule(StyleRuleMedia& mediaRule, CSSStyleSheet* parent)
     : CSSConditionRule(mediaRule, parent)

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -35,6 +35,7 @@ using MediaQueryList = Vector<MediaQuery>;
 }
 
 class CSSMediaRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSMediaRule);
 public:
     static Ref<CSSMediaRule> create(StyleRuleMedia& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSMediaRule(rule, sheet)); }
     virtual ~CSSMediaRule();

--- a/Source/WebCore/css/CSSNamespaceRule.cpp
+++ b/Source/WebCore/css/CSSNamespaceRule.cpp
@@ -29,8 +29,11 @@
 #include "CSSMarkup.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSNamespaceRule);
 
 CSSNamespaceRule::CSSNamespaceRule(StyleRuleNamespace& namespaceRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSNamespaceRule.h
+++ b/Source/WebCore/css/CSSNamespaceRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleNamespace;
 
 class CSSNamespaceRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSNamespaceRule);
 public:
     static Ref<CSSNamespaceRule> create(StyleRuleNamespace& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSNamespaceRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSNestedDeclarations.cpp
+++ b/Source/WebCore/css/CSSNestedDeclarations.cpp
@@ -28,8 +28,11 @@
 #include "StyleRule.h"
 
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSNestedDeclarations);
 
 CSSNestedDeclarations::CSSNestedDeclarations(StyleRuleNestedDeclarations& rule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSNestedDeclarations.h
+++ b/Source/WebCore/css/CSSNestedDeclarations.h
@@ -31,6 +31,7 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleNestedDeclarations;
 
 class CSSNestedDeclarations final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSNestedDeclarations);
 public:
     static Ref<CSSNestedDeclarations> create(StyleRuleNestedDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSNestedDeclarations(rule, sheet)); };
 

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -32,8 +32,11 @@
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
 #include <wtf/text/MakeString.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPageRule);
 
 CSSPageRule::CSSPageRule(StyleRulePage& pageRule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSPageRule.h
+++ b/Source/WebCore/css/CSSPageRule.h
@@ -30,6 +30,7 @@ class CSSStyleSheet;
 class StyleRulePage;
 
 class CSSPageRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPageRule);
 public:
     static Ref<CSSPageRule> create(StyleRulePage& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSPageRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -28,8 +28,11 @@
 
 #include "CSSPositionTryDescriptors.h"
 #include "CSSSerializationContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPositionTryRule);
 
 Ref<StyleRulePositionTry> StyleRulePositionTry::create(AtomString&& name, Ref<StyleProperties>&& properties)
 {

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -57,6 +57,7 @@ private:
 };
 
 class CSSPositionTryRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPositionTryRule);
 public:
     static Ref<CSSPositionTryRule> create(StyleRulePositionTry&, CSSStyleSheet*);
     virtual ~CSSPositionTryRule();

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -31,8 +31,11 @@
 #include "CSSStyleSheet.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSPropertyRule);
 
 CSSPropertyRule::CSSPropertyRule(StyleRuleProperty& rule, CSSStyleSheet* parent)
     : CSSRule(parent)

--- a/Source/WebCore/css/CSSPropertyRule.h
+++ b/Source/WebCore/css/CSSPropertyRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleProperty;
 
 class CSSPropertyRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSPropertyRule);
 public:
     static Ref<CSSPropertyRule> create(StyleRuleProperty&, CSSStyleSheet* parent);
     virtual ~CSSPropertyRule();

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -28,8 +28,11 @@
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
 #include "css/parser/CSSParserEnum.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSRule);
 
 struct SameSizeAsCSSRule : public RefCountedAndCanMakeWeakPtr<SameSizeAsCSSRule> {
     virtual ~SameSizeAsCSSRule();

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -43,6 +43,7 @@ struct SerializationContext;
 }
 
 class CSSRule : public RefCountedAndCanMakeWeakPtr<CSSRule> {
+    WTF_MAKE_TZONE_ALLOCATED(CSSRule);
 public:
     virtual ~CSSRule() = default;
 

--- a/Source/WebCore/css/CSSScopeRule.cpp
+++ b/Source/WebCore/css/CSSScopeRule.cpp
@@ -28,8 +28,11 @@
 
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSScopeRule);
 
 CSSScopeRule::CSSScopeRule(StyleRuleScope& rule, CSSStyleSheet* parent)
     : CSSGroupingRule(rule, parent)

--- a/Source/WebCore/css/CSSScopeRule.h
+++ b/Source/WebCore/css/CSSScopeRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleScope;
 
 class CSSScopeRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSScopeRule);
 public:
     static Ref<CSSScopeRule> create(StyleRuleScope&, CSSStyleSheet* parent);
 

--- a/Source/WebCore/css/CSSStartingStyleRule.cpp
+++ b/Source/WebCore/css/CSSStartingStyleRule.cpp
@@ -27,8 +27,11 @@
 #include "CSSStartingStyleRule.h"
 
 #include "StyleRule.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSStartingStyleRule);
 
 CSSStartingStyleRule::CSSStartingStyleRule(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
     : CSSGroupingRule(rule, parent)

--- a/Source/WebCore/css/CSSStartingStyleRule.h
+++ b/Source/WebCore/css/CSSStartingStyleRule.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class StyleRuleStartingStyle;
 
 class CSSStartingStyleRule final : public CSSGroupingRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSStartingStyleRule);
 public:
     static Ref<CSSStartingStyleRule> create(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
     {

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -38,8 +38,11 @@
 #include "StyleSheetContents.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSStyleRule);
 
 typedef HashMap<const CSSStyleRule*, String> SelectorTextCache;
 static SelectorTextCache& selectorTextCache()

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -36,6 +36,7 @@ class StyleRuleWithNesting;
 class StyleRuleCSSStyleProperties;
 
 class CSSStyleRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSStyleRule);
 public:
     static Ref<CSSStyleRule> create(StyleRule& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSStyleRule(rule, sheet)); }
     static Ref<CSSStyleRule> create(StyleRuleWithNesting& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSStyleRule(rule, sheet)); };

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -35,8 +35,11 @@
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSupportsRule);
 
 CSSSupportsRule::CSSSupportsRule(StyleRuleSupports& rule, CSSStyleSheet* parent)
     : CSSConditionRule(rule, parent)

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -37,6 +37,7 @@ namespace WebCore {
 class StyleRuleSupports;
 
 class CSSSupportsRule final : public CSSConditionRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSSupportsRule);
 public:
     static Ref<CSSSupportsRule> create(StyleRuleSupports&, CSSStyleSheet* parent);
 

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -35,8 +35,11 @@
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSViewTransitionRule);
 
 static std::optional<ViewTransitionNavigation> toViewTransitionNavigationEnum(RefPtr<CSSValue> navigation)
 {

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -57,6 +57,7 @@ private:
 };
 
 class CSSViewTransitionRule final : public CSSRule {
+    WTF_MAKE_TZONE_ALLOCATED(CSSViewTransitionRule);
 public:
     using ViewTransitionNavigation = WebCore::ViewTransitionNavigation;
 


### PR DESCRIPTION
#### b9d25f5f2dea06c8b12936e67c0f3704b72082ef
<pre>
Make CSSRule and children TZone-allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=304432">https://bugs.webkit.org/show_bug.cgi?id=304432</a>
&lt;<a href="https://rdar.apple.com/problem/166816539">rdar://problem/166816539</a>&gt;

Reviewed by NOBODY (OOPS!).

These classes predate adopting WebKit memory managers. We should incorporate them into the zone allocator.

* Source/WebCore/css/CSSConditionRule.cpp:
* Source/WebCore/css/CSSConditionRule.h:
* Source/WebCore/css/CSSContainerRule.cpp:
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSFontFaceRule.cpp:
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
* Source/WebCore/css/CSSFontPaletteValuesRule.h:
* Source/WebCore/css/CSSFunctionDeclarations.cpp:
* Source/WebCore/css/CSSFunctionDeclarations.h:
* Source/WebCore/css/CSSFunctionRule.cpp:
* Source/WebCore/css/CSSFunctionRule.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSImportRule.cpp:
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp:
* Source/WebCore/css/CSSInternalBaseAppearanceRule.h:
* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.cpp:
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSLayerBlockRule.cpp:
* Source/WebCore/css/CSSLayerBlockRule.h:
* Source/WebCore/css/CSSLayerStatementRule.cpp:
* Source/WebCore/css/CSSLayerStatementRule.h:
* Source/WebCore/css/CSSMediaRule.cpp:
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSNamespaceRule.cpp:
* Source/WebCore/css/CSSNamespaceRule.h:
* Source/WebCore/css/CSSNestedDeclarations.cpp:
* Source/WebCore/css/CSSNestedDeclarations.h:
* Source/WebCore/css/CSSPageRule.cpp:
* Source/WebCore/css/CSSPageRule.h:
* Source/WebCore/css/CSSPositionTryRule.cpp:
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSPropertyRule.cpp:
* Source/WebCore/css/CSSPropertyRule.h:
* Source/WebCore/css/CSSRule.cpp:
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSScopeRule.cpp:
* Source/WebCore/css/CSSScopeRule.h:
* Source/WebCore/css/CSSStartingStyleRule.cpp:
* Source/WebCore/css/CSSStartingStyleRule.h:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSSupportsRule.cpp:
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
* Source/WebCore/css/CSSViewTransitionRule.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d25f5f2dea06c8b12936e67c0f3704b72082ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89314 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d38bf0e-7560-446e-93fc-d27a29f3675e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104251 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/74878 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e54c3c89-eeb6-4271-a241-e5e0b60d7a03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85085 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4143 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146799 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8382 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112590 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112934 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6409 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36528 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->