### PR TITLE
Try enabling Swift IPC layout test

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -420,6 +420,18 @@ GENERATE_SINGLE_SWIFT_INTEROP_FILE = $(GENERATE_SINGLE_SWIFT_INTEROP_FILE_$(WK_G
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_ = ;
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_YES = GENERATE_SINGLE_SWIFT_INTEROP_FILE;
 
+// If (and only if) we've enabled IPC testing (on ASAN and debug builds, typically)
+// also enable testing of a Swift IPC receiver - but only if we're using a sufficiently
+// recent SDK.
+ENABLE_IPC_TESTING_SWIFT = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx*] = ENABLE_IPC_TESTING_SWIFT;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx14*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx15*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.0*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.1*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.2*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.3*] = ;
+
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
 OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)) $(OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_$(WK_GENERATE_SINGLE_SWIFT_INTEROP_FILE);


### PR DESCRIPTION
#### 87f1e8bbfc896fd935221e492039fc271fdb7cbb
<pre>
Try enabling Swift IPC layout test
<a href="https://bugs.webkit.org/show_bug.cgi?id=304433">https://bugs.webkit.org/show_bug.cgi?id=304433</a>
<a href="https://rdar.apple.com/166293273">rdar://166293273</a>

Reviewed by Elliott Williams.

This commit endeavours to enable a Swift CoreIPC message receiver test on a
very small permutation of platforms:

* Debug or ASAN or anything else where IPC tests are explicitly enabled;
* MacOS only;
* The most recent SDKs only.

Any such EWS builders matching that description will then run the layout
test in a mode where a Swift CoreIPC receiver is tested. This will be the
first time any builder has built any Swift into the main WebKit target.

It&apos;s possible that no builders yet exist matching this description, or
that only Apple internal builders match this description.

Canonical link: <a href="https://commits.webkit.org/305532@main">https://commits.webkit.org/305532@main</a>
</pre>
