### PR TITLE
[AutoFill Debugging] Add a heuristic to represent numerals split across superscript elements as decimals

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -6,4 +6,6 @@ This is a list:
 - foo
 - bar
 - baz
+On sale for
+£10.99
 <!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <head>
 <style>
-body {
+body.done {
     white-space: pre-wrap;
 }
 </style>
@@ -22,6 +22,12 @@ body {
     <li>bar</li>
     <li>baz</li>
 </ul>
+On sale for
+<p>
+    <sup>£</sup>
+    10
+    <sup>99</sup>
+</p>
 <script>
 addEventListener("load", async () => {
     if (!window.testRunner)
@@ -31,6 +37,7 @@ addEventListener("load", async () => {
     testRunner.waitUntilDone();
 
     document.body.textContent = await UIHelper.requestDebugText({ outputFormat: "markdown" });
+    document.body.classList.add("done");
 
     testRunner.notifyDone();
 });

--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -169,6 +169,11 @@ inline bool isCombiningMark(char32_t character)
     return 0x0300 <= character && character <= 0x036F;
 }
 
+inline bool isCurrencySymbol(char32_t character)
+{
+    return u_charType(character) == U_CURRENCY_SYMBOL;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -189,3 +194,4 @@ using WTF::isEastAsianFullWidth;
 using WTF::isCJKSymbolOrPunctuation;
 using WTF::isFullwidthMiddleDotPunctuation;
 using WTF::isCombiningMark;
+using WTF::isCurrencySymbol;

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -169,6 +169,7 @@ struct Item {
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
     HashMap<String, String> clientAttributes;
+    unsigned enclosingBlockNumber { 0 };
 
     template<typename T> bool hasData() const
     {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6916,6 +6916,7 @@ header: <WebCore/TextExtractionTypes.h>
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
     HashMap<String, String> clientAttributes;
+    unsigned enclosingBlockNumber;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### 85ab337b0ba3700b847d0568c2c9ff4423f770a2
<pre>
[AutoFill Debugging] Add a heuristic to represent numerals split across superscript elements as decimals
<a href="https://bugs.webkit.org/show_bug.cgi?id=304446">https://bugs.webkit.org/show_bug.cgi?id=304446</a>
<a href="https://rdar.apple.com/166707253">rdar://166707253</a>

Reviewed by Abrar Rahman Protyasha.

When performing text extraction on a DOM subtree like:

```
&lt;span&gt;$&lt;/span&gt;11&lt;sup&gt;99&lt;/sup&gt;
```

...we currently represent this in markdown text extraction results as:

```
$
11
99
```

...since each element is separated out into its own line. To ensure that this common way of
rendering monetary values is mapped into a more readable format, we add a heuristic to post-process
per-line text extraction results, so that:

1.  If a currency symbol is followed by a numeric value on the same line, the two pieces of text are
    joined together with no separator between them.

2.  If an integer is followed by another integer inside a superscript on the same line, the two
    pieces of text are joined together with a full stop character `.` between them.

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html:

Augment an existing test to exercise the change.

* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isCurrencySymbol):

Add a new helper function that uses ICU to determine whether the given character represents a
currency symbol.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::TraversalContext::pushEnclosingBlock):
(WebCore::TextExtraction::TraversalContext::enclosingBlockNumber const):
(WebCore::TextExtraction::TraversalContext::popEnclosingBlock):

Add a mechanism to assign numbers to each enclosing block-level container as we recursively extract
items from the DOM. This allows us to easily determine whether it&apos;s appropriate to merge the two
pieces of text later down the line (see below).

(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::shouldEmitFullStopBetweenLines):
(WebKit::shouldJoinWithPreviousLine):

Implement a heuristic to merge adjacent text items; see description above.

(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::takeResults):
(WebKit::TextExtractionAggregator::addResult):
(WebKit::TextExtractionAggregator::useTextTreeOutput const):
(WebKit::TextExtractionAggregator::appendToLine):

Refactor this logic to keep track of superscript level while traversing items, and add more
information about each line so that we can post-process the final result before invoking the
completion handler.

(WebKit::TextExtractionAggregator::pushSuperscript):
(WebKit::TextExtractionAggregator::superscriptLevel const):
(WebKit::TextExtractionAggregator::popSuperscript):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304753@main">https://commits.webkit.org/304753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ddb45c38c794b4c2aa153a3e907c481e44db067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144173 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/660f3bfa-be5e-42e1-8eb3-61440eafb04e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/efc48da4-2b1e-445e-8d9d-f1dfbd9a549d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139405 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3dee2f12-f0dd-4ed1-91df-20384c537b73) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4766 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128417 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146921 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134944 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8499 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8516 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/113033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/6514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62487 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8547 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167724 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8266 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/72106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8487 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->