### PR TITLE
[JSC] Add more tests for same-sized JSBigInt div / mod

### DIFF
--- a/JSTests/stress/bigint-div-same-size.js
+++ b/JSTests/stress/bigint-div-same-size.js
@@ -1,0 +1,50 @@
+var data = [{
+  a: 1n << 63n,
+  b: 2n,
+  r: 0x4000000000000000n,
+}, {
+  a: -(1n << 63n),
+  b: 2n,
+  r: -0x4000000000000000n,
+},{
+  a: 1n << 127n,
+  b: 1n << 64n,
+  r: 0x8000000000000000n,
+}, {
+  a: -(1n << 127n),
+  b: 1n << 64n,
+  r: -0x8000000000000000n,
+},{
+  a: (1n << 128n) - 1n,
+  b: 1n << 64n,
+  r: 0xffffffffffffffffn,
+}, {
+  a: -((1n << 128n) - 1n),
+  b: 1n << 64n,
+  r: -0xffffffffffffffffn,
+},{
+  a: (1n << 192n) - 1n,
+  b: 1n << 128n,
+  r: 0xffffffffffffffffn,
+}, {
+  a: -((1n << 192n) - 1n),
+  b: 1n << 128n,
+  r: -0xffffffffffffffffn,
+}];
+
+var error_count = 0;
+for (var i = 0; i < data.length; i++) {
+  var d = data[i];
+  var r = d.a / d.b;
+  if (d.r !== r) {
+    print("Input A:  " + d.a.toString(16));
+    print("Input B:  " + d.b.toString(16));
+    print("Result:   " + r.toString(16));
+    print("Expected: " + d.r);
+    print("Op: /");
+    error_count++;
+  }
+}
+if (error_count !== 0)
+  throw new Error("Finished with " + error_count + " errors.")
+

--- a/JSTests/stress/bigint-mod-same-size.js
+++ b/JSTests/stress/bigint-mod-same-size.js
@@ -1,0 +1,50 @@
+var data = [{
+  a: 1n << 63n,
+  b: 2n,
+  r: 0n,
+}, {
+  a: -(1n << 63n),
+  b: 2n,
+  r: 0n,
+},{
+  a: 1n << 127n,
+  b: 1n << 64n,
+  r: 0n,
+}, {
+  a: -(1n << 127n),
+  b: 1n << 64n,
+  r: 0n,
+},{
+  a: (1n << 128n) - 1n,
+  b: 1n << 64n,
+  r: 0xffffffffffffffffn,
+}, {
+  a: -((1n << 128n) - 1n),
+  b: 1n << 64n,
+  r: -0xffffffffffffffffn,
+},{
+  a: (1n << 192n) - 1n,
+  b: 1n << 128n,
+  r: 0xffffffffffffffffffffffffffffffffn,
+}, {
+  a: -((1n << 192n) - 1n),
+  b: 1n << 128n,
+  r: -0xffffffffffffffffffffffffffffffffn,
+}];
+
+var error_count = 0;
+for (var i = 0; i < data.length; i++) {
+  var d = data[i];
+  var r = d.a % d.b;
+  if (d.r !== r) {
+    print("Input A:  " + d.a.toString(16));
+    print("Input B:  " + d.b.toString(16));
+    print("Result:   " + r.toString(16));
+    print("Expected: " + d.r);
+    print("Op: /");
+    error_count++;
+  }
+}
+if (error_count !== 0)
+  throw new Error("Finished with " + error_count + " errors.")
+


### PR DESCRIPTION
#### 98a4dabe644aeef11036bc008c4848d22cf06ca3
<pre>
[JSC] Add more tests for same-sized JSBigInt div / mod
<a href="https://bugs.webkit.org/show_bug.cgi?id=304452">https://bugs.webkit.org/show_bug.cgi?id=304452</a>
<a href="https://rdar.apple.com/166831531">rdar://166831531</a>

Reviewed by Keith Miller.

Follow-up change from the previous change. Add more same-sized div / mod
edge cases.

* JSTests/stress/bigint-div-same-size.js: Added.
* JSTests/stress/bigint-mod-same-size.js: Added.

Canonical link: <a href="https://commits.webkit.org/304716@main">https://commits.webkit.org/304716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/670b53ccfc8ea46090ef721af27b02b15ae703ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144090 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a1f9036-d711-4abd-93b1-3973515eba87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd50be6f-cfdb-4bbc-977b-eb4e22be4206) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6865 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c370da6-98de-4bbb-8de2-58c5b56feddd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4681 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128335 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146834 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134862 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40970 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8434 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112967 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6436 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118505 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21020 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8465 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36559 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8183 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43730 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->