### PR TITLE
Fix priority inversion in RunLoop::dispatch() by using UnfairLock

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -302,7 +302,11 @@ private:
 
     Deque<Function<void()>> m_currentIteration;
 
+#if ENABLE(UNFAIR_LOCK)
+    UnfairLock m_nextIterationLock;
+#else
     Lock m_nextIterationLock;
+#endif
     Deque<Function<void()>> m_nextIteration WTF_GUARDED_BY_LOCK(m_nextIterationLock);
 
     bool m_isFunctionDispatchSuspended { false };


### PR DESCRIPTION
#### b432d36acad41c1e19c3f7c17ca3191a0ffd0ae3
<pre>
Fix priority inversion in RunLoop::dispatch() by using UnfairLock
<a href="https://bugs.webkit.org/show_bug.cgi?id=304456">https://bugs.webkit.org/show_bug.cgi?id=304456</a>
<a href="https://rdar.apple.com/155316823">rdar://155316823</a>

Reviewed by Ben Nham.

The watchdog crash in this radar (<a href="https://rdar.apple.com/155316823">rdar://155316823</a>) occurs due to priority inversion.

TID 6615 (main thread) waits on m_incomingMessagesLock.
TID 7837 (com.apple.IPC.ReceiveQueue thread) holds m_incomingMessagesLock (that 6615 is waiting on) and is waiting on
m_nextIterationLock in RunLoop::dispatch().
TID 6933 (com.apple.Safari.Analytics) holds m_nextIterationLock.

But 6933 is a low priority background thread, and as a result, it&apos;s not able to progress very quickly (which ends up leading
to the watchdog timeout). More importantly, it&apos;s holding a resource (m_nextIterationLock) that a high priority thread (7837) needs.
This is a priority inversion problem.

m_nextIterationLock is a WTF::Lock which does not support priority inheritance.
The fix here is to make it an UnfairLock. That would boost 6933&apos;s priority as the lock holder and allow it to progress quickly
which would release the lock and prevent the hang here.

This mirrors the fix for m_incomingMessagesLock in <a href="https://commits.webkit.org/281223@main.">https://commits.webkit.org/281223@main.</a>

* Source/WTF/wtf/RunLoop.h:

Canonical link: <a href="https://commits.webkit.org/304775@main">https://commits.webkit.org/304775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74837cba0be0cf1249bed09fd2c43e1212c2cbc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144107 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ae8e0eda-0637-4983-9b13-4db643a6e444) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5bbf95c8-eb6c-4be6-be2d-2297bc826a70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85134 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b48df202-792e-4ba2-bd45-b1290304cbd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4219 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4698 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128352 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146859 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134879 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112985 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6456 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62421 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8482 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36571 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167658 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72041 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43734 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->