### PR TITLE
Re-land [Swift in WebKit] Fix the modularization of WebGPU (part 1)

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		075BAABA2EEFBCA2008765CE /* WGPUBufferImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BAAB92EEFBCA2008765CE /* WGPUBufferImpl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		075BAABC2EEFC6B4008765CE /* WGPUTextureImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BAABB2EEFC6B4008765CE /* WGPUTextureImpl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		075BAABE2EEFCA9C008765CE /* WGPUTextureViewImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BAABD2EEFCA9C008765CE /* WGPUTextureViewImpl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		075BAAC02EEFCAE1008765CE /* WGPUQuerySetImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 075BAABF2EEFCAE1008765CE /* WGPUQuerySetImpl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07662ED72EEB9E6B006C3698 /* Adapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACAB2273A426D0095F8D5 /* Adapter.h */; };
+		079861942EF13A1100659042 /* CxxBridgingPublic.h in Headers */ = {isa = PBXBuildFile; fileRef = 079861932EF13A1100659042 /* CxxBridgingPublic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		07D2916D2EC9C4D200A32120 /* CxxBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 07D2916C2EC9C4D200A32120 /* CxxBridging.h */; };
 		07D2916E2EC9C7A400A32120 /* ComputePassEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACAAA273A426D0095F8D5 /* ComputePassEncoder.h */; };
 		07D2916F2EC9CE9F00A32120 /* IsValidToUseWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C33755D27FA23B8002F1644 /* IsValidToUseWith.h */; };
@@ -317,6 +323,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		075BAAB92EEFBCA2008765CE /* WGPUBufferImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WGPUBufferImpl.h; sourceTree = "<group>"; };
+		075BAABB2EEFC6B4008765CE /* WGPUTextureImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WGPUTextureImpl.h; sourceTree = "<group>"; };
+		075BAABD2EEFCA9C008765CE /* WGPUTextureViewImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WGPUTextureViewImpl.h; sourceTree = "<group>"; };
+		075BAABF2EEFCAE1008765CE /* WGPUQuerySetImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WGPUQuerySetImpl.h; sourceTree = "<group>"; };
+		079861932EF13A1100659042 /* CxxBridgingPublic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CxxBridgingPublic.h; sourceTree = "<group>"; };
 		07D2916C2EC9C4D200A32120 /* CxxBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CxxBridging.h; sourceTree = "<group>"; };
 		0D078E8F2E737C0500A9B266 /* DDMesh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DDMesh.h; sourceTree = "<group>"; };
 		0D078E902E737C0500A9B266 /* DDMesh.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DDMesh.mm; sourceTree = "<group>"; };
@@ -682,6 +693,7 @@
 				1C5ACAA2273A426D0095F8D5 /* ComputePipeline.mm */,
 				1CEBD80A2716C36C00A5254D /* config.h */,
 				07D2916C2EC9C4D200A32120 /* CxxBridging.h */,
+				079861932EF13A1100659042 /* CxxBridgingPublic.h */,
 				0D078E8F2E737C0500A9B266 /* DDMesh.h */,
 				0D078E902E737C0500A9B266 /* DDMesh.mm */,
 				0DACD85A2E79E66F00CDA0DC /* DDModelTypes.h */,
@@ -733,6 +745,10 @@
 				1CC0C8C9273A7D8900D0B481 /* WebGPU.modulemap */,
 				1C5ACAD2273A4C860095F8D5 /* WebGPUExt.h */,
 				1CA7CDB12A2B284A0094071F /* WebGPUInternal.h */,
+				075BAAB92EEFBCA2008765CE /* WGPUBufferImpl.h */,
+				075BAABF2EEFCAE1008765CE /* WGPUQuerySetImpl.h */,
+				075BAABB2EEFC6B4008765CE /* WGPUTextureImpl.h */,
+				075BAABD2EEFCA9C008765CE /* WGPUTextureViewImpl.h */,
 				0D943C0D2C6571BC00D33BA5 /* XRBinding.h */,
 				0D943C0E2C6571BC00D33BA5 /* XRBinding.mm */,
 				0DD5FD332C66947B004AF552 /* XRProjectionLayer.h */,
@@ -997,6 +1013,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CEBD7E72716AFBA00A5254D /* WebGPU.h in Headers */,
+				07662ED72EEB9E6B006C3698 /* Adapter.h in Headers */,
 				07D291702EC9CEC400A32120 /* APIConversions.h in Headers */,
 				07D291712EC9CEC800A32120 /* BindableResource.h in Headers */,
 				07D291722EC9CECC00A32120 /* BindGroup.h in Headers */,
@@ -1008,6 +1025,7 @@
 				07D2916E2EC9C7A400A32120 /* ComputePassEncoder.h in Headers */,
 				07D291752EC9CEDF00A32120 /* ComputePipeline.h in Headers */,
 				07D2916D2EC9C4D200A32120 /* CxxBridging.h in Headers */,
+				079861942EF13A1100659042 /* CxxBridgingPublic.h in Headers */,
 				0D078E922E737C0500A9B266 /* DDMesh.h in Headers */,
 				0DACD85B2E79E66F00CDA0DC /* DDModelTypes.h in Headers */,
 				941C64B72CAB4A0700A63214 /* Device.h in Headers */,
@@ -1035,6 +1053,10 @@
 				07D291822EC9CF2A00A32120 /* TextureView.h in Headers */,
 				1C5ACAD3273A4C860095F8D5 /* WebGPUExt.h in Headers */,
 				07D291832EC9CF3100A32120 /* WebGPUInternal.h in Headers */,
+				075BAABA2EEFBCA2008765CE /* WGPUBufferImpl.h in Headers */,
+				075BAAC02EEFCAE1008765CE /* WGPUQuerySetImpl.h in Headers */,
+				075BAABC2EEFC6B4008765CE /* WGPUTextureImpl.h in Headers */,
+				075BAABE2EEFCA9C008765CE /* WGPUTextureViewImpl.h in Headers */,
 				0D943C0F2C6571BC00D33BA5 /* XRBinding.h in Headers */,
 				0DD5FD352C66947B004AF552 /* XRProjectionLayer.h in Headers */,
 				0D943C242C65E46400D33BA5 /* XRSubImage.h in Headers */,

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -26,10 +26,12 @@
 #pragma once
 
 #import "BindableResource.h"
+#import "Device.h"
 #import "Instance.h"
-#import "WebGPU.h"
-#import "WebGPUExt.h"
 #import <Metal/Metal.h>
+#import <WebGPU/WGPUBufferImpl.h>
+#import <WebGPU/WebGPU.h>
+#import <WebGPU/WebGPUExt.h>
 #import <utility>
 #import <wtf/Compiler.h>
 #import <wtf/CompletionHandler.h>
@@ -45,11 +47,6 @@
 #import <wtf/WeakPtr.h>
 
 IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
-
-// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
-// annotating incomplete types
-struct SWIFT_SHARED_REFERENCE(wgpuBufferReference, wgpuBufferRelease) WGPUBufferImpl {
-};
 
 namespace WebGPU {
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -36,6 +36,9 @@
 
 #if ENABLE(WEBGPU_SWIFT)
 #import "CxxBridging.h"
+#import <WebGPU/CxxBridgingPublic.h>
+#import <WebGPU/WGPUTextureImpl.h>
+#import <WebGPU/WebGPU.h>
 #import "WebGPUSwift-Generated.h"
 
 DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, copyFrom, void, const std::span<const uint8_t>, const size_t);

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -36,20 +36,24 @@ extension WebGPU.Buffer {
 }
 
 // FIXME(emw): Find a way to generate thunks like these, maybe via a macro?
+// FIXME: Eventually all these "thunks" should be removed.
+// swift-format-ignore: AlwaysUseLowerCamelCase
 @_expose(Cxx)
-public func Buffer_copyFrom_thunk(_ buffer: WebGPU.Buffer, from data: SpanConstUInt8, offset: Int) {
+public func Buffer_copyFrom_thunk(_ buffer: WebGPU.Buffer, from data: WebGPU.SpanConstUInt8, offset: Int) {
     buffer.copy(from: unsafe Span<UInt8>(_unsafeCxxSpan: data), offset: offset)
 }
 
+// FIXME: Eventually all these "thunks" should be removed.
+// swift-format-ignore: AlwaysUseLowerCamelCase
 @_expose(Cxx)
-public func Buffer_getMappedRange_thunk(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> SpanUInt8 {
+public func Buffer_getMappedRange_thunk(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> WebGPU.SpanUInt8 {
     unsafe buffer.getMappedRange(offset: offset, size: size)
 }
 
 extension WebGPU.Buffer {
-    func getMappedRange(offset: Int, size: Int) -> SpanUInt8 {
+    func getMappedRange(offset: Int, size: Int) -> WebGPU.SpanUInt8 {
         if !isValid() {
-            return unsafe SpanUInt8()
+            return unsafe WebGPU.SpanUInt8()
         }
 
         var rangeSize = size
@@ -58,14 +62,14 @@ extension WebGPU.Buffer {
         }
 
         if !validateGetMappedRange(offset, rangeSize) {
-            return unsafe SpanUInt8()
+            return unsafe WebGPU.SpanUInt8()
         }
 
         m_mappedRanges.add(.init(UInt(offset), UInt(offset + rangeSize)))
         m_mappedRanges.compact()
 
         if m_buffer.storageMode == .private || m_buffer.storageMode == .memoryless || m_buffer.length == 0 {
-            return unsafe SpanUInt8()
+            return unsafe WebGPU.SpanUInt8()
         }
 
         return unsafe getBufferContents().subspan(offset, rangeSize)

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import <Metal/Metal.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -28,8 +28,9 @@
 #import "BindableResource.h"
 #import "CommandBuffer.h"
 #import "CommandsMixin.h"
-#import "WebGPU.h"
-#import "WebGPUExt.h"
+#import "Device.h"
+#import <WebGPU/WebGPU.h>
+#import <WebGPU/WebGPUExt.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
 #import <wtf/Ref.h>
@@ -60,7 +61,6 @@ class BindGroup;
 class Buffer;
 class CommandBuffer;
 class ComputePassEncoder;
-class Device;
 class ExternalTexture;
 class QuerySet;
 class RenderPassEncoder;
@@ -189,7 +189,7 @@ private:
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
     NSMutableSet<id<MTLTexture>> * _Nullable m_managedTextures { nil };
     NSMutableSet<id<MTLBuffer>> * _Nullable m_managedBuffers { nil };
-#endif
+#endif // CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
 private:
     NSMutableSet<id<MTLIndirectCommandBuffer>> * _Nullable m_retainedICBs { nil };
     NSMutableSet<id<MTLTexture>> * _Nullable m_retainedTextures { nil };

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -38,6 +38,9 @@
 #import "TextureOrTextureView.h"
 #if ENABLE(WEBGPU_SWIFT)
 #import "CxxBridging.h"
+#import <WebGPU/CxxBridgingPublic.h>
+#import <WebGPU/WGPUTextureImpl.h>
+#import <WebGPU/WebGPU.h>
 #import "WebGPUSwift-Generated.h"
 #endif
 #import <wtf/CheckedArithmetic.h>

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -25,16 +25,31 @@
 
 import Metal
 import WebGPU_Internal
+
 public typealias WTFString = String
 public typealias String = Swift.String
 
+// FIXME: Eventually all these "thunks" should be removed.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 public func clearBuffer(
-    commandEncoder: WebGPU.CommandEncoder, buffer: WebGPU.Buffer, offset: UInt64, size: inout UInt64
+    commandEncoder: WebGPU.CommandEncoder,
+    buffer: WebGPU.Buffer,
+    offset: UInt64,
+    size: inout UInt64
 ) {
     commandEncoder.clearBuffer(buffer: buffer, offset: offset, size: &size)
 }
-public func resolveQuerySet(commandEncoder: WebGPU.CommandEncoder, querySet: WebGPU.QuerySet, firstQuery: UInt32, queryCount:UInt32, destination: WebGPU.Buffer, destinationOffset: UInt64)
-{
+
+// FIXME: Eventually all these "thunks" should be removed.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+public func resolveQuerySet(
+    commandEncoder: WebGPU.CommandEncoder,
+    querySet: WebGPU.QuerySet,
+    firstQuery: UInt32,
+    queryCount: UInt32,
+    destination: WebGPU.Buffer,
+    destinationOffset: UInt64
+) {
     commandEncoder.resolveQuerySet(querySet, firstQuery: firstQuery, queryCount: queryCount, destination: destination, destinationOffset: destinationOffset)
 }
 
@@ -66,7 +81,14 @@ public func CommandEncoder_copyTextureToTexture_thunk(commandEncoder: WebGPU.Com
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_copyBufferToBuffer_thunk(commandEncoder: WebGPU.CommandEncoder, source: WebGPU.Buffer, sourceOffset: UInt64, destination: WebGPU.Buffer, destinationOffset: UInt64, size: UInt64) {
+public func CommandEncoder_copyBufferToBuffer_thunk(
+    commandEncoder: WebGPU.CommandEncoder,
+    source: WebGPU.Buffer,
+    sourceOffset: UInt64,
+    destination: WebGPU.Buffer,
+    destinationOffset: UInt64,
+    size: UInt64
+) {
     commandEncoder.copyBufferToBuffer(source: source, sourceOffset: sourceOffset, destination: destination, destinationOffset: destinationOffset, size: size)
 }
 
@@ -256,16 +278,21 @@ extension WebGPU.CommandEncoder {
 
         return result
     }
+
     public func clearTextureIfNeeded(destination: WGPUImageCopyTexture, slice: UInt) {
-        return WebGPU.CommandEncoder.clearTextureIfNeeded(destination, slice, m_device.ptr(), m_blitCommandEncoder)
+        WebGPU.CommandEncoder.clearTextureIfNeeded(destination, slice, m_device.ptr(), m_blitCommandEncoder)
     }
-    private func clearTextureIfNeeded(destination: WGPUImageCopyTexture , slice: UInt, device: WebGPU.Device , blitCommandEncoder: MTLBlitCommandEncoder?)
-    {
+
+    private func clearTextureIfNeeded(
+        destination: WGPUImageCopyTexture,
+        slice: UInt,
+        device: WebGPU.Device,
+        blitCommandEncoder: MTLBlitCommandEncoder?
+    ) {
         let texture = WebGPU.fromAPI(destination.texture)
         let mipLevel: UInt = UInt(destination.mipLevel)
         clearTextureIfNeeded(texture, mipLevel, slice, device, blitCommandEncoder)
     }
-
 
     private func clearTextureIfNeeded(
         _ texture: WebGPU.Texture,

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#import "CommandEncoder.h"
 #import "CommandsMixin.h"
-#import "WebGPU.h"
-#import "WebGPUExt.h"
+#import <WebGPU/WebGPU.h>
+#import <WebGPU/WebGPUExt.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/Ref.h>
@@ -44,7 +45,6 @@ namespace WebGPU {
 
 class BindGroup;
 class Buffer;
-class CommandEncoder;
 class ComputePipeline;
 class Device;
 class QuerySet;

--- a/Source/WebGPU/WebGPU/CxxBridging.h
+++ b/Source/WebGPU/WebGPU/CxxBridging.h
@@ -31,9 +31,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/Ref.h>
 
-using SpanConstUInt8 = std::span<const uint8_t>;
-using SpanUInt8 = std::span<uint8_t>;
-
 inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo(x, y); }
 inline uint32_t roundUpToMultipleOfNonPowerOfTwoUInt32UInt32(uint32_t a, uint32_t b) { return WTF::roundUpToMultipleOfNonPowerOfTwo<uint32_t, Checked<uint32_t>>(a, b); }
 

--- a/Source/WebGPU/WebGPU/CxxBridgingPublic.h
+++ b/Source/WebGPU/WebGPU/CxxBridgingPublic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,14 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
-#include <WebGPU/WebGPU.h>
-#include <WebGPU/WebGPUExt.h>
-#include <optional>
-#include <wtf/Vector.h>
+// FIXME: Remove this file once compiler support for `-emit-clang-header-min-access` is available
+// everywhere where needed.
+
+#include <span>
 
 namespace WebGPU {
 
-struct HardwareCapabilities {
-    WGPULimits limits { };
-    Vector<WGPUFeatureName> features;
+using SpanConstUInt8 = std::span<const uint8_t>;
+using SpanUInt8 = std::span<uint8_t>;
 
-    struct BaseCapabilities {
-        MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
-        id<MTLCounterSet> timestampCounterSet { nil };
-        id<MTLCounterSet> statisticCounterSet { nil };
-        uint32_t memoryBarrierLimit { 0 };
-        bool supportsNonPrivateDepthStencilTextures { false };
-        bool canPresentRGB10A2PixelFormats { false };
-        bool supportsResidencySets { false };
-    } baseCapabilities;
-};
-
-std::optional<HardwareCapabilities> hardwareCapabilities(id<MTLDevice>);
-bool isValid(const WGPULimits&);
-WGPULimits defaultLimits();
-bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
-bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
-bool isShaderValidationEnabled(id<MTLDevice>);
-bool isWebGPUSwiftEnabled();
-
-} // namespace WebGPU
+}

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -25,17 +25,15 @@
 
 #pragma once
 
-#import "API.h"
-#import "Adapter.h"
 #import "BindableResource.h"
 #import "HardwareCapabilities.h"
 #import "Queue.h"
-#import "WebGPU.h"
-#import "WebGPUExt.h"
 #import <CoreVideo/CVMetalTextureCache.h>
 #import <CoreVideo/CoreVideo.h>
 #import <IOSurface/IOSurfaceRef.h>
 #import <Metal/Metal.h>
+#import <WebGPU/WebGPU.h>
+#import <WebGPU/WebGPUExt.h>
 #import <simd/matrix_types.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
@@ -178,11 +176,7 @@ public:
     uint32_t maxBuffersForFragmentStage() const { return m_capabilities.limits.maxBindGroups; }
 
     uint32_t maxBuffersForComputeStage() const { return m_capabilities.limits.maxBindGroups; }
-    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const
-    {
-        ASSERT(maxBuffersPlusVertexBuffersForVertexStage() > 0);
-        return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxBuffersPlusVertexBuffersForVertexStage() - 1);
-    }
+    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
 
     id<MTLBuffer> newBufferWithBytes(const void*, size_t, MTLResourceOptions, bool skipMemoryAttribution = false) const;
     id<MTLBuffer> newBufferWithBytesNoCopy(void*, size_t, MTLResourceOptions, bool skipMemoryAttribution = false) const;

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -1056,6 +1056,12 @@ void Device::pauseErrorReporting(bool pauseReporting)
     m_supressAllErrors = pauseReporting;
 }
 
+uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
+{
+    ASSERT(maxBuffersPlusVertexBuffersForVertexStage() > 0);
+    return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxBuffersPlusVertexBuffersForVertexStage() - 1);
+}
+
 id<MTLSharedEvent> Device::resolveTimestampsSharedEvent()
 {
     if (!m_resolveTimestampsSharedEvent)

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -26,8 +26,9 @@
 #pragma once
 
 #import "BindableResource.h"
-#import "WebGPU.h"
-#import "WebGPUExt.h"
+#import <WebGPU/WGPUQuerySetImpl.h>
+#import <WebGPU/WebGPU.h>
+#import <WebGPU/WebGPUExt.h>
 #import <optional>
 #import <wtf/FastMalloc.h>
 #import <wtf/Range.h>
@@ -39,11 +40,6 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
-
-// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
-// annotating incomplete types
-struct SWIFT_SHARED_REFERENCE(wgpuQuerySetReference, wgpuQuerySetRelease) WGPUQuerySetImpl {
-};
 
 namespace WebGPU {
 

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -37,6 +37,8 @@
 #import "TextureView.h"
 #if ENABLE(WEBGPU_SWIFT)
 #import "CxxBridging.h"
+#import <WebGPU/CxxBridgingPublic.h>
+#import <WebGPU/WGPUTextureImpl.h>
 #import "WebGPUSwift-Generated.h"
 #endif
 #import <simd/simd.h>

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -28,14 +28,16 @@ import WebGPU_Internal
 
 private let largeBufferSize = 32 * 1024 * 1024
 
+// FIXME: Eventually all these "thunks" should be removed.
+// swift-format-ignore: AlwaysUseLowerCamelCase
 @_expose(Cxx)
-public func Queue_writeBuffer_thunk(queue: WebGPU.Queue, buffer: MTLBuffer, bufferOffset: UInt64, data: SpanUInt8) {
+public func Queue_writeBuffer_thunk(queue: WebGPU.Queue, buffer: MTLBuffer, bufferOffset: UInt64, data: WebGPU.SpanUInt8) {
     // FIXME (rdar://161269480): We should be able to declare 'data' as MutableSpan<UInt8>, which will remove this use of 'unsafe'.
     queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: unsafe MutableSpan(_unsafeCxxSpan: data))
 }
 
 extension WebGPU.Queue {
-    public func writeBuffer(buffer: MTLBuffer, bufferOffset: UInt64, data: consuming MutableSpan<UInt8>) {
+    func writeBuffer(buffer: MTLBuffer, bufferOffset: UInt64, data: consuming MutableSpan<UInt8>) {
         guard let _ = self.metalDevice() else {
             return
         }
@@ -47,7 +49,7 @@ extension WebGPU.Queue {
         let count = data.count
         let noCopy = data.count >= largeBufferSize
         // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here
-        let bufferWithOffset = unsafe newTemporaryBufferWithBytes(SpanUInt8(data), noCopy)
+        let bufferWithOffset = unsafe newTemporaryBufferWithBytes(WebGPU.SpanUInt8(data), noCopy)
         let temporaryBuffer = unsafe bufferWithOffset.first
         let temporaryBufferOffset = unsafe bufferWithOffset.second
 

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -27,6 +27,7 @@
 
 #import "BindableResource.h"
 #import <Metal/Metal.h>
+#import <WebGPU/WGPUTextureImpl.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
@@ -37,11 +38,6 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
-
-// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
-// annotating incomplete types
-struct SWIFT_SHARED_REFERENCE(wgpuTextureReference, wgpuTextureRelease) WGPUTextureImpl {
-};
 
 namespace WebGPU {
 

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import "BindableResource.h"
+#import <WebGPU/WGPUTextureViewImpl.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -33,11 +34,6 @@
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
-
-// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
-// annotating incomplete types
-struct SWIFT_SHARED_REFERENCE(wgpuTextureViewReference, wgpuTextureViewRelease) WGPUTextureViewImpl {
-};
 
 namespace WebGPU {
 

--- a/Source/WebGPU/WebGPU/WGPUBufferImpl.h
+++ b/Source/WebGPU/WebGPU/WGPUBufferImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,10 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
-#include <WebGPU/WebGPU.h>
-#include <WebGPU/WebGPUExt.h>
-#include <optional>
-#include <wtf/Vector.h>
+#import <WebGPU/WebGPU.h>
+#import <wtf/SwiftBridging.h>
 
-namespace WebGPU {
-
-struct HardwareCapabilities {
-    WGPULimits limits { };
-    Vector<WGPUFeatureName> features;
-
-    struct BaseCapabilities {
-        MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
-        id<MTLCounterSet> timestampCounterSet { nil };
-        id<MTLCounterSet> statisticCounterSet { nil };
-        uint32_t memoryBarrierLimit { 0 };
-        bool supportsNonPrivateDepthStencilTextures { false };
-        bool canPresentRGB10A2PixelFormats { false };
-        bool supportsResidencySets { false };
-    } baseCapabilities;
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct SWIFT_SHARED_REFERENCE(wgpuBufferReference, wgpuBufferRelease) WGPUBufferImpl {
 };
-
-std::optional<HardwareCapabilities> hardwareCapabilities(id<MTLDevice>);
-bool isValid(const WGPULimits&);
-WGPULimits defaultLimits();
-bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
-bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
-bool isShaderValidationEnabled(id<MTLDevice>);
-bool isWebGPUSwiftEnabled();
-
-} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/WGPUQuerySetImpl.h
+++ b/Source/WebGPU/WebGPU/WGPUQuerySetImpl.h
@@ -25,35 +25,10 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
-#include <WebGPU/WebGPU.h>
-#include <WebGPU/WebGPUExt.h>
-#include <optional>
-#include <wtf/Vector.h>
+#import <WebGPU/WebGPU.h>
+#import <wtf/SwiftBridging.h>
 
-namespace WebGPU {
-
-struct HardwareCapabilities {
-    WGPULimits limits { };
-    Vector<WGPUFeatureName> features;
-
-    struct BaseCapabilities {
-        MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
-        id<MTLCounterSet> timestampCounterSet { nil };
-        id<MTLCounterSet> statisticCounterSet { nil };
-        uint32_t memoryBarrierLimit { 0 };
-        bool supportsNonPrivateDepthStencilTextures { false };
-        bool canPresentRGB10A2PixelFormats { false };
-        bool supportsResidencySets { false };
-    } baseCapabilities;
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct SWIFT_SHARED_REFERENCE(wgpuQuerySetReference, wgpuQuerySetRelease) WGPUQuerySetImpl {
 };
-
-std::optional<HardwareCapabilities> hardwareCapabilities(id<MTLDevice>);
-bool isValid(const WGPULimits&);
-WGPULimits defaultLimits();
-bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
-bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
-bool isShaderValidationEnabled(id<MTLDevice>);
-bool isWebGPUSwiftEnabled();
-
-} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/WGPUTextureImpl.h
+++ b/Source/WebGPU/WebGPU/WGPUTextureImpl.h
@@ -25,35 +25,10 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
-#include <WebGPU/WebGPU.h>
-#include <WebGPU/WebGPUExt.h>
-#include <optional>
-#include <wtf/Vector.h>
+#import <WebGPU/WebGPU.h>
+#import <wtf/SwiftBridging.h>
 
-namespace WebGPU {
-
-struct HardwareCapabilities {
-    WGPULimits limits { };
-    Vector<WGPUFeatureName> features;
-
-    struct BaseCapabilities {
-        MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
-        id<MTLCounterSet> timestampCounterSet { nil };
-        id<MTLCounterSet> statisticCounterSet { nil };
-        uint32_t memoryBarrierLimit { 0 };
-        bool supportsNonPrivateDepthStencilTextures { false };
-        bool canPresentRGB10A2PixelFormats { false };
-        bool supportsResidencySets { false };
-    } baseCapabilities;
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct SWIFT_SHARED_REFERENCE(wgpuTextureReference, wgpuTextureRelease) WGPUTextureImpl {
 };
-
-std::optional<HardwareCapabilities> hardwareCapabilities(id<MTLDevice>);
-bool isValid(const WGPULimits&);
-WGPULimits defaultLimits();
-bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
-bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
-bool isShaderValidationEnabled(id<MTLDevice>);
-bool isWebGPUSwiftEnabled();
-
-} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/WGPUTextureViewImpl.h
+++ b/Source/WebGPU/WebGPU/WGPUTextureViewImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,10 @@
 
 #pragma once
 
-#include <Metal/Metal.h>
-#include <WebGPU/WebGPU.h>
-#include <WebGPU/WebGPUExt.h>
-#include <optional>
-#include <wtf/Vector.h>
+#import <WebGPU/WebGPU.h>
+#import <wtf/SwiftBridging.h>
 
-namespace WebGPU {
-
-struct HardwareCapabilities {
-    WGPULimits limits { };
-    Vector<WGPUFeatureName> features;
-
-    struct BaseCapabilities {
-        MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
-        id<MTLCounterSet> timestampCounterSet { nil };
-        id<MTLCounterSet> statisticCounterSet { nil };
-        uint32_t memoryBarrierLimit { 0 };
-        bool supportsNonPrivateDepthStencilTextures { false };
-        bool canPresentRGB10A2PixelFormats { false };
-        bool supportsResidencySets { false };
-    } baseCapabilities;
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct SWIFT_SHARED_REFERENCE(wgpuTextureViewReference, wgpuTextureViewRelease) WGPUTextureViewImpl {
 };
-
-std::optional<HardwareCapabilities> hardwareCapabilities(id<MTLDevice>);
-bool isValid(const WGPULimits&);
-WGPULimits defaultLimits();
-bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
-bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
-bool isShaderValidationEnabled(id<MTLDevice>);
-bool isWebGPUSwiftEnabled();
-
-} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/WebGPU.modulemap
+++ b/Source/WebGPU/WebGPU/WebGPU.modulemap
@@ -1,6 +1,7 @@
-framework module WebGPU {
-  umbrella header "WebGPU.h"
-  header "WebGPUExt.h"
-  export *
-  module * { export * }
+framework module WebGPU [system] {
+    umbrella "Headers"
+
+    module * {
+        export *
+    }
 }


### PR DESCRIPTION
#### 7f0745387b13f48683c6891635ebf60fa8122359
<pre>
Re-land [Swift in WebKit] Fix the modularization of WebGPU (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304454">https://bugs.webkit.org/show_bug.cgi?id=304454</a>
<a href="https://rdar.apple.com/166832914">rdar://166832914</a>

Reviewed by Mike Wyrzykowski.

This is effectively the same as 304590@main, but only the part that fixes the public module and not the private or internal ones.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
* Source/WebGPU/WebGPU/Buffer.swift:
(Buffer_copyFrom_thunk(_:from:offset:)):
(Buffer_getMappedRange_thunk(_:offset:size:)):
(WebGPU.getMappedRange(_:size:)):
* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.clearTextureIfNeeded(_:slice:)):
(resolveQuerySet(_:querySet:firstQuery:queryCount:destination:destinationOffset:)): Deleted.
(CommandEncoder_copyBufferToBuffer_thunk(_:source:sourceOffset:destination:destinationOffset:size:)): Deleted.
(WebGPU.clearTextureIfNeeded(_:slice:device:blitCommandEncoder:)): Deleted.
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/CxxBridging.h:
* Source/WebGPU/WebGPU/CxxBridgingPublic.h: Copied from Source/WebGPU/WebGPU/HardwareCapabilities.h.
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::vertexBufferIndexForBindGroup const): Deleted.
* Source/WebGPU/WebGPU/Device.mm:
* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/Queue.mm:
* Source/WebGPU/WebGPU/Queue.swift:
(Queue_writeBuffer_thunk(_:buffer:bufferOffset:data:)):
(WebGPU.writeBuffer(_:bufferOffset:data:)):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/WGPUBufferImpl.h: Copied from Source/WebGPU/WebGPU/HardwareCapabilities.h.
* Source/WebGPU/WebGPU/WGPUQuerySetImpl.h: Copied from Source/WebGPU/WebGPU/HardwareCapabilities.h.
* Source/WebGPU/WebGPU/WGPUTextureImpl.h: Copied from Source/WebGPU/WebGPU/HardwareCapabilities.h.
* Source/WebGPU/WebGPU/WGPUTextureViewImpl.h: Copied from Source/WebGPU/WebGPU/HardwareCapabilities.h.
* Source/WebGPU/WebGPU/WebGPU.modulemap:

Canonical link: <a href="https://commits.webkit.org/304779@main">https://commits.webkit.org/304779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5227cadc605674bbc91b8a8c757c2e406b3c006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144203 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104373 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85208 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6606 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115909 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146952 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112713 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113057 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6537 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62521 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8577 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36655 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->