### PR TITLE
[GLib] Add webkit_context_menu_item_get_title API

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
@@ -61,6 +61,7 @@ struct _WebKitContextMenuItemPrivate {
 
     std::unique_ptr<WebContextMenuItemGlib> menuItem;
     GRefPtr<WebKitContextMenu> subMenu;
+    CString titleUTF8;
 #endif // ENABLE(CONTEXT_MENUS)
 };
 
@@ -334,6 +335,29 @@ GAction* webkit_context_menu_item_get_gaction(WebKitContextMenuItem* item)
 }
 
 /**
+ * webkit_context_menu_item_get_gaction_target:
+ * @item: a #WebKitContextMenuItem
+ *
+ * Gets the target #GVariant associated with @item.
+ *
+ * Returns: (transfer none) (nullable): the target #GVariant of the #WebKitContextMenuItem,
+ *    or %NULL if @item was not created with webkit_context_menu_item_new_from_gaction()
+ *    or if no target was specified.
+ *
+ * Since: 2.52
+ */
+GVariant* webkit_context_menu_item_get_gaction_target(WebKitContextMenuItem* item)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), nullptr);
+
+#if ENABLE(CONTEXT_MENUS)
+    return item->priv->menuItem->gActionTarget();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
+}
+
+/**
  * webkit_context_menu_item_get_stock_action:
  * @item: a #WebKitContextMenuItem
  *
@@ -352,6 +376,31 @@ WebKitContextMenuAction webkit_context_menu_item_get_stock_action(WebKitContextM
 
 #if ENABLE(CONTEXT_MENUS)
     return webkitContextMenuActionGetForContextMenuItem(*item->priv->menuItem);
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
+}
+
+/**
+ * webkit_context_menu_item_get_title:
+ * @item: a #WebKitContextMenuItem
+ *
+ * Gets the title of @item.
+ *
+ * Returns: (transfer none): the title of @item, or %NULL if @item is a separator.
+ *
+ * Since: 2.52
+ */
+const gchar* webkit_context_menu_item_get_title(WebKitContextMenuItem* item)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), nullptr);
+
+#if ENABLE(CONTEXT_MENUS)
+    if (item->priv->menuItem->type() == WebCore::ContextMenuItemType::Separator)
+        return nullptr;
+    if (item->priv->titleUTF8.isNull())
+        item->priv->titleUTF8 = item->priv->menuItem->title().utf8();
+    return item->priv->titleUTF8.data();
 #else
     g_assert_not_reached();
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
@@ -86,8 +86,14 @@ webkit_context_menu_item_get_action                       (WebKitContextMenuItem
 WEBKIT_API GAction *
 webkit_context_menu_item_get_gaction                      (WebKitContextMenuItem  *item);
 
+WEBKIT_API GVariant *
+webkit_context_menu_item_get_gaction_target               (WebKitContextMenuItem  *item);
+
 WEBKIT_API WebKitContextMenuAction
 webkit_context_menu_item_get_stock_action                 (WebKitContextMenuItem  *item);
+
+WEBKIT_API const gchar *
+webkit_context_menu_item_get_title                        (WebKitContextMenuItem  *item);
 
 WEBKIT_API gboolean
 webkit_context_menu_item_is_separator                     (WebKitContextMenuItem  *item);


### PR DESCRIPTION
#### 8a4ffd46ddaa97213e5575a7cde3e92086036a48
<pre>
[GLib] Add webkit_context_menu_item_get_title API

  <a href="https://bugs.webkit.org/show_bug.cgi?id=272354">https://bugs.webkit.org/show_bug.cgi?id=272354</a>

  Reviewed by Carlos Garcia Campos.
  Add webkit_context_menu_item_get_title() API to get the title of a context
  menu item, and webkit_context_menu_item_get_gaction_target() API to get
  the target GVariant associated with a context menu item created from
  a GAction.

  API tests for GTK/WPE will be added in a follow-up patch.

  * Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp:
    (webkit_context_menu_item_get_gaction_target):
    (webkit_context_menu_item_get_title):
  * Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in:&quot;

Canonical link: <a href="https://commits.webkit.org/304810@main">https://commits.webkit.org/304810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf742f548d7dc65f186d1816b582eec366f61e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144171 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104348 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6576 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4238 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115877 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8497 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113031 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6512 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118576 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62485 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36628 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72104 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->