### PR TITLE
[Swift in WebKit] Work towards fixing the WTF clang module

### DIFF
--- a/Source/WTF/wtf/AnsiColors.h
+++ b/Source/WTF/wtf/AnsiColors.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if PLATFORM(WIN)
 
 #define RESET

--- a/Source/WTF/wtf/AutodrainedPool.h
+++ b/Source/WTF/wtf/AutodrainedPool.h
@@ -30,6 +30,7 @@
 
 #if !(defined(__OBJC__) && !defined(__clang_tapi__))
 
+#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/BubbleSort.h
+++ b/Source/WTF/wtf/BubbleSort.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <span>
+
 namespace WTF {
 
 // Why would you want to use bubble sort? When you know that your input is already mostly

--- a/Source/WTF/wtf/ByteOrder.h
+++ b/Source/WTF/wtf/ByteOrder.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <bit>
+#include <wtf/Platform.h>
 
 #if OS(UNIX)
 #include <arpa/inet.h>

--- a/Source/WTF/wtf/ClockType.h
+++ b/Source/WTF/wtf/ClockType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 class PrintStream;

--- a/Source/WTF/wtf/CryptographicUtilities.h
+++ b/Source/WTF/wtf/CryptographicUtilities.h
@@ -27,6 +27,8 @@
 
 #include <span>
 #include <string>
+#include <wtf/Assertions.h>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.h
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.h
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <span>
 #include <stdint.h>
+#include <wtf/ExportMacros.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -28,6 +28,7 @@
 #include <ranges>
 #include <wtf/BitSet.h>
 #include <wtf/CommaPrinter.h>
+#include <wtf/DataLog.h>
 #include <wtf/FastBitVector.h>
 #include <wtf/GraphNodeWorklist.h>
 #include <wtf/Vector.h>

--- a/Source/WTF/wtf/DoublyLinkedList.h
+++ b/Source/WTF/wtf/DoublyLinkedList.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <wtf/Assertions.h>
+
 namespace WTF {
 
 // This class allows nodes to share code without dictating data member layout.

--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -57,8 +57,10 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
 #include <span>
 #include <type_traits>
+#include <utility>
 #include <wtf/Compiler.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -27,6 +27,7 @@
 
 #include <array>
 #include <wtf/EnumTraits.h>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -184,6 +184,7 @@ inline namespace fundamentals_v3 {
 #include <utility>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Unexpected.h>
 #include <wtf/Variant.h>

--- a/Source/WTF/wtf/ExperimentalFeatureNames.h
+++ b/Source/WTF/wtf/ExperimentalFeatureNames.h
@@ -25,11 +25,17 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 namespace WTF {
 
 #if USE(APPLE_INTERNAL_SDK)
 
+// FIXME: Properly support using WKA in modules.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
 #include <WebKitAdditions/ExperimentalFeatureNameAdditions.h>
+#pragma clang diagnostic pop
 
 #endif
 

--- a/Source/WTF/wtf/FastTLS.h
+++ b/Source/WTF/wtf/FastTLS.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(FAST_TLS)
 
 #include <pthread.h>

--- a/Source/WTF/wtf/FlipBytes.h
+++ b/Source/WTF/wtf/FlipBytes.h
@@ -28,7 +28,10 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cstddef>
+#include <type_traits>
 #include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/FunctionTraits.h
+++ b/Source/WTF/wtf/FunctionTraits.h
@@ -27,6 +27,7 @@
 
 #include <tuple>
 #include <type_traits>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/IndexKeyType.h
+++ b/Source/WTF/wtf/IndexKeyType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace WTF {
 
 template<typename T>

--- a/Source/WTF/wtf/IndexedContainerIterator.h
+++ b/Source/WTF/wtf/IndexedContainerIterator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <type_traits>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/IndexedRange.h
+++ b/Source/WTF/wtf/IndexedRange.h
@@ -25,6 +25,13 @@
 
 #pragma once
 
+#include <concepts>
+#include <iterator>
+#include <utility>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/StdLibExtras.h>
+
 namespace WTF {
 
 template<typename Iterator> class BoundsCheckedIterator {

--- a/Source/WTF/wtf/Insertion.h
+++ b/Source/WTF/wtf/Insertion.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
+
 namespace WTF {
 
 template<typename T>

--- a/Source/WTF/wtf/InstanceCounted.h
+++ b/Source/WTF/wtf/InstanceCounted.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstddef>
+#include <wtf/Assertions.h>
+
 // This class implements "instance count" management for regression test coverage.
 // Since it adds runtime overhead to manage the count variable, the actual
 // functionality of the class is limited to debug builds.

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <limits>
 #include <utility>
+#include <wtf/ExportMacros.h>
 #include <wtf/Platform.h>
 
 #if COMPILER(MSVC)

--- a/Source/WTF/wtf/IteratorRange.h
+++ b/Source/WTF/wtf/IteratorRange.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <iterator>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/LEBDecoder.h
+++ b/Source/WTF/wtf/LEBDecoder.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <limits.h>
+#include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
 
 // This file contains a bunch of helper functions for decoding LEB numbers.

--- a/Source/WTF/wtf/LLVMProfilingUtils.h
+++ b/Source/WTF/wtf/LLVMProfilingUtils.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(LLVM_PROFILE_GENERATION) && PLATFORM(IOS_FAMILY)
 
 #include <unistd.h>

--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/Logger.h>
 

--- a/Source/WTF/wtf/LoggingHashMap.h
+++ b/Source/WTF/wtf/LoggingHashMap.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/LoggingHashID.h>
 #include <wtf/LoggingHashTraits.h>
+#include <wtf/StringPrintStream.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/LoggingHashSet.h
+++ b/Source/WTF/wtf/LoggingHashSet.h
@@ -29,6 +29,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/LoggingHashID.h>
 #include <wtf/LoggingHashTraits.h>
+#include <wtf/StringPrintStream.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
+#include <wtf/Platform.h>
 
 #if PLATFORM(COCOA)
 

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <span>
 #include <wtf/Forward.h>
+#include <wtf/Platform.h>
 
 #if HAVE(MMAP)
 #include <wtf/MallocSpan.h>

--- a/Source/WTF/wtf/MemoryDump.h
+++ b/Source/WTF/wtf/MemoryDump.h
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include <span>
+#include <wtf/Compiler.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/MemoryFootprint.h
+++ b/Source/WTF/wtf/MemoryFootprint.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE size_t memoryFootprint();

--- a/Source/WTF/wtf/MmapSpan.h
+++ b/Source/WTF/wtf/MmapSpan.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(MMAP)
 
 #include <sys/mman.h>

--- a/Source/WTF/wtf/NumberOfCores.h
+++ b/Source/WTF/wtf/NumberOfCores.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
 namespace WTF {
 
 // This counts logical cores.

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <algorithm>
+#include <wtf/FastMalloc.h>
+#include <wtf/Platform.h>
 #include <wtf/VMTags.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/OSRandomSource.h
+++ b/Source/WTF/wtf/OSRandomSource.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <span>
+
 namespace WTF {
 
 // This function attempts to fill buffer with randomness from the operating

--- a/Source/WTF/wtf/OverflowPolicy.h
+++ b/Source/WTF/wtf/OverflowPolicy.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 enum class OverflowPolicy : uint8_t { CrashOnOverflow, RecordOverflow };

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <array>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashFunctions.h>

--- a/Source/WTF/wtf/ParallelJobsGeneric.h
+++ b/Source/WTF/wtf/ParallelJobsGeneric.h
@@ -28,6 +28,8 @@
 #ifndef ParallelJobsGeneric_h
 #define ParallelJobsGeneric_h
 
+#include <wtf/Platform.h>
+
 #if ENABLE(THREADING_GENERIC)
 
 #include <wtf/Condition.h>

--- a/Source/WTF/wtf/ParallelJobsLibdispatch.h
+++ b/Source/WTF/wtf/ParallelJobsLibdispatch.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
+#include <wtf/Platform.h>
+
 #if ENABLE(THREADING_LIBDISPATCH)
 
 #include <wtf/darwin/DispatchExtras.h>

--- a/Source/WTF/wtf/ParallelJobsOpenMP.h
+++ b/Source/WTF/wtf/ParallelJobsOpenMP.h
@@ -28,6 +28,8 @@
 #ifndef ParallelJobsOpenMP_h
 #define ParallelJobsOpenMP_h
 
+#include <wtf/Platform.h>
+
 #if ENABLE(THREADING_OPENMP)
 
 #include <omp.h>

--- a/Source/WTF/wtf/Platform.h
+++ b/Source/WTF/wtf/Platform.h
@@ -70,7 +70,15 @@
 /* ==== Platform additions: additions to Platform.h from outside the main repository ==== */
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AdditionalPlatform.h>)
+/* FIXME: Properly support using WKA in modules. */
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
+#endif
 #include <WebKitAdditions/AdditionalPlatform.h>
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic pop
+#endif
 #endif
 
 /* IWYU pragma: end_exports */

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -73,7 +73,15 @@
 /* ==== Platform additions: additions to PlatformEnable.h from outside the main repository ==== */
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AdditionalFeatureDefines.h>)
+/* FIXME: Properly support using WKA in modules. */
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
+#endif
 #include <WebKitAdditions/AdditionalFeatureDefines.h>
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic pop
+#endif
 #endif
 
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -45,7 +45,15 @@
 
 // This can't use USE(APPLE_INTERNAL_SDK) because this comes before PlatformUse.h.
 #if PLATFORM(COCOA) && __has_include(<WebKitAdditions/AdditionalPlatformHave.h>)
+/* FIXME: Properly support using WKA in modules. */
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
+#endif
 #include <WebKitAdditions/AdditionalPlatformHave.h>
+#if defined(__clang__) && defined(__has_feature) && __has_feature(modules)
+#pragma clang diagnostic pop
+#endif
 #endif
 
 

--- a/Source/WTF/wtf/PointerPreparations.h
+++ b/Source/WTF/wtf/PointerPreparations.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if CPU(ARM64E)
 #include <ptrauth.h>
 #endif

--- a/Source/WTF/wtf/ProcessID.h
+++ b/Source/WTF/wtf/ProcessID.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if OS(UNIX)
 #include <unistd.h>
 #endif

--- a/Source/WTF/wtf/RAMSize.h
+++ b/Source/WTF/wtf/RAMSize.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE size_t ramSize();

--- a/Source/WTF/wtf/RandomDevice.h
+++ b/Source/WTF/wtf/RandomDevice.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WTF/wtf/RawHex.h
+++ b/Source/WTF/wtf/RawHex.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 namespace WTF {
 
 // For printing integral values in hex.

--- a/Source/WTF/wtf/RawPointer.h
+++ b/Source/WTF/wtf/RawPointer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace WTF {
 
 class RawPointer {

--- a/Source/WTF/wtf/RawValueTraits.h
+++ b/Source/WTF/wtf/RawValueTraits.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <wtf/Compiler.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/RecursableLambda.h
+++ b/Source/WTF/wtf/RecursableLambda.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/ResourceUsage.h
+++ b/Source/WTF/wtf/ResourceUsage.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <array>
+#include <wtf/ExportMacros.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/RuntimeApplicationChecks.h
+++ b/Source/WTF/wtf/RuntimeApplicationChecks.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include <optional>
+#include <wtf/ExportMacros.h>
 #include <wtf/Forward.h>
+#include <wtf/Platform.h>
 #include <wtf/ProcessID.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -56,6 +56,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <optional>
 #include <wtf/StdLibExtras.h>
 #include <wtf/simde/simde.h>
+#include <wtf/text/Latin1Character.h>
 
 namespace WTF::SIMD {
 

--- a/Source/WTF/wtf/SafeStrerror.h
+++ b/Source/WTF/wtf/SafeStrerror.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
 #include <wtf/Forward.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/SaturatedArithmetic.h
+++ b/Source/WTF/wtf/SaturatedArithmetic.h
@@ -31,10 +31,12 @@
 
 #pragma once
 
+#include <concepts>
 #include <limits>
 #include <stdint.h>
 #include <stdlib.h>
 #include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/ScopedPrintStream.h
+++ b/Source/WTF/wtf/ScopedPrintStream.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/DataLog.h>
 #include <wtf/StringPrintStream.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/SetForScope.h
+++ b/Source/WTF/wtf/SetForScope.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WTF/wtf/SimpleStats.h
+++ b/Source/WTF/wtf/SimpleStats.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WTF/wtf/SixCharacterHash.h
+++ b/Source/WTF/wtf/SixCharacterHash.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <array>
+#include <span>
+#include <wtf/ExportMacros.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/SoftLinking.h
+++ b/Source/WTF/wtf/SoftLinking.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/SoftLinking.h>
 #elif OS(WINDOWS)

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <wtf/Compiler.h>
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
 #pragma once
 
 namespace WTF {

--- a/Source/WTF/wtf/StackStats.h
+++ b/Source/WTF/wtf/StackStats.h
@@ -27,7 +27,7 @@
 
 #include <mutex>
 #include <wtf/ExportMacros.h>
-
+#include <wtf/FastMalloc.h>
 
 // Define this flag to enable Stack stats collection. This feature is useful
 // for getting a sample of native stack usage sizes.

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -28,7 +28,9 @@
 
 #include <optional>
 #include <span>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
+#include <wtf/Platform.h>
 #include <wtf/SystemFree.h>
 
 #if HAVE(BACKTRACE_SYMBOLS) || HAVE(BACKTRACE)

--- a/Source/WTF/wtf/StdFilesystem.h
+++ b/Source/WTF/wtf/StdFilesystem.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(STD_FILESYSTEM)
 #include <filesystem>
 #elif HAVE(STD_EXPERIMENTAL_FILESYSTEM)

--- a/Source/WTF/wtf/StdIntExtras.h
+++ b/Source/WTF/wtf/StdIntExtras.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <cstdint>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/Stopwatch.h
+++ b/Source/WTF/wtf/Stopwatch.h
@@ -29,6 +29,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <cstdlib>
+#include <wtf/Assertions.h>
+#include <wtf/Platform.h>
+
 // Require that HAVE(TYPE_AWARE_MALLOC) from PlatformHave.h is enabled when
 // _MALLOC_TYPE_ENABLED is true.
 #if defined __has_include && __has_include(<malloc/malloc.h>)

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
+#include <wtf/Platform.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 #include <sys/kdebug_private.h>
 #define HAVE_KDEBUG_H 1

--- a/Source/WTF/wtf/TaggedPtr.h
+++ b/Source/WTF/wtf/TaggedPtr.h
@@ -27,6 +27,9 @@
 
 #include <bit>
 #include <concepts>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -26,7 +26,11 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <utility>
+#include <wtf/Assertions.h>
+#include <wtf/ExportMacros.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSafetyAnalysis.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/TranslatedProcess.h
+++ b/Source/WTF/wtf/TranslatedProcess.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
 namespace WTF {
 
 #if HAVE(CPU_TRANSLATION_CAPABILITY)

--- a/Source/WTF/wtf/TriState.h
+++ b/Source/WTF/wtf/TriState.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 enum class TriState : uint8_t {

--- a/Source/WTF/wtf/URLHelpers.h
+++ b/Source/WTF/wtf/URLHelpers.h
@@ -30,7 +30,9 @@
 #pragma once
 
 #include <optional>
+#include <wtf/ExportMacros.h>
 #include <wtf/Forward.h>
+#include <wtf/text/WTFString.h>
 
 namespace WTF {
 namespace URLHelpers {

--- a/Source/WTF/wtf/Unexpected.h
+++ b/Source/WTF/wtf/Unexpected.h
@@ -65,6 +65,7 @@ inline namespace fundamentals_v3 {
 
 #include <cstdlib>
 #include <utility>
+#include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 
 namespace std {

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -29,6 +29,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/GetPtr.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/TypeTraits.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/VMTags.h
+++ b/Source/WTF/wtf/VMTags.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(SYSTEM_MALLOC)
 
 #define VM_TAG_FOR_TCMALLOC_MEMORY -1

--- a/Source/WTF/wtf/WTFProcess.h
+++ b/Source/WTF/wtf/WTFProcess.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 // Expect exit call on UNIX platforms.

--- a/Source/WTF/wtf/WeakRandom.h
+++ b/Source/WTF/wtf/WeakRandom.h
@@ -32,6 +32,7 @@
 
 #include <limits>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/WeakRandomNumber.h
+++ b/Source/WTF/wtf/WeakRandomNumber.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 template<typename IntegerType> IntegerType weakRandomNumber() = delete;

--- a/Source/WTF/wtf/WindowsExtras.h
+++ b/Source/WTF/wtf/WindowsExtras.h
@@ -25,6 +25,8 @@
 #ifndef WindowsExtras_h
 #define WindowsExtras_h
 
+#include <wtf/Platform.h>
+
 #if OS(WINDOWS)
 
 #include <windows.h>

--- a/Source/WTF/wtf/ZippedRange.h
+++ b/Source/WTF/wtf/ZippedRange.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/IndexedRange.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/cf/CFURLExtras.h
+++ b/Source/WTF/wtf/cf/CFURLExtras.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <span>
+#include <wtf/ExportMacros.h>
 #include <wtf/Forward.h>
 
 typedef const struct __CFData* CFDataRef;

--- a/Source/WTF/wtf/cf/NotificationCenterCF.h
+++ b/Source/WTF/wtf/cf/NotificationCenterCF.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <CoreFoundation/CFNotificationCenter.h>
+#include <wtf/Platform.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -28,6 +28,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CTFontDescriptor.h>
 #include <wtf/Assertions.h>
+#include <wtf/RetainPtr.h>
 
 #ifndef CF_BRIDGED_TYPE
 #define CF_BRIDGED_TYPE(T)

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(CF)
 
 #include <wtf/CheckedArithmetic.h>

--- a/Source/WTF/wtf/cocoa/AuditToken.h
+++ b/Source/WTF/wtf/cocoa/AuditToken.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <optional>
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE std::optional<audit_token_t> auditTokenForSelf();

--- a/Source/WTF/wtf/cocoa/CrashReporter.h
+++ b/Source/WTF/wtf/cocoa/CrashReporter.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE void setCrashLogMessage(const char*);

--- a/Source/WTF/wtf/cocoa/Entitlements.h
+++ b/Source/WTF/wtf/cocoa/Entitlements.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
 
 #include <wtf/Forward.h>

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
 
 #include <optional>

--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -27,6 +27,7 @@
 #import <dlfcn.h>
 #import <objc/runtime.h>
 #import <wtf/Assertions.h>
+#import <wtf/Platform.h>
 
 #ifndef NS_RETURNS_RETAINED
 #if __has_feature(attribute_ns_returns_retained)

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.h
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if OS(DARWIN)
 
 #include <wtf/Lock.h>

--- a/Source/WTF/wtf/dragonbox/detail/decimal_fp.h
+++ b/Source/WTF/wtf/dragonbox/detail/decimal_fp.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 namespace dragonbox {

--- a/Source/WTF/wtf/ios/WebCoreThread.h
+++ b/Source/WTF/wtf/ios/WebCoreThread.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Source/WTF/wtf/spi/cf/CFBundleSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFBundleSPI.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <CoreFoundation/CFPriv.h>

--- a/Source/WTF/wtf/spi/cf/CFPrivSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFPrivSPI.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFRunLoopSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/Source/WTF/wtf/spi/cf/CFStringSPI.h
+++ b/Source/WTF/wtf/spi/cf/CFStringSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/Source/WTF/wtf/spi/cocoa/BOMSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/BOMSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 typedef struct _BOMCopier* BOMCopier;

--- a/Source/WTF/wtf/spi/cocoa/CFXPCBridgeSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/CFXPCBridgeSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <CoreFoundation/CFXPCBridge.h>

--- a/Source/WTF/wtf/spi/cocoa/CrashReporterClientSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/CrashReporterClientSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if __has_include(<CrashReporterClient.h>)

--- a/Source/WTF/wtf/spi/cocoa/IOReturnSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOReturnSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if HAVE(IOSURFACE)
 

--- a/Source/WTF/wtf/spi/cocoa/IOTypesSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOTypesSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if PLATFORM(MAC) || PLATFORM(IOS) || USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
@@ -25,11 +25,14 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <mach/boolean.h>
 #include <mach/kern_return.h>
 #include <mach/mach_types.h>
+#include <wtf/Platform.h>
 
 #if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 #include <mach/mach_vm.h>

--- a/Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #ifdef __OBJC__
 

--- a/Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #ifdef __OBJC__
 

--- a/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <os/log.h>
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/cocoa/XTSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/XTSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 enum {
     kXTScopeNone    = 0,
     kXTScopeProcess = 1UL << 0,

--- a/Source/WTF/wtf/spi/cocoa/objcSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/objcSPI.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <objc/objc.h>
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/darwin/CodeSignSPI.h
+++ b/Source/WTF/wtf/spi/darwin/CodeSignSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/darwin/DataVaultSPI.h
+++ b/Source/WTF/wtf/spi/darwin/DataVaultSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if OS(DARWIN)
 

--- a/Source/WTF/wtf/spi/darwin/DispatchSPI.h
+++ b/Source/WTF/wtf/spi/darwin/DispatchSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/darwin/OSVariantSPI.h
+++ b/Source/WTF/wtf/spi/darwin/OSVariantSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
+++ b/Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if OS(DARWIN)
 
 #if !PLATFORM(IOS_FAMILY_SIMULATOR) && __has_include(<libproc.h>)

--- a/Source/WTF/wtf/spi/darwin/SandboxSPI.h
+++ b/Source/WTF/wtf/spi/darwin/SandboxSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if OS(DARWIN)
 

--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -25,10 +25,13 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <dispatch/dispatch.h>
 #include <os/object.h>
+#include <wtf/Platform.h>
 
 #if HAVE(XPC_API) || USE(APPLE_INTERNAL_SDK)
 #include <xpc/xpc.h>

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WTF/wtf/spi/mac/MetadataSPI.h
+++ b/Source/WTF/wtf/spi/mac/MetadataSPI.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
+
+#include <wtf/Platform.h>
 
 #ifdef __OBJC__
 

--- a/Source/WTF/wtf/text/FastCharacterComparison.h
+++ b/Source/WTF/wtf/text/FastCharacterComparison.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/text/LineEnding.h
+++ b/Source/WTF/wtf/text/LineEnding.h
@@ -31,7 +31,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <wtf/Forward.h>
+#include <wtf/Vector.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/text/TextBreakIteratorInternalICU.h
+++ b/Source/WTF/wtf/text/TextBreakIteratorInternalICU.h
@@ -23,6 +23,8 @@
 // FIXME: Now that this handles locales for ICU, not just for text breaking,
 // this file and the various implementation files should be renamed.
 
+#include <wtf/ExportMacros.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE const char* currentSearchLocaleID();

--- a/Source/WTF/wtf/text/UTF8ConversionError.h
+++ b/Source/WTF/wtf/text/UTF8ConversionError.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 enum class UTF8ConversionError : uint8_t { OutOfMemory, Invalid };

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
 #include <CoreFoundation/CoreFoundation.h>
 #endif

--- a/Source/WTF/wtf/text/icu/UTextProvider.h
+++ b/Source/WTF/wtf/text/icu/UTextProvider.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include <limits>
+#include <span>
 #include <unicode/utext.h>
+#include <wtf/Assertions.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <unicode/utext.h>
+#include <wtf/ExportMacros.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/text/Latin1Character.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include <span>
 #include <unicode/utext.h>
+#include <wtf/ExportMacros.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/text/icu/UnicodeExtras.h
+++ b/Source/WTF/wtf/text/icu/UnicodeExtras.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <span>
 #include <unicode/ucsdet.h>
+#include <wtf/ExportMacros.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/unicode/Collator.h
+++ b/Source/WTF/wtf/unicode/Collator.h
@@ -28,9 +28,13 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <unicode/uconfig.h>
+#include <wtf/ExportMacros.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
 struct UCharIterator;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <span>
+#include <wtf/ExportMacros.h>
 #include <wtf/text/Latin1Character.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/unicode/icu/ICUHelpers.h
+++ b/Source/WTF/wtf/unicode/icu/ICUHelpers.h
@@ -27,6 +27,7 @@
 
 #include <tuple>
 #include <unicode/utypes.h>
+#include <wtf/Assertions.h>
 #include <wtf/Forward.h>
 #include <wtf/FunctionTraits.h>
 


### PR DESCRIPTION
#### a37b18497f9a36e072449253c8580acfcb87bd34
<pre>
[Swift in WebKit] Work towards fixing the WTF clang module
<a href="https://bugs.webkit.org/show_bug.cgi?id=304457">https://bugs.webkit.org/show_bug.cgi?id=304457</a>
<a href="https://rdar.apple.com/166842178">rdar://166842178</a>

Reviewed by Megan Gardner.

Add some missing header includes across WTF.

* Source/WTF/wtf/AnsiColors.h:
* Source/WTF/wtf/AutodrainedPool.h:
* Source/WTF/wtf/BubbleSort.h:
* Source/WTF/wtf/ByteOrder.h:
* Source/WTF/wtf/ClockType.h:
* Source/WTF/wtf/CryptographicUtilities.h:
* Source/WTF/wtf/CryptographicallyRandomNumber.h:
* Source/WTF/wtf/Dominators.h:
* Source/WTF/wtf/DoublyLinkedList.h:
* Source/WTF/wtf/EnumTraits.h:
* Source/WTF/wtf/EnumeratedArray.h:
* Source/WTF/wtf/Expected.h:
* Source/WTF/wtf/ExperimentalFeatureNames.h:
* Source/WTF/wtf/FastTLS.h:
* Source/WTF/wtf/FlipBytes.h:
* Source/WTF/wtf/FunctionTraits.h:
* Source/WTF/wtf/IndexKeyType.h:
* Source/WTF/wtf/IndexedContainerIterator.h:
* Source/WTF/wtf/IndexedRange.h:
* Source/WTF/wtf/Insertion.h:
* Source/WTF/wtf/InstanceCounted.h:
* Source/WTF/wtf/Int128.h:
* Source/WTF/wtf/IteratorRange.h:
* Source/WTF/wtf/LEBDecoder.h:
* Source/WTF/wtf/LLVMProfilingUtils.h:
* Source/WTF/wtf/LoggerHelper.h:
* Source/WTF/wtf/LoggingHashMap.h:
* Source/WTF/wtf/LoggingHashSet.h:
* Source/WTF/wtf/MachSendRight.h:
* Source/WTF/wtf/MappedFileData.h:
* Source/WTF/wtf/MemoryDump.h:
* Source/WTF/wtf/MemoryFootprint.h:
* Source/WTF/wtf/MmapSpan.h:
* Source/WTF/wtf/NumberOfCores.h:
* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/OSRandomSource.h:
* Source/WTF/wtf/OverflowPolicy.h:
* Source/WTF/wtf/Packed.h:
* Source/WTF/wtf/ParallelJobsGeneric.h:
* Source/WTF/wtf/ParallelJobsLibdispatch.h:
* Source/WTF/wtf/ParallelJobsOpenMP.h:
* Source/WTF/wtf/Platform.h:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/PointerPreparations.h:
* Source/WTF/wtf/ProcessID.h:
* Source/WTF/wtf/RAMSize.h:
* Source/WTF/wtf/RandomDevice.h:
* Source/WTF/wtf/RawHex.h:
* Source/WTF/wtf/RawPointer.h:
* Source/WTF/wtf/RawValueTraits.h:
* Source/WTF/wtf/RecursableLambda.h:
* Source/WTF/wtf/ResourceUsage.h:
* Source/WTF/wtf/RuntimeApplicationChecks.h:
* Source/WTF/wtf/SIMDHelpers.h:
* Source/WTF/wtf/SafeStrerror.h:
* Source/WTF/wtf/SaturatedArithmetic.h:
* Source/WTF/wtf/ScopedPrintStream.h:
* Source/WTF/wtf/SetForScope.h:
* Source/WTF/wtf/SimpleStats.h:
* Source/WTF/wtf/SixCharacterHash.h:
* Source/WTF/wtf/SoftLinking.h:
* Source/WTF/wtf/StackPointer.h:
* Source/WTF/wtf/StackStats.h:
* Source/WTF/wtf/StackTrace.h:
* Source/WTF/wtf/StdFilesystem.h:
* Source/WTF/wtf/StdIntExtras.h:
* Source/WTF/wtf/Stopwatch.h:
* Source/WTF/wtf/SystemMalloc.h:
* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/TaggedPtr.h:
* Source/WTF/wtf/ThreadAssertions.h:
* Source/WTF/wtf/TranslatedProcess.h:
* Source/WTF/wtf/TriState.h:
* Source/WTF/wtf/URLHelpers.h:
* Source/WTF/wtf/Unexpected.h:
* Source/WTF/wtf/UniqueRef.h:
* Source/WTF/wtf/VMTags.h:
* Source/WTF/wtf/WTFProcess.h:
* Source/WTF/wtf/WeakRandom.h:
* Source/WTF/wtf/WeakRandomNumber.h:
* Source/WTF/wtf/WindowsExtras.h:
* Source/WTF/wtf/ZippedRange.h:
* Source/WTF/wtf/cf/CFURLExtras.h:
* Source/WTF/wtf/cf/NotificationCenterCF.h:
* Source/WTF/wtf/cf/TypeCastsCF.h:
* Source/WTF/wtf/cf/VectorCF.h:
* Source/WTF/wtf/cocoa/AuditToken.h:
* Source/WTF/wtf/cocoa/CrashReporter.h:
* Source/WTF/wtf/cocoa/Entitlements.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WTF/wtf/darwin/OSLogPrintStream.h:
* Source/WTF/wtf/dragonbox/detail/decimal_fp.h:
* Source/WTF/wtf/ios/WebCoreThread.h:
* Source/WTF/wtf/spi/cf/CFBundleSPI.h:
* Source/WTF/wtf/spi/cf/CFPrivSPI.h:
* Source/WTF/wtf/spi/cf/CFRunLoopSPI.h:
* Source/WTF/wtf/spi/cf/CFStringSPI.h:
* Source/WTF/wtf/spi/cocoa/BOMSPI.h:
* Source/WTF/wtf/spi/cocoa/CFXPCBridgeSPI.h:
* Source/WTF/wtf/spi/cocoa/CrashReporterClientSPI.h:
* Source/WTF/wtf/spi/cocoa/IOReturnSPI.h:
* Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h:
* Source/WTF/wtf/spi/cocoa/IOTypesSPI.h:
* Source/WTF/wtf/spi/cocoa/MachVMSPI.h:
* Source/WTF/wtf/spi/cocoa/NSLocaleSPI.h:
* Source/WTF/wtf/spi/cocoa/NSObjCRuntimeSPI.h:
* Source/WTF/wtf/spi/cocoa/OSLogSPI.h:
* Source/WTF/wtf/spi/cocoa/SecuritySPI.h:
* Source/WTF/wtf/spi/cocoa/XTSPI.h:
* Source/WTF/wtf/spi/cocoa/objcSPI.h:
* Source/WTF/wtf/spi/darwin/CodeSignSPI.h:
* Source/WTF/wtf/spi/darwin/DataVaultSPI.h:
* Source/WTF/wtf/spi/darwin/DispatchSPI.h:
* Source/WTF/wtf/spi/darwin/OSVariantSPI.h:
* Source/WTF/wtf/spi/darwin/ProcessMemoryFootprint.h:
* Source/WTF/wtf/spi/darwin/SandboxSPI.h:
* Source/WTF/wtf/spi/darwin/XPCSPI.h:
* Source/WTF/wtf/spi/darwin/dyldSPI.h:
* Source/WTF/wtf/spi/mac/MetadataSPI.h:
* Source/WTF/wtf/text/FastCharacterComparison.h:
* Source/WTF/wtf/text/LineEnding.h:
* Source/WTF/wtf/text/TextBreakIteratorInternalICU.h:
* Source/WTF/wtf/text/UTF8ConversionError.h:
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
* Source/WTF/wtf/text/icu/UTextProvider.h:
* Source/WTF/wtf/text/icu/UTextProviderLatin1.h:
* Source/WTF/wtf/text/icu/UTextProviderUTF16.h:
* Source/WTF/wtf/text/icu/UnicodeExtras.h:
* Source/WTF/wtf/unicode/Collator.h:
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WTF/wtf/unicode/icu/ICUHelpers.h:

Canonical link: <a href="https://commits.webkit.org/304750@main">https://commits.webkit.org/304750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b504289840888ddf23256008a27933da3d6cdf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144127 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/151be280-937f-49a0-a679-b84571cf6ac0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/903625e8-df45-448b-9295-0f89b9368dc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85153 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eb532d27-291b-401a-9d05-e10e3db5e077) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4199 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128372 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146874 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134899 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6477 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62441 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36593 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167678 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72061 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43739 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->