### PR TITLE
Update style script to encourage the use of `WTF::move()` directly

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2786,7 +2786,7 @@ def check_wtf_checked_size(clean_lines, line_number, file_state, error):
 
 
 def check_wtf_move(clean_lines, line_number, file_state, error):
-    """Looks for use of 'std::move()' which should be replaced with 'WTFMove()'.
+    """Looks for use of 'std::move()' and `WTFMove` which should be replaced with 'WTF::move()'.
 
     Args:
       clean_lines: A CleansedLines instance containing the file.
@@ -2803,11 +2803,11 @@ def check_wtf_move(clean_lines, line_number, file_state, error):
     line = clean_lines.elided[line_number]  # Get rid of comments and strings.
 
     using_std_move = search(r'\bstd::move\s*\(', line)
-    if not using_std_move:
-        return
-
-    error(line_number, 'runtime/wtf_move', 4, "Use 'WTFMove()' instead of 'std::move()'.")
-
+    if using_std_move:
+        error(line_number, 'runtime/wtf_move', 4, "Use 'WTF::move()' instead of 'std::move()'.")
+    using_wtfmove = search(r'\bWTFMove\s*\(', line)
+    if using_wtfmove:
+        error(line_number, 'runtime/wtf_move', 4, "Use 'WTF::move()' instead of 'WTFMove()'.")
 
 def check_unsafe_get(clean_lines, line_number, file_state, error):
     """Looks for use of 'unsafeGet()' or 'unsafePtr()' which should be avoided.

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1602,7 +1602,7 @@ class CppStyleTest(CppStyleTestBase):
             'void f()\n'
             '{\n'
             '    if (auto createdHandle = SandboxExtension::createHandle(URL.fileSystemPath(), SandboxExtension::Type::ReadWrite))\n'
-            '        handle = WTFMove(*createdHandle);\n'
+            '        handle = WTF::move(*createdHandle);\n'
             '    else\n'
             '        ASSERT_NOT_REACHED();\n\n'
             '    m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, URL, handle), 0);]\n'
@@ -1615,7 +1615,7 @@ class CppStyleTest(CppStyleTestBase):
             'void f()\n'
             '{\n'
             '    if (auto createdHandle = SandboxExtension::createHandle(URL.fileSystemPath(), SandboxExtension::Type::ReadWrite))\n'
-            '        handle = WTFMove(*createdHandle);\n'
+            '        handle = WTF::move(*createdHandle);\n'
             '    else\n'
             '        RELEASE_ASSERT_NOT_REACHED();\n\n'
             '    m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, URL, handle), 0);]\n'
@@ -4935,8 +4935,8 @@ class WebKitStyleTest(CppStyleTestBase):
             'Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeallocator, Vector<Attachment>&& attachments)\n'
             '    : m_buffer { buffer }\n'
             '    , m_bufferPosition { m_buffer.begin() }\n'
-            '    , m_bufferDeallocator { WTFMove(bufferDeallocator) }\n'
-            '    , m_attachments { WTFMove(attachments) }\n'
+            '    , m_bufferDeallocator { WTF::move(bufferDeallocator) }\n'
+            '    , m_attachments { WTF::move(attachments) }\n'
             '{ }',
             '',
             'Decoder.cpp')
@@ -6071,19 +6071,25 @@ class WebKitStyleTest(CppStyleTestBase):
 
     def test_wtf_move(self):
         self.assert_lint(
-             'A a = WTFMove(b);',
-             '',
-             'foo.cpp')
+            'A a = WTF::move(b);',
+            '',
+            'foo.cpp')
 
         self.assert_lint(
-            'A a = std::move(b);',
-            "Use 'WTFMove()' instead of 'std::move()'."
+            'A a = WTFMove(b);',
+            "Use 'WTF::move()' instead of 'WTFMove()'."
             "  [runtime/wtf_move] [4]",
             'foo.cpp')
 
         self.assert_lint(
             'A a = std::move(b);',
-            "Use 'WTFMove()' instead of 'std::move()'."
+            "Use 'WTF::move()' instead of 'std::move()'."
+            "  [runtime/wtf_move] [4]",
+            'foo.cpp')
+
+        self.assert_lint(
+            'A a = std::move(b);',
+            "Use 'WTF::move()' instead of 'std::move()'."
             "  [runtime/wtf_move] [4]",
             'foo.mm')
 


### PR DESCRIPTION
#### f6d22fb9c683271e4a7f44bc616d423aac326b08
<pre>
Update style script to encourage the use of `WTF::move()` directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=304451">https://bugs.webkit.org/show_bug.cgi?id=304451</a>

Reviewed by Geoffrey Garen.

Update style script to encourage the use of `WTF::move()` directly,
instead of `WTFMove()`. This is in preparation for the removal of the
`WTFMove()` macro which doesn&apos;t add much value after 304711@main.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_wtf_move):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
(WebKitStyleTest.test_indentation):
(WebKitStyleTest.test_wtf_move):

Canonical link: <a href="https://commits.webkit.org/304725@main">https://commits.webkit.org/304725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd8b82aa3cbce69cc69710a571002a92e51f4d21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144087 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/719fcc98-c759-4f20-8fe4-f4809a069f59) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c63a727-7a34-4d20-b231-582387bf4f8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85117 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8036ec9-652e-452f-876c-cda9705b8ce0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135722 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6510 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4170 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4678 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146831 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112617 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6446 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118503 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8462 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36558 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->