### PR TITLE
Dragging a selection into a pseudo element results in incorrect selection of the host element.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
@@ -2,8 +2,8 @@ helloworld
 helloworld
 helloworld
 
-FAIL Selection ending in ::before assert_equals: toString expected "hello" but got "o"
-FAIL Selection contained in ::before assert_equals: toString expected "" but got "llo"
+PASS Selection ending in ::before
+PASS Selection contained in ::before
 PASS Selection ending in ::marker
 PASS Selection contained in ::marker
 FAIL Selection ending in ::before-marker assert_equals: toString expected "hello" but got "o"

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -206,6 +206,11 @@ LocalFrame* HitTestResult::innerNodeFrame() const
     return 0;
 }
 
+void HitTestResult::setLocalPoint(const LayoutPoint& p)
+{
+    m_localPoint = m_pseudoElementIdentifier ? LayoutPoint() : p;
+}
+
 std::optional<Style::PseudoElementIdentifier> HitTestResult::pseudoElementIdentifier() const
 {
     return m_pseudoElementIdentifier;

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -99,7 +99,7 @@ public:
 
     // The hit-tested point in the coordinates of the inner node.
     const LayoutPoint& localPoint() const { return m_localPoint; }
-    void setLocalPoint(const LayoutPoint& p) { m_localPoint = p; }
+    void setLocalPoint(const LayoutPoint&);
 
     WEBCORE_EXPORT void setToNonUserAgentShadowAncestor();
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1887,8 +1887,8 @@ void RenderObject::updateHitTestResult(HitTestResult& result, const LayoutPoint&
         result.setInnerNode(node.get());
         if (!result.innerNonSharedNode())
             result.setInnerNonSharedNode(node.get());
-        result.setLocalPoint(point);
         result.setPseudoElementIdentifier(style().pseudoElementIdentifier());
+        result.setLocalPoint(point);
     }
 }
 


### PR DESCRIPTION
#### 7bfe33497d6e15b8511f36daea4677daa11ec92c
<pre>
Dragging a selection into a pseudo element results in incorrect selection of the host element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304434">https://bugs.webkit.org/show_bug.cgi?id=304434</a>
<a href="https://rdar.apple.com/142905243">rdar://142905243</a>

Reviewed by Tim Nguyen.

We do not support selection in pseudo elements.
So when we drag a selection across a pseudo element,
and we set the inner node for the hit test, if
it is a pseudo element, we set the node to the
host element instead. However, when we do this,
we did nothing to set the localPoint in that element
to something that made sense.

In the following illustration, &apos;Pseudo&apos; is a pseudo
element, &apos;Element&apos; is the host element that is a
regular div otherwise.

Pseudo Element
  ^      ^
  |      |
When the cursor is at &apos;e&apos; in Pseudo, and the element is
reset, the cursor is then effectively at the second &apos;e&apos;
in Element.
If you started your selection after the first
&apos;E&apos; and dragged backwards, once you reached the &apos;e&apos; in
Pseudo, you selection would be &apos;le&apos;, not just the first
&apos;E&apos; as you would expect.

To avoid this issue, when setting the local point
we check to see if the pseudo element identifier has been
set, and if so, we zero out the point instead of using the
offset that is not longer applicable.

Progressed imported/w3c/web-platform-tests/css/css-pseudo/text-selection.html

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::setLocalPoint):
* Source/WebCore/rendering/HitTestResult.h:
(WebCore::HitTestResult::setLocalPoint): Deleted.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::updateHitTestResult const):

Canonical link: <a href="https://commits.webkit.org/304719@main">https://commits.webkit.org/304719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0691bd49f6a6b16db4eefd6776306989535a95e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144075 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a505f788-3608-408b-9e58-34704de5ea71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/884266c9-e63c-4ebb-8908-ece1eec4785f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85105 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19e78e45-53c0-49cd-b016-3540cf5f48ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4156 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4666 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146819 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6425 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118488 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8450 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36543 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->