### PR TITLE
REGRESSION(304572@main): [macOS iOS] fast/html/a-tooltip-null.html is a flaky crash

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3090,6 +3090,10 @@ void FrameLoader::didReachLayoutMilestone(OptionSet<LayoutMilestone> milestones)
 {
     ASSERT(m_frame->isMainFrame());
 
+    RefPtr documentLoader = activeDocumentLoader();
+    if (!documentLoader)
+        return;
+
     auto queuedNavigationID = protectedActiveDocumentLoader()->navigationID();
 
     m_client->willDispatchDidReachLayoutMilestone(milestones);


### PR DESCRIPTION
#### 66c4d350e6bf3d9b9b3f3a7179141982ea9d5ca9
<pre>
REGRESSION(<a href="https://commits.webkit.org/304572@main">304572@main</a>): [macOS iOS] fast/html/a-tooltip-null.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=304427">https://bugs.webkit.org/show_bug.cgi?id=304427</a>
<a href="https://rdar.apple.com/166812256">rdar://166812256</a>

Fix flaky null pointer exceptions from accessing the document loader.

I tested this manually with the repro steps and confirmed it did not reproduces.
The below tests all pass:
run-webkit-tests fast/html/a-tooltip-null.html --release --iteration 10
run-webkit-tests fast/html/HTMLPluginElement-renderer-destroyed-crash.html --release --iteration 10

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didReachLayoutMilestone):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66c4d350e6bf3d9b9b3f3a7179141982ea9d5ca9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144105 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d723aff-ee41-47e5-ba48-eb1a24a8c2f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138265 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9433 "Hash 66c4d350 for PR 55667 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/680745b8-0ab4-46fc-a247-bc88f0b3460c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139338 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/9433 "Hash 66c4d350 for PR 55667 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85129 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ecc4806-5554-415b-b5c1-3542e0df6767) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/9433 "Hash 66c4d350 for PR 55667 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4179 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4696 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/9433 "Hash 66c4d350 for PR 55667 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146849 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112629 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112976 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6452 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118516 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62419 "Failed to checkout and rebase branch from PR 55667") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36568 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8420 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->