### PR TITLE
Use WTF::move() instead of WTFMove() macro in Source/WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -37,7 +37,7 @@ namespace WebKit {
 class GPUServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
     GPUServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
-        : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
+        : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }
 };

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -242,7 +242,7 @@ private:
     {
         auto mediaEnvironment = m_process.get()->mediaEnvironment(pageIdentifier);
         bool result = !mediaEnvironment.isEmpty();
-        WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(WTFMove(mediaEnvironment));
+        WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(WTF::move(mediaEnvironment));
         return result;
     }
 #endif
@@ -308,14 +308,14 @@ static ProcessIdentity adjustProcessIdentityIfNeeded(ProcessIdentity&& identity)
 
 Ref<GPUConnectionToWebProcess> GPUConnectionToWebProcess::create(GPUProcess& gpuProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters)
 {
-    return adoptRef(*new GPUConnectionToWebProcess(gpuProcess, webProcessIdentifier, sessionID, WTFMove(connectionHandle), WTFMove(parameters)));
+    return adoptRef(*new GPUConnectionToWebProcess(gpuProcess, webProcessIdentifier, sessionID, WTF::move(connectionHandle), WTF::move(parameters)));
 }
 
 GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, WebCore::ProcessIdentifier webProcessIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters)
-    : m_connection(IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(connectionHandle) }))
+    : m_connection(IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(connectionHandle) }))
     , m_gpuProcess(gpuProcess)
     , m_webProcessIdentifier(webProcessIdentifier)
-    , m_webProcessIdentity(adjustProcessIdentityIfNeeded(WTFMove(parameters.webProcessIdentity)))
+    , m_webProcessIdentity(adjustProcessIdentityIfNeeded(WTF::move(parameters.webProcessIdentity)))
 #if ENABLE(VIDEO)
     , m_remoteMediaPlayerManagerProxy(RemoteMediaPlayerManagerProxy::create(*this))
 #endif
@@ -338,7 +338,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_libWebRTCCodecsProxy(LibWebRTCCodecsProxy::create(*this, parameters.sharedPreferencesForWebProcess))
 #endif
 #if HAVE(AUDIT_TOKEN)
-    , m_presentingApplicationAuditTokens(WTFMove(parameters.presentingApplicationAuditTokens))
+    , m_presentingApplicationAuditTokens(WTF::move(parameters.presentingApplicationAuditTokens))
 #endif
 #if PLATFORM(COCOA)
     , m_applicationBundleIdentifier(parameters.applicationBundleIdentifier)
@@ -347,7 +347,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
 #if ENABLE(IPC_TESTING_API)
     , m_ipcTester(IPCTester::create())
 #endif
-    , m_sharedPreferencesForWebProcess(WTFMove(parameters.sharedPreferencesForWebProcess))
+    , m_sharedPreferencesForWebProcess(WTF::move(parameters.sharedPreferencesForWebProcess))
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
@@ -486,7 +486,7 @@ void GPUConnectionToWebProcess::createVisibilityPropagationContextForPage(WebPag
     auto contextForVisibilityPropagation = LayerHostingContext::create({ canShowWhileLocked });
     RELEASE_LOG(Process, "GPUConnectionToWebProcess::createVisibilityPropagationContextForPage: pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", contextID=%u", pageProxyID.toUInt64(), pageID.toUInt64(), contextForVisibilityPropagation->contextID());
     gpuProcess().send(Messages::GPUProcessProxy::DidCreateContextForVisibilityPropagation(pageProxyID, pageID, contextForVisibilityPropagation->contextID()));
-    m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTFMove(contextForVisibilityPropagation));
+    m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTF::move(contextForVisibilityPropagation));
 }
 
 void GPUConnectionToWebProcess::destroyVisibilityPropagationContextForPage(WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID)
@@ -523,7 +523,7 @@ void GPUConnectionToWebProcess::configureLoggingChannel(const String& channelNam
 #if USE(GRAPHICS_LAYER_WC)
 void GPUConnectionToWebProcess::createWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering)
 {
-    auto addResult = m_remoteWCLayerTreeHostMap.add(identifier, RemoteWCLayerTreeHost::create(*this, WTFMove(identifier), nativeWindow, usesOffscreenRendering));
+    auto addResult = m_remoteWCLayerTreeHostMap.add(identifier, RemoteWCLayerTreeHost::create(*this, WTF::move(identifier), nativeWindow, usesOffscreenRendering));
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
 
@@ -626,7 +626,7 @@ RemoteMediaResourceManager& GPUConnectionToWebProcess::remoteMediaResourceManage
     if (!m_remoteMediaResourceManager) {
         Ref manager = RemoteMediaResourceManager::create();
         manager->initializeConnection(m_connection.ptr());
-        m_remoteMediaResourceManager = WTFMove(manager);
+        m_remoteMediaResourceManager = WTF::move(manager);
     }
 
     return *m_remoteMediaResourceManager;
@@ -747,7 +747,7 @@ void GPUConnectionToWebProcess::createRenderingBackend(RemoteRenderingBackendIde
 #if ENABLE(IPC_TESTING_API)
     params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
 #endif
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTF::move(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteRenderingBackendMap.ensure(identifier, [&] {
@@ -780,11 +780,11 @@ void GPUConnectionToWebProcess::createGraphicsContextGL(RemoteGraphicsContextGLI
 #if ENABLE(IPC_TESTING_API)
     params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
 #endif
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTF::move(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteGraphicsContextGLMap.ensure(identifier, [&] {
-        return IPC::ScopedActiveMessageReceiveQueue { RemoteGraphicsContextGL::create(*this, WTFMove(attributes), identifier, *renderingBackend, streamConnection.releaseNonNull()) };
+        return IPC::ScopedActiveMessageReceiveQueue { RemoteGraphicsContextGL::create(*this, WTF::move(attributes), identifier, *renderingBackend, streamConnection.releaseNonNull()) };
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
@@ -852,7 +852,7 @@ void GPUConnectionToWebProcess::createGPU(WebGPUIdentifier identifier, RemoteRen
 #if ENABLE(IPC_TESTING_API)
     params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
 #endif
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTF::move(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteGPUMap.ensure(identifier, [&] {
@@ -883,7 +883,7 @@ void GPUConnectionToWebProcess::setNowPlayingInfo(NowPlayingInfo&& nowPlayingInf
     m_isActiveNowPlayingProcess = true;
     Ref gpuProcess = this->gpuProcess();
     gpuProcess->nowPlayingManager().addClient(*this);
-    gpuProcess->nowPlayingManager().setNowPlayingInfo(WTFMove(nowPlayingInfo));
+    gpuProcess->nowPlayingManager().setNowPlayingInfo(WTF::move(nowPlayingInfo));
     updateSupportedRemoteCommands();
 }
 
@@ -955,7 +955,7 @@ Ref<RemoteMediaEngineConfigurationFactoryProxy> GPUConnectionToWebProcess::prote
 void GPUConnectionToWebProcess::createAudioHardwareListener(RemoteAudioHardwareListenerIdentifier identifier)
 {
     auto addResult = m_remoteAudioHardwareListenerMap.ensure(identifier, [&]() {
-        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTFMove(identifier));
+        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTF::move(identifier));
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
@@ -968,7 +968,7 @@ void GPUConnectionToWebProcess::releaseAudioHardwareListener(RemoteAudioHardware
 
 void GPUConnectionToWebProcess::createRemoteCommandListener(RemoteRemoteCommandListenerIdentifier identifier)
 {
-    m_remoteRemoteCommandListener = RemoteRemoteCommandListenerProxy::create(*this, WTFMove(identifier));
+    m_remoteRemoteCommandListener = RemoteRemoteCommandListenerProxy::create(*this, WTF::move(identifier));
 }
 
 void GPUConnectionToWebProcess::releaseRemoteCommandListener(RemoteRemoteCommandListenerIdentifier identifier)
@@ -990,14 +990,14 @@ void GPUConnectionToWebProcess::setMediaOverridesForTesting(MediaOverridesForTes
         return;
     }
 #if ENABLE(VP9) && PLATFORM(COCOA)
-    VP9TestingOverrides::singleton().setHardwareDecoderDisabled(WTFMove(overrides.vp9HardwareDecoderDisabled));
-    VP9TestingOverrides::singleton().setVP9DecoderDisabled(WTFMove(overrides.vp9DecoderDisabled));
-    VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(WTFMove(overrides.vp9ScreenSizeAndScale));
+    VP9TestingOverrides::singleton().setHardwareDecoderDisabled(WTF::move(overrides.vp9HardwareDecoderDisabled));
+    VP9TestingOverrides::singleton().setVP9DecoderDisabled(WTF::move(overrides.vp9DecoderDisabled));
+    VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(WTF::move(overrides.vp9ScreenSizeAndScale));
 #endif
 
 #if PLATFORM(COCOA)
-    SystemBatteryStatusTestingOverrides::singleton().setHasAC(WTFMove(overrides.systemHasAC));
-    SystemBatteryStatusTestingOverrides::singleton().setHasBattery(WTFMove(overrides.systemHasBattery));
+    SystemBatteryStatusTestingOverrides::singleton().setHasAC(WTF::move(overrides.systemHasAC));
+    SystemBatteryStatusTestingOverrides::singleton().setHasBattery(WTF::move(overrides.systemHasBattery));
 #endif
 }
 
@@ -1318,13 +1318,13 @@ void GPUConnectionToWebProcess::enableMockMediaSource()
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 void GPUConnectionToWebProcess::updateSampleBufferDisplayLayerBoundsAndPosition(SampleBufferDisplayLayerIdentifier identifier, WebCore::FloatRect bounds, std::optional<MachSendRightAnnotated>&& fence)
 {
-    m_sampleBufferDisplayLayerManager->updateSampleBufferDisplayLayerBoundsAndPosition(identifier, bounds, WTFMove(fence));
+    m_sampleBufferDisplayLayerManager->updateSampleBufferDisplayLayerBoundsAndPosition(identifier, bounds, WTF::move(fence));
 }
 #endif
 
 void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess)
 {
-    m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
+    m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess);
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     protectedLibWebRTCCodecsProxy()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
@@ -1388,7 +1388,7 @@ void GPUConnectionToWebProcess::takeInvalidMessageStringForTesting(CompletionHan
 {
     ASCIILiteral error = connection().takeErrorString();
     String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
-    callback(WTFMove(errorString));
+    callback(WTF::move(errorString));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -112,12 +112,12 @@ void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier iden
 {
     RELEASE_LOG(Process, "%p - GPUProcess::createGPUConnectionToWebProcess: processIdentifier=%" PRIu64, this, identifier.toUInt64());
 
-    auto reply = makeScopeExit(WTFMove(completionHandler));
+    auto reply = makeScopeExit(WTF::move(completionHandler));
     // If sender exited before we received the handle, the handle may not be valid.
     if (!connectionHandle)
         return;
 
-    auto newConnection = GPUConnectionToWebProcess::create(*this, identifier, sessionID, WTFMove(connectionHandle), WTFMove(parameters));
+    auto newConnection = GPUConnectionToWebProcess::create(*this, identifier, sessionID, WTF::move(connectionHandle), WTF::move(parameters));
 
 #if ENABLE(MEDIA_STREAM)
     // FIXME: We should refactor code to go from WebProcess -> GPUProcess -> UIProcess when getUserMedia is called instead of going from WebProcess -> UIProcess directly.
@@ -132,13 +132,13 @@ void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier iden
 #endif
 
     ASSERT(!m_webProcessConnections.contains(identifier));
-    m_webProcessConnections.add(identifier, WTFMove(newConnection));
+    m_webProcessConnections.add(identifier, WTF::move(newConnection));
 }
 
 void GPUProcess::sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier identifier, SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess, CompletionHandler<void()>&& completionHandler)
 {
     if (RefPtr connection = m_webProcessConnections.get(identifier))
-        connection->updateSharedPreferencesForWebProcess(WTFMove(sharedPreferencesForWebProcess));
+        connection->updateSharedPreferencesForWebProcess(WTF::move(sharedPreferencesForWebProcess));
     completionHandler();
 }
 
@@ -217,9 +217,9 @@ void GPUProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)
 
 void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters, CompletionHandler<void()>&& completionHandler)
 {
-    CompletionHandlerCallingScope callCompletionHandler(WTFMove(completionHandler));
+    CompletionHandlerCallingScope callCompletionHandler(WTF::move(completionHandler));
 
-    applyProcessCreationParameters(WTFMove(parameters.auxiliaryProcessParameters));
+    applyProcessCreationParameters(WTF::move(parameters.auxiliaryProcessParameters));
     RELEASE_LOG(Process, "%p - GPUProcess::initializeGPUProcess:", this);
     WTF::Thread::setCurrentThreadIsUserInitiated();
     WebCore::initializeCommonAtomStrings();
@@ -254,7 +254,7 @@ CoreAudioCaptureUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProc
     grantAccessToContainerTempDirectory(parameters.containerTemporaryDirectoryExtensionHandle);
 #endif
 
-    populateMobileGestaltCache(WTFMove(parameters.mobileGestaltExtensionHandle));
+    populateMobileGestaltCache(WTF::move(parameters.mobileGestaltExtensionHandle));
 
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     SandboxExtension::consumePermanently(parameters.gpuToolsExtensionHandles);
@@ -264,7 +264,7 @@ CoreAudioCaptureUnit::defaultSingleton().setStatusBarWasTappedCallback([weakProc
     WebCore::setImageSourceAllowableTypes({ });
 #endif
 
-    m_applicationVisibleName = WTFMove(parameters.applicationVisibleName);
+    m_applicationVisibleName = WTF::move(parameters.applicationVisibleName);
 
     // Match the QoS of the UIProcess since the GPU process is doing rendering on its behalf.
     WTF::Thread::setCurrentThreadIsUserInteractive(0);
@@ -306,7 +306,7 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
 bool GPUProcess::updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference)
 {
     if (newPreference.has_value() && oldPreference != newPreference) {
-        oldPreference = WTFMove(newPreference);
+        oldPreference = WTF::move(newPreference);
         return true;
     }
     
@@ -386,7 +386,7 @@ void GPUProcess::sinkCompletedSnapshotToPDF(RemoteSnapshotIdentifier identifier,
         ASSERT_NOT_REACHED();
         return;
     }
-    completionHandler(WTFMove(*result));
+    completionHandler(WTF::move(*result));
 }
 
 #endif
@@ -527,7 +527,7 @@ void GPUProcess::setShouldListenToVoiceActivity(bool shouldListen)
 #if HAVE(SCREEN_CAPTURE_KIT)
 void GPUProcess::promptForGetDisplayMedia(WebCore::DisplayCapturePromptType type, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&& completionHandler)
 {
-    WebCore::ScreenCaptureKitSharingSessionManager::singleton().promptForGetDisplayMedia(type, WTFMove(completionHandler));
+    WebCore::ScreenCaptureKitSharingSessionManager::singleton().promptForGetDisplayMedia(type, WTF::move(completionHandler));
 }
 
 void GPUProcess::cancelGetDisplayMediaPrompt()
@@ -546,9 +546,9 @@ void GPUProcess::addSession(PAL::SessionID sessionID, GPUProcessSessionParameter
 #endif
 
     m_sessions.add(sessionID, GPUSession {
-        WTFMove(parameters.mediaCacheDirectory)
+        WTF::move(parameters.mediaCacheDirectory)
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
-        , WTFMove(parameters.mediaKeysStorageDirectory)
+        , WTF::move(parameters.mediaKeysStorageDirectory)
 #endif
     });
 }
@@ -672,7 +672,7 @@ void GPUProcess::webXRPromptAccepted(std::optional<WebCore::ProcessIdentity> pro
 void GPUProcess::setPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<WebKit::CoreIPCAuditToken>&& auditToken)
 {
     if (RefPtr connection = m_webProcessConnections.get(processIdentifier))
-        connection->setPresentingApplicationAuditToken(pageIdentifier, WTFMove(auditToken));
+        connection->setPresentingApplicationAuditToken(pageIdentifier, WTF::move(auditToken));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
@@ -75,7 +75,7 @@ RemoteSharedResourceCache::~RemoteSharedResourceCache() = default;
 bool RemoteSharedResourceCache::addSerializedImageBuffer(RemoteSerializedImageBufferIdentifier identifier, Ref<ImageBuffer> imageBuffer)
 {
     didCreateImageBuffer(imageBuffer->renderingPurpose(), imageBuffer->renderingMode());
-    return m_serializedImageBuffers.add({ identifier, 0 }, WTFMove(imageBuffer));
+    return m_serializedImageBuffers.add({ identifier, 0 }, WTF::move(imageBuffer));
 }
 
 RefPtr<ImageBuffer> RemoteSharedResourceCache::takeSerializedImageBuffer(RemoteSerializedImageBufferIdentifier identifier)
@@ -88,7 +88,7 @@ RefPtr<ImageBuffer> RemoteSharedResourceCache::takeSerializedImageBuffer(RemoteS
 
 bool RemoteSharedResourceCache::addNativeImage(RenderingResourceIdentifier identifier, Ref<NativeImage> image)
 {
-    return m_nativeImages.add({ identifier, 0 }, WTFMove(image));
+    return m_nativeImages.add({ identifier, 0 }, WTF::move(image));
 }
 
 RefPtr<NativeImage> RemoteSharedResourceCache::takeNativeImage(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -44,7 +44,7 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBarcodeDetector);
 
 RemoteBarcodeDetector::RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier)
-    : m_backing(WTFMove(barcodeDetector))
+    : m_backing(WTF::move(barcodeDetector))
     , m_renderingBackend(backend)
     , m_identifier(identifier)
 {
@@ -61,7 +61,7 @@ void RemoteBarcodeDetector::detect(WebCore::RenderingResourceIdentifier renderin
 {
     RefPtr sourceImage = m_renderingBackend.get().remoteResourceCache().cachedNativeImage(renderingResourceIdentifier);
     MESSAGE_CHECK(sourceImage);
-    m_backing->detect(*sourceImage, WTFMove(completionHandler));
+    m_backing->detect(*sourceImage, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -59,7 +59,7 @@ public:
 public:
     static Ref<RemoteBarcodeDetector> create(Ref<WebCore::ShapeDetection::BarcodeDetector>&& barcodeDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteBarcodeDetector(WTFMove(barcodeDetector), renderingBackend, identifier));
+        return adoptRef(*new RemoteBarcodeDetector(WTF::move(barcodeDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -43,7 +43,7 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFaceDetector);
 
 RemoteFaceDetector::RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, RemoteRenderingBackend& backend, ShapeDetectionIdentifier identifier)
-    : m_backing(WTFMove(faceDetector))
+    : m_backing(WTF::move(faceDetector))
     , m_renderingBackend(backend)
     , m_identifier(identifier)
 {
@@ -60,7 +60,7 @@ void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingRe
 {
     RefPtr sourceImage = m_renderingBackend.get().remoteResourceCache().cachedNativeImage(renderingResourceIdentifier);
     MESSAGE_CHECK(sourceImage);
-    m_backing->detect(*sourceImage, WTFMove(completionHandler));
+    m_backing->detect(*sourceImage, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -59,7 +59,7 @@ public:
 public:
     static Ref<RemoteFaceDetector> create(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), renderingBackend, identifier));
+        return adoptRef(*new RemoteFaceDetector(WTF::move(faceDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
@@ -43,7 +43,7 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextDetector);
 
 RemoteTextDetector::RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
-    : m_backing(WTFMove(textDetector))
+    : m_backing(WTF::move(textDetector))
     , m_renderingBackend(renderingBackend)
     , m_identifier(identifier)
 {
@@ -60,7 +60,7 @@ void RemoteTextDetector::detect(WebCore::RenderingResourceIdentifier renderingRe
 {
     RefPtr sourceImage = m_renderingBackend.get().remoteResourceCache().cachedNativeImage(renderingResourceIdentifier);
     MESSAGE_CHECK(sourceImage);
-    m_backing->detect(*sourceImage, WTFMove(completionHandler));
+    m_backing->detect(*sourceImage, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -58,7 +58,7 @@ public:
 public:
     static Ref<RemoteTextDetector> create(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, RemoteRenderingBackend& renderingBackend, ShapeDetectionIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), renderingBackend, identifier));
+        return adoptRef(*new RemoteTextDetector(WTF::move(textDetector), renderingBackend, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -104,7 +104,7 @@ void GPUConnectionToWebProcess::setTCCIdentity()
         return;
     }
 
-    WebCore::RealtimeMediaSourceCenter::singleton().setIdentity(WTFMove(identity));
+    WebCore::RealtimeMediaSourceCenter::singleton().setIdentity(WTF::move(identity));
 #endif // !PLATFORM(MACCATALYST)
 }
 #endif // ENABLE(APP_PRIVACY_REPORT)

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -109,7 +109,7 @@ void GPUProcess::ensureAVCaptureServerConnection()
 void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& parameters)
 {
 #if PLATFORM(MAC)
-    auto launchServicesExtension = SandboxExtension::create(WTFMove(parameters.launchServicesExtensionHandle));
+    auto launchServicesExtension = SandboxExtension::create(WTF::move(parameters.launchServicesExtensionHandle));
     if (launchServicesExtension) {
         bool ok = launchServicesExtension->consume();
         ASSERT_UNUSED(ok, ok);
@@ -176,7 +176,7 @@ void GPUProcess::resolveBookmarkDataForCacheDirectory(std::span<const uint8_t> b
 void GPUProcess::requestSharedSimulationConnection(CoreIPCAuditToken&& modelProcessAuditToken, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler)
 {
     Ref<WKSharedSimulationConnectionHelper> sharedSimulationConnectionHelper = adoptRef(*new WKSharedSimulationConnectionHelper);
-    sharedSimulationConnectionHelper->requestSharedSimulationConnectionForAuditToken(modelProcessAuditToken.auditToken(), [sharedSimulationConnectionHelper, completionHandler = WTFMove(completionHandler)] (RetainPtr<NSFileHandle> sharedSimulationConnection, RetainPtr<id> appService) mutable {
+    sharedSimulationConnectionHelper->requestSharedSimulationConnectionForAuditToken(modelProcessAuditToken.auditToken(), [sharedSimulationConnectionHelper, completionHandler = WTF::move(completionHandler)] (RetainPtr<NSFileHandle> sharedSimulationConnection, RetainPtr<id> appService) mutable {
         if (!sharedSimulationConnection) {
             RELEASE_LOG_ERROR(ModelElement, "GPUProcess: Shared simulation join request failed");
             completionHandler(std::nullopt);
@@ -192,7 +192,7 @@ void GPUProcess::requestSharedSimulationConnection(CoreIPCAuditToken&& modelProc
 void GPUProcess::createMemoryAttributionIDForTask(WebCore::ProcessIdentity processIdentity, CompletionHandler<void(const std::optional<String>&)>&& completionHandler)
 {
     Ref<WKSharedSimulationConnectionHelper> sharedSimulationConnectionHelper = adoptRef(*new WKSharedSimulationConnectionHelper);
-    sharedSimulationConnectionHelper->createMemoryAttributionIDForTask(processIdentity.taskIdToken(), [sharedSimulationConnectionHelper, completionHandler = WTFMove(completionHandler)] (RetainPtr<NSString> attributionTaskID, RetainPtr<id> appService) mutable {
+    sharedSimulationConnectionHelper->createMemoryAttributionIDForTask(processIdentity.taskIdToken(), [sharedSimulationConnectionHelper, completionHandler = WTF::move(completionHandler)] (RetainPtr<NSString> attributionTaskID, RetainPtr<id> appService) mutable {
         if (!attributionTaskID) {
             RELEASE_LOG_ERROR(ModelElement, "GPUProcess: Memory attribution ID request failed");
             completionHandler(std::nullopt);
@@ -207,7 +207,7 @@ void GPUProcess::createMemoryAttributionIDForTask(WebCore::ProcessIdentity proce
 void GPUProcess::unregisterMemoryAttributionID(const String& attributionID, CompletionHandler<void()>&& completionHandler)
 {
     Ref<WKSharedSimulationConnectionHelper> sharedSimulationConnectionHelper = adoptRef(*new WKSharedSimulationConnectionHelper);
-    sharedSimulationConnectionHelper->unregisterMemoryAttributionID(attributionID.createNSString().get(), [sharedSimulationConnectionHelper, completionHandler = WTFMove(completionHandler)] (RetainPtr<id> appService) mutable {
+    sharedSimulationConnectionHelper->unregisterMemoryAttributionID(attributionID.createNSString().get(), [sharedSimulationConnectionHelper, completionHandler = WTF::move(completionHandler)] (RetainPtr<id> appService) mutable {
         if (appService)
             RELEASE_LOG(ModelElement, "GPUProcess: Memory attribution ID unregistration succeeded");
         else

--- a/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
+++ b/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& parameters)
 {
 #if USE(GBM)
-    WebCore::DRMDeviceManager::singleton().initializeMainDevice(WTFMove(parameters.drmDevice));
+    WebCore::DRMDeviceManager::singleton().initializeMainDevice(WTF::move(parameters.drmDevice));
 
     if (auto device = WebCore::DRMDeviceManager::singleton().mainGBMDevice(WebCore::DRMDeviceManager::NodeType::Render)) {
         WebCore::PlatformDisplay::setSharedDisplay(WebCore::PlatformDisplayGBM::create(device->device()));

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
@@ -84,7 +84,7 @@ RefPtr<ImageBuffer> ImageBufferShareableAllocator::createImageBuffer(const Float
     if (!handle)
         return nullptr;
 
-    transferMemoryOwnership(WTFMove(handle->handle()));
+    transferMemoryOwnership(WTF::move(handle->handle()));
     return imageBuffer;
 }
 
@@ -98,7 +98,7 @@ RefPtr<PixelBuffer> ImageBufferShareableAllocator::createPixelBuffer(const Pixel
     if (!handle)
         return nullptr;
 
-    transferMemoryOwnership(WTFMove(*handle));
+    transferMemoryOwnership(WTF::move(*handle));
     return pixelBuffer;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteDDMesh);
 RemoteDDMesh::RemoteDDMesh(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::DDModel::DDMesh& mesh, DDModel::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, DDModelIdentifier identifier)
     : m_backing(mesh)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
@@ -80,7 +80,7 @@ void RemoteDDMesh::destruct()
 
 void RemoteDDMesh::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    m_backing->setLabel(WTF::move(label));
 }
 
 void RemoteDDMesh::update(const WebCore::DDModel::DDUpdateMeshDescriptor& descriptor)

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteDDMesh.h
@@ -63,7 +63,7 @@ class RemoteDDMesh final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteDDMesh> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::DDModel::DDMesh& mesh, DDModel::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, DDModelIdentifier identifier)
     {
-        return adoptRef(*new RemoteDDMesh(gpuConnectionToWebProcess, gpu, mesh, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteDDMesh(gpuConnectionToWebProcess, gpu, mesh, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteDDMesh();

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -42,7 +42,7 @@ Ref<RemoteDisplayListRecorder> RemoteDisplayListRecorder::create(RemoteDisplayLi
 
 RemoteDisplayListRecorder::RemoteDisplayListRecorder(UniqueRef<DisplayList::RecorderImpl>&& recorder, RemoteDisplayListRecorderIdentifier identifier, RemoteRenderingBackend& renderingBackend)
     : RemoteGraphicsContext(recorder, renderingBackend)
-    , m_recorder(WTFMove(recorder))
+    , m_recorder(WTF::move(recorder))
     , m_identifier(identifier)
 {
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -147,7 +147,7 @@ void RemoteGraphicsContext::setFillCachedGradient(RemoteGradientIdentifier ident
 
 void RemoteGraphicsContext::setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
-    context().setFillGradient(WTFMove(gradient), spaceTransform);
+    context().setFillGradient(WTF::move(gradient), spaceTransform);
 }
 
 void RemoteGraphicsContext::setFillPatternNativeImage(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
@@ -188,7 +188,7 @@ void RemoteGraphicsContext::setStrokeCachedGradient(RemoteGradientIdentifier ide
 
 void RemoteGraphicsContext::setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
-    context().setStrokeGradient(WTFMove(gradient), spaceTransform);
+    context().setStrokeGradient(WTF::move(gradient), spaceTransform);
 }
 
 void RemoteGraphicsContext::setStrokePatternNativeImage(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
@@ -360,7 +360,7 @@ void RemoteGraphicsContext::drawFilteredImageBufferInternal(std::optional<Render
 
         auto effectImage = sourceImage(feImage->sourceImage().imageIdentifier());
         MESSAGE_CHECK(effectImage);
-        feImage->setImageSource(WTFMove(*effectImage));
+        feImage->setImageSource(WTF::move(*effectImage));
     }
 
     context().drawFilteredImageBuffer(sourceImageBuffer.get(), sourceImageRect, filter, results);
@@ -381,7 +381,7 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
     }
 
     RefPtr cachedFilter = resourceCache().cachedFilter(filter->renderingResourceIdentifier());
-    RefPtr cachedSVGFilter = dynamicDowncast<SVGFilterRenderer>(WTFMove(cachedFilter));
+    RefPtr cachedSVGFilter = dynamicDowncast<SVGFilterRenderer>(WTF::move(cachedFilter));
     MESSAGE_CHECK(cachedSVGFilter);
 
     cachedSVGFilter->mergeEffects(svgFilter->effects());
@@ -392,7 +392,7 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
 #else
         auto allocator = makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner());
 #endif
-        return makeUnique<FilterResults>(WTFMove(allocator));
+        return makeUnique<FilterResults>(WTF::move(allocator));
     });
 
     drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, *cachedSVGFilter, results);
@@ -599,18 +599,18 @@ SharedVideoFrameReader& RemoteGraphicsContext::sharedVideoFrameReader()
 
 void RemoteGraphicsContext::drawVideoFrame(SharedVideoFrame&& frame, const FloatRect& destination, ImageOrientation orientation, bool shouldDiscardAlpha)
 {
-    if (auto videoFrame = sharedVideoFrameReader().read(WTFMove(frame)))
+    if (auto videoFrame = sharedVideoFrameReader().read(WTF::move(frame)))
         context().drawVideoFrame(*videoFrame, destination, orientation, shouldDiscardAlpha);
 }
 
 void RemoteGraphicsContext::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)
 {
-    sharedVideoFrameReader().setSemaphore(WTFMove(semaphore));
+    sharedVideoFrameReader().setSemaphore(WTF::move(semaphore));
 }
 
 void RemoteGraphicsContext::setSharedVideoFrameMemory(SharedMemory::Handle&& handle)
 {
-    sharedVideoFrameReader().setSharedMemory(WTFMove(handle));
+    sharedVideoFrameReader().setSharedMemory(WTF::move(handle));
 }
 #endif // PLATFORM(COCOA) && ENABLE(VIDEO)
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -72,8 +72,8 @@ IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueueSingleton(
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLAttributes&& attributes, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
 {
     ASSERT_NOT_REACHED();
-    auto instance = adoptRef(*new RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection)));
-    instance->initialize(WTFMove(attributes));
+    auto instance = adoptRef(*new RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection)));
+    instance->initialize(WTF::move(attributes));
     return instance;
 }
 #endif
@@ -81,7 +81,7 @@ Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebP
 RemoteGraphicsContextGL::RemoteGraphicsContextGL(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGraphicsContextGLIdentifier identifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_workQueue(remoteGraphicsContextGLStreamWorkQueueSingleton())
-    , m_connection(WTFMove(streamConnection))
+    , m_connection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)
     , m_sharedResourceCache(gpuConnectionToWebProcess.sharedResourceCache())
@@ -108,15 +108,15 @@ IGNORE_GCC_WARNINGS_END
 void RemoteGraphicsContextGL::initialize(GraphicsContextGLAttributes&& attributes)
 {
     assertIsMainRunLoop();
-    m_workQueue->dispatch([attributes = WTFMove(attributes), protectedThis = Ref { *this }]() mutable {
-        protectedThis->workQueueInitialize(WTFMove(attributes));
+    m_workQueue->dispatch([attributes = WTF::move(attributes), protectedThis = Ref { *this }]() mutable {
+        protectedThis->workQueueInitialize(WTF::move(attributes));
     });
 }
 
 void RemoteGraphicsContextGL::stopListeningForIPC(Ref<RemoteGraphicsContextGL>&& refFromConnection)
 {
     assertIsMainRunLoop();
-    m_workQueue->dispatch([protectedThis = WTFMove(refFromConnection)] {
+    m_workQueue->dispatch([protectedThis = WTF::move(refFromConnection)] {
         protectedThis->workQueueUninitialize();
     });
 }
@@ -124,7 +124,7 @@ void RemoteGraphicsContextGL::stopListeningForIPC(Ref<RemoteGraphicsContextGL>&&
 void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttributes&& attributes)
 {
     assertIsCurrent(workQueue());
-    platformWorkQueueInitialize(WTFMove(attributes));
+    platformWorkQueueInitialize(WTF::move(attributes));
     m_connection->open(*this, m_workQueue);
     if (RefPtr context = m_context) {
         context->setClient(this);
@@ -224,7 +224,7 @@ void RemoteGraphicsContextGL::surfaceBufferToVideoFrame(WebCore::GraphicsContext
     std::optional<WebKit::RemoteVideoFrameProxy::Properties> result;
     if (auto videoFrame = protectedContext()->surfaceBufferToVideoFrame(buffer))
         result = m_videoFrameObjectHeap->add(videoFrame.releaseNonNull());
-    completionHandler(WTFMove(result));
+    completionHandler(WTF::move(result));
 }
 #endif
 
@@ -302,7 +302,7 @@ void RemoteGraphicsContextGL::getBufferSubDataSharedMemory(uint32_t target, uint
     RefPtr context = m_context;
 
     handle.setOwnershipOfMemory(m_sharedResourceCache->resourceOwner(), WebKit::MemoryLedger::Default);
-    auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite);
+    auto buffer = SharedMemory::map(WTF::move(handle), SharedMemory::Protection::ReadWrite);
     if (buffer && dataSize <= buffer->size())
         validBufferData = context->getBufferSubDataWithStatus(target, offset, buffer->mutableSpan().subspan(0, dataSize));
     else
@@ -350,7 +350,7 @@ void RemoteGraphicsContextGL::readPixelsSharedMemory(WebCore::IntRect rect, uint
 
     RefPtr context = m_context;
     handle.setOwnershipOfMemory(m_sharedResourceCache->resourceOwner(), WebKit::MemoryLedger::Default);
-    if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
+    if (auto buffer = SharedMemory::map(WTF::move(handle), SharedMemory::Protection::ReadWrite))
         readArea = context->readPixelsWithStatus(rect, format, type, packReverseRowOrder, buffer->mutableSpan());
     else
         context->addError(GCGLErrorCode::InvalidOperation);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -49,7 +49,7 @@ namespace WebKit {
 void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame&& frame, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    RefPtr videoFrame = m_sharedVideoFrameReader.read(WTFMove(frame));
+    RefPtr videoFrame = m_sharedVideoFrameReader.read(WTF::move(frame));
     if (!videoFrame) {
         ASSERT_IS_TESTING_IPC();
         completionHandler(false);
@@ -66,12 +66,12 @@ void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame
 
 void RemoteGraphicsContextGL::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)
 {
-    m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
+    m_sharedVideoFrameReader.setSemaphore(WTF::move(semaphore));
 }
 
 void RemoteGraphicsContextGL::setSharedVideoFrameMemory(SharedMemory::Handle&& handle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(WTFMove(handle));
+    m_sharedVideoFrameReader.setSharedMemory(WTF::move(handle));
 }
 #endif
 
@@ -97,20 +97,20 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGLCocoa);
 
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::GraphicsContextGLAttributes&& attributes, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
 {
-    auto instance = adoptRef(*new RemoteGraphicsContextGLCocoa(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection)));
-    instance->initialize(WTFMove(attributes));
+    auto instance = adoptRef(*new RemoteGraphicsContextGLCocoa(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection)));
+    instance->initialize(WTF::move(attributes));
     return instance;
 }
 
 RemoteGraphicsContextGLCocoa::RemoteGraphicsContextGLCocoa(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
-    : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection))
+    : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection))
 {
 }
 
 void RemoteGraphicsContextGLCocoa::platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&& attributes)
 {
     assertIsCurrent(workQueue());
-    m_context = WebCore::GraphicsContextGLCocoa::create(WTFMove(attributes), WebCore::ProcessIdentity { m_sharedResourceCache->resourceOwner() });
+    m_context = WebCore::GraphicsContextGLCocoa::create(WTF::move(attributes), WebCore::ProcessIdentity { m_sharedResourceCache->resourceOwner() });
 }
 
 void RemoteGraphicsContextGLCocoa::prepareForDisplay(IPC::Semaphore&& finishedSemaphore, CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
@@ -118,13 +118,13 @@ void RemoteGraphicsContextGLCocoa::prepareForDisplay(IPC::Semaphore&& finishedSe
     assertIsCurrent(workQueue());
     RefPtr context = m_context;
 
-    context->prepareForDisplayWithFinishedSignal([finishedSemaphore = WTFMove(finishedSemaphore)]() mutable {
+    context->prepareForDisplayWithFinishedSignal([finishedSemaphore = WTF::move(finishedSemaphore)]() mutable {
         finishedSemaphore.signal();
     });
     MachSendRight sendRight;
     if (WebCore::IOSurface* surface = context->displayBufferSurface())
         sendRight = surface->createSendRight();
-    completionHandler(WTFMove(sendRight));
+    completionHandler(WTF::move(sendRight));
 }
 
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
@@ -424,7 +424,7 @@ void RemoteGraphicsContextGL::activeAttribs(uint32_t program, CompletionHandler<
     if (program)
         program = m_objectNames.get(program);
     returnValue = protectedContext()->activeAttribs(program);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::activeUniforms(uint32_t program, CompletionHandler<void(Vector<WebCore::GCGLUniformActiveInfo>&&)>&& completionHandler)
@@ -435,7 +435,7 @@ void RemoteGraphicsContextGL::activeUniforms(uint32_t program, CompletionHandler
     if (program)
         program = m_objectNames.get(program);
     returnValue = protectedContext()->activeUniforms(program);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::getBufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -451,7 +451,7 @@ void RemoteGraphicsContextGL::getString(uint32_t name, CompletionHandler<void(CS
     assertIsCurrent(workQueue());
     CString returnValue = { };
     returnValue = protectedContext()->getString(name);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::getFloatv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
@@ -535,7 +535,7 @@ void RemoteGraphicsContextGL::getProgramInfoLog(uint32_t arg0, CompletionHandler
     if (arg0)
         arg0 = m_objectNames.get(arg0);
     returnValue = protectedContext()->getProgramInfoLog(arg0);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::getRenderbufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -565,7 +565,7 @@ void RemoteGraphicsContextGL::getShaderInfoLog(uint32_t arg0, CompletionHandler<
     if (arg0)
         arg0 = m_objectNames.get(arg0);
     returnValue = protectedContext()->getShaderInfoLog(arg0);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::getShaderPrecisionFormat(uint32_t shaderType, uint32_t precisionType, CompletionHandler<void(std::span<const int32_t, 2>, int32_t)>&& completionHandler)
@@ -1652,7 +1652,7 @@ void RemoteGraphicsContextGL::getTransformFeedbackVarying(uint32_t program, uint
     if (program)
         program = m_objectNames.get(program);
     returnValue = protectedContext()->getTransformFeedbackVarying(program, index);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::pauseTransformFeedback()
@@ -1704,7 +1704,7 @@ void RemoteGraphicsContextGL::getActiveUniformBlockName(uint32_t program, uint32
     if (program)
         program = m_objectNames.get(program);
     returnValue = protectedContext()->getActiveUniformBlockName(program, uniformBlockIndex);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
@@ -1737,7 +1737,7 @@ void RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE(uint32_t arg0, Comp
     if (arg0)
         arg0 = m_objectNames.get(arg0);
     returnValue = protectedContext()->getTranslatedShaderSourceANGLE(arg0);
-    completionHandler(WTFMove(returnValue));
+    completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::createQueryEXT(uint32_t name)
@@ -1932,7 +1932,7 @@ void RemoteGraphicsContextGL::createExternalImage(uint32_t name, WebCore::Graphi
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createExternalImage(WTFMove(arg0), internalFormat, layer);
+    auto result = protectedContext()->createExternalImage(WTF::move(arg0), internalFormat, layer);
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1963,7 +1963,7 @@ void RemoteGraphicsContextGL::createExternalSync(uint32_t name, WebCore::Graphic
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createExternalSync(WTFMove(arg0));
+    auto result = protectedContext()->createExternalSync(WTF::move(arg0));
     if (result)
         m_objectNames.add(name, result);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLGBM.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLGBM.cpp
@@ -49,13 +49,13 @@ private:
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGLGBM);
 
 RemoteGraphicsContextGLGBM::RemoteGraphicsContextGLGBM(GPUConnectionToWebProcess& connection, RemoteGraphicsContextGLIdentifier identifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
-    : RemoteGraphicsContextGL(connection, identifier, renderingBackend, WTFMove(streamConnection))
+    : RemoteGraphicsContextGL(connection, identifier, renderingBackend, WTF::move(streamConnection))
 { }
 
 void RemoteGraphicsContextGLGBM::platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&& attributes)
 {
     assertIsCurrent(workQueue());
-    m_context = WebCore::GraphicsContextGLTextureMapperGBM::create(WTFMove(attributes));
+    m_context = WebCore::GraphicsContextGLTextureMapperGBM::create(WTF::move(attributes));
 }
 
 void RemoteGraphicsContextGLGBM::prepareForDisplay(CompletionHandler<void(uint64_t, std::optional<WebCore::DMABufBuffer::Attributes>&&, UnixFileDescriptor&&)>&& completionHandler)
@@ -75,13 +75,13 @@ void RemoteGraphicsContextGLGBM::prepareForDisplay(CompletionHandler<void(uint64
         return;
     }
 
-    completionHandler(buffer->id(), buffer->takeAttributes(), WTFMove(fenceFD));
+    completionHandler(buffer->id(), buffer->takeAttributes(), WTF::move(fenceFD));
 }
 
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& connection, WebCore::GraphicsContextGLAttributes&& attributes, RemoteGraphicsContextGLIdentifier identifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
 {
-    auto instance = adoptRef(*new RemoteGraphicsContextGLGBM(connection, identifier, renderingBackend, WTFMove(streamConnection)));
-    instance->initialize(WTFMove(attributes));
+    auto instance = adoptRef(*new RemoteGraphicsContextGLGBM(connection, identifier, renderingBackend, WTF::move(streamConnection)));
+    instance->initialize(WTF::move(attributes));
     return instance;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
@@ -55,20 +55,20 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGLWC);
 
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::GraphicsContextGLAttributes&& attributes, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
 {
-    auto instance = adoptRef(*new RemoteGraphicsContextGLWC(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection)));
-    instance->initialize(WTFMove(attributes));
+    auto instance = adoptRef(*new RemoteGraphicsContextGLWC(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection)));
+    instance->initialize(WTF::move(attributes));
     return instance;
 }
 
 RemoteGraphicsContextGLWC::RemoteGraphicsContextGLWC(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
-    : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection))
+    : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection))
     , m_webProcessIdentifier(gpuConnectionToWebProcess.webProcessIdentifier())
 {
 }
 
 void RemoteGraphicsContextGLWC::platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&& attributes)
 {
-    m_context = GCGLContext::create(WTFMove(attributes));
+    m_context = GCGLContext::create(WTF::move(attributes));
 }
 
 void RemoteGraphicsContextGLWC::prepareForDisplay(CompletionHandler<void(std::optional<WCContentBufferIdentifier>)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -46,13 +46,13 @@ namespace WebKit {
 
 Ref<RemoteImageBuffer> RemoteImageBuffer::create(Ref<WebCore::ImageBuffer>&& imageBuffer, WebCore::RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier, RemoteRenderingBackend& renderingBackend)
 {
-    auto instance = adoptRef(*new RemoteImageBuffer(WTFMove(imageBuffer), identifier, contextIdentifier, renderingBackend));
+    auto instance = adoptRef(*new RemoteImageBuffer(WTF::move(imageBuffer), identifier, contextIdentifier, renderingBackend));
     instance->startListeningForIPC();
     return instance;
 }
 
 RemoteImageBuffer::RemoteImageBuffer(Ref<WebCore::ImageBuffer>&& imageBuffer, WebCore::RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier, RemoteRenderingBackend& renderingBackend)
-    : m_imageBuffer(WTFMove(imageBuffer))
+    : m_imageBuffer(WTF::move(imageBuffer))
     , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)
     , m_context(RemoteImageBufferGraphicsContext::create(m_imageBuffer, contextIdentifier, m_renderingBackend))
@@ -63,7 +63,7 @@ RemoteImageBuffer::RemoteImageBuffer(Ref<WebCore::ImageBuffer>&& imageBuffer, We
     // allocation failure.
     auto* sharing = m_imageBuffer->toBackendSharing();
     auto handle = sharing ? downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle() : std::nullopt;
-    m_renderingBackend->streamConnection().send(Messages::RemoteImageBufferProxy::DidCreateBackend(WTFMove(handle)), m_identifier);
+    m_renderingBackend->streamConnection().send(Messages::RemoteImageBufferProxy::DidCreateBackend(WTF::move(handle)), m_identifier);
 }
 
 RemoteImageBuffer::~RemoteImageBuffer()
@@ -94,7 +94,7 @@ void RemoteImageBuffer::stopListeningForIPC()
 
 Ref<WebCore::ImageBuffer> RemoteImageBuffer::sinkIntoImageBuffer(Ref<RemoteImageBuffer>&& remote)
 {
-    Ref localRemote = WTFMove(remote);
+    Ref localRemote = WTF::move(remote);
     RELEASE_ASSERT(localRemote->hasOneRef());
     Ref imageBuffer = localRemote->m_imageBuffer;
     return imageBuffer;
@@ -119,10 +119,10 @@ void RemoteImageBuffer::getPixelBufferWithNewMemory(WebCore::SharedMemory::Handl
 {
     assertIsCurrent(workQueue());
     m_renderingBackend->setSharedMemoryForGetPixelBuffer(nullptr);
-    auto sharedMemory = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadWrite);
+    auto sharedMemory = WebCore::SharedMemory::map(WTF::move(handle), WebCore::SharedMemory::Protection::ReadWrite);
     MESSAGE_CHECK(sharedMemory, "Shared memory could not be mapped.");
-    m_renderingBackend->setSharedMemoryForGetPixelBuffer(WTFMove(sharedMemory));
-    getPixelBuffer(WTFMove(destinationFormat), WTFMove(srcPoint), WTFMove(srcSize), WTFMove(completionHandler));
+    m_renderingBackend->setSharedMemoryForGetPixelBuffer(WTF::move(sharedMemory));
+    getPixelBuffer(WTF::move(destinationFormat), WTF::move(srcPoint), WTF::move(srcSize), WTF::move(completionHandler));
 }
 
 void RemoteImageBuffer::putPixelBuffer(const WebCore::PixelBufferSourceView& pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat)
@@ -166,7 +166,7 @@ void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, Complet
         context->drawNativeImage(*image, WebCore::FloatRect { { }, imageSize }, WebCore::FloatRect { { }, imageSize });
         return handle;
     }();
-    completionHandler(WTFMove(handle));
+    completionHandler(WTF::move(handle));
 }
 
 void RemoteImageBuffer::convertToLuminanceMask()
@@ -183,7 +183,7 @@ void RemoteImageBuffer::transformToColorSpace(const WebCore::DestinationColorSpa
 
 void RemoteImageBuffer::setFlushSignal(IPC::Signal&& signal)
 {
-    m_flushSignal = WTFMove(signal);
+    m_flushSignal = WTF::move(signal);
 }
 
 void RemoteImageBuffer::flushContext()
@@ -206,7 +206,7 @@ void RemoteImageBuffer::dynamicContentScalingDisplayList(CompletionHandler<void(
 {
     assertIsCurrent(workQueue());
     auto displayList = m_imageBuffer->dynamicContentScalingDisplayList();
-    completionHandler({ WTFMove(displayList) });
+    completionHandler({ WTF::move(displayList) });
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -113,7 +113,7 @@ void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdat
     }
 
     outputData.bufferCacheIdentifiers = BufferIdentifierSet { bufferIdentifier(frontBuffer), bufferIdentifier(m_backBuffer), bufferIdentifier(m_secondaryBackBuffer) };
-    completionHandler(WTFMove(outputData), renderingUpdateID);
+    completionHandler(WTF::move(outputData), renderingUpdateID);
 }
 
 // This is the GPU Process version of RemoteLayerBackingStore::prepareBuffers().
@@ -138,7 +138,7 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
         if (m_configuration.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes)
             creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
 #endif
-        m_frontBuffer = m_renderingBackend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.bufferFormat, WTFMove(creationContext));
+        m_frontBuffer = m_renderingBackend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.bufferFormat, WTF::move(creationContext));
         m_frontBufferIsCleared = true;
     }
 
@@ -198,7 +198,7 @@ void RemoteImageBufferSet::dynamicContentScalingDisplayList(CompletionHandler<vo
     std::optional<WebCore::DynamicContentScalingDisplayList> displayList;
     if (m_frontBuffer)
         displayList = m_frontBuffer->dynamicContentScalingDisplayList();
-    completionHandler({ WTFMove(displayList) });
+    completionHandler({ WTF::move(displayList) });
 }
 
 DynamicContentScalingResourceCache RemoteImageBufferSet::ensureDynamicContentScalingResourceCache()

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -124,7 +124,7 @@ public:
 
     GPUConnectionToWebProcess& gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
 
-    void setSharedMemoryForGetPixelBuffer(RefPtr<WebCore::SharedMemory> memory) { m_getPixelBufferSharedMemory = WTFMove(memory); }
+    void setSharedMemoryForGetPixelBuffer(RefPtr<WebCore::SharedMemory> memory) { m_getPixelBufferSharedMemory = WTF::move(memory); }
     RefPtr<WebCore::SharedMemory> sharedMemoryForGetPixelBuffer() const { return m_getPixelBufferSharedMemory; }
 
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -44,7 +44,7 @@ RemoteResourceCache::~RemoteResourceCache() = default;
 
 bool RemoteResourceCache::cacheNativeImage(WebCore::RenderingResourceIdentifier identifier, Ref<NativeImage>&& image)
 {
-    return m_nativeImages.add(identifier, WTFMove(image)).isNewEntry;
+    return m_nativeImages.add(identifier, WTF::move(image)).isNewEntry;
 }
 
 bool RemoteResourceCache::releaseNativeImage(RenderingResourceIdentifier identifier)
@@ -59,7 +59,7 @@ RefPtr<NativeImage> RemoteResourceCache::cachedNativeImage(RenderingResourceIden
 
 bool RemoteResourceCache::cacheGradient(RemoteGradientIdentifier identifier, Ref<Gradient>&& gradient)
 {
-    return m_gradients.add(identifier, WTFMove(gradient)).isNewEntry;
+    return m_gradients.add(identifier, WTF::move(gradient)).isNewEntry;
 }
 
 bool RemoteResourceCache::releaseGradient(RemoteGradientIdentifier identifier)
@@ -75,7 +75,7 @@ RefPtr<Gradient> RemoteResourceCache::cachedGradient(RemoteGradientIdentifier id
 void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
 {
     auto identifier = filter->renderingResourceIdentifier();
-    m_filters.add(identifier, WTFMove(filter));
+    m_filters.add(identifier, WTF::move(filter));
 }
 
 bool RemoteResourceCache::releaseFilter(RenderingResourceIdentifier identifier)
@@ -91,7 +91,7 @@ RefPtr<Filter> RemoteResourceCache::cachedFilter(RenderingResourceIdentifier ide
 void RemoteResourceCache::cacheFont(Ref<Font>&& font)
 {
     auto identifier = font->renderingResourceIdentifier();
-    m_fonts.add(identifier, WTFMove(font));
+    m_fonts.add(identifier, WTF::move(font));
 }
 
 bool RemoteResourceCache::releaseFont(RenderingResourceIdentifier identifier)
@@ -107,7 +107,7 @@ RefPtr<Font> RemoteResourceCache::cachedFont(RenderingResourceIdentifier identif
 void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& customPlatformData)
 {
     auto identifier = customPlatformData->m_renderingResourceIdentifier;
-    m_fontCustomPlatformDatas.add(identifier, WTFMove(customPlatformData));
+    m_fontCustomPlatformDatas.add(identifier, WTF::move(customPlatformData));
 }
 
 bool RemoteResourceCache::releaseFontCustomPlatformData(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshot.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshot.cpp
@@ -62,13 +62,13 @@ bool RemoteSnapshot::setFrame(FrameIdentifier frameIdentifier, Ref<const Display
     m_completedFrames++;
     auto iterator = m_frameDisplayLists.find(frameIdentifier);
     if (iterator == m_frameDisplayLists.end()) {
-        m_frameDisplayLists.add(frameIdentifier, DisplayListAndReleaseDispatcher { WTFMove(displayList), releaseDispatcher });
+        m_frameDisplayLists.add(frameIdentifier, DisplayListAndReleaseDispatcher { WTF::move(displayList), releaseDispatcher });
         return true;
     }
     // It is ok to addFrameReference to win the race. It's not ok to have two setFrames.
     if (iterator->value)
         return false;
-    iterator->value = DisplayListAndReleaseDispatcher { WTFMove(displayList), releaseDispatcher };
+    iterator->value = DisplayListAndReleaseDispatcher { WTF::move(displayList), releaseDispatcher };
     return true;
 }
 
@@ -94,7 +94,7 @@ bool RemoteSnapshot::isComplete() const
 }
 
 RemoteSnapshot::DisplayListAndReleaseDispatcher::DisplayListAndReleaseDispatcher(Ref<const WebCore::DisplayList::DisplayList>&& displayList, SerialFunctionDispatcher& dispatcher)
-    : m_displayList(WTFMove(displayList))
+    : m_displayList(WTF::move(displayList))
     , m_dispatcher(dispatcher)
 {
 }
@@ -102,7 +102,7 @@ RemoteSnapshot::DisplayListAndReleaseDispatcher::DisplayListAndReleaseDispatcher
 RemoteSnapshot::DisplayListAndReleaseDispatcher::~DisplayListAndReleaseDispatcher()
 {
     if (m_displayList)
-        m_dispatcher->dispatch([displayList = WTFMove(m_displayList)]() mutable { });
+        m_dispatcher->dispatch([displayList = WTF::move(m_displayList)]() mutable { });
 }
 
 #if PLATFORM(COCOA)
@@ -119,7 +119,7 @@ std::optional<RefPtr<SharedBuffer>> RemoteSnapshot::drawToPDF(const FloatSize& s
     if (!applyFrame(rootIdentifier, context))
         return std::nullopt;
 
-    return ImageBuffer::sinkIntoPDFDocument(WTFMove(buffer));
+    return ImageBuffer::sinkIntoPDFDocument(WTF::move(buffer));
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
@@ -48,7 +48,7 @@ Ref<RemoteSnapshotRecorder> RemoteSnapshotRecorder::create(RemoteSnapshotRecorde
 RemoteSnapshotRecorder::RemoteSnapshotRecorder(UniqueRef<DisplayList::RecorderImpl>&& recorder, RemoteSnapshotRecorderIdentifier identifier, RemoteSnapshot& snapshot, RemoteRenderingBackend& renderingBackend)
     : RemoteGraphicsContext(recorder, renderingBackend)
     , m_snapshot(snapshot)
-    , m_recorder(WTFMove(recorder))
+    , m_recorder(WTF::move(recorder))
     , m_identifier(identifier)
 {
 }

--- a/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.h
+++ b/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.h
@@ -38,7 +38,7 @@ public:
     ScopedWebGLRenderingResourcesRequest() = default;
     ScopedWebGLRenderingResourcesRequest(ScopedWebGLRenderingResourcesRequest&& other)
         : m_requested(std::exchange(other.m_requested, false))
-        , m_renderingResourcesRequest(WTFMove(other.m_renderingResourcesRequest))
+        , m_renderingResourcesRequest(WTF::move(other.m_renderingResourcesRequest))
     {
     }
     ~ScopedWebGLRenderingResourcesRequest()
@@ -50,7 +50,7 @@ public:
         if (this != &other) {
             reset();
             m_requested = std::exchange(other.m_requested, false);
-            m_renderingResourcesRequest = WTFMove(other.m_renderingResourcesRequest);
+            m_renderingResourcesRequest = WTF::move(other.m_renderingResourcesRequest);
         }
         return *this;
     }

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -47,7 +47,7 @@ RefPtr<ShareablePixelBuffer> ShareablePixelBuffer::tryCreate(const PixelBufferFo
 
 ShareablePixelBuffer::ShareablePixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<SharedMemory>&& data)
     : PixelBuffer(format, size, data->mutableSpan())
-    , m_data(WTFMove(data))
+    , m_data(WTF::move(data))
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(computeBufferSize(format.pixelFormat, size).value() <= bytes().size());
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAdapter);
 RemoteAdapter::RemoteAdapter(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::Adapter& adapter, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(adapter)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
     , m_identifier(identifier)
@@ -76,14 +76,14 @@ void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, We
         return;
     }
 
-    Ref { m_backing }->requestDevice(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protectedGPU()] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
+    Ref { m_backing }->requestDevice(*convertedDescriptor, [callback = WTF::move(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protectedGPU()] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
         if (!devicePtr.get() || !gpuConnectionToWebProcess) {
             callback({ }, { });
             return;
         }
 
         auto device = devicePtr.releaseNonNull();
-        auto remoteDevice = RemoteDevice::create(*gpuConnectionToWebProcess, gpu, device, objectHeap, WTFMove(streamConnection), identifier, queueIdentifier);
+        auto remoteDevice = RemoteDevice::create(*gpuConnectionToWebProcess, gpu, device, objectHeap, WTF::move(streamConnection), identifier, queueIdentifier);
         objectHeap->addObject(identifier, remoteDevice);
         objectHeap->addObject(queueIdentifier, remoteDevice->queue());
         Ref features = device->features();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -58,7 +58,7 @@ class RemoteAdapter final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteAdapter> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::Adapter& adapter, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteAdapter(gpuConnectionToWebProcess, gpu, adapter, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteAdapter(gpuConnectionToWebProcess, gpu, adapter, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteAdapter();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBindGroup);
 RemoteBindGroup::RemoteBindGroup(WebCore::WebGPU::BindGroup& bindGroup, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(bindGroup)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -72,7 +72,7 @@ void RemoteBindGroup::stopListeningForIPC()
 
 void RemoteBindGroup::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::BindGroup> RemoteBindGroup::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -54,7 +54,7 @@ class RemoteBindGroup final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteBindGroup> create(WebCore::WebGPU::BindGroup& bindGroup, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteBindGroup(bindGroup, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteBindGroup(bindGroup, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteBindGroup();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBindGroupLayout);
 RemoteBindGroupLayout::RemoteBindGroupLayout(WebCore::WebGPU::BindGroupLayout& bindGroupLayout, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(bindGroupLayout)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemoteBindGroupLayout::stopListeningForIPC()
 
 void RemoteBindGroupLayout::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemoteBindGroupLayout::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -54,7 +54,7 @@ class RemoteBindGroupLayout final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteBindGroupLayout> create(WebCore::WebGPU::BindGroupLayout& bindGroupLayout, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteBindGroupLayout(bindGroupLayout, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteBindGroupLayout(bindGroupLayout, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteBindGroupLayout();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBuffer);
 RemoteBuffer::RemoteBuffer(WebCore::WebGPU::Buffer& buffer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, bool mappedAtCreation, WebGPUIdentifier identifier)
     : m_backing(buffer)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
     , m_isMapped(mappedAtCreation)
@@ -64,7 +64,7 @@ void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore:
     m_isMapped = true;
     m_mapModeFlags = mapModeFlags;
 
-    protectedBacking()->mapAsync(mapModeFlags, offset, size, [protectedThis = Ref<RemoteBuffer>(*this), callback = WTFMove(callback)] (bool success) mutable {
+    protectedBacking()->mapAsync(mapModeFlags, offset, size, [protectedThis = Ref<RemoteBuffer>(*this), callback = WTF::move(callback)] (bool success) mutable {
         if (!success) {
             callback(false);
             return;
@@ -109,7 +109,7 @@ void RemoteBuffer::copyWithCopy(Vector<uint8_t>&& data, uint64_t offset)
 
 void RemoteBuffer::copy(std::optional<WebCore::SharedMemoryHandle>&& dataHandle, uint64_t offset, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto sharedData = dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
+    auto sharedData = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto data = sharedData ? sharedData->span() : std::span<const uint8_t> { };
     if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write)) {
         completionHandler(false);
@@ -150,7 +150,7 @@ void RemoteBuffer::destruct()
 
 void RemoteBuffer::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::Buffer> RemoteBuffer::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -63,7 +63,7 @@ class RemoteBuffer final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteBuffer> create(WebCore::WebGPU::Buffer& buffer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, bool mappedAtCreation, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteBuffer(buffer, objectHeap, WTFMove(streamConnection), gpu, mappedAtCreation, identifier));
+        return adoptRef(*new RemoteBuffer(buffer, objectHeap, WTF::move(streamConnection), gpu, mappedAtCreation, identifier));
     }
 
     virtual ~RemoteBuffer();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandBuffer);
 RemoteCommandBuffer::RemoteCommandBuffer(WebCore::WebGPU::CommandBuffer& commandBuffer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(commandBuffer)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemoteCommandBuffer::stopListeningForIPC()
 
 void RemoteCommandBuffer::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemoteCommandBuffer::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -54,7 +54,7 @@ class RemoteCommandBuffer final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteCommandBuffer> create(WebCore::WebGPU::CommandBuffer& commandBuffer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteCommandBuffer(commandBuffer, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteCommandBuffer(commandBuffer, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteCommandBuffer();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandEncoder);
 RemoteCommandEncoder::RemoteCommandEncoder(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::CommandEncoder& commandEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(commandEncoder)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
@@ -89,7 +89,7 @@ void RemoteCommandEncoder::beginComputePass(const std::optional<WebGPU::ComputeP
     if (descriptor) {
         auto resultDescriptor = objectHeap->convertFromBacking(*descriptor);
         MESSAGE_CHECK(resultDescriptor);
-        convertedDescriptor = WTFMove(resultDescriptor);
+        convertedDescriptor = WTF::move(resultDescriptor);
     }
 
     auto computePassEncoder = protectedBacking()->beginComputePass(convertedDescriptor);
@@ -182,7 +182,7 @@ void RemoteCommandEncoder::clearBuffer(
 
 void RemoteCommandEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteCommandEncoder::popDebugGroup()
@@ -192,7 +192,7 @@ void RemoteCommandEncoder::popDebugGroup()
 
 void RemoteCommandEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteCommandEncoder::writeTimestamp(WebGPUIdentifier querySet, WebCore::WebGPU::Size32 queryIndex)
@@ -237,7 +237,7 @@ void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descrip
 
 void RemoteCommandEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::CommandEncoder> RemoteCommandEncoder::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -64,7 +64,7 @@ class RemoteCommandEncoder final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteCommandEncoder> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::CommandEncoder& commandEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteCommandEncoder(gpuConnectionToWebProcess, gpu, commandEncoder, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteCommandEncoder(gpuConnectionToWebProcess, gpu, commandEncoder, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteCommandEncoder();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCompositorIntegration);
 RemoteCompositorIntegration::RemoteCompositorIntegration(WebCore::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(compositorIntegration)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -63,7 +63,7 @@ void RemoteCompositorIntegration::destruct()
 void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&& completionHandler)
 {
     UNUSED_PARAM(imageBufferIdentifier);
-    protectedBacking()->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTFMove(completionHandler)] (WebCore::NativeImage* image) mutable {
+    protectedBacking()->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTF::move(completionHandler)] (WebCore::NativeImage* image) mutable {
         if (image && gpu.ptr())
             gpu->paintNativeImageToImageBuffer(*image, imageBufferIdentifier);
         completionHandler();
@@ -81,13 +81,13 @@ void RemoteCompositorIntegration::recreateRenderBuffers(int width, int height, W
     auto convertedDevice = protectedObjectHeap()->convertDeviceFromBacking(deviceIdentifier);
     MESSAGE_CHECK_COMPLETION(convertedDevice, callback({ }));
 
-    callback(protectedBacking()->recreateRenderBuffers(width, height, WTFMove(destinationColorSpace), alphaMode, textureFormat, bufferCount, *convertedDevice));
+    callback(protectedBacking()->recreateRenderBuffers(width, height, WTF::move(destinationColorSpace), alphaMode, textureFormat, bufferCount, *convertedDevice));
 }
 #endif
 
 void RemoteCompositorIntegration::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedBacking()->prepareForDisplay(frameIndex, [completionHandler = WTFMove(completionHandler)]() mutable {
+    protectedBacking()->prepareForDisplay(frameIndex, [completionHandler = WTF::move(completionHandler)]() mutable {
         completionHandler(true);
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -70,7 +70,7 @@ class RemoteCompositorIntegration final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteCompositorIntegration> create(WebCore::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteCompositorIntegration(compositorIntegration, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteCompositorIntegration(compositorIntegration, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteCompositorIntegration();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoder);
 RemoteComputePassEncoder::RemoteComputePassEncoder(WebCore::WebGPU::ComputePassEncoder& computePassEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(computePassEncoder)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -97,7 +97,7 @@ void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std:
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& offsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTFMove(offsets));
+        protectedBacking()->setBindGroup(index, nullptr, WTF::move(offsets));
         return;
     }
 
@@ -106,12 +106,12 @@ void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std:
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTFMove(offsets));
+    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(offsets));
 }
 
 void RemoteComputePassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteComputePassEncoder::popDebugGroup()
@@ -121,12 +121,12 @@ void RemoteComputePassEncoder::popDebugGroup()
 
 void RemoteComputePassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteComputePassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::ComputePassEncoder> RemoteComputePassEncoder::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -55,7 +55,7 @@ class RemoteComputePassEncoder final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteComputePassEncoder> create(WebCore::WebGPU::ComputePassEncoder& computePassEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteComputePassEncoder(computePassEncoder, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteComputePassEncoder(computePassEncoder, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteComputePassEncoder();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePipeline);
 RemoteComputePipeline::RemoteComputePipeline(WebCore::WebGPU::ComputePipeline& computePipeline, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(computePipeline)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -73,7 +73,7 @@ void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier 
 
 void RemoteComputePipeline::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::ComputePipeline> RemoteComputePipeline::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -54,7 +54,7 @@ class RemoteComputePipeline final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteComputePipeline> create(WebCore::WebGPU::ComputePipeline& computePipeline, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteComputePipeline(computePipeline, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteComputePipeline(computePipeline, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -93,7 +93,7 @@ class RemoteDevice final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteDevice> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::Device& device, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier)
     {
-        return adoptRef(*new RemoteDevice(gpuConnectionToWebProcess, gpu, device, objectHeap, WTFMove(streamConnection), identifier, queueIdentifier));
+        return adoptRef(*new RemoteDevice(gpuConnectionToWebProcess, gpu, device, objectHeap, WTF::move(streamConnection), identifier, queueIdentifier));
     }
 
     ~RemoteDevice();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteExternalTexture);
 RemoteExternalTexture::RemoteExternalTexture(WebCore::WebGPU::ExternalTexture& externalTexture, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(externalTexture)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -72,7 +72,7 @@ void RemoteExternalTexture::stopListeningForIPC()
 
 void RemoteExternalTexture::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::ExternalTexture> RemoteExternalTexture::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -54,7 +54,7 @@ class RemoteExternalTexture final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteExternalTexture> create(WebCore::WebGPU::ExternalTexture& externalTexture, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteExternalTexture(externalTexture, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteExternalTexture(externalTexture, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteExternalTexture();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -65,7 +65,7 @@ RemoteGPU::RemoteGPU(WebGPUIdentifier identifier, GPUConnectionToWebProcess& gpu
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_sharedPreferencesForWebProcess(gpuConnectionToWebProcess.sharedPreferencesForWebProcessValue())
     , m_workQueue(IPC::StreamConnectionWorkQueue::create("WebGPU work queue"_s))
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_objectHeap(WebGPU::ObjectHeap::create())
     , m_modelObjectHeap(DDModel::ObjectHeap::create())
     , m_identifier(identifier)
@@ -110,7 +110,7 @@ void RemoteGPU::workQueueInitialize()
     // The retain cycle is broken in workQueueUninitialize().
     auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();
     auto backing = WebCore::WebGPU::create([protectedThis = Ref { *this }](WebCore::WebGPU::WorkItem&& workItem) {
-        protectedThis->protectedWorkQueue()->dispatch(WTFMove(workItem));
+        protectedThis->protectedWorkQueue()->dispatch(WTF::move(workItem));
     }, gpuProcessConnection ? &gpuProcessConnection->webProcessIdentity() : nullptr);
 #else
     RefPtr<WebCore::WebGPU::GPU> backing;
@@ -158,19 +158,19 @@ void RemoteGPU::requestAdapter(const WebGPU::RequestAdapterOptions& options, Web
         return;
     }
 
-    backing->requestAdapter(*convertedOptions, [callback = WTFMove(callback), objectHeap, streamConnection = Ref { *m_streamConnection }, identifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = Ref { *this }] (RefPtr<WebCore::WebGPU::Adapter>&& adapter) mutable {
+    backing->requestAdapter(*convertedOptions, [callback = WTF::move(callback), objectHeap, streamConnection = Ref { *m_streamConnection }, identifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = Ref { *this }] (RefPtr<WebCore::WebGPU::Adapter>&& adapter) mutable {
         if (!adapter) {
             callback(std::nullopt);
             return;
         }
 
-        auto remoteAdapter = RemoteAdapter::create(*gpuConnectionToWebProcess, gpu, *adapter, objectHeap, WTFMove(streamConnection), identifier);
+        auto remoteAdapter = RemoteAdapter::create(*gpuConnectionToWebProcess, gpu, *adapter, objectHeap, WTF::move(streamConnection), identifier);
         objectHeap->addObject(identifier, remoteAdapter);
 
         auto name = adapter->name();
         Ref features = adapter->features();
         Ref limits = adapter->limits();
-        callback({ { WTFMove(name), WebGPU::SupportedFeatures { features->features() }, WebGPU::SupportedLimits {
+        callback({ { WTF::move(name), WebGPU::SupportedFeatures { features->features() }, WebGPU::SupportedLimits {
             limits->maxTextureDimension1D(),
             limits->maxTextureDimension2D(),
             limits->maxTextureDimension3D(),
@@ -271,7 +271,7 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, DDModelIdent
     Ref objectHeap = m_modelObjectHeap.get();
 
     RefPtr gpu = m_backing.get();
-    auto mesh = gpu->createModelBacking(width, height, WTFMove(callback));
+    auto mesh = gpu->createModelBacking(width, height, WTF::move(callback));
 #if ENABLE(GPU_PROCESS_MODEL)
     auto remoteMesh = RemoteDDMesh::create(*m_gpuConnectionToWebProcess.get(), *this, *mesh, objectHeap, Ref { *m_streamConnection }, identifier);
     objectHeap->addObject(identifier, remoteMesh);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -83,7 +83,7 @@ class RemoteGPU final : public CanMakeWeakPtr<RemoteGPU>, public IPC::StreamServ
 public:
     static Ref<RemoteGPU> create(WebGPUIdentifier identifier, GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& serverConnection)
     {
-        auto result = adoptRef(*new RemoteGPU(identifier, gpuConnectionToWebProcess, renderingBackend, WTFMove(serverConnection)));
+        auto result = adoptRef(*new RemoteGPU(identifier, gpuConnectionToWebProcess, renderingBackend, WTF::move(serverConnection)));
         result->initialize();
         return result;
     }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePipelineLayout);
 RemotePipelineLayout::RemotePipelineLayout(WebCore::WebGPU::PipelineLayout& pipelineLayout, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(pipelineLayout)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemotePipelineLayout::stopListeningForIPC()
 
 void RemotePipelineLayout::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemotePipelineLayout::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -54,7 +54,7 @@ class RemotePipelineLayout final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemotePipelineLayout> create(WebCore::WebGPU::PipelineLayout& pipelineLayout, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemotePipelineLayout(pipelineLayout, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemotePipelineLayout(pipelineLayout, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemotePipelineLayout();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePresentationContext);
 RemotePresentationContext::RemotePresentationContext(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::PresentationContext& presentationContext, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(presentationContext)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -57,7 +57,7 @@ class RemotePresentationContext final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemotePresentationContext> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::PresentationContext& presentationContext, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemotePresentationContext(gpuConnectionToWebProcess, gpu, presentationContext, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemotePresentationContext(gpuConnectionToWebProcess, gpu, presentationContext, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemotePresentationContext();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteQuerySet);
 RemoteQuerySet::RemoteQuerySet(WebCore::WebGPU::QuerySet& querySet, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(querySet)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -67,7 +67,7 @@ void RemoteQuerySet::destruct()
 
 void RemoteQuerySet::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::QuerySet> RemoteQuerySet::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -54,7 +54,7 @@ class RemoteQuerySet final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteQuerySet> create(WebCore::WebGPU::QuerySet& querySet, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteQuerySet(querySet, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteQuerySet(querySet, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteQuerySet();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteQueue);
 RemoteQueue::RemoteQueue(WebCore::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(queue)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -73,12 +73,12 @@ void RemoteQueue::submit(Vector<WebGPUIdentifier>&& commandBuffers)
             return;
         convertedCommandBuffers.append(*convertedCommandBuffer);
     }
-    protectedBacking()->submit(WTFMove(convertedCommandBuffers));
+    protectedBacking()->submit(WTF::move(convertedCommandBuffers));
 }
 
 void RemoteQueue::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
 {
-    protectedBacking()->onSubmittedWorkDone([callback = WTFMove(callback)] () mutable {
+    protectedBacking()->onSubmittedWorkDone([callback = WTF::move(callback)] () mutable {
         callback();
     });
 }
@@ -89,7 +89,7 @@ void RemoteQueue::writeBuffer(
     std::optional<WebCore::SharedMemoryHandle>&& dataHandle,
     CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto data = dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
+    auto data = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer) {
@@ -122,7 +122,7 @@ void RemoteQueue::writeTexture(
     const WebGPU::Extent3D& size,
     CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto data = dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
+    auto data = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     Ref objectHeap = m_objectHeap.get();
     auto convertedDestination = objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
@@ -178,7 +178,7 @@ void RemoteQueue::copyExternalImageToTexture(
 
 void RemoteQueue::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::Queue> RemoteQueue::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -67,7 +67,7 @@ class RemoteQueue final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteQueue> create(WebCore::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteQueue(queue, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteQueue(queue, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteQueue();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundle);
 RemoteRenderBundle::RemoteRenderBundle(WebCore::WebGPU::RenderBundle& renderBundle, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(renderBundle)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemoteRenderBundle::stopListeningForIPC()
 
 void RemoteRenderBundle::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemoteRenderBundle::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -54,7 +54,7 @@ class RemoteRenderBundle final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteRenderBundle> create(WebCore::WebGPU::RenderBundle& renderBundle, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteRenderBundle(renderBundle, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteRenderBundle(renderBundle, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteRenderBundle();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundleEncoder);
 RemoteRenderBundleEncoder::RemoteRenderBundleEncoder(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::RenderBundleEncoder& renderBundleEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(renderBundleEncoder)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
@@ -143,7 +143,7 @@ void RemoteRenderBundleEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTFMove(dynamicOffsets));
+        protectedBacking()->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
         return;
     }
 
@@ -152,12 +152,12 @@ void RemoteRenderBundleEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTFMove(dynamicOffsets));
+    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
 }
 
 void RemoteRenderBundleEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteRenderBundleEncoder::popDebugGroup()
@@ -167,7 +167,7 @@ void RemoteRenderBundleEncoder::popDebugGroup()
 
 void RemoteRenderBundleEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& descriptor, WebGPUIdentifier identifier)
@@ -184,7 +184,7 @@ void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& des
 
 void RemoteRenderBundleEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::RenderBundleEncoder> RemoteRenderBundleEncoder::protectedBacking() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -60,7 +60,7 @@ class RemoteRenderBundleEncoder final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteRenderBundleEncoder> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::RenderBundleEncoder& renderBundleEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteRenderBundleEncoder(gpuConnectionToWebProcess, gpu, renderBundleEncoder, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteRenderBundleEncoder(gpuConnectionToWebProcess, gpu, renderBundleEncoder, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     ~RemoteRenderBundleEncoder();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoder);
 RemoteRenderPassEncoder::RemoteRenderPassEncoder(WebCore::WebGPU::RenderPassEncoder& renderPassEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(renderPassEncoder)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -138,7 +138,7 @@ void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std::
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTFMove(dynamicOffsets));
+        protectedBacking()->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
         return;
     }
 
@@ -146,12 +146,12 @@ void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std::
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTFMove(dynamicOffsets));
+    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
 }
 
 void RemoteRenderPassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteRenderPassEncoder::popDebugGroup()
@@ -161,7 +161,7 @@ void RemoteRenderPassEncoder::popDebugGroup()
 
 void RemoteRenderPassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteRenderPassEncoder::setViewport(float x, float y,
@@ -213,7 +213,7 @@ void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBu
             return;
         convertedBundles.append(*convertedBundle);
     }
-    protectedBacking()->executeBundles(WTFMove(convertedBundles));
+    protectedBacking()->executeBundles(WTF::move(convertedBundles));
 }
 
 void RemoteRenderPassEncoder::end()
@@ -223,7 +223,7 @@ void RemoteRenderPassEncoder::end()
 
 void RemoteRenderPassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::RenderPassEncoder> RemoteRenderPassEncoder::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -57,7 +57,7 @@ class RemoteRenderPassEncoder final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteRenderPassEncoder> create(WebCore::WebGPU::RenderPassEncoder& renderPassEncoder, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteRenderPassEncoder(renderPassEncoder, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteRenderPassEncoder(renderPassEncoder, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     ~RemoteRenderPassEncoder();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPipeline);
 RemoteRenderPipeline::RemoteRenderPipeline(WebCore::WebGPU::RenderPipeline& renderPipeline, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(renderPipeline)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -73,7 +73,7 @@ void RemoteRenderPipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier i
 
 void RemoteRenderPipeline::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::RenderPipeline> RemoteRenderPipeline::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -54,7 +54,7 @@ class RemoteRenderPipeline final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteRenderPipeline> create(WebCore::WebGPU::RenderPipeline& renderPipeline, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteRenderPipeline(renderPipeline, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteRenderPipeline(renderPipeline, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteRenderPipeline();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSampler);
 RemoteSampler::RemoteSampler(WebCore::WebGPU::Sampler& sampler, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(sampler)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemoteSampler::stopListeningForIPC()
 
 void RemoteSampler::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemoteSampler::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -54,7 +54,7 @@ class RemoteSampler final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteSampler> create(WebCore::WebGPU::Sampler& sampler, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteSampler(sampler, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteSampler(sampler, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteSampler();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteShaderModule);
 RemoteShaderModule::RemoteShaderModule(WebCore::WebGPU::ShaderModule& shaderModule, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(shaderModule)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -64,7 +64,7 @@ void RemoteShaderModule::stopListeningForIPC()
 
 void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&& callback)
 {
-    protectedBacking()->compilationInfo([callback = WTFMove(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
+    protectedBacking()->compilationInfo([callback = WTF::move(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
         auto convertedMessages = compilationMessage->messages().map([] (const Ref<WebCore::WebGPU::CompilationMessage>& message) {
             return WebGPU::CompilationMessage {
                 message->message(),
@@ -75,13 +75,13 @@ void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::C
                 message->length(),
             };
         });
-        callback(WTFMove(convertedMessages));
+        callback(WTF::move(convertedMessages));
     });
 }
 
 void RemoteShaderModule::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::ShaderModule> RemoteShaderModule::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -57,7 +57,7 @@ class RemoteShaderModule final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteShaderModule> create(WebCore::WebGPU::ShaderModule& shaderModule, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteShaderModule(shaderModule, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteShaderModule(shaderModule, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteShaderModule();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTexture);
 RemoteTexture::RemoteTexture(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::Texture& texture, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(texture)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
@@ -72,7 +72,7 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
     if (descriptor) {
         auto resultDescriptor = objectHeap->convertFromBacking(*descriptor);
         MESSAGE_CHECK(resultDescriptor);
-        convertedDescriptor = WTFMove(resultDescriptor);
+        convertedDescriptor = WTF::move(resultDescriptor);
     }
     auto textureView = protectedBacking()->createView(convertedDescriptor);
     MESSAGE_CHECK(textureView);
@@ -97,7 +97,7 @@ void RemoteTexture::destruct()
 
 void RemoteTexture::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTF::move(label));
 }
 
 Ref<WebCore::WebGPU::Texture> RemoteTexture::protectedBacking()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -58,7 +58,7 @@ class RemoteTexture final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteTexture> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebCore::WebGPU::Texture& texture, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTexture(gpuConnectionToWebProcess, gpu, texture, objectHeap, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteTexture(gpuConnectionToWebProcess, gpu, texture, objectHeap, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteTexture();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextureView);
 RemoteTextureView::RemoteTextureView(WebCore::WebGPU::TextureView& textureView, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(textureView)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
@@ -62,7 +62,7 @@ void RemoteTextureView::stopListeningForIPC()
 
 void RemoteTextureView::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTF::move(label));
 }
 
 Ref<IPC::StreamServerConnection> RemoteTextureView::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -54,7 +54,7 @@ class RemoteTextureView final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteTextureView> create(WebCore::WebGPU::TextureView& textureView, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureView(textureView, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteTextureView(textureView, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteTextureView();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteXRBinding);
 RemoteXRBinding::RemoteXRBinding(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::WebGPU::XRBinding& xrBinding, WebGPU::ObjectHeap& objectHeap, RemoteGPU& gpu, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(xrBinding)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_identifier(identifier)
     , m_gpu(gpu)
@@ -80,11 +80,11 @@ void RemoteXRBinding::createProjectionLayer(WebCore::WebGPU::TextureFormat color
 {
     WebCore::WebGPU::XRProjectionLayerInit init {
         .colorFormat = colorFormat,
-        .depthStencilFormat = WTFMove(depthStencilFormat),
+        .depthStencilFormat = WTF::move(depthStencilFormat),
         .textureUsage = textureUsage,
         .scaleFactor = scaleFactor
     };
-    RefPtr projectionLayer = protectedBacking()->createProjectionLayer(WTFMove(init));
+    RefPtr projectionLayer = protectedBacking()->createProjectionLayer(WTF::move(init));
     if (!projectionLayer) {
         // FIXME: Add MESSAGE_CHECK call
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
@@ -60,7 +60,7 @@ class RemoteXRBinding final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteXRBinding> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::WebGPU::XRBinding& xrBinding, WebGPU::ObjectHeap& objectHeap, RemoteGPU& gpu, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteXRBinding(gpuConnectionToWebProcess, xrBinding, objectHeap, gpu, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteXRBinding(gpuConnectionToWebProcess, xrBinding, objectHeap, gpu, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteXRBinding();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteXRProjectionLayer);
 RemoteXRProjectionLayer::RemoteXRProjectionLayer(WebCore::WebGPU::XRProjectionLayer& xrProjectionLayer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(xrProjectionLayer)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
@@ -79,7 +79,7 @@ void RemoteXRProjectionLayer::destruct()
 #if PLATFORM(COCOA)
 void RemoteXRProjectionLayer::startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex, PlatformXR::RateMapDescription&& rateMapDescription)
 {
-    protectedBacking()->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex, WTFMove(rateMapDescription));
+    protectedBacking()->startFrame(frameIndex, WTF::move(colorBuffer), WTF::move(depthBuffer), WTF::move(completionSyncEvent), reusableTextureIndex, WTF::move(rateMapDescription));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -75,7 +75,7 @@ class RemoteXRProjectionLayer final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteXRProjectionLayer> create(WebCore::WebGPU::XRProjectionLayer& xrProjectionLayer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteXRProjectionLayer(xrProjectionLayer, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteXRProjectionLayer(xrProjectionLayer, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteXRProjectionLayer();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteXRSubImage);
 RemoteXRSubImage::RemoteXRSubImage(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::WebGPU::XRSubImage& xrSubImage, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     : m_backing(xrSubImage)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_identifier(identifier)
     , m_gpu(gpu)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -70,7 +70,7 @@ class RemoteXRSubImage final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteXRSubImage> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::WebGPU::XRSubImage& xrSubImage, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, RemoteGPU& gpu, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteXRSubImage(gpuConnectionToWebProcess, xrSubImage, objectHeap, WTFMove(streamConnection), gpu, identifier));
+        return adoptRef(*new RemoteXRSubImage(gpuConnectionToWebProcess, xrSubImage, objectHeap, WTF::move(streamConnection), gpu, identifier));
     }
 
     virtual ~RemoteXRSubImage();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteXRView);
 RemoteXRView::RemoteXRView(WebCore::WebGPU::XRView& xrView, WebGPU::ObjectHeap& objectHeap, RemoteGPU& gpu, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     : m_backing(xrView)
     , m_objectHeap(objectHeap)
-    , m_streamConnection(WTFMove(streamConnection))
+    , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpu(gpu)
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -69,7 +69,7 @@ class RemoteXRView final : public IPC::StreamMessageReceiver {
 public:
     static Ref<RemoteXRView> create(WebCore::WebGPU::XRView& xrView, WebGPU::ObjectHeap& objectHeap, RemoteGPU& gpu, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteXRView(xrView, objectHeap, gpu, WTFMove(streamConnection), identifier));
+        return adoptRef(*new RemoteXRView(xrView, objectHeap, gpu, WTF::move(streamConnection), identifier));
     }
 
     virtual ~RemoteXRView();

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -80,7 +80,7 @@ RemoteWCLayerTreeHost::~RemoteWCLayerTreeHost()
     m_connectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteWCLayerTreeHost::messageReceiverName(), m_identifier.toUInt64());
     auto sceneContextHolder = m_connectionToWebProcess->gpuProcess().sharedSceneContext().removeHolder(m_sharedSceneContextHolder.releaseNonNull());
 
-    remoteGraphicsStreamWorkQueue().dispatch([sceneContextHolder = WTFMove(sceneContextHolder), scene = WTFMove(m_scene)]() mutable {
+    remoteGraphicsStreamWorkQueue().dispatch([sceneContextHolder = WTF::move(sceneContextHolder), scene = WTF::move(m_scene)]() mutable {
         // Destroy scene on the StreamWorkQueue thread.
         scene = nullptr;
         // sceneContextHolder can be destroyed on the StreamWorkQueue thread because it hasOneRef.
@@ -99,10 +99,10 @@ uint64_t RemoteWCLayerTreeHost::messageSenderDestinationID() const
 
 void RemoteWCLayerTreeHost::update(WCUpdateInfo&& update, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
 {
-    remoteGraphicsStreamWorkQueue().dispatch([scene = m_scene.get(), update = WTFMove(update), completionHandler = WTFMove(completionHandler)]() mutable {
-        auto updateInfo = scene->update(WTFMove(update));
-        RunLoop::mainSingleton().dispatch([updateInfo = WTFMove(updateInfo), completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(WTFMove(updateInfo));
+    remoteGraphicsStreamWorkQueue().dispatch([scene = m_scene.get(), update = WTF::move(update), completionHandler = WTF::move(completionHandler)]() mutable {
+        auto updateInfo = scene->update(WTF::move(update));
+        RunLoop::mainSingleton().dispatch([updateInfo = WTF::move(updateInfo), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(updateInfo));
         });
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
@@ -98,7 +98,7 @@ void WCRemoteFrameHostLayerManager::updateTexture(WebCore::LayerHostingContextId
     m_layers.ensure(layerHostingContextIdentifier, [&] {
         // Create a new data if the frame host didn't create it yet. The initial owner is the remote frame process.
         return makeUnique<RemoteFrameHostLayerData>(webProcessIdentifier);
-    }).iterator->value->layer().setTexture(WTFMove(texture));
+    }).iterator->value->layer().setTexture(WTF::move(texture));
 }
 
 void WCRemoteFrameHostLayerManager::removeAllLayersForProcess(WebCore::ProcessIdentifier webProcessIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -103,7 +103,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
 
     for (auto id : update.addedLayers) {
         auto layer = makeUnique<Layer>();
-        m_layers.add(id, WTFMove(layer));
+        m_layers.add(id, WTF::move(layer));
     }
 
     for (auto& layerUpdate : update.changedLayers) {
@@ -282,7 +282,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
 
     std::optional<UpdateInfo> result;
     if (update.remoteContextHostedIdentifier)
-        WCRemoteFrameHostLayerManager::singleton().updateTexture(*update.remoteContextHostedIdentifier, m_webProcessIdentifier, WTFMove(texture));
+        WCRemoteFrameHostLayerManager::singleton().updateTexture(*update.remoteContextHostedIdentifier, m_webProcessIdentifier, WTF::move(texture));
     else if (m_usesOffscreenRendering) {
         if (auto handle = bitmap->createHandle()) {
             result.emplace();
@@ -292,7 +292,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
             WebCore::IntRect viewport = { { }, update.viewport };
             result->updateRectBounds = viewport;
             result->updateRects.append(viewport);
-            result->bitmapHandle = WTFMove(*handle);
+            result->bitmapHandle = WTF::move(*handle);
         }
     } else
         m_context->swapBuffers();

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -111,17 +111,17 @@ void GPUProcess::setScreenProperties(const WebCore::ScreenProperties& screenProp
 
 void GPUProcess::openDirectoryCacheInvalidated(SandboxExtension::Handle&& handle)
 {
-    auto cacheInvalidationHandler = [handle = WTFMove(handle)] () mutable {
-        AuxiliaryProcess::openDirectoryCacheInvalidated(WTFMove(handle));
+    auto cacheInvalidationHandler = [handle = WTF::move(handle)] () mutable {
+        AuxiliaryProcess::openDirectoryCacheInvalidated(WTF::move(handle));
     };
-    dispatch_async(globalDispatchQueueSingleton(QOS_CLASS_UTILITY, 0), makeBlockPtr(WTFMove(cacheInvalidationHandler)).get());
+    dispatch_async(globalDispatchQueueSingleton(QOS_CLASS_UTILITY, 0), makeBlockPtr(WTF::move(cacheInvalidationHandler)).get());
 }
 #endif // PLATFORM(MAC)
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)
 void GPUProcess::enablePowerLogging(SandboxExtension::Handle&& handle)
 {
-    SandboxExtension::consumePermanently(WTFMove(handle));
+    SandboxExtension::consumePermanently(WTF::move(handle));
 }
 #endif // HAVE(POWERLOG_TASK_MODE_QUERY)
 

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -67,7 +67,7 @@ void LocalAudioSessionRoutingArbitrator::processDidTerminate()
 void LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
     ALWAYS_LOG(LOGIDENTIFIER, category);
-    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), 0);
+    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTF::move(callback), 0);
 }
 
 void LocalAudioSessionRoutingArbitrator::leaveRoutingArbitration()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -61,7 +61,7 @@ class RemoteAudioDestination final
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteAudioDestination);
 public:
     RemoteAudioDestination(GPUConnectionToWebProcess& connection, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore)
-        : m_renderSemaphore(WTFMove(renderSemaphore))
+        : m_renderSemaphore(WTF::move(renderSemaphore))
 #if !RELEASE_LOG_DISABLED
         , m_logger(connection.logger())
         , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
@@ -90,7 +90,7 @@ public:
 #if PLATFORM(COCOA)
     void setSharedMemory(WebCore::SharedMemory::Handle&& handle)
     {
-        m_frameCount = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadWrite);
+        m_frameCount = WebCore::SharedMemory::map(WTF::move(handle), WebCore::SharedMemory::Protection::ReadWrite);
     }
 
     void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle)
@@ -102,7 +102,7 @@ public:
             if (m_isPlaying)
                 return;
         }
-        m_ringBuffer = ConsumerSharedCARingBuffer::map(sizeof(Float32), m_numOutputChannels, WTFMove(handle));
+        m_ringBuffer = ConsumerSharedCARingBuffer::map(sizeof(Float32), m_numOutputChannels, WTF::move(handle));
         if (!m_ringBuffer)
             return;
         if (wasPlaying) {
@@ -259,9 +259,9 @@ void RemoteAudioDestinationManager::createAudioDestination(RemoteAudioDestinatio
     }
     MESSAGE_CHECK(!connection->isLockdownModeEnabled(), "Received a createAudioDestination() message from a webpage in Lockdown mode.");
 
-    auto destination = makeUniqueRef<RemoteAudioDestination>(*connection, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate, hardwareSampleRate, WTFMove(renderSemaphore));
+    auto destination = makeUniqueRef<RemoteAudioDestination>(*connection, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate, hardwareSampleRate, WTF::move(renderSemaphore));
 #if PLATFORM(COCOA)
-    destination->setSharedMemory(WTFMove(handle));
+    destination->setSharedMemory(WTF::move(handle));
 #else
     UNUSED_PARAM(handle);
 #endif
@@ -272,7 +272,7 @@ void RemoteAudioDestinationManager::createAudioDestination(RemoteAudioDestinatio
 #endif
 
     size_t latency = destination->audioUnitLatency();
-    m_audioDestinations.add(identifier, WTFMove(destination));
+    m_audioDestinations.add(identifier, WTF::move(destination));
     completionHandler(latency);
 }
 
@@ -325,7 +325,7 @@ void RemoteAudioDestinationManager::stopAudioDestination(RemoteAudioDestinationI
 void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle)
 {
     if (auto* item = m_audioDestinations.get(identifier))
-        item->audioSamplesStorageChanged(WTFMove(handle));
+        item->audioSamplesStorageChanged(WTF::move(handle));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioHardwareListenerProxy);
 
 RemoteAudioHardwareListenerProxy::RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess& gpuConnection, RemoteAudioHardwareListenerIdentifier&& identifier)
     : m_gpuConnection(gpuConnection)
-    , m_identifier(WTFMove(identifier))
+    , m_identifier(WTF::move(identifier))
     , m_listener(WebCore::AudioHardwareListener::create(*this))
 {
     audioOutputDeviceChanged();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -128,7 +128,7 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 void RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride(std::optional<bool>&& value)
 {
     m_isPlayingToBluetoothOverrideChanged = true;
-    protectedAudioSessionManager()->protectedSession()->setIsPlayingToBluetoothOverride(WTFMove(value));
+    protectedAudioSessionManager()->protectedSession()->setIsPlayingToBluetoothOverride(WTF::move(value));
 }
 
 void RemoteAudioSessionProxy::configurationChanged()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -285,7 +285,7 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
         presentingProcesses.append(*token);
 
     if (!presentingProcesses.isEmpty())
-        AudioSession::singleton().setPresentingProcesses(WTFMove(presentingProcesses));
+        AudioSession::singleton().setPresentingProcesses(WTF::move(presentingProcesses));
 }
 
 void RemoteAudioSessionProxyManager::beginInterruptionRemote()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -35,7 +35,7 @@ namespace WebKit {
 
 Ref<RemoteAudioSourceProviderProxy> RemoteAudioSourceProviderProxy::create(WebCore::MediaPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, WebCore::AudioSourceProviderAVFObjC& localProvider)
 {
-    auto remoteProvider = adoptRef(*new RemoteAudioSourceProviderProxy(identifier, WTFMove(connection)));
+    auto remoteProvider = adoptRef(*new RemoteAudioSourceProviderProxy(identifier, WTF::move(connection)));
 
     localProvider.setConfigureAudioStorageCallback([remoteProvider](auto&&... args) {
         return remoteProvider->configureAudioStorage(args...);
@@ -49,7 +49,7 @@ Ref<RemoteAudioSourceProviderProxy> RemoteAudioSourceProviderProxy::create(WebCo
 
 RemoteAudioSourceProviderProxy::RemoteAudioSourceProviderProxy(WebCore::MediaPlayerIdentifier identifier, Ref<IPC::Connection>&& connection)
     : m_identifier(identifier)
-    , m_connection(WTFMove(connection))
+    , m_connection(WTF::move(connection))
 {
 }
 
@@ -59,10 +59,10 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
 {
     auto result = ProducerSharedCARingBuffer::allocate(format, frameCount);
     RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
-    auto [ringBuffer, handle] = WTFMove(*result);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
+    auto [ringBuffer, handle] = WTF::move(*result);
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTF::move(handle), format }, 0);
     // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
-    std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.
+    std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTF::move(ringBuffer);  // NOLINT: see above.
     return caRingBuffer;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -49,7 +49,7 @@ RemoteAudioTrackProxy::RemoteAudioTrackProxy(GPUConnectionToWebProcess& connecti
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
     m_clientId = trackPrivate.addClient([](auto&& task) {
-        ensureOnMainThread(WTFMove(task));
+        ensureOnMainThread(WTF::move(task));
     }, *this);
 
     connectionToWebProcess.connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteAudioTrack(configuration()), m_mediaPlayerIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -163,7 +163,7 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
     context.renderer->setVideoTarget(videoTarget.get());
 #endif
 
-    m_renderers.set(identifier, WTFMove(context));
+    m_renderers.set(identifier, WTF::move(context));
 
     m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)), identifier);
 }
@@ -258,7 +258,7 @@ void RemoteAudioVideoRendererProxyManager::newTrackInfoForTrack(RemoteAudioVideo
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
 
     MESSAGE_CHECK(m_renderers.contains(identifier));
-    converterFor(contextFor(identifier), trackIdentifier).setTrackInfo(WTFMove(info));
+    converterFor(contextFor(identifier), trackIdentifier).setTrackInfo(WTF::move(info));
 }
 
 void RemoteAudioVideoRendererProxyManager::enqueueSample(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock&& samplesBlock, std::optional<MediaTime> minimumPresentationTime, CompletionHandler<void(bool)>&& completionHandler)
@@ -268,7 +268,7 @@ void RemoteAudioVideoRendererProxyManager::enqueueSample(RemoteAudioVideoRendere
 
     auto& converter = converterFor(iterator->value, trackIdentifier);
     MESSAGE_CHECK_COMPLETION(!!converter.currentTrackInfo(), completionHandler(false));
-    if (RefPtr mediaSample = converter.convert(WTFMove(samplesBlock))) {
+    if (RefPtr mediaSample = converter.convert(WTF::move(samplesBlock))) {
         iterator->value.renderer->enqueueSample(trackIdentifier, mediaSample.releaseNonNull());
         completionHandler(iterator->value.renderer->isReadyForMoreSamples(trackIdentifier));
         return;
@@ -335,7 +335,7 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenErrorOccurs(RemoteAudioVide
         completionHandler(PlatformMediaError::NotSupportedError);
         return;
     }
-    renderer->notifyWhenErrorOccurs([completionHandler = WTFMove(completionHandler)](auto error) mutable {
+    renderer->notifyWhenErrorOccurs([completionHandler = WTF::move(completionHandler)](auto error) mutable {
         completionHandler(error);
     });
 }
@@ -378,9 +378,9 @@ void RemoteAudioVideoRendererProxyManager::seekTo(RemoteAudioVideoRendererIdenti
         completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
         return;
     }
-    renderer->seekTo(time)->whenSettled(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, identifier, completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
+    renderer->seekTo(time)->whenSettled(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
         protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
-        completionHandler(WTFMove(result));
+        completionHandler(WTF::move(result));
     });
 }
 
@@ -495,7 +495,7 @@ void RemoteAudioVideoRendererProxyManager::currentVideoFrame(RemoteAudioVideoRen
     std::optional<RemoteVideoFrameProxy::Properties> result;
     if (RefPtr videoFrame = renderer->currentVideoFrame())
         result = m_videoFrameObjectHeap->add(videoFrame.releaseNonNull());
-    completionHandler(WTFMove(result));
+    completionHandler(WTF::move(result));
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -572,7 +572,7 @@ void RemoteAudioVideoRendererProxyManager::setVideoLayerSizeFenced(RemoteAudioVi
 
     auto& context = contextFor(identifier);
     context.layerHostingContextManager.setVideoLayerSizeFenced(size, WTF::MachSendRightAnnotated { sendRightAnnotated }, [&] {
-        context.renderer->setVideoLayerSizeFenced(size, WTFMove(sendRightAnnotated));
+        context.renderer->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
     });
 }
 #endif
@@ -582,7 +582,7 @@ void RemoteAudioVideoRendererProxyManager::requestHostingContext(RemoteAudioVide
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
 #if PLATFORM(COCOA)
     MESSAGE_CHECK_COMPLETION(m_renderers.contains(identifier), completionHandler({ }));
-    contextFor(identifier).layerHostingContextManager.requestHostingContext(WTFMove(completionHandler));
+    contextFor(identifier).layerHostingContextManager.requestHostingContext(WTF::move(completionHandler));
 #else
     completionHandler({ });
 #endif
@@ -631,7 +631,7 @@ void RemoteAudioVideoRendererProxyManager::setInitData(RemoteAudioVideoRendererI
 {
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
     if (RefPtr renderer = rendererFor(identifier))
-        renderer->setInitData(initData)->whenSettled(RunLoop::mainSingleton(), WTFMove(completionHandler));
+        renderer->setInitData(initData)->whenSettled(RunLoop::mainSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteAudioVideoRendererProxyManager::attemptToDecrypt(RemoteAudioVideoRendererIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -80,11 +80,11 @@ void RemoteCDMFactoryProxy::createCDM(const String& keySystem, const String& med
         return;
     }
 
-    auto proxy = RemoteCDMProxy::create(*this, WTFMove(privateCDM));
+    auto proxy = RemoteCDMProxy::create(*this, WTF::move(privateCDM));
     auto identifier = RemoteCDMIdentifier::generate();
     RemoteCDMConfiguration configuration = proxy->configuration();
-    addProxy(identifier, WTFMove(proxy));
-    completion(WTFMove(identifier), WTFMove(configuration));
+    addProxy(identifier, WTF::move(proxy));
+    completion(WTF::move(identifier), WTF::move(configuration));
 }
 
 void RemoteCDMFactoryProxy::supportsKeySystem(const String& keySystem, CompletionHandler<void(bool)>&& completion)
@@ -149,7 +149,7 @@ void RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connect
 void RemoteCDMFactoryProxy::addProxy(const RemoteCDMIdentifier& identifier, RefPtr<RemoteCDMProxy>&& proxy)
 {
     ASSERT(!m_proxies.contains(identifier));
-    m_proxies.set(identifier, WTFMove(proxy));
+    m_proxies.set(identifier, WTF::move(proxy));
 }
 
 void RemoteCDMFactoryProxy::removeProxy(const RemoteCDMIdentifier& identifier)
@@ -161,7 +161,7 @@ void RemoteCDMFactoryProxy::removeProxy(const RemoteCDMIdentifier& identifier)
 void RemoteCDMFactoryProxy::addInstance(const RemoteCDMInstanceIdentifier& identifier, Ref<RemoteCDMInstanceProxy>&& instance)
 {
     ASSERT(!m_instances.contains(identifier));
-    m_instances.set(identifier, WTFMove(instance));
+    m_instances.set(identifier, WTF::move(instance));
 }
 
 void RemoteCDMFactoryProxy::removeInstance(const RemoteCDMInstanceIdentifier& identifier)
@@ -181,7 +181,7 @@ RemoteCDMInstanceProxy* RemoteCDMFactoryProxy::getInstance(const RemoteCDMInstan
 void RemoteCDMFactoryProxy::addSession(const RemoteCDMInstanceSessionIdentifier& identifier, Ref<RemoteCDMInstanceSessionProxy>&& session)
 {
     ASSERT(!m_sessions.contains(identifier));
-    m_sessions.set(identifier, WTFMove(session));
+    m_sessions.set(identifier, WTF::move(session));
 }
 
 void RemoteCDMFactoryProxy::removeSession(const RemoteCDMInstanceSessionIdentifier& identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -43,13 +43,13 @@ Ref<RemoteCDMInstanceProxy> RemoteCDMInstanceProxy::create(RemoteCDMProxy& cdm, 
     auto configuration = makeUniqueRefWithoutFastMallocCheck<RemoteCDMInstanceConfiguration, RemoteCDMInstanceConfiguration&&>({
         priv->keySystem(),
     });
-    return adoptRef(*new RemoteCDMInstanceProxy(cdm, WTFMove(priv), WTFMove(configuration), identifier));
+    return adoptRef(*new RemoteCDMInstanceProxy(cdm, WTF::move(priv), WTF::move(configuration), identifier));
 }
 
 RemoteCDMInstanceProxy::RemoteCDMInstanceProxy(RemoteCDMProxy& cdm, Ref<CDMInstance>&& priv, UniqueRef<RemoteCDMInstanceConfiguration>&& configuration, RemoteCDMInstanceIdentifier identifier)
     : m_cdm(cdm)
-    , m_instance(WTFMove(priv))
-    , m_configuration(WTFMove(configuration))
+    , m_instance(WTF::move(priv))
+    , m_configuration(WTF::move(configuration))
     , m_identifier(identifier)
 #if !RELEASE_LOG_DISABLED
     , m_logger(cdm.logger())
@@ -77,17 +77,17 @@ void RemoteCDMInstanceProxy::unrequestedInitializationDataReceived(const String&
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstance::UnrequestedInitializationDataReceived(type, WTFMove(initData)), m_identifier);
+    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstance::UnrequestedInitializationDataReceived(type, WTF::move(initData)), m_identifier);
 }
 
 void RemoteCDMInstanceProxy::initializeWithConfiguration(const WebCore::CDMKeySystemConfiguration& configuration, AllowDistinctiveIdentifiers allowDistinctiveIdentifiers, AllowPersistentState allowPersistentState, CompletionHandler<void(SuccessValue)>&& completion)
 {
-    m_instance->initializeWithConfiguration(configuration, allowDistinctiveIdentifiers, allowPersistentState, WTFMove(completion));
+    m_instance->initializeWithConfiguration(configuration, allowDistinctiveIdentifiers, allowPersistentState, WTF::move(completion));
 }
 
 void RemoteCDMInstanceProxy::setServerCertificate(Ref<SharedBuffer>&& certificate, CompletionHandler<void(SuccessValue)>&& completion)
 {
-    m_instance->setServerCertificate(WTFMove(certificate), WTFMove(completion));
+    m_instance->setServerCertificate(WTF::move(certificate), WTF::move(completion));
 }
 
 void RemoteCDMInstanceProxy::setStorageDirectory(const String& directory)
@@ -121,7 +121,7 @@ void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHan
 
     auto identifier = RemoteCDMInstanceSessionIdentifier::generate();
     auto session = RemoteCDMInstanceSessionProxy::create(m_cdm.get(), privSession.releaseNonNull(), logIdentifier, identifier);
-    protectedCdm()->protectedFactory()->addSession(identifier, WTFMove(session));
+    protectedCdm()->protectedFactory()->addSession(identifier, WTF::move(session));
     completion(identifier);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -39,15 +39,15 @@ using namespace WebCore;
 
 Ref<RemoteCDMInstanceSessionProxy> RemoteCDMInstanceSessionProxy::create(WeakPtr<RemoteCDMProxy>&& proxy, Ref<WebCore::CDMInstanceSession>&& session, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier identifier)
 {
-    Ref sessionProxy = adoptRef(*new RemoteCDMInstanceSessionProxy(WTFMove(proxy), WTFMove(session), logIdentifier, identifier));
+    Ref sessionProxy = adoptRef(*new RemoteCDMInstanceSessionProxy(WTF::move(proxy), WTF::move(session), logIdentifier, identifier));
     WeakPtr<WebCore::CDMInstanceSessionClient> client = sessionProxy.get();
-    sessionProxy->protectedSession()->setClient(WTFMove(client));
+    sessionProxy->protectedSession()->setClient(WTF::move(client));
     return sessionProxy;
 }
 
 RemoteCDMInstanceSessionProxy::RemoteCDMInstanceSessionProxy(WeakPtr<RemoteCDMProxy>&& cdm, Ref<WebCore::CDMInstanceSession>&& session, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier identifier)
-    : m_cdm(WTFMove(cdm))
-    , m_session(WTFMove(session))
+    : m_cdm(WTF::move(cdm))
+    , m_session(WTF::move(session))
     , m_identifier(identifier)
 {
 }
@@ -78,8 +78,8 @@ void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGrouping
         return;
     }
 
-    protectedSession()->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTFMove(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
-        completion(WTFMove(message), sessionId, needsIndividualization, succeeded == CDMInstanceSession::Succeeded);
+    protectedSession()->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTF::move(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
+        completion(WTF::move(message), sessionId, needsIndividualization, succeeded == CDMInstanceSession::Succeeded);
     });
 }
 
@@ -97,8 +97,8 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
         return;
     }
 
-    protectedSession()->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTFMove(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
-        completion(sessionClosed, WTFMove(keyStatuses), WTFMove(expirationTime), WTFMove(message), succeeded == CDMInstanceSession::Succeeded);
+    protectedSession()->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTF::move(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
+        completion(sessionClosed, WTF::move(keyStatuses), WTF::move(expirationTime), WTF::move(message), succeeded == CDMInstanceSession::Succeeded);
     });
 }
 
@@ -111,22 +111,22 @@ void RemoteCDMInstanceSessionProxy::loadSession(LicenseType type, String session
         return;
     }
 
-    protectedSession()->loadSession(type, *sanitizedSessionId, origin, [completion = WTFMove(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
-        completion(WTFMove(keyStatuses), WTFMove(expirationTime), WTFMove(message), succeeded == CDMInstanceSession::Succeeded, failure);
+    protectedSession()->loadSession(type, *sanitizedSessionId, origin, [completion = WTF::move(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+        completion(WTF::move(keyStatuses), WTF::move(expirationTime), WTF::move(message), succeeded == CDMInstanceSession::Succeeded, failure);
     });
 }
 
 void RemoteCDMInstanceSessionProxy::closeSession(const String& sessionId, CloseSessionCallback&& completion)
 {
-    protectedSession()->closeSession(sessionId, [completion = WTFMove(completion)] () mutable {
+    protectedSession()->closeSession(sessionId, [completion = WTF::move(completion)] () mutable {
         completion();
     });
 }
 
 void RemoteCDMInstanceSessionProxy::removeSessionData(const String& sessionId, LicenseType type, RemoveSessionDataCallback&& completion)
 {
-    protectedSession()->removeSessionData(sessionId, type, [completion = WTFMove(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
-        completion(WTFMove(keyStatuses), WTFMove(expiredSessionsData), succeeded == CDMInstanceSession::Succeeded);
+    protectedSession()->removeSessionData(sessionId, type, [completion = WTF::move(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
+        completion(WTF::move(keyStatuses), WTF::move(expiredSessionsData), succeeded == CDMInstanceSession::Succeeded);
     });
 }
 
@@ -148,7 +148,7 @@ void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatu
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTFMove(keyStatuses)), m_identifier);
+    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTF::move(keyStatuses)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedBuffer>&& message)
@@ -164,7 +164,7 @@ void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedB
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTFMove(message)), m_identifier);
+    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTF::move(message)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -51,13 +51,13 @@ RefPtr<RemoteCDMProxy> RemoteCDMProxy::create(RemoteCDMFactoryProxy& factory, st
         priv->supportsSessions()
     });
 
-    return adoptRef(new RemoteCDMProxy(factory, WTFMove(priv), WTFMove(configuration)));
+    return adoptRef(new RemoteCDMProxy(factory, WTF::move(priv), WTF::move(configuration)));
 }
 
 RemoteCDMProxy::RemoteCDMProxy(RemoteCDMFactoryProxy& factory, std::unique_ptr<CDMPrivate>&& priv, UniqueRef<RemoteCDMConfiguration>&& configuration)
     : m_factory(factory)
-    , m_private(WTFMove(priv))
-    , m_configuration(WTFMove(configuration))
+    , m_private(WTF::move(priv))
+    , m_configuration(WTF::move(configuration))
 #if !RELEASE_LOG_DISABLED
     , m_logger(factory.logger())
 #endif
@@ -83,7 +83,7 @@ std::optional<String> RemoteCDMProxy::sanitizeSessionId(const String& sessionId)
 
 void RemoteCDMProxy::getSupportedConfiguration(WebCore::CDMKeySystemConfiguration&& configuration, WebCore::CDMPrivate::LocalStorageAccess access, CompletionHandler<void(std::optional<WebCore::CDMKeySystemConfiguration>)>&& callback)
 {
-    m_private->getSupportedConfiguration(WTFMove(configuration), access, WTFMove(callback));
+    m_private->getSupportedConfiguration(WTF::move(configuration), access, WTF::move(callback));
 }
 
 void RemoteCDMProxy::createInstance(CompletionHandler<void(std::optional<RemoteCDMInstanceIdentifier>, RemoteCDMInstanceConfiguration&&)>&& completion)
@@ -96,8 +96,8 @@ void RemoteCDMProxy::createInstance(CompletionHandler<void(std::optional<RemoteC
     auto identifier = RemoteCDMInstanceIdentifier::generate();
     auto instance = RemoteCDMInstanceProxy::create(*this, privateInstance.releaseNonNull(), identifier);
     RemoteCDMInstanceConfiguration configuration = instance->configuration();
-    protectedFactory()->addInstance(identifier, WTFMove(instance));
-    completion(identifier, WTFMove(configuration));
+    protectedFactory()->addInstance(identifier, WTF::move(instance));
+    completion(identifier, WTF::move(configuration));
 }
 
 void RemoteCDMProxy::loadAndInitialize()

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -68,7 +68,7 @@ void RemoteImageDecoderAVFProxy::createDecoder(const IPC::SharedBufferReference&
 
     std::optional<ImageDecoderIdentifier> imageDecoderIdentifier;
     if (!imageDecoder)
-        return completionHandler(WTFMove(imageDecoderIdentifier));
+        return completionHandler(WTF::move(imageDecoderIdentifier));
 
     auto identifier = ImageDecoderIdentifier::generate();
     m_imageDecoders.add(identifier, imageDecoder.copyRef());
@@ -79,7 +79,7 @@ void RemoteImageDecoderAVFProxy::createDecoder(const IPC::SharedBufferReference&
     });
 
     imageDecoderIdentifier = identifier;
-    completionHandler(WTFMove(imageDecoderIdentifier));
+    completionHandler(WTF::move(imageDecoderIdentifier));
 }
 
 void RemoteImageDecoderAVFProxy::deleteDecoder(ImageDecoderIdentifier identifier)
@@ -135,7 +135,7 @@ void RemoteImageDecoderAVFProxy::setData(ImageDecoderIdentifier identifier, cons
     if (frameCount)
         frameInfos = imageDecoder->frameInfos();
 
-    completionHandler(frameCount, imageDecoder->size(), imageDecoder->hasTrack(), WTFMove(frameInfos));
+    completionHandler(frameCount, imageDecoder->size(), imageDecoder->hasTrack(), WTF::move(frameInfos));
 }
 
 void RemoteImageDecoderAVFProxy::createFrameImageAtIndex(ImageDecoderIdentifier identifier, uint64_t index, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
@@ -145,7 +145,7 @@ void RemoteImageDecoderAVFProxy::createFrameImageAtIndex(ImageDecoderIdentifier 
     std::optional<ShareableBitmap::Handle> imageHandle;
 
     auto invokeCallbackAtScopeExit = makeScopeExit([&] {
-        completionHandler(WTFMove(imageHandle));
+        completionHandler(WTF::move(imageHandle));
     });
 
     RefPtr imageDecoder = m_imageDecoders.get(identifier);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -80,8 +80,8 @@ void RemoteLegacyCDMFactoryProxy::createCDM(const String& keySystem, std::option
 
     auto proxy = RemoteLegacyCDMProxy::create(*this, playerId, privateCDM.releaseNonNull());
     auto identifier = RemoteLegacyCDMIdentifier::generate();
-    addProxy(identifier, WTFMove(proxy));
-    completion(WTFMove(identifier));
+    addProxy(identifier, WTF::move(proxy));
+    completion(WTF::move(identifier));
 }
 
 void RemoteLegacyCDMFactoryProxy::supportsKeySystem(const String& keySystem, std::optional<String> mimeType, CompletionHandler<void(bool)>&& completion)
@@ -137,7 +137,7 @@ void RemoteLegacyCDMFactoryProxy::addProxy(RemoteLegacyCDMIdentifier identifier,
     connection->messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMProxy::messageReceiverName(), identifier.toUInt64(), proxy.get());
 
     ASSERT(!m_proxies.contains(identifier));
-    m_proxies.set(identifier, WTFMove(proxy));
+    m_proxies.set(identifier, WTF::move(proxy));
 }
 
 void RemoteLegacyCDMFactoryProxy::removeProxy(RemoteLegacyCDMIdentifier identifier)
@@ -161,7 +161,7 @@ void RemoteLegacyCDMFactoryProxy::addSession(RemoteLegacyCDMSessionIdentifier id
     connection->messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMSessionProxy::messageReceiverName(), identifier.toUInt64(), session.get());
 
     ASSERT(!m_sessions.contains(identifier));
-    m_sessions.set(identifier, WTFMove(session));
+    m_sessions.set(identifier, WTF::move(session));
 }
 
 void RemoteLegacyCDMFactoryProxy::removeSession(RemoteLegacyCDMSessionIdentifier identifier, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -38,13 +38,13 @@ using namespace WebCore;
 
 Ref<RemoteLegacyCDMProxy> RemoteLegacyCDMProxy::create(WeakPtr<RemoteLegacyCDMFactoryProxy> factory, std::optional<MediaPlayerIdentifier> playerId, Ref<WebCore::LegacyCDM>&& cdm)
 {
-    return adoptRef(*new RemoteLegacyCDMProxy(WTFMove(factory), playerId, WTFMove(cdm)));
+    return adoptRef(*new RemoteLegacyCDMProxy(WTF::move(factory), playerId, WTF::move(cdm)));
 }
 
 RemoteLegacyCDMProxy::RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&& factory, std::optional<MediaPlayerIdentifier> playerId, Ref<WebCore::LegacyCDM>&& cdm)
-    : m_factory(WTFMove(factory))
+    : m_factory(WTF::move(factory))
     , m_playerId(playerId)
-    , m_cdm(WTFMove(cdm))
+    , m_cdm(WTF::move(cdm))
 {
     m_cdm->setClient(this);
 }
@@ -69,8 +69,8 @@ void RemoteLegacyCDMProxy::createSession(uint64_t logIdentifier, CreateSessionCa
 
     auto sessionIdentifier = RemoteLegacyCDMSessionIdentifier::generate();
     Ref session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, protectedCDM());
-    factory->addSession(sessionIdentifier, WTFMove(session));
-    callback(WTFMove(sessionIdentifier));
+    factory->addSession(sessionIdentifier, WTF::move(session));
+    callback(WTF::move(sessionIdentifier));
 }
 
 RefPtr<MediaPlayer> RemoteLegacyCDMProxy::cdmMediaPlayer(const LegacyCDM*) const

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -94,7 +94,7 @@ void RemoteLegacyCDMSessionProxy::generateKeyRequest(const String& mimeType, Ref
         return;
     }
     
-    auto initDataArray = convertToUint8Array(WTFMove(initData));
+    auto initDataArray = convertToUint8Array(WTF::move(initData));
     if (!initDataArray) {
         completion({ }, emptyString(), 0, 0);
         return;
@@ -126,7 +126,7 @@ void RemoteLegacyCDMSessionProxy::update(RefPtr<SharedBuffer>&& update, UpdateCa
         return;
     }
     
-    auto updateArray = convertToUint8Array(WTFMove(update));
+    auto updateArray = convertToUint8Array(WTF::move(update));
     if (!updateArray) {
         completion(false, nullptr, 0, 0);
         return;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
@@ -52,15 +52,15 @@ RemoteMediaEngineConfigurationFactoryProxy::~RemoteMediaEngineConfigurationFacto
 
 void RemoteMediaEngineConfigurationFactoryProxy:: createDecodingConfiguration(WebCore::MediaDecodingConfiguration&& configuration, CompletionHandler<void(WebCore::MediaCapabilitiesDecodingInfo&&)>&& completion)
 {
-    MediaEngineConfigurationFactory::createDecodingConfiguration(WTFMove(configuration), [completion = WTFMove(completion)] (auto info) mutable {
-        completion(WTFMove(info));
+    MediaEngineConfigurationFactory::createDecodingConfiguration(WTF::move(configuration), [completion = WTF::move(completion)] (auto info) mutable {
+        completion(WTF::move(info));
     });
 }
 
 void RemoteMediaEngineConfigurationFactoryProxy::createEncodingConfiguration(WebCore::MediaEncodingConfiguration&& configuration, CompletionHandler<void(WebCore::MediaCapabilitiesEncodingInfo&&)>&& completion)
 {
-    MediaEngineConfigurationFactory::createEncodingConfiguration(WTFMove(configuration), [completion = WTFMove(completion)] (auto info) mutable {
-        completion(WTFMove(info));
+    MediaEngineConfigurationFactory::createEncodingConfiguration(WTF::move(configuration), [completion = WTF::move(completion)] (auto info) mutable {
+        completion(WTF::move(info));
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -102,8 +102,8 @@ void RemoteMediaPlayerManagerProxy::createMediaPlayer(MediaPlayerIdentifier iden
     ASSERT(RunLoop::isMain());
     ASSERT(!m_proxies.contains(identifier));
 
-    auto proxy = RemoteMediaPlayerProxy::create(*this, identifier, clientIdentifier, connection->connection(), engineIdentifier, WTFMove(proxyConfiguration), Ref { connection->videoFrameObjectHeap() }, connection->webProcessIdentity());
-    m_proxies.add(identifier, WTFMove(proxy));
+    auto proxy = RemoteMediaPlayerProxy::create(*this, identifier, clientIdentifier, connection->connection(), engineIdentifier, WTF::move(proxyConfiguration), Ref { connection->videoFrameObjectHeap() }, connection->webProcessIdentity());
+    m_proxies.add(identifier, WTF::move(proxy));
 }
 
 void RemoteMediaPlayerManagerProxy::deleteMediaPlayer(MediaPlayerIdentifier identifier)
@@ -137,7 +137,7 @@ void RemoteMediaPlayerManagerProxy::getSupportedTypes(MediaPlayerEnums::MediaEng
         return type;
     });
 
-    completionHandler(WTFMove(result));
+    completionHandler(WTF::move(result));
 }
 
 void RemoteMediaPlayerManagerProxy::supportsTypeAndCodecs(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier, const MediaEngineSupportParameters&& parameters, CompletionHandler<void(MediaPlayer::SupportsType)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp
@@ -69,7 +69,7 @@ void RemoteMediaResource::shutdown()
     if (RefPtr remoteMediaResourceManager = m_remoteMediaResourceManager.get())
         remoteMediaResourceManager->removeMediaResource(m_id);
 
-    ensureOnMainRunLoop([remoteMediaPlayerProxy = WTFMove(m_remoteMediaPlayerProxy), id = m_id] {
+    ensureOnMainRunLoop([remoteMediaPlayerProxy = WTF::move(m_remoteMediaPlayerProxy), id = m_id] {
         if (remoteMediaPlayerProxy)
             remoteMediaPlayerProxy->removeResource(id);
     });
@@ -89,7 +89,7 @@ void RemoteMediaResource::responseReceived(const ResourceResponse& response, boo
         return completionHandler(ShouldContinuePolicyCheck::No);
 
     m_didPassAccessControlCheck = didPassAccessControlCheck;
-    client->responseReceived(*this, response, [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto shouldContinue) mutable {
+    client->responseReceived(*this, response, [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](auto shouldContinue) mutable {
         if (shouldContinue == ShouldContinuePolicyCheck::No) {
             ensureOnMainThread([protectedThis] {
                 protectedThis->shutdown();
@@ -105,7 +105,7 @@ void RemoteMediaResource::redirectReceived(ResourceRequest&& request, const Reso
     assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
     if (auto client = this->client())
-        client->redirectReceived(*this, WTFMove(request), response, WTFMove(completionHandler));
+        client->redirectReceived(*this, WTF::move(request), response, WTF::move(completionHandler));
 }
 
 void RemoteMediaResource::dataSent(uint64_t bytesSent, uint64_t totalBytesToBeSent)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
@@ -55,7 +55,7 @@ RefPtr<PlatformMediaResource> RemoteMediaResourceLoader::requestResource(Resourc
     if (!remoteMediaPlayerProxy)
         return nullptr;
 
-    return remoteMediaPlayerProxy->requestResource(WTFMove(request), options);
+    return remoteMediaPlayerProxy->requestResource(WTF::move(request), options);
 }
 
 void RemoteMediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler)
@@ -65,7 +65,7 @@ void RemoteMediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<voi
     if (!remoteMediaPlayerProxy)
         return completionHandler(makeUnexpected(internalError(url)));
     
-    remoteMediaPlayerProxy->sendH2Ping(url, WTFMove(completionHandler));
+    remoteMediaPlayerProxy->sendH2Ping(url, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -53,7 +53,7 @@ RemoteMediaResourceManager::~RemoteMediaResourceManager()
 {
     Locker locker { m_lock };
     // Shutdown any stale RemoteMediaResources. We must complete this step in a follow-up task to prevent re-entry in RemoteMediaResourceManager.
-    callOnMainRunLoop([resources = WTFMove(m_remoteMediaResources)] {
+    callOnMainRunLoop([resources = WTF::move(m_remoteMediaResources)] {
         for (auto&& resource : resources) {
             if (RefPtr protectedResource = resource.value.get())
                 protectedResource->shutdown();
@@ -109,7 +109,7 @@ void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier 
 {
     if (RefPtr resource = resourceForId(identifier)) {
         assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-        resource->responseReceived(response, didPassAccessControlCheck, WTFMove(completionHandler));
+        resource->responseReceived(response, didPassAccessControlCheck, WTF::move(completionHandler));
     } else
         completionHandler(ShouldContinuePolicyCheck::No);
 }
@@ -118,7 +118,7 @@ void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier 
 {
     if (RefPtr resource = resourceForId(identifier)) {
         assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
-        resource->redirectReceived(WTFMove(request), response, WTFMove(completionHandler));
+        resource->redirectReceived(WTF::move(request), response, WTF::move(completionHandler));
     } else
         completionHandler({ });
 }
@@ -147,7 +147,7 @@ void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier iden
         return completionHandler(std::nullopt);
 
     resource->dataReceived(sharedMemory->createSharedBuffer(buffer.size()));
-    completionHandler(WTFMove(handle));
+    completionHandler(WTF::move(handle));
 }
 
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -84,7 +84,7 @@ void RemoteMediaSourceProxy::disconnect()
 void RemoteMediaSourceProxy::setPrivateAndOpen(Ref<MediaSourcePrivate>&& mediaSourcePrivate)
 {
     ASSERT(!m_private);
-    m_private = WTFMove(mediaSourcePrivate);
+    m_private = WTF::move(mediaSourcePrivate);
 }
 
 void RemoteMediaSourceProxy::reOpen()
@@ -129,7 +129,7 @@ void RemoteMediaSourceProxy::addSourceBuffer(const WebCore::ContentType& content
         auto identifier = RemoteSourceBufferIdentifier::generate();
         Ref remoteMediaPlayerProxy { *m_remoteMediaPlayerProxy };
         auto remoteSourceBufferProxy = RemoteSourceBufferProxy::create(*connection, identifier, sourceBufferPrivate.releaseNonNull(), remoteMediaPlayerProxy);
-        m_sourceBuffers.append(WTFMove(remoteSourceBufferProxy));
+        m_sourceBuffers.append(WTF::move(remoteSourceBufferProxy));
         remoteSourceIdentifier = identifier;
     }
 
@@ -145,7 +145,7 @@ void RemoteMediaSourceProxy::durationChanged(const MediaTime& duration)
 void RemoteMediaSourceProxy::bufferedChanged(WebCore::PlatformTimeRanges&& buffered)
 {
     if (RefPtr protectedPrivate = m_private)
-        protectedPrivate->bufferedChanged(WTFMove(buffered));
+        protectedPrivate->bufferedChanged(WTF::move(buffered));
 }
 
 void RemoteMediaSourceProxy::markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status )

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
@@ -42,7 +42,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRemoteCommandListenerProxy);
 
 RemoteRemoteCommandListenerProxy::RemoteRemoteCommandListenerProxy(GPUConnectionToWebProcess& gpuConnection, RemoteRemoteCommandListenerIdentifier&& identifier)
     : m_gpuConnection(gpuConnection)
-    , m_identifier(WTFMove(identifier))
+    , m_identifier(WTF::move(identifier))
 {
 }
 
@@ -51,7 +51,7 @@ RemoteRemoteCommandListenerProxy::~RemoteRemoteCommandListenerProxy() = default;
 void RemoteRemoteCommandListenerProxy::updateSupportedCommands(Vector<WebCore::PlatformMediaSession::RemoteControlCommandType>&& registeredCommands, bool supportsSeeking)
 {
     m_supportedCommands.clear();
-    m_supportedCommands.addAll(WTFMove(registeredCommands));
+    m_supportedCommands.addAll(WTF::move(registeredCommands));
     m_supportsSeeking = supportsSeeking;
 
     if (auto connection = m_gpuConnection.get())

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
@@ -50,7 +50,7 @@ class RemoteRemoteCommandListenerProxy : public RefCounted<RemoteRemoteCommandLi
 public:
     static Ref<RemoteRemoteCommandListenerProxy> create(GPUConnectionToWebProcess& process, RemoteRemoteCommandListenerIdentifier&& identifier)
     {
-        return adoptRef(*new RemoteRemoteCommandListenerProxy(process, WTFMove(identifier)));
+        return adoptRef(*new RemoteRemoteCommandListenerProxy(process, WTF::move(identifier)));
     }
 
     virtual ~RemoteRemoteCommandListenerProxy();

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -51,7 +51,7 @@ RemoteTextTrackProxy::RemoteTextTrackProxy(GPUConnectionToWebProcess& connection
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
     m_clientId = trackPrivate.addClient([](auto&& task) {
-        ensureOnMainThread(WTFMove(task));
+        ensureOnMainThread(WTF::move(task));
     }, *this);
     connectionToWebProcess.connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteTextTrack(configuration()), m_mediaPlayerIdentifier);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -49,7 +49,7 @@ RemoteVideoTrackProxy::RemoteVideoTrackProxy(GPUConnectionToWebProcess& connecti
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
     m_clientRegistrationId = trackPrivate.addClient([](auto&& task) {
-        ensureOnMainThread(WTFMove(task));
+        ensureOnMainThread(WTF::move(task));
     }, *this);
     connectionToWebProcess.connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteVideoTrack(configuration()), m_mediaPlayerIdentifier);
 }

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -76,7 +76,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 
 void RemoteMediaPlayerProxy::requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&& completionHandler)
 {
-    m_layerHostingContextManager->requestHostingContext(WTFMove(completionHandler));
+    m_layerHostingContextManager->requestHostingContext(WTF::move(completionHandler));
 }
 
 void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
@@ -85,13 +85,13 @@ void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& s
 
     ALWAYS_LOG(LOGIDENTIFIER, size.width(), "x", size.height());
     m_layerHostingContextManager->setVideoLayerSizeFenced(size, WTF::MachSendRightAnnotated { sendRightAnnotated }, [&] {
-        protectedPlayer()->setVideoLayerSizeFenced(size, WTFMove(sendRightAnnotated));
+        protectedPlayer()->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
     });
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerOnNewVideoFrameMetadata(WebCore::VideoFrameMetadata&& metadata, RetainPtr<CVPixelBufferRef>&& buffer)
 {
-    auto properties = protectedVideoFrameObjectHeap()->add(WebCore::VideoFrameCV::create({ }, false, WebCore::VideoFrame::Rotation::None, WTFMove(buffer)));
+    auto properties = protectedVideoFrameObjectHeap()->add(WebCore::VideoFrameCV::create({ }, false, WebCore::VideoFrame::Rotation::None, WTF::move(buffer)));
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::PushVideoFrameMetadata(metadata, properties), m_id);
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -59,7 +59,7 @@ class RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit
 public:
     static Ref<RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit> create(
         AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, const String& deviceID, GPUConnectionToWebProcess& connection, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, uint64_t)>&& callback) {
-        return adoptRef(*new RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit(identifier, deviceID, connection, WTFMove(callback)));
+        return adoptRef(*new RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit(identifier, deviceID, connection, WTF::move(callback)));
     }
 
     ~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit();
@@ -137,7 +137,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit(AudioMed
 {
     ASSERT(!m_units.contains(identifier));
     if (auto connection = m_gpuConnectionToWebProcess.get())
-        m_units.add(identifier, RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::create(identifier, deviceID, *connection, WTFMove(callback)));
+        m_units.add(identifier, RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::create(identifier, deviceID, *connection, WTF::move(callback)));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -154,7 +154,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, IPC::Semaphore&& semaphore)
 {
     if (RefPtr unit = m_units.get(identifier))
-        unit->start(WTFMove(handle), WTFMove(semaphore));
+        unit->start(WTF::move(handle), WTF::move(semaphore));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -195,7 +195,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
     , m_canUseCaptureUnit(deviceID == WebCore::AudioMediaStreamTrackRenderer::defaultDeviceID())
 {
     WebCore::AudioSession::addInterruptionObserver(*this);
-    protectedLocalUnit()->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)](auto&& description) mutable {
+    protectedLocalUnit()->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTF::move(callback)](auto&& description) mutable {
         if (!weakThis || !description) {
             RELEASE_LOG_IF(!description, WebRTC, "RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit unable to get format description");
             callback(std::nullopt, 0);
@@ -254,14 +254,14 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::start(ConsumerS
 {
     if (m_isPlaying)
         stop();
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(*m_description, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(*m_description, WTF::move(handle));
     if (!m_ringBuffer)
         return;
     m_readOffset = 0;
     m_generateOffset = 0;
     m_isPlaying = true;
     m_canReset = true;
-    m_renderSemaphore = WTFMove(semaphore);
+    m_renderSemaphore = WTF::move(semaphore);
     m_shouldRegisterAsSpeakerSamplesProducer = computeShouldRegisterAsSpeakerSamplesProducer();
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -47,14 +47,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSampleBufferDisplayLayer);
 
 RefPtr<RemoteSampleBufferDisplayLayer> RemoteSampleBufferDisplayLayer::create(GPUConnectionToWebProcess& gpuConnection, SampleBufferDisplayLayerIdentifier identifier, Ref<IPC::Connection>&& connection, RemoteSampleBufferDisplayLayerManager& remoteSampleBufferDisplayLayerManager)
 {
-    RefPtr layer = adoptRef(*new RemoteSampleBufferDisplayLayer(gpuConnection, identifier, WTFMove(connection), remoteSampleBufferDisplayLayerManager));
-    return layer->m_sampleBufferDisplayLayer ? WTFMove(layer) : nullptr;
+    RefPtr layer = adoptRef(*new RemoteSampleBufferDisplayLayer(gpuConnection, identifier, WTF::move(connection), remoteSampleBufferDisplayLayerManager));
+    return layer->m_sampleBufferDisplayLayer ? WTF::move(layer) : nullptr;
 }
 
 RemoteSampleBufferDisplayLayer::RemoteSampleBufferDisplayLayer(GPUConnectionToWebProcess& gpuConnection, SampleBufferDisplayLayerIdentifier identifier, Ref<IPC::Connection>&& connection, RemoteSampleBufferDisplayLayerManager& remoteSampleBufferDisplayLayerManager)
     : m_gpuConnection(gpuConnection)
     , m_identifier(identifier)
-    , m_connection(WTFMove(connection))
+    , m_connection(WTF::move(connection))
     , m_sampleBufferDisplayLayer(LocalSampleBufferDisplayLayer::create(*this))
     , m_sharedVideoFrameReader(Ref { gpuConnection.videoFrameObjectHeap() }, gpuConnection.webProcessIdentity())
     , m_remoteSampleBufferDisplayLayerManager(remoteSampleBufferDisplayLayerManager)
@@ -78,7 +78,7 @@ void RemoteSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size
 #else
     UNUSED_PARAM(canShowWhileLocked);
 #endif
-    protectedSampleBufferDisplayLayer()->initialize(hideRootLayer, size, shouldMaintainAspectRatio, [weakThis = WeakPtr { *this }, contextOptions, callback = WTFMove(callback)](bool didSucceed) mutable {
+    protectedSampleBufferDisplayLayer()->initialize(hideRootLayer, size, shouldMaintainAspectRatio, [weakThis = WeakPtr { *this }, contextOptions, callback = WTF::move(callback)](bool didSucceed) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !didSucceed)
             return callback({ });
@@ -116,7 +116,7 @@ void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std:
     RetainPtr<BELayerHierarchyHostingTransactionCoordinator> hostingUpdateCoordinator;
     if (fence && fence->sendRight.sendRight()) {
 #if ENABLE(MACH_PORT_LAYER_HOSTING)
-        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTFMove(*fence));
+        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTF::move(*fence));
 #else
         hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(fence->sendRight.sendRight());
 #endif // ENABLE(MACH_PORT_LAYER_HOSTING)
@@ -158,7 +158,7 @@ void RemoteSampleBufferDisplayLayer::pause()
 
 void RemoteSampleBufferDisplayLayer::enqueueVideoFrame(SharedVideoFrame&& frame)
 {
-    if (auto videoFrame = m_sharedVideoFrameReader.read(WTFMove(frame)))
+    if (auto videoFrame = m_sharedVideoFrameReader.read(WTF::move(frame)))
         protectedSampleBufferDisplayLayer()->enqueueVideoFrame(*videoFrame);
 }
 
@@ -179,12 +179,12 @@ void RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail()
 
 void RemoteSampleBufferDisplayLayer::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)
 {
-    m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
+    m_sharedVideoFrameReader.setSemaphore(WTF::move(semaphore));
 }
 
 void RemoteSampleBufferDisplayLayer::setSharedVideoFrameMemory(SharedMemory::Handle&& handle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(WTFMove(handle));
+    m_sharedVideoFrameReader.setSharedMemory(WTF::move(handle));
 }
 
 void RemoteSampleBufferDisplayLayer::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -74,7 +74,7 @@ void RemoteSampleBufferDisplayLayerManager::close()
     ipcConnection->removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
     m_queue->dispatch([this, protectedThis = Ref { *this }] {
         Locker lock(m_layersLock);
-        callOnMainRunLoop([layers = WTFMove(m_layers)] { });
+        callOnMainRunLoop([layers = WTF::move(m_layers)] { });
     });
 }
 
@@ -92,7 +92,7 @@ bool RemoteSampleBufferDisplayLayerManager::dispatchMessage(IPC::Connection& con
 
 void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayerIdentifier identifier, bool hideRootLayer, WebCore::IntSize size, bool shouldMaintainAspectRatio, bool canShowWhileLocked, LayerCreationCallback&& callback)
 {
-    callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier, hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, callback = WTFMove(callback)]() mutable {
+    callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier, hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, callback = WTF::move(callback)]() mutable {
         auto connection = m_connectionToWebProcess.get();
         if (!connection)
             return callback({ });
@@ -101,12 +101,12 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
             callback({ });
             return;
         }
-        layer->initialize(hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = Ref { *layer }](auto hostingContext) mutable {
-            m_queue->dispatch([protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = WTFMove(layer), hostingContext = WTFMove(hostingContext)]() mutable {
+        layer->initialize(hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, [this, protectedThis = Ref { *this }, callback = WTF::move(callback), identifier, layer = Ref { *layer }](auto hostingContext) mutable {
+            m_queue->dispatch([protectedThis = Ref { *this }, callback = WTF::move(callback), identifier, layer = WTF::move(layer), hostingContext = WTF::move(hostingContext)]() mutable {
                 Locker lock(protectedThis->m_layersLock);
                 ASSERT(!protectedThis->m_layers.contains(identifier));
-                protectedThis->m_layers.add(identifier, WTFMove(layer));
-                callback(WTFMove(hostingContext));
+                protectedThis->m_layers.add(identifier, WTF::move(layer));
+                callback(WTF::move(hostingContext));
             });
         });
     });
@@ -133,12 +133,12 @@ void RemoteSampleBufferDisplayLayerManager::updateSampleBufferDisplayLayerBounds
 {
     Locker lock(m_layersLock);
     if (RefPtr layer = m_layers.get(identifier))
-        layer->updateBoundsAndPosition(bounds, WTFMove(sendRight));
+        layer->updateBoundsAndPosition(bounds, WTF::move(sendRight));
 }
 
 void RemoteSampleBufferDisplayLayerManager::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess)
 {
-    m_queue->dispatch([this, protectedThis = Ref { *this }, sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess)] {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess)] {
         m_sharedPreferencesForWebProcess = sharedPreferencesForWebProcess;
     });
 }

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -37,7 +37,7 @@ namespace WebKit {
 class ModelServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
     ModelServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
-        : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
+        : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }
 };
@@ -45,7 +45,7 @@ public:
 template<>
 void initializeAuxiliaryProcess<ModelProcess>(AuxiliaryProcessInitializationParameters&& parameters)
 {
-    static NeverDestroyed<ModelProcess> modelProcess(WTFMove(parameters));
+    static NeverDestroyed<ModelProcess> modelProcess(WTF::move(parameters));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -63,7 +63,7 @@ Ref<ModelConnectionToWebProcess> ModelConnectionToWebProcess::create(
     ModelProcessConnectionParameters&& parameters,
     const std::optional<String>& attributionTaskID)
 {
-    return adoptRef(*new ModelConnectionToWebProcess(modelProcess, webProcessIdentifier, sessionID, WTFMove(connectionHandle), WTFMove(parameters), attributionTaskID));
+    return adoptRef(*new ModelConnectionToWebProcess(modelProcess, webProcessIdentifier, sessionID, WTF::move(connectionHandle), WTF::move(parameters), attributionTaskID));
 }
 
 ModelConnectionToWebProcess::ModelConnectionToWebProcess(
@@ -74,10 +74,10 @@ ModelConnectionToWebProcess::ModelConnectionToWebProcess(
     ModelProcessConnectionParameters&& parameters,
     const std::optional<String>& attributionTaskID)
     : m_modelProcessModelPlayerManagerProxy(ModelProcessModelPlayerManagerProxy::create(*this))
-    , m_connection(IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(connectionHandle) }))
+    , m_connection(IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(connectionHandle) }))
     , m_modelProcess(modelProcess)
     , m_webProcessIdentifier(webProcessIdentifier)
-    , m_webProcessIdentity(WTFMove(parameters.webProcessIdentity))
+    , m_webProcessIdentity(WTF::move(parameters.webProcessIdentity))
     , m_sessionID(sessionID)
 #if HAVE(AUDIT_TOKEN)
     , m_presentingApplicationAuditToken(parameters.presentingApplicationAuditToken ? std::optional(parameters.presentingApplicationAuditToken->auditToken()) : std::nullopt)
@@ -86,7 +86,7 @@ ModelConnectionToWebProcess::ModelConnectionToWebProcess(
     , m_ipcTester(IPCTester::create())
 #endif
     , m_attributionTaskID(attributionTaskID)
-    , m_sharedPreferencesForWebProcess(WTFMove(parameters.sharedPreferencesForWebProcess))
+    , m_sharedPreferencesForWebProcess(WTF::move(parameters.sharedPreferencesForWebProcess))
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
@@ -128,7 +128,7 @@ void ModelConnectionToWebProcess::createVisibilityPropagationContextForPage(WebP
     auto contextForVisibilityPropagation = LayerHostingContext::create({ canShowWhileLocked });
     RELEASE_LOG(Process, "ModelConnectionToWebProcess::createVisibilityPropagationContextForPage: pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", contextID=%u", pageProxyID.toUInt64(), pageID.toUInt64(), contextForVisibilityPropagation->contextID());
     modelProcess().send(Messages::ModelProcessProxy::DidCreateContextForVisibilityPropagation(pageProxyID, pageID, contextForVisibilityPropagation->contextID()));
-    m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTFMove(contextForVisibilityPropagation));
+    m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTF::move(contextForVisibilityPropagation));
 }
 
 void ModelConnectionToWebProcess::destroyVisibilityPropagationContextForPage(WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID)

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -81,7 +81,7 @@ public:
     USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<ModelConnectionToWebProcess>);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
-    void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess); }
+    void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess); }
 
     IPC::Connection& connection() { return m_connection.get(); }
     Ref<IPC::Connection> protectedConnection() { return m_connection; }

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -70,7 +70,7 @@ constexpr Seconds minimumLifetimeBeforeIdleExit { 5_s };
 ModelProcess::ModelProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_idleExitTimer(*this, &ModelProcess::tryExitIfUnused)
 {
-    initialize(WTFMove(parameters));
+    initialize(WTF::move(parameters));
     RELEASE_LOG(Process, "%p - ModelProcess::ModelProcess:", this);
 }
 
@@ -86,7 +86,7 @@ void ModelProcess::createModelConnectionToWebProcess(
 {
     RELEASE_LOG(Process, "%p - ModelProcess::createModelConnectionToWebProcess: processIdentifier=%" PRIu64, this, identifier.toUInt64());
 
-    auto reply = makeScopeExit(WTFMove(completionHandler));
+    auto reply = makeScopeExit(WTF::move(completionHandler));
     // If sender exited before we received the identifier, the identifier
     // may not be valid.
     if (!connectionHandle)
@@ -100,11 +100,11 @@ void ModelProcess::createModelConnectionToWebProcess(
             return;
         }
 
-        protectedThis->requestSharedSimulationConnection(identifier, WTFMove(completionHandler));
+        protectedThis->requestSharedSimulationConnection(identifier, WTF::move(completionHandler));
     });
 #endif
 
-    auto newConnection = ModelConnectionToWebProcess::create(*this, identifier, sessionID, WTFMove(connectionHandle), WTFMove(parameters), attributionTaskID);
+    auto newConnection = ModelConnectionToWebProcess::create(*this, identifier, sessionID, WTF::move(connectionHandle), WTF::move(parameters), attributionTaskID);
 
 #if ENABLE(IPC_TESTING_API)
     if (parameters.ignoreInvalidMessageForTesting)
@@ -112,13 +112,13 @@ void ModelProcess::createModelConnectionToWebProcess(
 #endif
 
     ASSERT(!m_webProcessConnections.contains(identifier));
-    m_webProcessConnections.add(identifier, WTFMove(newConnection));
+    m_webProcessConnections.add(identifier, WTF::move(newConnection));
 }
 
 void ModelProcess::sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier identifier, SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess, CompletionHandler<void()>&& completionHandler)
 {
     if (RefPtr connection = m_webProcessConnections.get(identifier))
-        connection->updateSharedPreferencesForWebProcess(WTFMove(sharedPreferencesForWebProcess));
+        connection->updateSharedPreferencesForWebProcess(WTF::move(sharedPreferencesForWebProcess));
     completionHandler();
 }
 
@@ -197,12 +197,12 @@ void ModelProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)
 
 void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& parameters, CompletionHandler<void()>&& completionHandler)
 {
-    CompletionHandlerCallingScope callCompletionHandler(WTFMove(completionHandler));
+    CompletionHandlerCallingScope callCompletionHandler(WTF::move(completionHandler));
 
     m_debugEntityMemoryLimit = parameters.debugEntityMemoryLimit;
     WKREEngine::enableRestrictiveRenderingMode(parameters.restrictiveRenderingMode);
 
-    applyProcessCreationParameters(WTFMove(parameters.auxiliaryProcessParameters));
+    applyProcessCreationParameters(WTF::move(parameters.auxiliaryProcessParameters));
     RELEASE_LOG(Process, "%p - ModelProcess::initializeModelProcess:", this);
     WTF::Thread::setCurrentThreadIsUserInitiated();
     WebCore::initializeCommonAtomStrings();
@@ -213,7 +213,7 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
     });
     memoryPressureHandler.install();
 
-    m_applicationVisibleName = WTFMove(parameters.applicationVisibleName);
+    m_applicationVisibleName = WTF::move(parameters.applicationVisibleName);
 
     // Match the QoS of the UIProcess since the model process is doing rendering on its behalf.
     WTF::Thread::setCurrentThreadIsUserInteractive(0);
@@ -251,7 +251,7 @@ ModelConnectionToWebProcess* ModelProcess::webProcessConnection(WebCore::Process
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
 void ModelProcess::requestSharedSimulationConnection(WebCore::ProcessIdentifier webProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler)
 {
-    parentProcessConnection()->sendWithAsyncReply(Messages::ModelProcessProxy::RequestSharedSimulationConnection(webProcessIdentifier), WTFMove(completionHandler));
+    parentProcessConnection()->sendWithAsyncReply(Messages::ModelProcessProxy::RequestSharedSimulationConnection(webProcessIdentifier), WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -70,7 +70,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
     ASSERT(!m_proxies.contains(identifier));
 
     auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, m_modelConnectionToWebProcess->protectedConnection(), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
-    m_proxies.add(identifier, WTFMove(proxy));
+    m_proxies.add(identifier, WTF::move(proxy));
 }
 
 void ModelProcessModelPlayerManagerProxy::deleteModelPlayer(WebCore::ModelPlayerIdentifier identifier)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -101,15 +101,15 @@ class RKModelUSD final : public WebCore::REModel {
 public:
     static Ref<RKModelUSD> create(Ref<Model> model, RetainPtr<WKRKEntity> entity)
     {
-        return adoptRef(*new RKModelUSD(WTFMove(model), WTFMove(entity)));
+        return adoptRef(*new RKModelUSD(WTF::move(model), WTF::move(entity)));
     }
 
     virtual ~RKModelUSD() = default;
 
 private:
     RKModelUSD(Ref<Model> model, RetainPtr<WKRKEntity> entity)
-        : m_model { WTFMove(model) }
-        , m_entity { WTFMove(entity) }
+        : m_model { WTF::move(model) }
+        , m_entity { WTF::move(entity) }
     {
     }
 
@@ -168,7 +168,7 @@ private:
             return;
 
         if (auto strongClient = m_client.get())
-            strongClient->didFinishLoading(*this, RKModelUSD::create(WTFMove(m_model), entity));
+            strongClient->didFinishLoading(*this, RKModelUSD::create(WTF::move(m_model), entity));
     }
 
     void didFail(ResourceError error)
@@ -177,7 +177,7 @@ private:
             return;
 
         if (auto strongClient = m_client.get())
-            strongClient->didFailLoading(*this, WTFMove(error));
+            strongClient->didFailLoading(*this, WTF::move(error));
     }
 
     bool m_canceled { false };
@@ -201,7 +201,7 @@ void RKModelLoaderUSD::load(CompletionHandler<void()>&& completionHandler)
     RetainPtr<NSString> attributionID;
     if (m_attributionTaskID.has_value())
         attributionID = m_attributionTaskID.value().createNSString();
-    [getWKRKEntityClassSingleton() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID.get() entityMemoryLimit:(m_entityMemoryLimit ? *m_entityMemoryLimit : 0) completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (WKRKEntity *entity) mutable {
+    [getWKRKEntityClassSingleton() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID.get() entityMemoryLimit:(m_entityMemoryLimit ? *m_entityMemoryLimit : 0) completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (WKRKEntity *entity) mutable {
         completionHandler();
 
         RefPtr protectedThis = weakThis.get();
@@ -281,12 +281,12 @@ uint64_t ModelProcessModelPlayerProxy::gObjectCountForTesting = 0;
 
 Ref<ModelProcessModelPlayerProxy> ModelProcessModelPlayerProxy::create(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit)
 {
-    return adoptRef(*new ModelProcessModelPlayerProxy(manager, identifier, WTFMove(connection), attributionTaskID, debugEntityMemoryLimit));
+    return adoptRef(*new ModelProcessModelPlayerProxy(manager, identifier, WTF::move(connection), attributionTaskID, debugEntityMemoryLimit));
 }
 
 ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit)
     : m_id(identifier)
-    , m_webProcessConnection(WTFMove(connection))
+    , m_webProcessConnection(WTF::move(connection))
     , m_manager(manager)
     , m_attributionTaskID(attributionTaskID)
     , m_debugEntityMemoryLimit(debugEntityMemoryLimit)
@@ -372,8 +372,8 @@ void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCor
 
 void ModelProcessModelPlayerProxy::reloadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
 {
-    m_entityTransformToRestore = WTFMove(entityTransformToRestore);
-    m_animationStateToRestore = WTFMove(animationStateToRestore);
+    m_entityTransformToRestore = WTF::move(entityTransformToRestore);
+    m_animationStateToRestore = WTF::move(animationStateToRestore);
     if (m_animationStateToRestore) {
         m_autoplay = m_animationStateToRestore->autoplay();
         m_loop = m_animationStateToRestore->loop();
@@ -885,7 +885,7 @@ void ModelProcessModelPlayerProxy::setCurrentTime(Seconds currentTime, Completio
 
 void ModelProcessModelPlayerProxy::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
 {
-    m_transientEnvironmentMapData = WTFMove(data);
+    m_transientEnvironmentMapData = WTF::move(data);
     if (m_modelRKEntity)
         applyEnvironmentMapDataAndRelease([] { });
 }
@@ -961,7 +961,7 @@ void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease(CompletionH
 #if HAVE(MODEL_MEMORY_ATTRIBUTION)
                 setIBLAssetOwnership(*(protectedThis->m_attributionTaskID), coreEnvironmentResourceAsset);
 #endif
-            }).get() withCompletion:makeBlockPtr([weakThis = WeakPtr { *this }, completion = WTFMove(completion)] (BOOL succeeded) mutable {
+            }).get() withCompletion:makeBlockPtr([weakThis = WeakPtr { *this }, completion = WTF::move(completion)] (BOOL succeeded) mutable {
                 completion();
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
@@ -1053,7 +1053,7 @@ void ModelProcessModelPlayerProxy::applyDefaultIBL()
 void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&& completion)
 {
     setImmersivePresentation(true);
-    ensureModelLoaded([weakThis = WeakPtr { *this }, completion = WTFMove(completion)] (bool loaded) mutable {
+    ensureModelLoaded([weakThis = WeakPtr { *this }, completion = WTF::move(completion)] (bool loaded) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completion(std::nullopt);
@@ -1095,7 +1095,7 @@ void ModelProcessModelPlayerProxy::ensureModelLoaded(CompletionHandler<void(bool
         return;
     }
 
-    m_modelLoadedCallbacks.append(WTFMove(completion));
+    m_modelLoadedCallbacks.append(WTF::move(completion));
 }
 
 void ModelProcessModelPlayerProxy::triggerModelLoadedCallbacks(bool result)

--- a/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.cpp
@@ -48,7 +48,7 @@ struct AuthenticationManager::Challenge {
     Challenge(std::optional<WebPageProxyIdentifier> pageID, const WebCore::AuthenticationChallenge& challenge, ChallengeCompletionHandler&& completionHandler)
         : pageID(pageID)
         , challenge(challenge)
-        , completionHandler(WTFMove(completionHandler)) { }
+        , completionHandler(WTF::move(completionHandler)) { }
 
     Markable<WebPageProxyIdentifier> pageID;
     WebCore::AuthenticationChallenge challenge;
@@ -97,7 +97,7 @@ AuthenticationChallengeIdentifier AuthenticationManager::addChallengeToChallenge
     ASSERT(RunLoop::isMain());
 
     auto challengeID = AuthenticationChallengeIdentifier::generate();
-    m_challenges.set(challengeID, WTFMove(challenge));
+    m_challenges.set(challengeID, WTF::move(challenge));
     return challengeID;
 }
 
@@ -140,7 +140,7 @@ void AuthenticationManager::didReceiveAuthenticationChallenge(PAL::SessionID ses
     if (!pageID)
         return completionHandler(AuthenticationChallengeDisposition::PerformDefaultHandling, { });
 
-    auto challengeID = addChallengeToChallengeMap(makeUniqueRef<Challenge>(*pageID, authenticationChallenge, WTFMove(completionHandler)));
+    auto challengeID = addChallengeToChallengeMap(makeUniqueRef<Challenge>(*pageID, authenticationChallenge, WTF::move(completionHandler)));
 
     // Coalesce challenges in the same protection space and in the same page.
     if (shouldCoalesceChallenge(*pageID, challengeID, authenticationChallenge))
@@ -155,7 +155,7 @@ void AuthenticationManager::didReceiveAuthenticationChallenge(PAL::SessionID ses
 void AuthenticationManager::didReceiveAuthenticationChallenge(IPC::MessageSender& download, const WebCore::AuthenticationChallenge& authenticationChallenge, ChallengeCompletionHandler&& completionHandler)
 {
     std::optional<WebPageProxyIdentifier> dummyPageID;
-    auto challengeID = addChallengeToChallengeMap(makeUniqueRef<Challenge>(dummyPageID, authenticationChallenge, WTFMove(completionHandler)));
+    auto challengeID = addChallengeToChallengeMap(makeUniqueRef<Challenge>(dummyPageID, authenticationChallenge, WTF::move(completionHandler)));
 
     // Coalesce challenges in the same protection space and in the same page.
     if (shouldCoalesceChallenge(dummyPageID, challengeID, authenticationChallenge))

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -47,7 +47,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchLoad);
 
 BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, BackgroundFetchRecordLoaderClient& client, const BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)
-    : m_sessionID(WTFMove(sessionID))
+    : m_sessionID(WTF::move(sessionID))
     , m_client(client)
     , m_request(request.internalRequest)
     , m_networkLoadChecker(NetworkLoadChecker::create(networkProcess, nullptr, nullptr, FetchOptions { request.options }, m_sessionID, std::nullopt, HTTPHeaderMap { request.httpHeaders }, URL { m_request.url() }, URL { }, clientOrigin.clientOrigin.securityOrigin(), clientOrigin.topOrigin.securityOrigin(), RefPtr<SecurityOrigin> { }, PreflightPolicy::Consider, String { request.referrer }, true, OptionSet<AdvancedPrivacyProtections> { }))
@@ -73,7 +73,7 @@ BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::Se
             // We should never send a synthetic redirect for BackgroundFetchLoads.
             ASSERT_NOT_REACHED();
         }, [&] (ResourceRequest& request) {
-            this->loadRequest(networkProcess, WTFMove(request));
+            this->loadRequest(networkProcess, WTF::move(request));
         });
     });
 }
@@ -114,33 +114,33 @@ void BackgroundFetchLoad::loadRequest(NetworkProcess& networkProcess, ResourceRe
         return;
 
     NetworkLoadParameters loadParameters;
-    loadParameters.request = WTFMove(request);
+    loadParameters.request = WTF::move(request);
     loadParameters.topOrigin = m_networkLoadChecker->topOrigin();
     loadParameters.sourceOrigin = m_networkLoadChecker->origin();
     loadParameters.storedCredentialsPolicy = m_networkLoadChecker->options().credentials == FetchOptions::Credentials::Include ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
     loadParameters.clientCredentialPolicy = ClientCredentialPolicy::CannotAskClientForCredentials;
 
-    Ref task = NetworkDataTask::create(*networkSession, *this, WTFMove(loadParameters));
+    Ref task = NetworkDataTask::create(*networkSession, *this, WTF::move(loadParameters));
     m_task = task.ptr();
     task->resume();
 }
 
 void BackgroundFetchLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse, ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
-    m_networkLoadChecker->checkRedirection(ResourceRequest { }, WTFMove(request), WTFMove(redirectResponse), nullptr, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
+    m_networkLoadChecker->checkRedirection(ResourceRequest { }, WTF::move(request), WTF::move(redirectResponse), nullptr, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (auto&& result) mutable {
         if (!result.has_value()) {
             weakThis->didFinish(result.error());
             completionHandler({ });
             return;
         }
-        auto request = WTFMove(result->redirectRequest);
+        auto request = WTF::move(result->redirectRequest);
         if (!request.url().protocolIsInHTTPFamily()) {
             weakThis->didFinish(ResourceError { String { }, 0, request.url(), "Redirection to URL with a scheme that is not HTTP(S)"_s, ResourceError::Type::AccessControl });
             completionHandler({ });
             return;
         }
 
-        completionHandler(WTFMove(request));
+        completionHandler(WTF::move(request));
     });
 }
 
@@ -148,7 +148,7 @@ void BackgroundFetchLoad::didReceiveChallenge(AuthenticationChallenge&& challeng
 {
     BGLOAD_RELEASE_LOG("didReceiveChallenge");
     if (challenge.protectionSpace().authenticationScheme() == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
-        Ref { m_networkLoadChecker }->protectedNetworkProcess()->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, { }, nullptr, challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+        Ref { m_networkLoadChecker }->protectedNetworkProcess()->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, { }, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
         return;
     }
     WeakPtr weakThis { *this };
@@ -180,7 +180,7 @@ void BackgroundFetchLoad::didReceiveResponse(ResourceResponse&& response, Negoti
     if (!weakThis)
         return;
 
-    protectedClient()->didReceiveResponse(WTFMove(response));
+    protectedClient()->didReceiveResponse(WTF::move(response));
 }
 
 void BackgroundFetchLoad::didReceiveData(const SharedBuffer& data)

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -416,18 +416,18 @@ void ResourceLoadStatisticsStore::removeDataRecords(CompletionHandler<void()>&& 
 
     setDataRecordsBeingRemoved(true);
 
-    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, domainsToDeleteOrRestrictWebsiteDataFor = crossThreadCopy(WTFMove(domainsToDeleteOrRestrictWebsiteDataFor)), completionHandler = WTFMove(completionHandler), weakThis = WeakPtr { *this }, workQueue = m_workQueue] () mutable {
-        store->deleteAndRestrictWebsiteDataForRegistrableDomains(WebResourceLoadStatisticsStore::monitoredDataTypes(), WTFMove(domainsToDeleteOrRestrictWebsiteDataFor), [completionHandler = WTFMove(completionHandler), weakThis = WTFMove(weakThis), workQueue](HashSet<RegistrableDomain>&& domainsWithDeletedWebsiteData) mutable {
-            workQueue->dispatch([domainsWithDeletedWebsiteData = crossThreadCopy(WTFMove(domainsWithDeletedWebsiteData)), completionHandler = WTFMove(completionHandler), weakThis = WTFMove(weakThis)] () mutable {
+    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, domainsToDeleteOrRestrictWebsiteDataFor = crossThreadCopy(WTF::move(domainsToDeleteOrRestrictWebsiteDataFor)), completionHandler = WTF::move(completionHandler), weakThis = WeakPtr { *this }, workQueue = m_workQueue] () mutable {
+        store->deleteAndRestrictWebsiteDataForRegistrableDomains(WebResourceLoadStatisticsStore::monitoredDataTypes(), WTF::move(domainsToDeleteOrRestrictWebsiteDataFor), [completionHandler = WTF::move(completionHandler), weakThis = WTF::move(weakThis), workQueue](HashSet<RegistrableDomain>&& domainsWithDeletedWebsiteData) mutable {
+            workQueue->dispatch([domainsWithDeletedWebsiteData = crossThreadCopy(WTF::move(domainsWithDeletedWebsiteData)), completionHandler = WTF::move(completionHandler), weakThis = WTF::move(weakThis)] () mutable {
                 if (!weakThis) {
                     completionHandler();
                     return;
                 }
 
-                weakThis->incrementRecordsDeletedCountForDomains(WTFMove(domainsWithDeletedWebsiteData));
+                weakThis->incrementRecordsDeletedCountForDomains(WTF::move(domainsWithDeletedWebsiteData));
                 weakThis->setDataRecordsBeingRemoved(false);
 
-                auto dataRecordRemovalCompletionHandlers = WTFMove(weakThis->m_dataRecordRemovalCompletionHandlers);
+                auto dataRecordRemovalCompletionHandlers = WTF::move(weakThis->m_dataRecordRemovalCompletionHandlers);
                 completionHandler();
 
                 for (auto& dataRecordRemovalCompletionHandler : dataRecordRemovalCompletionHandlers)
@@ -449,7 +449,7 @@ void ResourceLoadStatisticsStore::processStatisticsAndDataRecords(CompletionHand
     if (m_parameters.shouldClassifyResourcesBeforeDataRecordsRemoval)
         classifyPrevalentResources();
     
-    removeDataRecords([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] () mutable {
+    removeDataRecords([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] () mutable {
         ASSERT(!RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
@@ -483,9 +483,9 @@ void ResourceLoadStatisticsStore::grandfatherExistingWebsiteData(CompletionHandl
 {
     ASSERT(!RunLoop::isMain());
 
-    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, callback = WTFMove(callback), workQueue = m_workQueue, store = Ref { m_store.get() }] () mutable {
-        store->registrableDomainsWithWebsiteData(WebResourceLoadStatisticsStore::monitoredDataTypes(), [weakThis = WTFMove(weakThis), callback = WTFMove(callback), workQueue] (HashSet<RegistrableDomain>&& domainsWithWebsiteData) mutable {
-            workQueue->dispatch([weakThis = WTFMove(weakThis), domainsWithWebsiteData = crossThreadCopy(WTFMove(domainsWithWebsiteData)), callback = WTFMove(callback)] () mutable {
+    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, callback = WTF::move(callback), workQueue = m_workQueue, store = Ref { m_store.get() }] () mutable {
+        store->registrableDomainsWithWebsiteData(WebResourceLoadStatisticsStore::monitoredDataTypes(), [weakThis = WTF::move(weakThis), callback = WTF::move(callback), workQueue] (HashSet<RegistrableDomain>&& domainsWithWebsiteData) mutable {
+            workQueue->dispatch([weakThis = WTF::move(weakThis), domainsWithWebsiteData = crossThreadCopy(WTF::move(domainsWithWebsiteData)), callback = WTF::move(callback)] () mutable {
                 if (!weakThis) {
                     callback();
                     return;
@@ -532,14 +532,14 @@ void ResourceLoadStatisticsStore::setPrevalentResourceForDebugMode(const Registr
 #if ENABLE(APP_BOUND_DOMAINS)
 void ResourceLoadStatisticsStore::setAppBoundDomains(HashSet<RegistrableDomain>&& domains)
 {
-    m_appBoundDomains = WTFMove(domains);
+    m_appBoundDomains = WTF::move(domains);
 }
 #endif
 
 #if ENABLE(MANAGED_DOMAINS)
 void ResourceLoadStatisticsStore::setManagedDomains(HashSet<RegistrableDomain>&& domains)
 {
-    m_managedDomains = WTFMove(domains);
+    m_managedDomains = WTF::move(domains);
 }
 #endif
 
@@ -654,9 +654,9 @@ void ResourceLoadStatisticsStore::updateCookieBlockingForDomains(RegistrableDoma
 {
     ASSERT(!RunLoop::isMain());
     
-    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, domainsToBlock = crossThreadCopy(WTFMove(domainsToBlock)), completionHandler = WTFMove(completionHandler)] () mutable {
-        store->callUpdatePrevalentDomainsToBlockCookiesForHandler(domainsToBlock, [store, completionHandler = WTFMove(completionHandler)]() mutable {
-            store->statisticsQueue().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, domainsToBlock = crossThreadCopy(WTF::move(domainsToBlock)), completionHandler = WTF::move(completionHandler)] () mutable {
+        store->callUpdatePrevalentDomainsToBlockCookiesForHandler(domainsToBlock, [store, completionHandler = WTF::move(completionHandler)]() mutable {
+            store->statisticsQueue().dispatch([completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler();
             });
         });
@@ -700,7 +700,7 @@ void ResourceLoadStatisticsStore::logTestingEvent(String&& event)
 {
     ASSERT(!RunLoop::isMain());
 
-    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, event = WTFMove(event).isolatedCopy()] {
+    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, event = WTF::move(event).isolatedCopy()] {
         store->logTestingEvent(event);
     });
 }
@@ -708,9 +708,9 @@ void ResourceLoadStatisticsStore::logTestingEvent(String&& event)
 void ResourceLoadStatisticsStore::removeAllStorageAccess(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
-    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, completionHandler = WTFMove(completionHandler)]() mutable {
-        store->removeAllStorageAccess([store, completionHandler = WTFMove(completionHandler)]() mutable {
-            store->statisticsQueue().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+    RunLoop::mainSingleton().dispatch([store = Ref { m_store.get() }, completionHandler = WTF::move(completionHandler)]() mutable {
+        store->removeAllStorageAccess([store, completionHandler = WTF::move(completionHandler)]() mutable {
+            store->statisticsQueue().dispatch([completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler();
             });
         });
@@ -943,16 +943,16 @@ void ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary()
     }
 
     if (!unattributed.isEmpty() || !attributed.isEmpty()) {
-        RunLoop::mainSingleton().dispatch([store = Ref { store() }, unattributed = crossThreadCopy(WTFMove(unattributed)), attributed = crossThreadCopy(WTFMove(attributed))] () mutable {
+        RunLoop::mainSingleton().dispatch([store = Ref { store() }, unattributed = crossThreadCopy(WTF::move(unattributed)), attributed = crossThreadCopy(WTF::move(attributed))] () mutable {
             CheckedPtr networkSession = store->networkSession();
             if (!networkSession)
                 return;
 
             Ref manager = networkSession->privateClickMeasurement();
-            for (auto&& pcm : WTFMove(attributed))
-                manager->migratePrivateClickMeasurementFromLegacyStorage(WTFMove(pcm), PrivateClickMeasurementAttributionType::Attributed);
-            for (auto&& pcm : WTFMove(unattributed))
-                manager->migratePrivateClickMeasurementFromLegacyStorage(WTFMove(pcm), PrivateClickMeasurementAttributionType::Unattributed);
+            for (auto&& pcm : WTF::move(attributed))
+                manager->migratePrivateClickMeasurementFromLegacyStorage(WTF::move(pcm), PrivateClickMeasurementAttributionType::Attributed);
+            for (auto&& pcm : WTF::move(unattributed))
+                manager->migratePrivateClickMeasurementFromLegacyStorage(WTF::move(pcm), PrivateClickMeasurementAttributionType::Unattributed);
         });
 
     }
@@ -1569,7 +1569,7 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
                 continue;
             NotVeryPrevalentResources value({ RegistrableDomain::uncheckedCreateFromRegistrableDomainString(notVeryPrevalentResourcesStatement->columnText(1))
                 , notVeryPrevalentResourcesStatement->columnInt(2) ? ResourceLoadPrevalence::High : ResourceLoadPrevalence::Low , 0, 0, 0, 0 });
-            results.add(key, WTFMove(value));
+            results.add(key, WTF::move(value));
         }
     }
 
@@ -1683,9 +1683,9 @@ void ResourceLoadStatisticsStore::hasStorageAccess(SubFrameDomain&& subFrameDoma
         completionHandler(false);
         return;
     case CookieAccess::BasedOnCookiePolicy:
-        RunLoop::mainSingleton().dispatch([store = Ref { store() }, subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
-            store->hasCookies(subFrameDomain, [store, completionHandler = WTFMove(completionHandler)](bool result) mutable {
-                store->statisticsQueue().dispatch([completionHandler = WTFMove(completionHandler), result] () mutable {
+        RunLoop::mainSingleton().dispatch([store = Ref { store() }, subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+            store->hasCookies(subFrameDomain, [store, completionHandler = WTF::move(completionHandler)](bool result) mutable {
+                store->statisticsQueue().dispatch([completionHandler = WTF::move(completionHandler), result] () mutable {
                     completionHandler(result);
                 });
             });
@@ -1696,9 +1696,9 @@ void ResourceLoadStatisticsStore::hasStorageAccess(SubFrameDomain&& subFrameDoma
         break;
     };
 
-    RunLoop::mainSingleton().dispatch([store = Ref { store() }, subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), frameID, pageID, completionHandler = WTFMove(completionHandler)]() mutable {
-        store->callHasStorageAccessForFrameHandler(subFrameDomain, topFrameDomain, frameID.value(), pageID, [store, completionHandler = WTFMove(completionHandler)](bool result) mutable {
-            store->statisticsQueue().dispatch([completionHandler = WTFMove(completionHandler), result] () mutable {
+    RunLoop::mainSingleton().dispatch([store = Ref { store() }, subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), frameID, pageID, completionHandler = WTF::move(completionHandler)]() mutable {
+        store->callHasStorageAccessForFrameHandler(subFrameDomain, topFrameDomain, frameID.value(), pageID, [store, completionHandler = WTF::move(completionHandler)](bool result) mutable {
+            store->statisticsQueue().dispatch([completionHandler = WTF::move(completionHandler), result] () mutable {
                 completionHandler(result);
             });
         });
@@ -1760,7 +1760,7 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
         return completionHandler(StorageAccessStatus::CannotRequestAccess);
     }
 
-    grantStorageAccessInternal(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, userWasPromptedEarlier, scope, canRequestStorageAccessWithoutUserInteraction, [completionHandler = WTFMove(completionHandler)] (StorageAccessWasGranted wasGranted) mutable {
+    grantStorageAccessInternal(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, pageID, userWasPromptedEarlier, scope, canRequestStorageAccessWithoutUserInteraction, [completionHandler = WTF::move(completionHandler)] (StorageAccessWasGranted wasGranted) mutable {
         completionHandler(wasGranted == StorageAccessWasGranted::Yes ? StorageAccessStatus::HasAccess : StorageAccessStatus::CannotRequestAccess);
     });
 }
@@ -1792,7 +1792,7 @@ void ResourceLoadStatisticsStore::requestStorageAccessUnderOpener(DomainInNeedOf
         debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] Storage access was granted for '"_s, domainInNeedOfStorageAccess.string(), "' under opener page from '"_s, openerDomain.string(), "', with user interaction in the opened window."_s));
     }
 
-    grantStorageAccessInternal(WTFMove(domainInNeedOfStorageAccess), WTFMove(openerDomain), std::nullopt, openerPageID, StorageAccessPromptWasShown::No, StorageAccessScope::PerPage, canRequestStorageAccessWithoutUserInteraction, [](StorageAccessWasGranted) { });
+    grantStorageAccessInternal(WTF::move(domainInNeedOfStorageAccess), WTF::move(openerDomain), std::nullopt, openerPageID, StorageAccessPromptWasShown::No, StorageAccessScope::PerPage, canRequestStorageAccessWithoutUserInteraction, [](StorageAccessWasGranted) { });
 }
 
 auto ResourceLoadStatisticsStore::grantStorageAccessPermission(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) -> std::pair<AddedRecord, std::optional<unsigned>>
@@ -1847,10 +1847,10 @@ void ResourceLoadStatisticsStore::grantStorageAccess(SubFrameDomain&& subFrameDo
 #endif
         }
 
-        protectedThis->grantStorageAccessInternal(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, promptWasShown, scope, canRequestStorageAccessWithoutUserInteraction, WTFMove(completionHandler));
+        protectedThis->grantStorageAccessInternal(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, pageID, promptWasShown, scope, canRequestStorageAccessWithoutUserInteraction, WTF::move(completionHandler));
     };
 
-    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), workQueue = m_workQueue, store = Ref { store() }, addGrant = WTFMove(addGrant), completionHandler = WTFMove(completionHandler)]() mutable {
+    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), workQueue = m_workQueue, store = Ref { store() }, addGrant = WTF::move(addGrant), completionHandler = WTF::move(completionHandler)]() mutable {
 
         std::optional<OrganizationStorageAccessPromptQuirk> additionalDomainGrants;
         CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
@@ -1861,7 +1861,7 @@ void ResourceLoadStatisticsStore::grantStorageAccess(SubFrameDomain&& subFrameDo
                 canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(subFrameDomain, topFrameDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
             }
         }
-        workQueue->dispatch([weakThis = WTFMove(weakThis), additionalDomainGrants = crossThreadCopy(WTFMove(additionalDomainGrants)), subFrameDomain = crossThreadCopy(WTFMove(subFrameDomain)), topFrameDomain = crossThreadCopy(WTFMove(topFrameDomain)), addGrant = WTFMove(addGrant), canRequestStorageAccessWithoutUserInteraction, completionHandler = WTFMove(completionHandler)] () mutable {
+        workQueue->dispatch([weakThis = WTF::move(weakThis), additionalDomainGrants = crossThreadCopy(WTF::move(additionalDomainGrants)), subFrameDomain = crossThreadCopy(WTF::move(subFrameDomain)), topFrameDomain = crossThreadCopy(WTF::move(topFrameDomain)), addGrant = WTF::move(addGrant), canRequestStorageAccessWithoutUserInteraction, completionHandler = WTF::move(completionHandler)] () mutable {
             if (!weakThis) {
                 completionHandler(StorageAccessWasGranted::No);
                 return;
@@ -1875,7 +1875,7 @@ void ResourceLoadStatisticsStore::grantStorageAccess(SubFrameDomain&& subFrameDo
                     }
                 }
             }
-            addGrant(WTFMove(subFrameDomain), WTFMove(topFrameDomain), canRequestStorageAccessWithoutUserInteraction, WTFMove(completionHandler));
+            addGrant(WTF::move(subFrameDomain), WTF::move(topFrameDomain), canRequestStorageAccessWithoutUserInteraction, WTF::move(completionHandler));
         });
     });
 }
@@ -1906,9 +1906,9 @@ void ResourceLoadStatisticsStore::grantStorageAccessInternal(SubFrameDomain&& su
         setUserInteraction(subFrameDomain, true, nowTime(m_timeAdvanceForTesting));
     }
 
-    RunLoop::mainSingleton().dispatch([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), frameID, pageID, store = Ref { store() }, scope, completionHandler = WTFMove(completionHandler)]() mutable {
-        store->callGrantStorageAccessHandler(subFrameDomain, topFrameDomain, frameID, pageID, scope, [completionHandler = WTFMove(completionHandler), store](StorageAccessWasGranted wasGranted) mutable {
-            store->statisticsQueue().dispatch([wasGranted, completionHandler = WTFMove(completionHandler)] () mutable {
+    RunLoop::mainSingleton().dispatch([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), frameID, pageID, store = Ref { store() }, scope, completionHandler = WTF::move(completionHandler)]() mutable {
+        store->callGrantStorageAccessHandler(subFrameDomain, topFrameDomain, frameID, pageID, scope, [completionHandler = WTF::move(completionHandler), store](StorageAccessWasGranted wasGranted) mutable {
+            store->statisticsQueue().dispatch([wasGranted, completionHandler = WTF::move(completionHandler)] () mutable {
                 completionHandler(wasGranted);
             });
         });
@@ -2097,7 +2097,7 @@ void ResourceLoadStatisticsStore::logUserInteraction(const TopFrameDomain& domai
         completionHandler();
         return;
     }
-    updateCookieBlocking(WTFMove(completionHandler));
+    updateCookieBlocking(WTF::move(completionHandler));
 }
 
 void ResourceLoadStatisticsStore::clearUserInteraction(const RegistrableDomain& domain, CompletionHandler<void()>&& completionHandler)
@@ -2113,7 +2113,7 @@ void ResourceLoadStatisticsStore::clearUserInteraction(const RegistrableDomain& 
     // Update cookie blocking unconditionally since a call to hasHadUserInteraction()
     // to check the previous user interaction status could call clearUserInteraction(),
     // blowing the call stack.
-    updateCookieBlocking(WTFMove(completionHandler));
+    updateCookieBlocking(WTF::move(completionHandler));
 }
 
 bool ResourceLoadStatisticsStore::hasHadUserInteraction(const RegistrableDomain& domain, OperatingDatesWindow operatingDatesWindow)
@@ -2192,7 +2192,7 @@ void ResourceLoadStatisticsStore::setPrevalentResource(const RegistrableDomain& 
 
     StdSet<unsigned> nonPrevalentRedirectionSources;
     recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain(*registrableDomainID, nonPrevalentRedirectionSources, 0);
-    setDomainsAsPrevalent(WTFMove(nonPrevalentRedirectionSources));
+    setDomainsAsPrevalent(WTF::move(nonPrevalentRedirectionSources));
 }
 
 void ResourceLoadStatisticsStore::setDomainsAsPrevalent(StdSet<unsigned>&& domains)
@@ -2208,10 +2208,10 @@ void ResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandler<v
 {
     ASSERT(!RunLoop::isMain());
     if (m_dataRecordsBeingRemoved) {
-        m_dataRecordRemovalCompletionHandlers.append([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+        m_dataRecordRemovalCompletionHandlers.append([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
             RefPtr protectedThis = weakThis.get();
             if (protectedThis)
-                protectedThis->dumpResourceLoadStatistics(WTFMove(completionHandler));
+                protectedThis->dumpResourceLoadStatistics(WTF::move(completionHandler));
             else
                 completionHandler({ });
         });
@@ -2573,7 +2573,7 @@ HashMap<RegistrableDomain, WallTime> ResourceLoadStatisticsStore::allDomainsWith
     HashMap<RegistrableDomain, WallTime> result;
     for (auto& domainData : domains()) {
         auto lastAccessedTime = std::max(domainData.mostRecentUserInteractionTime, domainData.mostRecentWebPushInteractionTime);
-        result.add(WTFMove(domainData.registrableDomain), lastAccessedTime);
+        result.add(WTF::move(domainData.registrableDomain), lastAccessedTime);
     }
 
     return result;
@@ -2585,13 +2585,13 @@ void ResourceLoadStatisticsStore::clear(CompletionHandler<void()>&& completionHa
 
     clearDatabaseContents();
 
-    auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
     removeAllStorageAccess([callbackAggregator] { });
 
     auto registrableDomainsToBlockAndDeleteCookiesFor = ensurePrevalentResourcesForDebugMode();
     RegistrableDomainsToBlockCookiesFor domainsToBlock { registrableDomainsToBlockAndDeleteCookiesFor, { }, { }, { } };
-    updateCookieBlockingForDomains(WTFMove(domainsToBlock), [callbackAggregator] { });
+    updateCookieBlockingForDomains(WTF::move(domainsToBlock), [callbackAggregator] { });
 }
 
 bool ResourceLoadStatisticsStore::areAllUnpartitionedThirdPartyCookiesBlockedUnder(const TopFrameDomain& topFrameDomain)
@@ -2731,9 +2731,9 @@ void ResourceLoadStatisticsStore::updateCookieBlocking(CompletionHandler<void()>
     if (debugLoggingEnabled() && (!domainsToBlockAndDeleteCookiesFor.isEmpty() || !domainsToBlockButKeepCookiesFor.isEmpty()))
         debugLogDomainsInBatches("Applying cross-site tracking restrictions"_s, domainsToBlock);
 
-    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, store = Ref { store() }, domainsToBlock = crossThreadCopy(WTFMove(domainsToBlock)), completionHandler = WTFMove(completionHandler)] () mutable {
-        store->callUpdatePrevalentDomainsToBlockCookiesForHandler(domainsToBlock, [weakThis = WTFMove(weakThis), store, completionHandler = WTFMove(completionHandler)]() mutable {
-            store->statisticsQueue().dispatch([weakThis = WTFMove(weakThis), completionHandler = WTFMove(completionHandler)]() mutable {
+    RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, store = Ref { store() }, domainsToBlock = crossThreadCopy(WTF::move(domainsToBlock)), completionHandler = WTF::move(completionHandler)] () mutable {
+        store->callUpdatePrevalentDomainsToBlockCookiesForHandler(domainsToBlock, [weakThis = WTF::move(weakThis), store, completionHandler = WTF::move(completionHandler)]() mutable {
+            store->statisticsQueue().dispatch([weakThis = WTF::move(weakThis), completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler();
 
                 if (!weakThis)
@@ -2912,7 +2912,7 @@ RegistrableDomainsToDeleteOrRestrictWebsiteDataFor ResourceLoadStatisticsStore::
     if (!parameters().isRunningTest && now - oldestUserInteraction < parameters().minimumTimeBetweenDataRecordsRemoval)
         toDeleteOrRestrictFor.domainsToDeleteAllScriptWrittenStorageFor.clear();
 
-    clearGrandfathering(WTFMove(domainIDsToClearGrandfathering));
+    clearGrandfathering(WTF::move(domainIDsToClearGrandfathering));
 
     return toDeleteOrRestrictFor;
 }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -170,8 +170,8 @@ public:
     bool isSameSiteStrictEnforcementEnabled() const { return m_sameSiteStrictEnforcementEnabled == WebCore::SameSiteStrictEnforcementEnabled::Yes; };
     void setFirstPartyWebsiteDataRemovalMode(WebCore::FirstPartyWebsiteDataRemovalMode mode) { m_firstPartyWebsiteDataRemovalMode = mode; }
     WebCore::FirstPartyWebsiteDataRemovalMode firstPartyWebsiteDataRemovalMode() const { return m_firstPartyWebsiteDataRemovalMode; }
-    void setPersistedDomains(HashSet<RegistrableDomain>&& domains) { m_persistedDomains = WTFMove(domains); }
-    void setStandaloneApplicationDomain(RegistrableDomain&& domain) { m_standaloneApplicationDomain = WTFMove(domain); }
+    void setPersistedDomains(HashSet<RegistrableDomain>&& domains) { m_persistedDomains = WTF::move(domains); }
+    void setStandaloneApplicationDomain(RegistrableDomain&& domain) { m_standaloneApplicationDomain = WTF::move(domain); }
 #if ENABLE(APP_BOUND_DOMAINS)
     void setAppBoundDomains(HashSet<RegistrableDomain>&&);
 #endif

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -95,11 +95,11 @@ void WebResourceLoadStatisticsStore::setIsRunningTest(bool value, CompletionHand
         return;
     }
 
-    postTask([value, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([value, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setIsRunningTest(value);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -107,11 +107,11 @@ void WebResourceLoadStatisticsStore::setShouldClassifyResourcesBeforeDataRecords
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([value, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([value, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setShouldClassifyResourcesBeforeDataRecordsRemoval(value);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -164,7 +164,7 @@ void WebResourceLoadStatisticsStore::didDestroyNetworkSession(CompletionHandler<
 {
     ASSERT(RunLoop::isMain());
 
-    auto callbackAggregator = CallbackAggregator::create([completionHandler = WTFMove(completionHandler)] () mutable {
+    auto callbackAggregator = CallbackAggregator::create([completionHandler = WTF::move(completionHandler)] () mutable {
         completionHandler();
     });
 
@@ -178,7 +178,7 @@ inline void WebResourceLoadStatisticsStore::postTask(WTF::Function<void(WebResou
     RELEASE_ASSERT(!isEphemeral());
 
     ASSERT(RunLoop::isMain());
-    m_statisticsQueue->dispatch([protectedThis = Ref { *this }, task = WTFMove(task)] {
+    m_statisticsQueue->dispatch([protectedThis = Ref { *this }, task = WTF::move(task)] {
         task(protectedThis.get());
     });
 }
@@ -186,7 +186,7 @@ inline void WebResourceLoadStatisticsStore::postTask(WTF::Function<void(WebResou
 inline void WebResourceLoadStatisticsStore::postTaskReply(WTF::Function<void()>&& reply)
 {
     ASSERT(!RunLoop::isMain());
-    RunLoop::mainSingleton().dispatch(WTFMove(reply));
+    RunLoop::mainSingleton().dispatch(WTF::move(reply));
 }
 
 void WebResourceLoadStatisticsStore::destroyResourceLoadStatisticsStore(CompletionHandler<void()>&& completionHandler)
@@ -198,9 +198,9 @@ void WebResourceLoadStatisticsStore::destroyResourceLoadStatisticsStore(Completi
         return;
     }
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         store.m_statisticsStore = nullptr;
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -208,20 +208,20 @@ void WebResourceLoadStatisticsStore::populateMemoryStoreFromDisk(CompletionHandl
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
             if (statisticsStore->isNewResourceLoadStatisticsDatabaseFile()) {
-                statisticsStore->grandfatherExistingWebsiteData([completionHandler = WTFMove(completionHandler)]() mutable {
-                    postTaskReply(WTFMove(completionHandler));
+                statisticsStore->grandfatherExistingWebsiteData([completionHandler = WTF::move(completionHandler)]() mutable {
+                    postTaskReply(WTF::move(completionHandler));
                 });
                 statisticsStore->setIsNewResourceLoadStatisticsDatabaseFile(false);
             } else
-                postTaskReply([protectedThis = Ref { store }, completionHandler = WTFMove(completionHandler)]() mutable {
+                postTaskReply([protectedThis = Ref { store }, completionHandler = WTF::move(completionHandler)]() mutable {
                     protectedThis->logTestingEvent("PopulatedWithoutGrandfathering"_s);
                     completionHandler();
                 });
         } else
-            postTaskReply(WTFMove(completionHandler));
+            postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -231,12 +231,12 @@ void WebResourceLoadStatisticsStore::loadWebsitesWithUserInteraction(CompletionH
         return completionHandler({ });
 
     ASSERT(RunLoop::isMain());
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         HashSet<RegistrableDomain> domains;
         if (RefPtr statisticsStore = store.m_statisticsStore)
             domains = statisticsStore->loadWebsitesWithUserInteraction();
-        store.postTaskReply([domains = crossThreadCopy(WTFMove(domains)), completionHandler = WTFMove(completionHandler)] mutable {
-            completionHandler(WTFMove(domains));
+        store.postTaskReply([domains = crossThreadCopy(WTF::move(domains)), completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(WTF::move(domains));
         });
     });
 }
@@ -255,10 +255,10 @@ void WebResourceLoadStatisticsStore::setResourceLoadStatisticsDebugMode(bool val
             storageSession->setTrackingPreventionDebugLoggingEnabled(value);
     }
 
-    postTask([value, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([value, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setResourceLoadStatisticsDebugMode(value);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -271,10 +271,10 @@ void WebResourceLoadStatisticsStore::setPrevalentResourceForDebugMode(Registrabl
         return;
     }
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setPrevalentResourceForDebugMode(domain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -282,16 +282,16 @@ void WebResourceLoadStatisticsStore::scheduleStatisticsAndDataRecordsProcessing(
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
-            statisticsStore->processStatisticsAndDataRecords([weakStore = ThreadSafeWeakPtr { store }, completionHandler = WTFMove(completionHandler)] () mutable {
+            statisticsStore->processStatisticsAndDataRecords([weakStore = ThreadSafeWeakPtr { store }, completionHandler = WTF::move(completionHandler)] () mutable {
                 if (RefPtr store = weakStore.get())
-                    store->postTaskReply(WTFMove(completionHandler));
+                    store->postTaskReply(WTF::move(completionHandler));
                 else
                     completionHandler();
             });
         } else
-            postTaskReply(WTFMove(completionHandler));
+            postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -299,7 +299,7 @@ void WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables(CompletionHa
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
             completionHandler(false);
@@ -307,7 +307,7 @@ void WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables(CompletionHa
             return;
         }
         auto missingTables = statisticsStore->checkForMissingTablesInSchema();
-        postTaskReply([hasAllTables = missingTables ? false : true, completionHandler = WTFMove(completionHandler)] () mutable {
+        postTaskReply([hasAllTables = missingTables ? false : true, completionHandler = WTF::move(completionHandler)] () mutable {
             completionHandler(hasAllTables);
         });
     });
@@ -320,15 +320,15 @@ void WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated(Vector<Resour
     // It is safe to move the origins to the background queue without isolated copy here because this is an r-value
     // coming from IPC. ResourceLoadStatistics only contains strings which are safe to move to other threads as long
     // as nobody on this thread holds a reference to those strings.
-    postTask([statistics = WTFMove(statistics), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([statistics = WTF::move(statistics), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply(WTFMove(completionHandler));
+            postTaskReply(WTF::move(completionHandler));
             return;
         }
 
-        statisticsStore->mergeStatistics(WTFMove(statistics));
-        postTaskReply(WTFMove(completionHandler));
+        statisticsStore->mergeStatistics(WTF::move(statistics));
+        postTaskReply(WTF::move(completionHandler));
         // We can cancel any pending request to process statistics since we're doing it synchronously below.
         statisticsStore->cancelPendingStatisticsProcessingRequest();
 
@@ -347,7 +347,7 @@ void WebResourceLoadStatisticsStore::hasStorageAccess(RegistrableDomain&& subFra
     ASSERT(RunLoop::isMain());
 
     if (isEphemeral())
-        return hasStorageAccessEphemeral(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, WTFMove(completionHandler));
+        return hasStorageAccessEphemeral(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, pageID, WTF::move(completionHandler));
 
     CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
     if (CheckedPtr networkSession = m_networkSession.get()) {
@@ -355,17 +355,17 @@ void WebResourceLoadStatisticsStore::hasStorageAccess(RegistrableDomain&& subFra
             canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(subFrameDomain, topFrameDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
     }
 
-    postTask([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), frameID, pageID, canRequestStorageAccessWithoutUserInteraction, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), frameID, pageID, canRequestStorageAccessWithoutUserInteraction, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply([completionHandler = WTFMove(completionHandler)]() mutable {
+            postTaskReply([completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler(false);
             });
             return;
         }
 
-        statisticsStore->hasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, canRequestStorageAccessWithoutUserInteraction, [completionHandler = WTFMove(completionHandler)](bool hasStorageAccess) mutable {
-            postTaskReply([completionHandler = WTFMove(completionHandler), hasStorageAccess]() mutable {
+        statisticsStore->hasStorageAccess(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, pageID, canRequestStorageAccessWithoutUserInteraction, [completionHandler = WTF::move(completionHandler)](bool hasStorageAccess) mutable {
+            postTaskReply([completionHandler = WTF::move(completionHandler), hasStorageAccess]() mutable {
                 completionHandler(hasStorageAccess);
             });
         });
@@ -416,7 +416,7 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
     ASSERT(RunLoop::isMain());
 
     if (subFrameDomain == topFrameDomain) {
-        completionHandler({ StorageAccessWasGranted::Yes, StorageAccessPromptWasShown::No, scope, WTFMove(topFrameDomain), WTFMove(subFrameDomain) });
+        completionHandler({ StorageAccessWasGranted::Yes, StorageAccessPromptWasShown::No, scope, WTF::move(topFrameDomain), WTF::move(subFrameDomain) });
         return;
     }
 
@@ -436,9 +436,9 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
     }
     
     if (isEphemeral())
-        return requestStorageAccessEphemeral(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, webPageID, webPageProxyID, scope, canRequestStorageAccessWithoutUserInteraction, WTFMove(storageAccessQuirk), WTFMove(completionHandler));
+        return requestStorageAccessEphemeral(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, webPageID, webPageProxyID, scope, canRequestStorageAccessWithoutUserInteraction, WTF::move(storageAccessQuirk), WTF::move(completionHandler));
 
-    auto statusHandler = [this, protectedThis = Ref { *this }, subFrameDomain = subFrameDomain.isolatedCopy(), topFrameDomain = topFrameDomain.isolatedCopy(), frameID, webPageID, webPageProxyID, scope, storageAccessQuirk = WTFMove(storageAccessQuirk), completionHandler = WTFMove(completionHandler)](StorageAccessStatus status) mutable {
+    auto statusHandler = [this, protectedThis = Ref { *this }, subFrameDomain = subFrameDomain.isolatedCopy(), topFrameDomain = topFrameDomain.isolatedCopy(), frameID, webPageID, webPageProxyID, scope, storageAccessQuirk = WTF::move(storageAccessQuirk), completionHandler = WTF::move(completionHandler)](StorageAccessStatus status) mutable {
         switch (status) {
         case StorageAccessStatus::CannotRequestAccess:
             completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::No, scope, topFrameDomain, subFrameDomain });
@@ -448,14 +448,14 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
             if (!networkSession)
                 return completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::No, scope, topFrameDomain, subFrameDomain });
 
-            CompletionHandler<void(bool)> requestConfirmationCompletionHandler = [this, protectedThis, subFrameDomain, topFrameDomain, frameID, webPageID, webPageProxyID, scope, completionHandler = WTFMove(completionHandler)] (bool userDidGrantAccess) mutable {
+            CompletionHandler<void(bool)> requestConfirmationCompletionHandler = [this, protectedThis, subFrameDomain, topFrameDomain, frameID, webPageID, webPageProxyID, scope, completionHandler = WTF::move(completionHandler)] (bool userDidGrantAccess) mutable {
                 if (userDidGrantAccess)
-                    grantStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, webPageID, webPageProxyID, StorageAccessPromptWasShown::Yes, scope, WTFMove(completionHandler));
+                    grantStorageAccess(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, webPageID, webPageProxyID, StorageAccessPromptWasShown::Yes, scope, WTF::move(completionHandler));
                 else
                     completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::Yes, scope, topFrameDomain, subFrameDomain });
             };
 
-            networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, storageAccessQuirk), WTFMove(requestConfirmationCompletionHandler));
+            networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, storageAccessQuirk), WTF::move(requestConfirmationCompletionHandler));
             return;
         }
         case StorageAccessStatus::HasAccess:
@@ -464,17 +464,17 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
         }
     };
 
-    postTask([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), frameID, webPageID, scope, canRequestStorageAccessWithoutUserInteraction, statusHandler = WTFMove(statusHandler)](auto& store) mutable {
+    postTask([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), frameID, webPageID, scope, canRequestStorageAccessWithoutUserInteraction, statusHandler = WTF::move(statusHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply([statusHandler = WTFMove(statusHandler)]() mutable {
+            postTaskReply([statusHandler = WTF::move(statusHandler)]() mutable {
                 statusHandler(StorageAccessStatus::CannotRequestAccess);
             });
             return;
         }
 
-        statisticsStore->requestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, webPageID, scope, canRequestStorageAccessWithoutUserInteraction, [statusHandler = WTFMove(statusHandler)](StorageAccessStatus status) mutable {
-            postTaskReply([statusHandler = WTFMove(statusHandler), status]() mutable {
+        statisticsStore->requestStorageAccess(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, webPageID, scope, canRequestStorageAccessWithoutUserInteraction, [statusHandler = WTF::move(statusHandler)](StorageAccessStatus status) mutable {
+            postTaskReply([statusHandler = WTF::move(statusHandler), status]() mutable {
                 statusHandler(status);
             });
         });
@@ -493,16 +493,16 @@ void WebResourceLoadStatisticsStore::queryStorageAccessPermission(SubFrameDomain
         return completionHandler(PermissionState::Prompt);
     }
 
-    postTask([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            return postTaskReply([completionHandler = WTFMove(completionHandler)] mutable {
+            return postTaskReply([completionHandler = WTF::move(completionHandler)] mutable {
                 completionHandler(PermissionState::Denied);
             });
         }
 
-        statisticsStore->queryStorageAccessPermission(WTFMove(subFrameDomain), WTFMove(topFrameDomain), [completionHandler = WTFMove(completionHandler)](PermissionState permissionState) mutable {
-            postTaskReply([completionHandler = WTFMove(completionHandler), permissionState] mutable {
+        statisticsStore->queryStorageAccessPermission(WTF::move(subFrameDomain), WTF::move(topFrameDomain), [completionHandler = WTF::move(completionHandler)](PermissionState permissionState) mutable {
+            postTaskReply([completionHandler = WTF::move(completionHandler), permissionState] mutable {
                 completionHandler(permissionState);
             });
         });
@@ -511,14 +511,14 @@ void WebResourceLoadStatisticsStore::queryStorageAccessPermission(SubFrameDomain
 
 void WebResourceLoadStatisticsStore::startListeningForStorageAccessPermissionChanges(StorageAccessPermissionChangeObserver& observer, TopFrameDomain&& topFrameDomain, SubFrameDomain&& subFrameDomain)
 {
-    m_storageAccessPermissionChangeObservers.ensure({ WTFMove(topFrameDomain), WTFMove(subFrameDomain) }, [] {
+    m_storageAccessPermissionChangeObservers.ensure({ WTF::move(topFrameDomain), WTF::move(subFrameDomain) }, [] {
         return WeakHashSet<StorageAccessPermissionChangeObserver> { };
     }).iterator->value.add(observer);
 }
 
 void WebResourceLoadStatisticsStore::stopListeningForStorageAccessPermissionChanges(StorageAccessPermissionChangeObserver& observer, TopFrameDomain&& topFrameDomain, SubFrameDomain&& subFrameDomain)
 {
-    if (auto it = m_storageAccessPermissionChangeObservers.find({ WTFMove(topFrameDomain), WTFMove(subFrameDomain) }); it != m_storageAccessPermissionChangeObservers.end())
+    if (auto it = m_storageAccessPermissionChangeObservers.find({ WTF::move(topFrameDomain), WTF::move(subFrameDomain) }); it != m_storageAccessPermissionChangeObservers.end())
         it->value.remove(observer);
 }
 
@@ -535,11 +535,11 @@ void WebResourceLoadStatisticsStore::setLoginStatus(RegistrableDomain&& domain, 
     ASSERT(RunLoop::isMain());
 
     if (loggedInStatus == IsLoggedIn::LoggedIn) {
-        auto loginStatusToSet = lastAuthentication && lastAuthentication->hasExpired() ? std::nullopt : std::optional(WTFMove(lastAuthentication));
+        auto loginStatusToSet = lastAuthentication && lastAuthentication->hasExpired() ? std::nullopt : std::optional(WTF::move(lastAuthentication));
         if (loginStatusToSet)
             loginStatusToSet->setTimeToLive(WebCore::LoginStatus::TimeToLiveLong);
         auto pair = std::make_pair(loggedInStatus, loginStatusToSet);
-        m_loginStatus.set(domain, WTFMove(pair));
+        m_loginStatus.set(domain, WTF::move(pair));
     } else
         m_loginStatus.remove(domain);
     completionHandler();
@@ -561,14 +561,14 @@ void WebResourceLoadStatisticsStore::requestStorageAccessEphemeral(const Registr
     if (!networkSession || (!m_domainsWithEphemeralUserInteraction.contains(subFrameDomain) && canRequestStorageAccessWithoutUserInteraction == CanRequestStorageAccessWithoutUserInteraction::No))
         return completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::No, scope, topFrameDomain, subFrameDomain });
 
-    CompletionHandler<void(bool)> requestConfirmationCompletionHandler = [this, protectedThis = Ref { *this }, subFrameDomain, topFrameDomain, frameID, webPageID, scope, completionHandler = WTFMove(completionHandler)] (bool userDidGrantAccess) mutable {
+    CompletionHandler<void(bool)> requestConfirmationCompletionHandler = [this, protectedThis = Ref { *this }, subFrameDomain, topFrameDomain, frameID, webPageID, scope, completionHandler = WTF::move(completionHandler)] (bool userDidGrantAccess) mutable {
         if (userDidGrantAccess)
-            grantStorageAccessEphemeral(subFrameDomain, topFrameDomain, frameID, webPageID, StorageAccessPromptWasShown::Yes, scope, WTFMove(completionHandler));
+            grantStorageAccessEphemeral(subFrameDomain, topFrameDomain, frameID, webPageID, StorageAccessPromptWasShown::Yes, scope, WTF::move(completionHandler));
         else
             completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::Yes, scope, topFrameDomain, subFrameDomain });
     };
 
-    networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, WTFMove(storageAccessPromptQuirk)), WTFMove(requestConfirmationCompletionHandler));
+    networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, WTF::move(storageAccessPromptQuirk)), WTF::move(requestConfirmationCompletionHandler));
 }
 
 void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener(RegistrableDomain&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, RegistrableDomain&& openerDomain)
@@ -576,7 +576,7 @@ void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener(Registrable
     ASSERT(RunLoop::isMain());
 
     if (isEphemeral())
-        return requestStorageAccessUnderOpenerEphemeral(WTFMove(domainInNeedOfStorageAccess), openerPageID, WTFMove(openerDomain));
+        return requestStorageAccessUnderOpenerEphemeral(WTF::move(domainInNeedOfStorageAccess), openerPageID, WTF::move(openerDomain));
 
     CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
     if (CheckedPtr networkSession = m_networkSession.get()) {
@@ -587,9 +587,9 @@ void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener(Registrable
     // It is safe to move the strings to the background queue without isolated copy here because they are r-value references
     // coming from IPC. Strings which are safe to move to other threads as long as nobody on this thread holds a reference
     // to those strings.
-    postTask([domainInNeedOfStorageAccess = WTFMove(domainInNeedOfStorageAccess), openerPageID, openerDomain = WTFMove(openerDomain), canRequestStorageAccessWithoutUserInteraction](auto& store) mutable {
+    postTask([domainInNeedOfStorageAccess = WTF::move(domainInNeedOfStorageAccess), openerPageID, openerDomain = WTF::move(openerDomain), canRequestStorageAccessWithoutUserInteraction](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
-            statisticsStore->requestStorageAccessUnderOpener(WTFMove(domainInNeedOfStorageAccess), openerPageID, WTFMove(openerDomain), canRequestStorageAccessWithoutUserInteraction);
+            statisticsStore->requestStorageAccessUnderOpener(WTF::move(domainInNeedOfStorageAccess), openerPageID, WTF::move(openerDomain), canRequestStorageAccessWithoutUserInteraction);
     });
 }
 
@@ -599,7 +599,7 @@ void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpenerEphemeral(Re
 
     if (CheckedPtr networkSession = m_networkSession.get()) {
         if (CheckedPtr storageSession = networkSession->networkStorageSession())
-            storageSession->grantStorageAccess(WTFMove(domainInNeedOfStorageAccess), WTFMove(openerDomain), std::nullopt, openerPageID);
+            storageSession->grantStorageAccess(WTF::move(domainInNeedOfStorageAccess), WTF::move(openerDomain), std::nullopt, openerPageID);
     }
 }
 
@@ -610,17 +610,17 @@ void WebResourceLoadStatisticsStore::grantStorageAccess(RegistrableDomain&& subF
     if (promptWasShown == StorageAccessPromptWasShown::Yes)
         wasGrantedStorageAccessPermissionInPage(webPageProxyID, topFrameDomain, subFrameDomain);
 
-    postTask([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), frameID, pageID, promptWasShown, scope, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), frameID, pageID, promptWasShown, scope, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), promptWasShown, scope, completionHandler = WTFMove(completionHandler)]() mutable {
+            postTaskReply([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), promptWasShown, scope, completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler({ StorageAccessWasGranted::No, promptWasShown, scope, topFrameDomain, subFrameDomain });
             });
             return;
         }
 
-        statisticsStore->grantStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, promptWasShown, scope, [weakStore = ThreadSafeWeakPtr { store }, frameID, subFrameDomain = subFrameDomain.isolatedCopy(), topFrameDomain = topFrameDomain.isolatedCopy(), promptWasShown, scope, completionHandler = WTFMove(completionHandler)](StorageAccessWasGranted wasGrantedAccess) mutable {
-            postTaskReply([weakStore = WTFMove(weakStore), frameID, subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), wasGrantedAccess, promptWasShown, scope, completionHandler = WTFMove(completionHandler)]() mutable {
+        statisticsStore->grantStorageAccess(WTF::move(subFrameDomain), WTF::move(topFrameDomain), frameID, pageID, promptWasShown, scope, [weakStore = ThreadSafeWeakPtr { store }, frameID, subFrameDomain = subFrameDomain.isolatedCopy(), topFrameDomain = topFrameDomain.isolatedCopy(), promptWasShown, scope, completionHandler = WTF::move(completionHandler)](StorageAccessWasGranted wasGrantedAccess) mutable {
+            postTaskReply([weakStore = WTF::move(weakStore), frameID, subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), wasGrantedAccess, promptWasShown, scope, completionHandler = WTF::move(completionHandler)]() mutable {
                 RefPtr store { weakStore.get() };
                 if (store && wasGrantedAccess == StorageAccessWasGranted::Yes) {
                     completionHandler({ store->storageAccessWasGrantedValueForFrame(frameID, subFrameDomain), promptWasShown, scope, topFrameDomain, subFrameDomain });
@@ -682,7 +682,7 @@ void WebResourceLoadStatisticsStore::hasCookies(const RegistrableDomain& domain,
 
     if (CheckedPtr networkSession = m_networkSession.get()) {
         if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
-            storageSession->hasCookies(domain, WTFMove(completionHandler));
+            storageSession->hasCookies(domain, WTF::move(completionHandler));
             return;
         }
     }
@@ -732,13 +732,13 @@ void WebResourceLoadStatisticsStore::setFirstPartyWebsiteDataRemovalMode(FirstPa
         return;
     }
 
-    postTask([mode, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([mode, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
             statisticsStore->setFirstPartyWebsiteDataRemovalMode(mode);
             if (mode == FirstPartyWebsiteDataRemovalMode::AllButCookiesReproTestingTimeout)
                 statisticsStore->setIsRunningTest(true);
         }
-        postTaskReply([completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler();
         });
     });
@@ -753,7 +753,7 @@ void WebResourceLoadStatisticsStore::setPersistedDomains(const HashSet<Registrab
 
     postTask([domains = crossThreadCopy(domains)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
-            statisticsStore->setPersistedDomains(WTFMove(domains));
+            statisticsStore->setPersistedDomains(WTF::move(domains));
     });
 }
 
@@ -768,10 +768,10 @@ void WebResourceLoadStatisticsStore::setStandaloneApplicationDomain(const Regist
 
     RELEASE_LOG(ResourceLoadStatistics, "WebResourceLoadStatisticsStore::setStandaloneApplicationDomain() called with non-empty domain.");
 
-    postTask([domain = domain.isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = domain.isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
-            statisticsStore->setStandaloneApplicationDomain(WTFMove(domain));
-        postTaskReply([completionHandler = WTFMove(completionHandler)]() mutable {
+            statisticsStore->setStandaloneApplicationDomain(WTF::move(domain));
+        postTaskReply([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler();
         });
     });
@@ -791,17 +791,17 @@ void WebResourceLoadStatisticsStore::setAppBoundDomains(HashSet<RegistrableDomai
 
     if (CheckedPtr networkSession = m_networkSession.get()) {
         if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
-            storageSession->setAppBoundDomains(WTFMove(domains));
+            storageSession->setAppBoundDomains(WTF::move(domains));
             storageSession->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptBetweenAppBoundDomains);
         }
     }
 
-    postTask([domains = WTFMove(domainsCopy), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domains = WTF::move(domainsCopy), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
-            statisticsStore->setAppBoundDomains(WTFMove(domains));
+            statisticsStore->setAppBoundDomains(WTF::move(domains));
             statisticsStore->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptBetweenAppBoundDomains);
         }
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 #endif
@@ -820,17 +820,17 @@ void WebResourceLoadStatisticsStore::setManagedDomains(HashSet<RegistrableDomain
 
     if (CheckedPtr networkSession = m_networkSession.get()) {
         if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
-            storageSession->setManagedDomains(WTFMove(domains));
+            storageSession->setManagedDomains(WTF::move(domains));
             storageSession->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptManagedDomains);
         }
     }
 
-    postTask([domains = WTFMove(domainsCopy), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domains = WTF::move(domainsCopy), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
-            statisticsStore->setManagedDomains(WTFMove(domains));
+            statisticsStore->setManagedDomains(WTF::move(domains));
             statisticsStore->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptManagedDomains);
         }
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 #endif
@@ -874,7 +874,7 @@ void WebResourceLoadStatisticsStore::logFrameNavigation(RegistrableDomain&& targ
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([targetDomain = WTFMove(targetDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), sourceDomain = WTFMove(sourceDomain).isolatedCopy(), isRedirect, isMainFrame, delayAfterMainFrameDocumentLoad, wasPotentiallyInitiatedByUser](auto& store) {
+    postTask([targetDomain = WTF::move(targetDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), sourceDomain = WTF::move(sourceDomain).isolatedCopy(), isRedirect, isMainFrame, delayAfterMainFrameDocumentLoad, wasPotentiallyInitiatedByUser](auto& store) {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->logFrameNavigation(targetDomain, topFrameDomain, sourceDomain, isRedirect, isMainFrame, delayAfterMainFrameDocumentLoad, wasPotentiallyInitiatedByUser);
     });
@@ -886,14 +886,14 @@ void WebResourceLoadStatisticsStore::logUserInteraction(RegistrableDomain&& doma
 
     // User interactions need to be logged for ephemeral sessions to support the Storage Access API.
     if (isEphemeral())
-        return logUserInteractionEphemeral(WTFMove(domain), WTFMove(completionHandler));
+        return logUserInteractionEphemeral(WTF::move(domain), WTF::move(completionHandler));
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
-        auto innerCompletionHandler = [completionHandler = WTFMove(completionHandler)]() mutable {
-            postTaskReply(WTFMove(completionHandler));
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
+        auto innerCompletionHandler = [completionHandler = WTF::move(completionHandler)]() mutable {
+            postTaskReply(WTF::move(completionHandler));
         };
         if (RefPtr statisticsStore = store.m_statisticsStore) {
-            statisticsStore->logUserInteraction(domain, WTFMove(innerCompletionHandler));
+            statisticsStore->logUserInteraction(domain, WTF::move(innerCompletionHandler));
             return;
         }
         innerCompletionHandler();
@@ -913,10 +913,10 @@ void WebResourceLoadStatisticsStore::logCrossSiteLoadWithLinkDecoration(Registra
     ASSERT(RunLoop::isMain());
     ASSERT(fromDomain != toDomain);
     
-    postTask([fromDomain = WTFMove(fromDomain).isolatedCopy(), toDomain = WTFMove(toDomain).isolatedCopy(), didFilterKnownLinkDecoration, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([fromDomain = WTF::move(fromDomain).isolatedCopy(), toDomain = WTF::move(toDomain).isolatedCopy(), didFilterKnownLinkDecoration, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->logCrossSiteLoadWithLinkDecoration(fromDomain, toDomain, didFilterKnownLinkDecoration);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -925,14 +925,14 @@ void WebResourceLoadStatisticsStore::clearUserInteraction(RegistrableDomain&& do
     ASSERT(RunLoop::isMain());
 
     if (isEphemeral())
-        return clearUserInteractionEphemeral(domain, WTFMove(completionHandler));
+        return clearUserInteractionEphemeral(domain, WTF::move(completionHandler));
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
-        auto innerCompletionHandler = [completionHandler = WTFMove(completionHandler)]() mutable {
-            postTaskReply(WTFMove(completionHandler));
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
+        auto innerCompletionHandler = [completionHandler = WTF::move(completionHandler)]() mutable {
+            postTaskReply(WTF::move(completionHandler));
         };
         if (RefPtr statisticsStore = store.m_statisticsStore) {
-            statisticsStore->clearUserInteraction(domain, WTFMove(innerCompletionHandler));
+            statisticsStore->clearUserInteraction(domain, WTF::move(innerCompletionHandler));
             return;
         }
         innerCompletionHandler();
@@ -942,10 +942,10 @@ void WebResourceLoadStatisticsStore::clearUserInteraction(RegistrableDomain&& do
 void WebResourceLoadStatisticsStore::setTimeAdvanceForTesting(Seconds time, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    postTask([time, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([time, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setTimeAdvanceForTesting(time);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -962,11 +962,11 @@ void WebResourceLoadStatisticsStore::hasHadUserInteraction(RegistrableDomain&& d
     ASSERT(RunLoop::isMain());
 
     if (isEphemeral())
-        return hasHadUserInteractionEphemeral(domain, WTFMove(completionHandler));
+        return hasHadUserInteractionEphemeral(domain, WTF::move(completionHandler));
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool hadUserInteraction = store.m_statisticsStore ? RefPtr { store.m_statisticsStore }->hasHadUserInteraction(domain, OperatingDatesWindow::Long) : false;
-        postTaskReply([hadUserInteraction, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([hadUserInteraction, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(hadUserInteraction);
         });
     });
@@ -983,10 +983,10 @@ void WebResourceLoadStatisticsStore::setLastSeen(RegistrableDomain&& domain, Sec
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([domain = WTFMove(domain).isolatedCopy(), seconds, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), seconds, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setLastSeen(domain, seconds);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -994,7 +994,7 @@ void WebResourceLoadStatisticsStore::mergeStatisticForTesting(RegistrableDomain&
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), topFrameDomain1 = WTFMove(topFrameDomain1).isolatedCopy(), topFrameDomain2 = WTFMove(topFrameDomain2).isolatedCopy(), lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), topFrameDomain1 = WTF::move(topFrameDomain1).isolatedCopy(), topFrameDomain2 = WTF::move(topFrameDomain2).isolatedCopy(), lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore) {
             ResourceLoadStatistics statistic(domain);
             statistic.lastSeen = WallTime::fromRawSeconds(lastSeen.seconds());
@@ -1013,11 +1013,11 @@ void WebResourceLoadStatisticsStore::mergeStatisticForTesting(RegistrableDomain&
             if (!topFrameDomain2.isEmpty())
                 topFrameDomains.add(topFrameDomain2);
 
-            statistic.subframeUnderTopFrameDomains = WTFMove(topFrameDomains);
+            statistic.subframeUnderTopFrameDomains = WTF::move(topFrameDomains);
 
-            statisticsStore->mergeStatistics(Vector<ResourceLoadStatistics>::from(WTFMove(statistic)));
+            statisticsStore->mergeStatistics(Vector<ResourceLoadStatistics>::from(WTF::move(statistic)));
         }
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1025,7 +1025,7 @@ void WebResourceLoadStatisticsStore::isRelationshipOnlyInDatabaseOnce(Registrabl
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([subDomain = WTFMove(subDomain).isolatedCopy(), topDomain = WTFMove(topDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subDomain = WTF::move(subDomain).isolatedCopy(), topDomain = WTF::move(topDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
             completionHandler(false);
@@ -1034,7 +1034,7 @@ void WebResourceLoadStatisticsStore::isRelationshipOnlyInDatabaseOnce(Registrabl
         
         bool isRelationshipOnlyInDatabaseOnce = statisticsStore->isCorrectSubStatisticsCount(subDomain, topDomain);
         
-        postTaskReply([isRelationshipOnlyInDatabaseOnce, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isRelationshipOnlyInDatabaseOnce, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isRelationshipOnlyInDatabaseOnce);
         });
     });
@@ -1044,10 +1044,10 @@ void WebResourceLoadStatisticsStore::setPrevalentResource(RegistrableDomain&& do
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setPrevalentResource(domain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1055,10 +1055,10 @@ void WebResourceLoadStatisticsStore::setVeryPrevalentResource(RegistrableDomain&
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setVeryPrevalentResource(domain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1066,10 +1066,10 @@ void WebResourceLoadStatisticsStore::setMostRecentWebPushInteractionTime(Registr
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([completionHandler = WTFMove(completionHandler), domain = WTFMove(domain).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), domain = WTF::move(domain).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setMostRecentWebPushInteractionTime(domain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1077,14 +1077,14 @@ void WebResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandle
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
-        auto innerCompletionHandler = [completionHandler = WTFMove(completionHandler)](const String& result) mutable {
-            postTaskReply([result = result.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
-                completionHandler(WTFMove(result));
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
+        auto innerCompletionHandler = [completionHandler = WTF::move(completionHandler)](const String& result) mutable {
+            postTaskReply([result = result.isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+                completionHandler(WTF::move(result));
             });
         };
         if (RefPtr statisticsStore = store.m_statisticsStore)
-            statisticsStore->dumpResourceLoadStatistics(WTFMove(innerCompletionHandler));
+            statisticsStore->dumpResourceLoadStatistics(WTF::move(innerCompletionHandler));
         else
             innerCompletionHandler(String { emptyString() });
     });
@@ -1099,9 +1099,9 @@ void WebResourceLoadStatisticsStore::isPrevalentResource(RegistrableDomain&& dom
         return;
     }
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool isPrevalentResource = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isPrevalentResource(domain);
-        postTaskReply([isPrevalentResource, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isPrevalentResource, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isPrevalentResource);
         });
     });
@@ -1111,9 +1111,9 @@ void WebResourceLoadStatisticsStore::isVeryPrevalentResource(RegistrableDomain&&
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool isVeryPrevalentResource = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isVeryPrevalentResource(domain);
-        postTaskReply([isVeryPrevalentResource, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isVeryPrevalentResource, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isVeryPrevalentResource);
         });
     });
@@ -1123,9 +1123,9 @@ void WebResourceLoadStatisticsStore::isRegisteredAsSubresourceUnder(RegistrableD
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([subresourceDomain = WTFMove(subresourceDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subresourceDomain = WTF::move(subresourceDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool isRegisteredAsSubresourceUnder = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isRegisteredAsSubresourceUnder(subresourceDomain, topFrameDomain);
-        postTaskReply([isRegisteredAsSubresourceUnder, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isRegisteredAsSubresourceUnder, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isRegisteredAsSubresourceUnder);
         });
     });
@@ -1135,9 +1135,9 @@ void WebResourceLoadStatisticsStore::isRegisteredAsSubFrameUnder(RegistrableDoma
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool isRegisteredAsSubFrameUnder = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isRegisteredAsSubFrameUnder(subFrameDomain, topFrameDomain);
-        postTaskReply([isRegisteredAsSubFrameUnder, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isRegisteredAsSubFrameUnder, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isRegisteredAsSubFrameUnder);
         });
     });
@@ -1147,9 +1147,9 @@ void WebResourceLoadStatisticsStore::isRegisteredAsRedirectingTo(RegistrableDoma
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domainRedirectedFrom = WTFMove(domainRedirectedFrom).isolatedCopy(), domainRedirectedTo = WTFMove(domainRedirectedTo).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domainRedirectedFrom = WTF::move(domainRedirectedFrom).isolatedCopy(), domainRedirectedTo = WTF::move(domainRedirectedTo).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         bool isRegisteredAsRedirectingTo = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isRegisteredAsRedirectingTo(domainRedirectedFrom, domainRedirectedTo);
-        postTaskReply([isRegisteredAsRedirectingTo, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isRegisteredAsRedirectingTo, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isRegisteredAsRedirectingTo);
         });
     });
@@ -1159,10 +1159,10 @@ void WebResourceLoadStatisticsStore::clearPrevalentResource(RegistrableDomain&& 
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->clearPrevalentResource(domain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1170,10 +1170,10 @@ void WebResourceLoadStatisticsStore::setGrandfathered(RegistrableDomain&& domain
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), value, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), value, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setGrandfathered(domain, value);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
     
@@ -1181,9 +1181,9 @@ void WebResourceLoadStatisticsStore::isGrandfathered(RegistrableDomain&& domain,
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([completionHandler = WTFMove(completionHandler), domain = WTFMove(domain).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), domain = WTF::move(domain).isolatedCopy()](auto& store) mutable {
         bool isGrandFathered = store.m_statisticsStore && RefPtr { store.m_statisticsStore }->isGrandfathered(domain);
-        postTaskReply([isGrandFathered, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([isGrandFathered, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(isGrandFathered);
         });
     });
@@ -1193,10 +1193,10 @@ void WebResourceLoadStatisticsStore::setSubframeUnderTopFrameDomain(RegistrableD
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setSubframeUnderTopFrameDomain(subFrameDomain, topFrameDomain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1204,10 +1204,10 @@ void WebResourceLoadStatisticsStore::setSubresourceUnderTopFrameDomain(Registrab
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), subresourceDomain = WTFMove(subresourceDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), subresourceDomain = WTF::move(subresourceDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setSubresourceUnderTopFrameDomain(subresourceDomain, topFrameDomain);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1215,10 +1215,10 @@ void WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectTo(RegistrableD
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), subresourceDomain = WTFMove(subresourceDomain).isolatedCopy(), domainRedirectedTo = WTFMove(domainRedirectedTo).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), subresourceDomain = WTF::move(subresourceDomain).isolatedCopy(), domainRedirectedTo = WTF::move(domainRedirectedTo).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setSubresourceUniqueRedirectTo(subresourceDomain, domainRedirectedTo);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1226,10 +1226,10 @@ void WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectFrom(Registrabl
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), subresourceDomain = WTFMove(subresourceDomain).isolatedCopy(), domainRedirectedFrom = WTFMove(domainRedirectedFrom).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), subresourceDomain = WTF::move(subresourceDomain).isolatedCopy(), domainRedirectedFrom = WTF::move(domainRedirectedFrom).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setSubresourceUniqueRedirectFrom(subresourceDomain, domainRedirectedFrom);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1237,10 +1237,10 @@ void WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectTo(RegistrableDoma
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), domainRedirectedTo = WTFMove(domainRedirectedTo).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), domainRedirectedTo = WTF::move(domainRedirectedTo).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setTopFrameUniqueRedirectTo(topFrameDomain, domainRedirectedTo);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1248,10 +1248,10 @@ void WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectFrom(RegistrableDo
 {
     ASSERT(RunLoop::isMain());
     
-    postTask([completionHandler = WTFMove(completionHandler), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), domainRedirectedFrom = WTFMove(domainRedirectedFrom).isolatedCopy()](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), domainRedirectedFrom = WTF::move(domainRedirectedFrom).isolatedCopy()](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setTopFrameUniqueRedirectFrom(topFrameDomain, domainRedirectedFrom);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1260,15 +1260,15 @@ void WebResourceLoadStatisticsStore::scheduleCookieBlockingUpdate(CompletionHand
     // Helper function used by testing system. Should only be called from the main thread.
     ASSERT(RunLoop::isMain());
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply(WTFMove(completionHandler));
+            postTaskReply(WTF::move(completionHandler));
             return;
         }
 
-        statisticsStore->updateCookieBlocking([completionHandler = WTFMove(completionHandler)]() mutable {
-            postTaskReply(WTFMove(completionHandler));
+        statisticsStore->updateCookieBlocking([completionHandler = WTF::move(completionHandler)]() mutable {
+            postTaskReply(WTF::move(completionHandler));
         });
     });
 }
@@ -1276,27 +1276,27 @@ void WebResourceLoadStatisticsStore::scheduleCookieBlockingUpdate(CompletionHand
 void WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent(ShouldGrandfatherStatistics shouldGrandfather, CompletionHandler<void()>&& completionHandler)
 {
     if (isEphemeral())
-        return clearInMemoryEphemeral(WTFMove(completionHandler));
+        return clearInMemoryEphemeral(WTF::move(completionHandler));
 
     ASSERT(RunLoop::isMain());
-    postTask([shouldGrandfather, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([shouldGrandfather, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
             if (shouldGrandfather == ShouldGrandfatherStatistics::Yes)
                 RELEASE_LOG(ResourceLoadStatistics, "WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent Before being cleared, m_statisticsStore is null when trying to grandfather data.");
 
-            postTaskReply(WTFMove(completionHandler));
+            postTaskReply(WTF::move(completionHandler));
             return;
         }
 
-        auto callbackAggregator = CallbackAggregator::create([completionHandler = WTFMove(completionHandler)] () mutable {
-            postTaskReply(WTFMove(completionHandler));
+        auto callbackAggregator = CallbackAggregator::create([completionHandler = WTF::move(completionHandler)] () mutable {
+            postTaskReply(WTF::move(completionHandler));
         });
 
         statisticsStore->clear([protectedThis = Ref { store }, shouldGrandfather, callbackAggregator] () mutable {
             if (shouldGrandfather == ShouldGrandfatherStatistics::Yes) {
                 if (RefPtr statisticsStore = protectedThis->m_statisticsStore) {
-                    statisticsStore->grandfatherExistingWebsiteData([callbackAggregator = WTFMove(callbackAggregator)]() mutable { });
+                    statisticsStore->grandfatherExistingWebsiteData([callbackAggregator = WTF::move(callbackAggregator)]() mutable { });
                     statisticsStore->setIsNewResourceLoadStatisticsDatabaseFile(true);
                 } else
                     RELEASE_LOG(ResourceLoadStatistics, "WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent After being cleared, m_statisticsStore is null when trying to grandfather data.");
@@ -1313,7 +1313,7 @@ void WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent(WallTime
 
     // For now, be conservative and clear everything regardless of modifiedSince.
     UNUSED_PARAM(modifiedSince);
-    scheduleClearInMemoryAndPersistent(shouldGrandfather, WTFMove(callback));
+    scheduleClearInMemoryAndPersistent(shouldGrandfather, WTF::move(callback));
 }
 
 void WebResourceLoadStatisticsStore::clearInMemoryEphemeral(CompletionHandler<void()>&& completionHandler)
@@ -1332,14 +1332,14 @@ void WebResourceLoadStatisticsStore::domainIDExistsInDatabase(int domainID, Comp
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domainID, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domainID, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
             completionHandler(false);
             return;
         }
         bool domainIDExists = statisticsStore->domainIDExistsInDatabase(domainID);
-        postTaskReply([domainIDExists, completionHandler = WTFMove(completionHandler)]() mutable {
+        postTaskReply([domainIDExists, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(domainIDExists);
         });
     });
@@ -1348,32 +1348,32 @@ void WebResourceLoadStatisticsStore::domainIDExistsInDatabase(int domainID, Comp
 void WebResourceLoadStatisticsStore::setTimeToLiveUserInteraction(Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    postTask([seconds, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([seconds, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setTimeToLiveUserInteraction(seconds);
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
 void WebResourceLoadStatisticsStore::setMinimumTimeBetweenDataRecordsRemoval(Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    postTask([seconds, completionHandler = WTFMove(completionHandler)](auto& store) mutable  {
+    postTask([seconds, completionHandler = WTF::move(completionHandler)](auto& store) mutable  {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setMinimumTimeBetweenDataRecordsRemoval(seconds);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
 void WebResourceLoadStatisticsStore::setGrandfatheringTime(Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    postTask([seconds, completionHandler = WTFMove(completionHandler)](auto& store) mutable  {
+    postTask([seconds, completionHandler = WTF::move(completionHandler)](auto& store) mutable  {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setGrandfatheringTime(seconds);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1447,11 +1447,11 @@ void WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesFor
 void WebResourceLoadStatisticsStore::setMaxStatisticsEntries(size_t maximumEntryCount, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    postTask([maximumEntryCount, completionHandler = WTFMove(completionHandler)](auto& store) mutable  {
+    postTask([maximumEntryCount, completionHandler = WTF::move(completionHandler)](auto& store) mutable  {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setMaxStatisticsEntries(maximumEntryCount);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
     
@@ -1459,11 +1459,11 @@ void WebResourceLoadStatisticsStore::setPruneEntriesDownTo(size_t pruneTargetCou
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([pruneTargetCount, completionHandler = WTFMove(completionHandler)](auto& store) mutable  {
+    postTask([pruneTargetCount, completionHandler = WTF::move(completionHandler)](auto& store) mutable  {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->setPruneEntriesDownTo(pruneTargetCount);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1490,11 +1490,11 @@ void WebResourceLoadStatisticsStore::resetParametersToDefaultValues(CompletionHa
     }
 #endif
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->resetParametersToDefaultValues();
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1528,11 +1528,11 @@ void WebResourceLoadStatisticsStore::removeDataForDomain(RegistrableDomain domai
     }
 
     ASSERT(RunLoop::isMain());
-    postTask([domain = WTFMove(domain), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
             statisticsStore->removeDataForDomain(domain);
 
-        postTaskReply(WTFMove(completionHandler));
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1545,10 +1545,10 @@ void WebResourceLoadStatisticsStore::registrableDomains(CompletionHandler<void(V
         return;
     }
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         auto domains = store.m_statisticsStore ? RefPtr { store.m_statisticsStore }->allDomains() : Vector<RegistrableDomain>();
-        postTaskReply([domains = crossThreadCopy(WTFMove(domains)), completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(WTFMove(domains));
+        postTaskReply([domains = crossThreadCopy(WTF::move(domains)), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(domains));
         });
     });
 }
@@ -1562,12 +1562,12 @@ void WebResourceLoadStatisticsStore::registrableDomainsWithLastAccessedTime(Comp
         return;
     }
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         std::optional<HashMap<RegistrableDomain, WallTime>> result;
         if (RefPtr statisticsStore = store.m_statisticsStore)
             result = statisticsStore->allDomainsWithLastAccessedTime();
-        postTaskReply([result = crossThreadCopy(WTFMove(result)), completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(WTFMove(result));
+        postTaskReply([result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(result));
         });
     });
 }
@@ -1581,12 +1581,12 @@ void WebResourceLoadStatisticsStore::registrableDomainsExemptFromWebsiteDataDele
         return;
     }
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         HashSet<RegistrableDomain> result;
         if (RefPtr statisticsStore = store.m_statisticsStore)
             result = statisticsStore->domainsExemptFromWebsiteDataDeletion();
-        postTaskReply([result = crossThreadCopy(WTFMove(result)), completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(WTFMove(result));
+        postTaskReply([result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(result));
         });
     });
 }
@@ -1596,7 +1596,7 @@ void WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableD
     ASSERT(RunLoop::isMain());
     
     if (CheckedPtr networkSession = m_networkSession.get()) {
-        networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTFMove(domainsToDeleteAndRestrictWebsiteDataFor), WTFMove(completionHandler));
+        networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTF::move(domainsToDeleteAndRestrictWebsiteDataFor), WTF::move(completionHandler));
         return;
     }
 
@@ -1608,7 +1608,7 @@ void WebResourceLoadStatisticsStore::registrableDomainsWithWebsiteData(OptionSet
     ASSERT(RunLoop::isMain());
     
     if (CheckedPtr networkSession = m_networkSession.get()) {
-        networkSession->registrableDomainsWithWebsiteData(dataTypes, WTFMove(completionHandler));
+        networkSession->registrableDomainsWithWebsiteData(dataTypes, WTF::move(completionHandler));
         return;
     }
 
@@ -1619,17 +1619,17 @@ void WebResourceLoadStatisticsStore::aggregatedThirdPartyData(CompletionHandler<
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore) {
-            postTaskReply([completionHandler = WTFMove(completionHandler)]() mutable {
+            postTaskReply([completionHandler = WTF::move(completionHandler)]() mutable {
                 completionHandler({ });
             });
             return;
         }
         auto thirdPartyData = statisticsStore->aggregatedThirdPartyData();
-        postTaskReply([thirdPartyData = WTFMove(thirdPartyData), completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(WTFMove(thirdPartyData));
+        postTaskReply([thirdPartyData = WTF::move(thirdPartyData), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(thirdPartyData));
         });
     });
 }
@@ -1637,7 +1637,7 @@ void WebResourceLoadStatisticsStore::aggregatedThirdPartyData(CompletionHandler<
 void WebResourceLoadStatisticsStore::suspend(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    sharedStatisticsQueue()->suspend(ResourceLoadStatisticsStore::interruptAllDatabases, WTFMove(completionHandler));
+    sharedStatisticsQueue()->suspend(ResourceLoadStatisticsStore::interruptAllDatabases, WTF::move(completionHandler));
 }
 
 void WebResourceLoadStatisticsStore::resume()
@@ -1651,10 +1651,10 @@ void WebResourceLoadStatisticsStore::insertExpiredStatisticForTesting(Registrabl
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([domain = WTFMove(domain).isolatedCopy(), numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([domain = WTF::move(domain).isolatedCopy(), numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         if (RefPtr statisticsStore = store.m_statisticsStore)
-            statisticsStore->insertExpiredStatisticForTesting(WTFMove(domain), numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent);
-        postTaskReply(WTFMove(completionHandler));
+            statisticsStore->insertExpiredStatisticForTesting(WTF::move(domain), numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent);
+        postTaskReply(WTF::move(completionHandler));
     });
 }
 
@@ -1709,13 +1709,13 @@ void WebResourceLoadStatisticsStore::setStorageAccessPermissionForTesting(bool g
     if (isEphemeral())
         return completionHandler();
 
-    postTask([granted, subFrameDomain = WTFMove(subFrameDomain).isolatedCopy(), topFrameDomain = WTFMove(topFrameDomain).isolatedCopy(), completionHandler = WTFMove(completionHandler)](auto& store) mutable {
+    postTask([granted, subFrameDomain = WTF::move(subFrameDomain).isolatedCopy(), topFrameDomain = WTF::move(topFrameDomain).isolatedCopy(), completionHandler = WTF::move(completionHandler)](auto& store) mutable {
         RefPtr statisticsStore = store.m_statisticsStore;
         if (!statisticsStore)
-            return postTaskReply(WTFMove(completionHandler));
+            return postTaskReply(WTF::move(completionHandler));
 
-        Ref callbackAggregator = CallbackAggregator::create([completionHandler = WTFMove(completionHandler)] mutable {
-            postTaskReply(WTFMove(completionHandler));
+        Ref callbackAggregator = CallbackAggregator::create([completionHandler = WTF::move(completionHandler)] mutable {
+            postTaskReply(WTF::move(completionHandler));
         });
 
         if (granted) {

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -83,7 +83,7 @@ struct RegistrableDomainsToBlockCookiesFor {
     Vector<WebCore::RegistrableDomain> domainsWithUserInteractionAsFirstParty;
     HashMap<TopFrameDomain, Vector<SubResourceDomain>> domainsWithStorageAccess;
     RegistrableDomainsToBlockCookiesFor isolatedCopy() const & { return { crossThreadCopy(domainsToBlockAndDeleteCookiesFor), crossThreadCopy(domainsToBlockButKeepCookiesFor), crossThreadCopy(domainsWithUserInteractionAsFirstParty), crossThreadCopy(domainsWithStorageAccess) }; }
-    RegistrableDomainsToBlockCookiesFor isolatedCopy() && { return { crossThreadCopy(WTFMove(domainsToBlockAndDeleteCookiesFor)), crossThreadCopy(WTFMove(domainsToBlockButKeepCookiesFor)), crossThreadCopy(WTFMove(domainsWithUserInteractionAsFirstParty)), crossThreadCopy(WTFMove(domainsWithStorageAccess)) }; }
+    RegistrableDomainsToBlockCookiesFor isolatedCopy() && { return { crossThreadCopy(WTF::move(domainsToBlockAndDeleteCookiesFor)), crossThreadCopy(WTF::move(domainsToBlockButKeepCookiesFor)), crossThreadCopy(WTF::move(domainsWithUserInteractionAsFirstParty)), crossThreadCopy(WTF::move(domainsWithStorageAccess)) }; }
 };
 struct RegistrableDomainsToDeleteOrRestrictWebsiteDataFor {
     Vector<WebCore::RegistrableDomain> domainsToDeleteAllCookiesFor;
@@ -91,7 +91,7 @@ struct RegistrableDomainsToDeleteOrRestrictWebsiteDataFor {
     Vector<WebCore::RegistrableDomain> domainsToDeleteAllScriptWrittenStorageFor;
     Vector<WebCore::RegistrableDomain> domainsToEnforceSameSiteStrictFor;
     RegistrableDomainsToDeleteOrRestrictWebsiteDataFor isolatedCopy() const & { return { crossThreadCopy(domainsToDeleteAllCookiesFor), crossThreadCopy(domainsToDeleteAllButHttpOnlyCookiesFor), crossThreadCopy(domainsToDeleteAllScriptWrittenStorageFor), crossThreadCopy(domainsToEnforceSameSiteStrictFor) }; }
-    RegistrableDomainsToDeleteOrRestrictWebsiteDataFor isolatedCopy() && { return { crossThreadCopy(WTFMove(domainsToDeleteAllCookiesFor)), crossThreadCopy(WTFMove(domainsToDeleteAllButHttpOnlyCookiesFor)), crossThreadCopy(WTFMove(domainsToDeleteAllScriptWrittenStorageFor)), crossThreadCopy(WTFMove(domainsToEnforceSameSiteStrictFor)) }; }
+    RegistrableDomainsToDeleteOrRestrictWebsiteDataFor isolatedCopy() && { return { crossThreadCopy(WTF::move(domainsToDeleteAllCookiesFor)), crossThreadCopy(WTF::move(domainsToDeleteAllButHttpOnlyCookiesFor)), crossThreadCopy(WTF::move(domainsToDeleteAllScriptWrittenStorageFor)), crossThreadCopy(WTF::move(domainsToEnforceSameSiteStrictFor)) }; }
     bool isEmpty() const { return domainsToDeleteAllCookiesFor.isEmpty() && domainsToDeleteAllButHttpOnlyCookiesFor.isEmpty() && domainsToDeleteAllScriptWrittenStorageFor.isEmpty() && domainsToEnforceSameSiteStrictFor.isEmpty(); }
 };
 

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -86,7 +86,7 @@ void WebCookieManager::getHostnamesWithCookies(PAL::SessionID sessionID, Complet
 void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const Vector<String>& hostnames, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
-        storageSession->deleteCookiesForHostnames(hostnames, WTFMove(completionHandler));
+        storageSession->deleteCookiesForHostnames(hostnames, WTF::move(completionHandler));
     else
         completionHandler();
 }
@@ -94,7 +94,7 @@ void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const
 void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
-        storageSession->deleteAllCookies(WTFMove(completionHandler));
+        storageSession->deleteAllCookies(WTF::move(completionHandler));
     else
         completionHandler();
 }
@@ -102,7 +102,7 @@ void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHand
 void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
-        storageSession->deleteCookie(cookie, WTFMove(completionHandler));
+        storageSession->deleteCookie(cookie, WTF::move(completionHandler));
     else
         completionHandler();
 }
@@ -110,7 +110,7 @@ void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cook
 void WebCookieManager::deleteAllCookiesModifiedSince(PAL::SessionID sessionID, WallTime time, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
-        storageSession->deleteAllCookiesModifiedSince(time, WTFMove(completionHandler));
+        storageSession->deleteAllCookiesModifiedSince(time, WTF::move(completionHandler));
     else
         completionHandler();
 }
@@ -120,7 +120,7 @@ void WebCookieManager::getAllCookies(PAL::SessionID sessionID, CompletionHandler
     Vector<Cookie> cookies;
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         cookies = storageSession->getAllCookies();
-    completionHandler(WTFMove(cookies));
+    completionHandler(WTF::move(cookies));
 }
 
 void WebCookieManager::getCookies(PAL::SessionID sessionID, const URL& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
@@ -128,7 +128,7 @@ void WebCookieManager::getCookies(PAL::SessionID sessionID, const URL& url, Comp
     Vector<Cookie> cookies;
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         cookies = storageSession->getCookies(url);
-    completionHandler(WTFMove(cookies));
+    completionHandler(WTF::move(cookies));
 }
 
 void WebCookieManager::setCookie(PAL::SessionID sessionID, const Vector<Cookie>& cookies, uint64_t cookiesVersion, CompletionHandler<void()>&& completionHandler)
@@ -174,7 +174,7 @@ void WebCookieManager::stopObservingCookieChanges(PAL::SessionID sessionID)
 void WebCookieManager::setHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
     RELEASE_LOG(Storage, "WebCookieManager::setHTTPCookieAcceptPolicy set policy %d for session %" PRIu64, static_cast<int>(policy), sessionID.toUInt64());
-    platformSetHTTPCookieAcceptPolicy(sessionID, policy, [policy, process = protectedProcess(), completionHandler = WTFMove(completionHandler)] () mutable {
+    platformSetHTTPCookieAcceptPolicy(sessionID, policy, [policy, process = protectedProcess(), completionHandler = WTF::move(completionHandler)] () mutable {
         process->cookieAcceptPolicyChanged(policy);
         completionHandler();
     });

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -67,7 +67,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
         return completionHandler();
 
     CFHTTPCookieStorageSetCookieAcceptPolicy([nsCookieStorage _cookieStorage], toCFHTTPCookieStorageAcceptPolicy(policy));
-    saveCookies(nsCookieStorage.get(), WTFMove(completionHandler));
+    saveCookies(nsCookieStorage.get(), WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -72,7 +72,7 @@ LegacyCustomProtocolID LegacyCustomProtocolManager::addCustomProtocol(CustomProt
 {
     Locker locker { m_customProtocolMapLock };
     auto customProtocolID = LegacyCustomProtocolID::generate();
-    m_customProtocolMap.add(customProtocolID, WTFMove(customProtocol));
+    m_customProtocolMap.add(customProtocolID, WTF::move(customProtocol));
     return customProtocolID;
 }
 

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.cpp
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.cpp
@@ -38,7 +38,7 @@
 namespace WebKit {
 
 DatabaseUtilities::DatabaseUtilities(String&& storageFilePath)
-    : m_storageFilePath(WTFMove(storageFilePath))
+    : m_storageFilePath(WTF::move(storageFilePath))
     , m_database(makeUniqueRef<WebCore::SQLiteDatabase>())
     , m_transaction(m_database.get())
 {
@@ -178,7 +178,7 @@ WebCore::PrivateClickMeasurement DatabaseUtilities::buildPrivateClickMeasurement
         destinationSecretToken.signatureBase64URL = destinationSignature;
         destinationSecretToken.keyIDBase64URL = destinationKeyID;
 
-        attribution.setDestinationSecretToken(WTFMove(destinationSecretToken));
+        attribution.setDestinationSecretToken(WTF::move(destinationSecretToken));
 
         std::optional<WallTime> sourceEarliestTimeToSend;
         std::optional<WallTime> destinationEarliestTimeToSend;
@@ -198,7 +198,7 @@ WebCore::PrivateClickMeasurement DatabaseUtilities::buildPrivateClickMeasurement
     sourceSecretToken.signatureBase64URL = signature;
     sourceSecretToken.keyIDBase64URL = keyID;
 
-    attribution.setSourceSecretToken(WTFMove(sourceSecretToken));
+    attribution.setSourceSecretToken(WTF::move(sourceSecretToken));
 
     return attribution;
 }
@@ -247,7 +247,7 @@ TableAndIndexPair DatabaseUtilities::currentTableAndIndexQueries(const String& t
             index = rawIndex;
     }
 
-    return std::make_pair<String, std::optional<String>>(WTFMove(createTableQuery), WTFMove(index));
+    return std::make_pair<String, std::optional<String>>(WTF::move(createTableQuery), WTF::move(index));
 }
 
 static std::unique_ptr<WebCore::SQLiteStatement> insertDistinctValuesInTableStatement(WebCore::SQLiteDatabase& database, const String& table)

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -103,7 +103,7 @@ void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& comple
     // completionHandler will inform the API that the cancellation succeeded.
     m_ignoreDidFailCallback = ignoreDidFailCallback;
 
-    auto completionHandlerWrapper = [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (std::span<const uint8_t> resumeData) mutable {
+    auto completionHandlerWrapper = [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (std::span<const uint8_t> resumeData) mutable {
         completionHandler(resumeData);
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || protectedThis->m_ignoreDidFailCallback == IgnoreDidFailCallback::No)
@@ -120,7 +120,7 @@ void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& comple
         completionHandlerWrapper({ });
         return;
     }
-    platformCancelNetworkLoad(WTFMove(completionHandlerWrapper));
+    platformCancelNetworkLoad(WTF::move(completionHandlerWrapper));
 }
 
 void Download::didReceiveChallenge(const WebCore::AuthenticationChallenge& challenge, ChallengeCompletionHandler&& completionHandler)
@@ -130,7 +130,7 @@ void Download::didReceiveChallenge(const WebCore::AuthenticationChallenge& chall
         return;
     }
 
-    m_client->protectedDownloadsAuthenticationManager()->didReceiveAuthenticationChallenge(*this, challenge, WTFMove(completionHandler));
+    m_client->protectedDownloadsAuthenticationManager()->didReceiveAuthenticationChallenge(*this, challenge, WTF::move(completionHandler));
 }
 
 void Download::didCreateDestination(const String& path)

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -90,7 +90,7 @@ public:
     DownloadID downloadID() const { return m_downloadID; }
     PAL::SessionID sessionID() const { return m_sessionID; }
 
-    void setSandboxExtension(RefPtr<SandboxExtension>&& sandboxExtension) { m_sandboxExtension = WTFMove(sandboxExtension); }
+    void setSandboxExtension(RefPtr<SandboxExtension>&& sandboxExtension) { m_sandboxExtension = WTF::move(sandboxExtension); }
     void didReceiveChallenge(const WebCore::AuthenticationChallenge&, ChallengeCompletionHandler&&);
     void didCreateDestination(const String& path);
     void didReceiveData(uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite);

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -69,7 +69,7 @@ void DownloadManager::startDownload(PAL::SessionID sessionID, DownloadID downloa
     }
     parameters.storedCredentialsPolicy = sessionID.isEphemeral() ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
 
-    m_pendingDownloads.add(downloadID, PendingDownload::create(client->protectedParentProcessConnectionForDownloads().get(), WTFMove(parameters), downloadID, *networkSession, suggestedName, fromDownloadAttribute, webProcessID));
+    m_pendingDownloads.add(downloadID, PendingDownload::create(client->protectedParentProcessConnectionForDownloads().get(), WTF::move(parameters), downloadID, *networkSession, suggestedName, fromDownloadAttribute, webProcessID));
 }
 
 void DownloadManager::dataTaskBecameDownloadTask(DownloadID downloadID, Ref<Download>&& download)
@@ -82,19 +82,19 @@ void DownloadManager::dataTaskBecameDownloadTask(DownloadID downloadID, Ref<Down
     }
     ASSERT(!m_downloads.contains(downloadID));
     m_downloadsAfterDestinationDecided.remove(downloadID);
-    m_downloads.add(downloadID, WTFMove(download));
+    m_downloads.add(downloadID, WTF::move(download));
 }
 
 void DownloadManager::convertNetworkLoadToDownload(DownloadID downloadID, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& completionHandler, Vector<RefPtr<WebCore::BlobDataFileReference>>&& blobFileReferences, const ResourceRequest& request, const ResourceResponse& response)
 {
     ASSERT(!m_pendingDownloads.contains(downloadID));
-    m_pendingDownloads.add(downloadID, PendingDownload::create(protectedClient()->protectedParentProcessConnectionForDownloads().get(), WTFMove(networkLoad), WTFMove(completionHandler), downloadID, request, response));
+    m_pendingDownloads.add(downloadID, PendingDownload::create(protectedClient()->protectedParentProcessConnectionForDownloads().get(), WTF::move(networkLoad), WTF::move(completionHandler), downloadID, request, response));
 }
 
 void DownloadManager::downloadDestinationDecided(DownloadID downloadID, Ref<NetworkDataTask>&& networkDataTask)
 {
     ASSERT(!m_downloadsAfterDestinationDecided.contains(downloadID));
-    m_downloadsAfterDestinationDecided.set(downloadID, WTFMove(networkDataTask));
+    m_downloadsAfterDestinationDecided.set(downloadID, WTF::move(networkDataTask));
 }
 
 void DownloadManager::resumeDownload(PAL::SessionID sessionID, DownloadID downloadID, std::span<const uint8_t> resumeData, const String& path, SandboxExtension::Handle&& sandboxExtensionHandle, CallDownloadDidStart callDownloadDidStart, std::span<const uint8_t> activityAccessToken)
@@ -107,14 +107,14 @@ void DownloadManager::resumeDownload(PAL::SessionID sessionID, DownloadID downlo
         return;
     Ref download = Download::create(*this, downloadID, nullptr, *networkSession);
 
-    download->resume(resumeData, path, WTFMove(sandboxExtensionHandle), activityAccessToken);
+    download->resume(resumeData, path, WTF::move(sandboxExtensionHandle), activityAccessToken);
 
     // For compatibility with the legacy download API, only send DidStart if we're using the new API.
     if (callDownloadDidStart == CallDownloadDidStart::Yes)
         download->send(Messages::DownloadProxy::DidStart({ }, { }));
 
     ASSERT(!m_downloads.contains(downloadID));
-    m_downloads.add(downloadID, WTFMove(download));
+    m_downloads.add(downloadID, WTF::move(download));
 #endif
 }
 
@@ -122,11 +122,11 @@ void DownloadManager::cancelDownload(DownloadID downloadID, CompletionHandler<vo
 {
     if (RefPtr download = m_downloads.get(downloadID)) {
         ASSERT(!m_pendingDownloads.contains(downloadID));
-        download->cancel(WTFMove(completionHandler), Download::IgnoreDidFailCallback::Yes);
+        download->cancel(WTF::move(completionHandler), Download::IgnoreDidFailCallback::Yes);
         return;
     }
     if (RefPtr pendingDownload = m_pendingDownloads.take(downloadID)) {
-        pendingDownload->cancel(WTFMove(completionHandler));
+        pendingDownload->cancel(WTF::move(completionHandler));
         return;
     }
     // If there is no active or pending download, then the download finished in a short race window after cancellation was requested.
@@ -151,9 +151,9 @@ void DownloadManager::publishDownloadProgress(DownloadID downloadID, const URL& 
 void DownloadManager::publishDownloadProgress(DownloadID downloadID, const URL& url, SandboxExtension::Handle&& sandboxExtensionHandle)
 {
     if (RefPtr download = m_downloads.get(downloadID))
-        download->publishProgress(url, WTFMove(sandboxExtensionHandle));
+        download->publishProgress(url, WTF::move(sandboxExtensionHandle));
     else if (RefPtr pendingDownload = m_pendingDownloads.get(downloadID))
-        pendingDownload->publishProgress(url, WTFMove(sandboxExtensionHandle));
+        pendingDownload->publishProgress(url, WTF::move(sandboxExtensionHandle));
 }
 #endif
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -63,12 +63,12 @@ class PendingDownload : public RefCounted<PendingDownload>, public NetworkLoadCl
 public:
     static Ref<PendingDownload> create(IPC::Connection* connection, NetworkLoadParameters&& networkLoadParameters, DownloadID downloadID, NetworkSession& networkSession, const String& suggestedName, WebCore::FromDownloadAttribute fromDownloadAttribute, std::optional<WebCore::ProcessIdentifier> webProcessId)
     {
-        return adoptRef(*new PendingDownload(connection, WTFMove(networkLoadParameters), downloadID, networkSession, suggestedName, fromDownloadAttribute, webProcessId));
+        return adoptRef(*new PendingDownload(connection, WTF::move(networkLoadParameters), downloadID, networkSession, suggestedName, fromDownloadAttribute, webProcessId));
     }
 
     static Ref<PendingDownload> create(IPC::Connection* connection, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& responseCompletionHandler, DownloadID downloadID, const WebCore::ResourceRequest& resourceRequest, const WebCore::ResourceResponse& resourceResponse)
     {
-        return adoptRef(*new PendingDownload(connection, WTFMove(networkLoad), WTFMove(responseCompletionHandler), downloadID, resourceRequest, resourceResponse));
+        return adoptRef(*new PendingDownload(connection, WTF::move(networkLoad), WTF::move(responseCompletionHandler), downloadID, resourceRequest, resourceResponse));
     }
 
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -44,7 +44,7 @@ namespace WebKit {
 
 void Download::resume(std::span<const uint8_t> resumeData, const String& path, SandboxExtension::Handle&& sandboxExtensionHandle, std::span<const uint8_t> activityAccessToken)
 {
-    m_sandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+    m_sandboxExtension = SandboxExtension::create(WTF::move(sandboxExtensionHandle));
     if (RefPtr extension = m_sandboxExtension)
         extension->consume();
 
@@ -109,8 +109,8 @@ void Download::platformCancelNetworkLoad(CompletionHandler<void(std::span<const 
 {
     ASSERT(isMainRunLoop());
     ASSERT(m_downloadTask);
-    [m_downloadTask cancelByProducingResumeData:makeBlockPtr([completionHandler = WTFMove(completionHandler), placeholderURL = m_placeholderURL] (NSData *resumeData) mutable {
-        ensureOnMainRunLoop([resumeData = retainPtr(resumeData), completionHandler = WTFMove(completionHandler), placeholderURL = WTFMove(placeholderURL)] () mutable  {
+    [m_downloadTask cancelByProducingResumeData:makeBlockPtr([completionHandler = WTF::move(completionHandler), placeholderURL = m_placeholderURL] (NSData *resumeData) mutable {
+        ensureOnMainRunLoop([resumeData = retainPtr(resumeData), completionHandler = WTF::move(completionHandler), placeholderURL = WTF::move(placeholderURL)] () mutable  {
 #if HAVE(MODERN_DOWNLOADPROGRESS)
             auto resumeDataWithPlaceholder = updateResumeDataWithPlaceholderURL(placeholderURL.get(), span(resumeData.get()));
             completionHandler(resumeDataWithPlaceholder.span());
@@ -198,7 +198,7 @@ void Download::setPlaceholderURL(NSURL *placeholderURL, NSData *bookmarkData)
 
     SandboxExtension::Handle sandboxExtensionHandle;
     if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(String::fromUTF8(placeholderURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
-        sandboxExtensionHandle = WTFMove(*handle);
+        sandboxExtensionHandle = WTF::move(*handle);
 
     if (usingSecurityScopedURL)
         [placeholderURL stopAccessingSecurityScopedResource];
@@ -211,7 +211,7 @@ void Download::setPlaceholderURL(NSURL *placeholderURL, NSData *bookmarkData)
         startUpdatingProgress();
     };
 
-    sendWithAsyncReply(Messages::DownloadProxy::DidReceivePlaceholderURL(placeholderURL, span(bookmarkData), WTFMove(sandboxExtensionHandle)), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::DownloadProxy::DidReceivePlaceholderURL(placeholderURL, span(bookmarkData), WTF::move(sandboxExtensionHandle)), WTF::move(completionHandler));
 }
 
 void Download::setFinalURL(NSURL *finalURL, NSData *bookmarkData)
@@ -225,12 +225,12 @@ void Download::setFinalURL(NSURL *finalURL, NSData *bookmarkData)
 
     SandboxExtension::Handle sandboxExtensionHandle;
     if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(String::fromUTF8(finalURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
-        sandboxExtensionHandle = WTFMove(*handle);
+        sandboxExtensionHandle = WTF::move(*handle);
 
     if (usingSecurityScopedURL)
         [finalURL stopAccessingSecurityScopedResource];
 
-    send(Messages::DownloadProxy::DidReceiveFinalURL(finalURL, span(bookmarkData), WTFMove(sandboxExtensionHandle)));
+    send(Messages::DownloadProxy::DidReceiveFinalURL(finalURL, span(bookmarkData), WTF::move(sandboxExtensionHandle)));
 }
 
 void Download::startUpdatingProgress()
@@ -312,7 +312,7 @@ void Download::publishProgress(const URL& url, SandboxExtension::Handle&& sandbo
     ASSERT(!m_progress);
     ASSERT(url.isValid());
 
-    auto sandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+    auto sandboxExtension = SandboxExtension::create(WTF::move(sandboxExtensionHandle));
 
     ASSERT(sandboxExtension);
     if (!sandboxExtension)
@@ -332,7 +332,7 @@ void Download::platformDidFinish(CompletionHandler<void()>&& completionHandler)
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     if (m_progress && [m_progress isKindOfClass:WKModernDownloadProgress.class]) {
         auto *progress = (WKModernDownloadProgress *)m_progress;
-        [progress didFinish:makeBlockPtr(WTFMove(completionHandler)).get()];
+        [progress didFinish:makeBlockPtr(WTF::move(completionHandler)).get()];
         return;
     }
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -79,7 +79,7 @@ Vector<uint8_t> activityAccessToken()
 {
     [m_downloadMonitor beginMonitoring:makeBlockPtr([weakDownload = WeakPtr { m_download }](BEDownloadMonitorLocation *location, NSError *error) mutable {
         RELEASE_LOG(Network, "Download begin for url %{sensitive}s, error %s", location.url.absoluteString.UTF8String, error.localizedDescription.UTF8String);
-        ensureOnMainRunLoop([weakDownload = WTFMove(weakDownload), location = RetainPtr { location }] {
+        ensureOnMainRunLoop([weakDownload = WTF::move(weakDownload), location = RetainPtr { location }] {
             if (!weakDownload)
                 return;
             weakDownload->setPlaceholderURL(location.get().url, location.get().bookmarkData);
@@ -109,14 +109,14 @@ Vector<uint8_t> activityAccessToken()
 
     self.cancellable = YES;
     self.cancellationHandler = makeBlockPtr([weakSelf = WeakObjCPtr<WKModernDownloadProgress> { self }] () mutable {
-        ensureOnMainRunLoop([weakSelf = WTFMove(weakSelf)] {
+        ensureOnMainRunLoop([weakSelf = WTF::move(weakSelf)] {
             [weakSelf performCancel];
         });
     }).get();
 
     auto fileCreatedHandlerDownloadMonitorLocation = makeBlockPtr([weakDownload = WeakPtr { m_download }, weakSelf = WeakObjCPtr<WKModernDownloadProgress> { self }](BEDownloadMonitorLocation *location) mutable {
         RELEASE_LOG(Network, "File created handler for url %{sensitive}s", location.url.absoluteString.UTF8String);
-        ensureOnMainRunLoop([weakDownload = WTFMove(weakDownload), location = RetainPtr { location }, weakSelf = WTFMove(weakSelf)] {
+        ensureOnMainRunLoop([weakDownload = WTF::move(weakDownload), location = RetainPtr { location }, weakSelf = WTF::move(weakSelf)] {
             if (!weakDownload)
                 return;
             weakDownload->setFinalURL(location.get().url, location.get().bookmarkData);
@@ -220,7 +220,7 @@ Vector<uint8_t> activityAccessToken()
 
     self.cancellable = YES;
     self.cancellationHandler = makeBlockPtr([weakSelf = WeakObjCPtr<WKDownloadProgress> { self }] () mutable {
-        ensureOnMainRunLoop([weakSelf = WTFMove(weakSelf)] {
+        ensureOnMainRunLoop([weakSelf = WTF::move(weakSelf)] {
             if (RetainPtr protectedSelf = weakSelf.get())
                 [protectedSelf performCancel];
         });

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -145,7 +145,7 @@ void EarlyHintsResourceLoader::startPreconnectTask(const URL& baseURL, const Lin
     parameters.shouldPreconnectOnly = PreconnectOnly::Yes;
     parameters.request = constructPreconnectRequest(originalRequest, url);
     parameters.isNavigatingToAppBoundDomain = m_loader->parameters().isNavigatingToAppBoundDomain;
-    Ref preconnectTask = PreconnectTask::create(*networkSession, WTFMove(parameters));
+    Ref preconnectTask = PreconnectTask::create(*networkSession, WTF::move(parameters));
     preconnectTask->start();
 
     addConsoleMessage(MessageSource::Network, MessageLevel::Info, makeString("Preconnecting to "_s, url.string(), " due to early hint"_s));

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -35,7 +35,7 @@ namespace WebKit {
 class NetworkServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
     NetworkServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
-        : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
+        : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }
 };
@@ -43,7 +43,7 @@ public:
 template<>
 void initializeAuxiliaryProcess<NetworkProcess>(AuxiliaryProcessInitializationParameters&& parameters)
 {
-    static NeverDestroyed<NetworkProcess> networkProcess(WTFMove(parameters));
+    static NeverDestroyed<NetworkProcess> networkProcess(WTF::move(parameters));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -99,7 +99,7 @@ void NetworkBroadcastChannelRegistry::postMessage(IPC::Connection& connection, c
     if (connectionIdentifiersForNameIterator == channelsForOriginIterator->value.end())
         return completionHandler();
 
-    auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     for (auto& connectionID : connectionIdentifiersForNameIterator->value) {
         // Only dispatch the post the messages to BroadcastChannels outside the source process.
         if (connectionID == connection.uniqueID())

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -47,9 +47,9 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkCORSPreflightChecker);
 
 NetworkCORSPreflightChecker::NetworkCORSPreflightChecker(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, Parameters&& parameters, bool shouldCaptureExtraNetworkLoadMetrics, CompletionCallback&& completionCallback)
-    : m_parameters(WTFMove(parameters))
+    : m_parameters(WTF::move(parameters))
     , m_networkProcess(networkProcess)
-    , m_completionCallback(WTFMove(completionCallback))
+    , m_completionCallback(WTF::move(completionCallback))
     , m_shouldCaptureExtraNetworkLoadMetrics(shouldCaptureExtraNetworkLoadMetrics)
     , m_networkResourceLoader(networkResourceLoader)
 {
@@ -83,7 +83,7 @@ void NetworkCORSPreflightChecker::startPreflight()
     loadParameters.allowPrivacyProxy = m_parameters.allowPrivacyProxy;
 
     if (CheckedPtr networkSession = m_networkProcess->networkSession(m_parameters.sessionID)) {
-        Ref task = NetworkDataTask::create(*networkSession, *this, WTFMove(loadParameters));
+        Ref task = NetworkDataTask::create(*networkSession, *this, WTF::move(loadParameters));
         m_task = task.copyRef();
         task->resume();
     } else
@@ -93,7 +93,7 @@ void NetworkCORSPreflightChecker::startPreflight()
 void NetworkCORSPreflightChecker::willPerformHTTPRedirection(WebCore::ResourceResponse&& response, WebCore::ResourceRequest&&, RedirectCompletionHandler&& completionHandler)
 {
     if (m_shouldCaptureExtraNetworkLoadMetrics)
-        m_loadInformation.response = WTFMove(response);
+        m_loadInformation.response = WTF::move(response);
 
     CORS_CHECKER_RELEASE_LOG("willPerformHTTPRedirection");
     completionHandler({ });
@@ -118,7 +118,7 @@ void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationCha
         return;
     }
 
-    m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, &m_parameters.topOrigin->data(), challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+    m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, &m_parameters.topOrigin->data(), challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
 }
 
 void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
@@ -128,7 +128,7 @@ void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&&
     if (m_shouldCaptureExtraNetworkLoadMetrics)
         m_loadInformation.response = response;
 
-    m_response = WTFMove(response);
+    m_response = WTF::move(response);
     completionHandler(PolicyAction::Use);
 }
 
@@ -148,7 +148,7 @@ void NetworkCORSPreflightChecker::didCompleteWithError(const WebCore::ResourceEr
         if (error.isNull() || error.isGeneral())
             error.setType(ResourceError::Type::AccessControl);
 
-        m_completionCallback(WTFMove(error));
+        m_completionCallback(WTF::move(error));
         return;
     }
 
@@ -193,7 +193,7 @@ void NetworkCORSPreflightChecker::wasBlockedByDisabledFTP()
 NetworkTransactionInformation NetworkCORSPreflightChecker::takeInformation()
 {
     ASSERT(m_shouldCaptureExtraNetworkLoadMetrics);
-    return WTFMove(m_loadInformation);
+    return WTF::move(m_loadInformation);
 }
 
 } // Namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -70,7 +70,7 @@ public:
 
     static Ref<NetworkCORSPreflightChecker> create(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, Parameters&& parameters, bool shouldCaptureExtraNetworkLoadMetrics, CompletionCallback&& completionCallback)
     {
-        return adoptRef(*new NetworkCORSPreflightChecker(networkProcess, networkResourceLoader, WTFMove(parameters), shouldCaptureExtraNetworkLoadMetrics, WTFMove(completionCallback)));
+        return adoptRef(*new NetworkCORSPreflightChecker(networkProcess, networkResourceLoader, WTF::move(parameters), shouldCaptureExtraNetworkLoadMetrics, WTF::move(completionCallback)));
     }
     ~NetworkCORSPreflightChecker();
     const WebCore::ResourceRequest& originalRequest() const { return m_parameters.originalRequest; }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -217,7 +217,7 @@ public:
     void addNetworkLoadInformation(WebCore::ResourceLoaderIdentifier identifier, WebCore::NetworkLoadInformation&& information)
     {
         ASSERT(!m_networkLoadInformationByID.contains(identifier));
-        m_networkLoadInformationByID.add(identifier, makeUnique<WebCore::NetworkLoadInformation>(WTFMove(information)));
+        m_networkLoadInformationByID.add(identifier, makeUnique<WebCore::NetworkLoadInformation>(WTF::move(information)));
     }
 
     void addNetworkLoadInformationMetrics(WebCore::ResourceLoaderIdentifier identifier, const WebCore::NetworkLoadMetrics& metrics)

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -42,7 +42,7 @@ NetworkContentRuleListManager::NetworkContentRuleListManager(NetworkProcess& net
 
 NetworkContentRuleListManager::~NetworkContentRuleListManager()
 {
-    auto pendingCallbacks = WTFMove(m_pendingCallbacks);
+    auto pendingCallbacks = WTF::move(m_pendingCallbacks);
     if (pendingCallbacks.isEmpty())
         return;
 
@@ -78,7 +78,7 @@ void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControll
     }
     m_pendingCallbacks.ensure(identifier, [] {
         return Vector<BackendCallback> { };
-    }).iterator->value.append(WTFMove(callback));
+    }).iterator->value.append(WTF::move(callback));
     protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
 }
 
@@ -89,10 +89,10 @@ void NetworkContentRuleListManager::addContentRuleLists(UserContentControllerIde
     }).iterator->value;
 
     for (auto&& pair : contentRuleLists) {
-        auto&& contentRuleList = WTFMove(pair.first);
+        auto&& contentRuleList = WTF::move(pair.first);
         String identifier = contentRuleList.identifier;
-        if (RefPtr compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(contentRuleList)))
-            backend.addContentExtension(identifier, compiledContentRuleList.releaseNonNull(), WTFMove(pair.second), ContentExtensions::ContentExtension::ShouldCompileCSS::No);
+        if (RefPtr compiledContentRuleList = WebCompiledContentRuleList::create(WTF::move(contentRuleList)))
+            backend.addContentExtension(identifier, compiledContentRuleList.releaseNonNull(), WTF::move(pair.second), ContentExtensions::ContentExtension::ShouldCompileCSS::No);
     }
 
     auto pendingCallbacks = m_pendingCallbacks.take(identifier);

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -149,7 +149,7 @@ void NetworkDataTask::scheduleFailure(FailureType type)
 void NetworkDataTask::didReceiveInformationalResponse(ResourceResponse&& headers)
 {
     if (RefPtr client = m_client.get())
-        client->didReceiveInformationalResponse(WTFMove(headers));
+        client->didReceiveInformationalResponse(WTF::move(headers));
 }
 
 void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, std::optional<IPAddress> resolvedIPAddress, ResponseCompletionHandler&& completionHandler)
@@ -187,7 +187,7 @@ void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, Negotiated
         response.setWasPrivateRelayed(WasPrivateRelayed::Yes);
 
     if (RefPtr client = m_client.get())
-        client->didReceiveResponse(WTFMove(response), negotiatedLegacyTLS, privateRelayed, WTFMove(completionHandler));
+        client->didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WTF::move(completionHandler));
     else
         completionHandler(PolicyAction::Ignore);
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -142,7 +142,7 @@ bool NetworkDataTaskBlob::erroredOrAborted() const
 
 void NetworkDataTaskBlob::didReceiveResponse(ResourceResponse&& response)
 {
-    NetworkDataTask::didReceiveResponse(WTFMove(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }](PolicyAction policyAction) {
+    NetworkDataTask::didReceiveResponse(WTF::move(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }](PolicyAction policyAction) {
         LOG(NetworkSession, "%p - NetworkDataTaskBlob::didReceiveResponse completionHandler (%s)", this, toString(policyAction).characters());
 
         if (m_state == State::Canceling || m_state == State::Completed) {
@@ -185,7 +185,7 @@ void NetworkDataTaskBlob::setPendingDownloadLocation(const String& filename, San
     NetworkDataTask::setPendingDownloadLocation(filename, { }, allowOverwrite);
 
     ASSERT(!m_sandboxExtension);
-    m_sandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+    m_sandboxExtension = SandboxExtension::create(WTF::move(sandboxExtensionHandle));
     if (RefPtr extension = m_sandboxExtension)
         extension->consume();
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -81,7 +81,7 @@ void NetworkDataTaskDataURL::resume()
         if (m_state == State::Canceling || m_state == State::Completed)
             return;
 
-        didDecodeDataURL(WTFMove(decodeResult));
+        didDecodeDataURL(WTF::move(decodeResult));
     });
 }
 
@@ -106,7 +106,7 @@ NetworkDataTask::State NetworkDataTaskDataURL::state() const
 
 void NetworkDataTaskDataURL::setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)
 {
-    NetworkDataTask::setPendingDownloadLocation(filename, WTFMove(sandboxExtensionHandle), allowOverwrite);
+    NetworkDataTask::setPendingDownloadLocation(filename, WTF::move(sandboxExtensionHandle), allowOverwrite);
     m_allowOverwriteDownload = allowOverwrite;
 }
 
@@ -134,7 +134,7 @@ void NetworkDataTaskDataURL::didDecodeDataURL(std::optional<WebCore::DataURLDeco
 
     m_response = ResourceResponse::dataURLResponse(firstRequest().url(), result.value());
 
-    didReceiveResponse(ResourceResponse(m_response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }, data = WTFMove(result.value().data)](PolicyAction policyAction) mutable {
+    didReceiveResponse(ResourceResponse(m_response), NegotiatedLegacyTLS::No, PrivateRelayed::No, std::nullopt, [this, protectedThis = Ref { *this }, data = WTF::move(result.value().data)](PolicyAction policyAction) mutable {
         if (m_state == State::Canceling || m_state == State::Completed)
             return;
 
@@ -148,7 +148,7 @@ void NetworkDataTaskDataURL::didDecodeDataURL(std::optional<WebCore::DataURLDeco
             invalidateAndCancel();
             break;
         case PolicyAction::Download:
-            downloadDecodedData(WTFMove(data));
+            downloadDecodedData(WTF::move(data));
             break;
         case PolicyAction::LoadWillContinueInAnotherProcess:
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -52,7 +52,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoad);
 NetworkLoad::NetworkLoad(NetworkLoadClient& client, NetworkLoadParameters&& parameters, NetworkSession& networkSession)
     : m_client(client)
     , m_networkProcess(networkSession.networkProcess())
-    , m_parameters(WTFMove(parameters))
+    , m_parameters(WTF::move(parameters))
     , m_currentRequest(m_parameters.request)
 {
     relaxAdoptionRequirement();
@@ -125,7 +125,7 @@ void NetworkLoad::updateRequestAfterRedirection(WebCore::ResourceRequest& newReq
 {
     ResourceRequest updatedRequest = m_currentRequest;
     updateRequest(updatedRequest, newRequest);
-    newRequest = WTFMove(updatedRequest);
+    newRequest = WTF::move(updatedRequest);
 }
 
 void NetworkLoad::reprioritizeRequest(ResourceLoadPriority priority)
@@ -157,7 +157,7 @@ void NetworkLoad::convertTaskToDownload(PendingDownload& pendingDownload, const 
     m_currentRequest = updatedRequest;
     task->setPendingDownload(pendingDownload);
     
-    m_networkProcess->findPendingDownloadLocation(*task, WTFMove(completionHandler), response);
+    m_networkProcess->findPendingDownloadLocation(*task, WTF::move(completionHandler), response);
 }
 
 void NetworkLoad::setPendingDownloadID(DownloadID downloadID)
@@ -203,11 +203,11 @@ void NetworkLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse
 
     redirectResponse.setSource(ResourceResponse::Source::Network);
 
-    auto oldRequest = WTFMove(m_currentRequest);
+    auto oldRequest = WTF::move(m_currentRequest);
     request.setRequester(oldRequest.requester());
 
     m_currentRequest = request;
-    client->willSendRedirectedRequest(WTFMove(oldRequest), WTFMove(request), WTFMove(redirectResponse), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (ResourceRequest&& newRequest) mutable {
+    client->willSendRedirectedRequest(WTF::move(oldRequest), WTF::move(request), WTF::move(redirectResponse), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (ResourceRequest&& newRequest) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
@@ -243,15 +243,15 @@ void NetworkLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, Negot
     }
     
     if (RefPtr pendingDownload = m_task->pendingDownload())
-        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(*pendingDownload, challenge, WTFMove(completionHandler));
+        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(*pendingDownload, challenge, WTF::move(completionHandler));
     else
-        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_task->sessionID(), m_parameters.webPageProxyID, m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_task->sessionID(), m_parameters.webPageProxyID, m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
 }
 
 void NetworkLoad::didReceiveInformationalResponse(ResourceResponse&& response)
 {
     if (RefPtr client = m_client.get())
-        client->didReceiveInformationalResponse(WTFMove(response));
+        client->didReceiveInformationalResponse(WTF::move(response));
 }
 
 void NetworkLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
@@ -259,14 +259,14 @@ void NetworkLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLega
     ASSERT(RunLoop::isMain());
 
     if (m_task && m_task->isDownload()) {
-        m_networkProcess->findPendingDownloadLocation(*m_task.get(), WTFMove(completionHandler), response);
+        m_networkProcess->findPendingDownloadLocation(*m_task.get(), WTF::move(completionHandler), response);
         return;
     }
 
     if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes)
         m_networkProcess->protectedAuthenticationManager()->negotiatedLegacyTLS(*m_parameters.webPageProxyID);
     
-    notifyDidReceiveResponse(WTFMove(response), negotiatedLegacyTLS, privateRelayed, WTFMove(completionHandler));
+    notifyDidReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WTF::move(completionHandler));
 }
 
 void NetworkLoad::notifyDidReceiveResponse(ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
@@ -290,7 +290,7 @@ void NetworkLoad::notifyDidReceiveResponse(ResourceResponse&& response, Negotiat
         response.includeCertificateInfo(auditToken);
     }
 
-    client->didReceiveResponse(WTFMove(response), privateRelayed, WTFMove(completionHandler));
+    client->didReceiveResponse(WTF::move(response), privateRelayed, WTF::move(completionHandler));
 }
 
 void NetworkLoad::didReceiveData(const WebCore::SharedBuffer& buffer)
@@ -360,7 +360,7 @@ String NetworkLoad::description() const
 void NetworkLoad::setH2PingCallback(const URL& url, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&& completionHandler)
 {
     if (RefPtr task = m_task)
-        task->setH2PingCallback(url, WTFMove(completionHandler));
+        task->setH2PingCallback(url, WTF::move(completionHandler));
     else
         completionHandler(makeUnexpected(internalError(url)));
 }

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -51,7 +51,7 @@ public:
 
     static Ref<NetworkLoad> create(NetworkLoadClient& networkLoadClient, NetworkLoadParameters&& networkLoadParameters, NetworkSession& networkSession)
     {
-        return adoptRef(*new NetworkLoad(networkLoadClient, WTFMove(networkLoadParameters), networkSession));
+        return adoptRef(*new NetworkLoad(networkLoadClient, WTF::move(networkLoadParameters), networkSession));
     }
 
     template<typename CreateTaskCallback> static Ref<NetworkLoad> create(NetworkLoadClient& networkLoadClient, NetworkSession& networkSession, NOESCAPE const CreateTaskCallback& createTask)

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -69,9 +69,9 @@ public:
         OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, bool shouldCaptureExtraNetworkLoadMetrics = false, LoadType requestLoadType = LoadType::Other)
     {
         return adoptRef(*new NetworkLoadChecker(networkProcess, networkResourceLoader, schemeRegistry,
-            WTFMove(options), sessionID, webPageProxyID, WTFMove(originalRequestHeaders),
-            WTFMove(url), WTFMove(documentURL), WTFMove(sourceOrigin), WTFMove(topOrigin),
-            WTFMove(parentOrigin), preflightPolicy, WTFMove(referrer), allowPrivacyProxy,
+            WTF::move(options), sessionID, webPageProxyID, WTF::move(originalRequestHeaders),
+            WTF::move(url), WTF::move(documentURL), WTF::move(sourceOrigin), WTF::move(topOrigin),
+            WTF::move(parentOrigin), preflightPolicy, WTF::move(referrer), allowPrivacyProxy,
             advancedPrivacyProtections, shouldCaptureExtraNetworkLoadMetrics, requestLoadType));
     }
 
@@ -93,14 +93,14 @@ public:
 
     WebCore::ResourceError validateResponse(const WebCore::ResourceRequest&, WebCore::ResourceResponse&);
 
-    void setCSPResponseHeaders(WebCore::ContentSecurityPolicyResponseHeaders&& headers) { m_cspResponseHeaders = WTFMove(headers); }
+    void setCSPResponseHeaders(WebCore::ContentSecurityPolicyResponseHeaders&& headers) { m_cspResponseHeaders = WTF::move(headers); }
     void setParentCrossOriginEmbedderPolicy(const WebCore::CrossOriginEmbedderPolicy& parentCrossOriginEmbedderPolicy) { m_parentCrossOriginEmbedderPolicy = parentCrossOriginEmbedderPolicy; }
     void setCrossOriginEmbedderPolicy(const WebCore::CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy) { m_crossOriginEmbedderPolicy = crossOriginEmbedderPolicy; }
 #if ENABLE(CONTENT_EXTENSIONS)
     void setContentExtensionController(URL&& mainDocumentURL, URL&& frameURL, std::optional<UserContentControllerIdentifier> identifier)
     {
-        m_mainDocumentURL = WTFMove(mainDocumentURL);
-        m_frameURL = WTFMove(frameURL);
+        m_mainDocumentURL = WTF::move(mainDocumentURL);
+        m_frameURL = WTF::move(frameURL);
         m_userContentControllerIdentifier = identifier;
     }
 #endif
@@ -111,7 +111,7 @@ public:
     const URL& url() const { return m_url; }
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const { return m_storedCredentialsPolicy; }
 
-    WebCore::NetworkLoadInformation takeNetworkLoadInformation() { return WTFMove(m_loadInformation); }
+    WebCore::NetworkLoadInformation takeNetworkLoadInformation() { return WTF::move(m_loadInformation); }
     void storeRedirectionIfNeeded(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
     void enableContentExtensionsCheck() { m_checkContentExtensions = true; }

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -218,7 +218,7 @@ void NetworkLoadScheduler::startedPreconnectForMainResource(const URL& url, cons
     }
 
     PendingMainResourcePreconnectInfo info;
-    m_pendingMainResourcePreconnects.add(key, WTFMove(info));
+    m_pendingMainResourcePreconnects.add(key, WTF::move(info));
 }
 
 void NetworkLoadScheduler::finishedPreconnectForMainResource(const URL& url, const String& userAgent, const WebCore::ResourceError& error)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 NetworkResourceLoadMap::NetworkResourceLoadMap(Function<void(bool hasUpload)>&& hasUploadChangeListener)
-    : m_hasUploadChangeListener(WTFMove(hasUploadChangeListener))
+    : m_hasUploadChangeListener(WTF::move(hasUploadChangeListener))
 {
 }
 
@@ -45,7 +45,7 @@ NetworkResourceLoadMap::MapType::AddResult NetworkResourceLoadMap::add(WebCore::
 {
     ASSERT(!m_loaders.contains(identifier));
     bool hasUpload = loader->originalRequest().hasUpload();
-    auto result = m_loaders.add(identifier, WTFMove(loader));
+    auto result = m_loaders.add(identifier, WTF::move(loader));
     if (hasUpload)
         setHasUpload(true);
     return result;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -42,7 +42,7 @@ void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
                 continue;
             const String& path = fileData->filename;
             if (auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly))
-                requestBodySandboxExtensions.append(WTFMove(*handle));
+                requestBodySandboxExtensions.append(WTF::move(*handle));
         }
     }
 
@@ -50,12 +50,12 @@ void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 #if HAVE(AUDIT_TOKEN)
         if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
             if (auto handle = SandboxExtension::createHandleForReadByAuditToken(request.url().fileSystemPath(), *networkProcessAuditToken))
-                resourceSandboxExtension = WTFMove(*handle);
+                resourceSandboxExtension = WTF::move(*handle);
         } else
 #endif
         {
             if (auto handle = SandboxExtension::createHandle(request.url().fileSystemPath(), SandboxExtension::Type::ReadOnly))
-                resourceSandboxExtension = WTFMove(*handle);
+                resourceSandboxExtension = WTF::move(*handle);
         }
     }
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -95,7 +95,7 @@ public:
 
     static Ref<NetworkResourceLoader> create(NetworkResourceLoadParameters&& parameters, NetworkConnectionToWebProcess& connection, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse, Vector<uint8_t>&&)>&& reply = nullptr)
     {
-        return adoptRef(*new NetworkResourceLoader(WTFMove(parameters), connection, WTFMove(reply)));
+        return adoptRef(*new NetworkResourceLoader(WTF::move(parameters), connection, WTF::move(reply)));
     }
     virtual ~NetworkResourceLoader();
 
@@ -113,7 +113,7 @@ public:
 
     void continueWillSendRequest(WebCore::ResourceRequest&&, bool isAllowedToAskUserForCredentials, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
 
-    void setResponse(WebCore::ResourceResponse&& response) { m_response = WTFMove(response); }
+    void setResponse(WebCore::ResourceResponse&& response) { m_response = WTF::move(response); }
     const WebCore::ResourceResponse& response() const { return m_response; }
 
     NetworkConnectionToWebProcess& connectionToWebProcess() const { return m_connection; }

--- a/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
@@ -30,7 +30,7 @@ namespace WebKit {
 
 void NetworkSchemeRegistry::registerURLSchemeAsCORSEnabled(String&& scheme)
 {
-    m_corsEnabledSchemes.add(WTFMove(scheme));
+    m_corsEnabledSchemes.add(WTF::move(scheme));
 }
 
 bool NetworkSchemeRegistry::shouldTreatURLSchemeAsCORSEnabled(StringView scheme)

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -140,7 +140,7 @@ static WebPushD::WebPushDaemonConnectionConfiguration configurationWithHostAudit
     if (token) {
         Vector<uint8_t> auditTokenData(sizeof(*token));
         memcpySpan(auditTokenData.mutableSpan(), asByteSpan(*token));
-        configuration.hostAppAuditTokenData = WTFMove(auditTokenData);
+        configuration.hostAppAuditTokenData = WTF::move(auditTokenData);
     }
 #endif
     return configuration;
@@ -248,7 +248,7 @@ void NetworkSession::destroyResourceLoadStatistics(CompletionHandler<void()>&& c
     if (!resourceLoadStatistics)
         return completionHandler();
 
-    resourceLoadStatistics->didDestroyNetworkSession(WTFMove(completionHandler));
+    resourceLoadStatistics->didDestroyNetworkSession(WTF::move(completionHandler));
     m_resourceLoadStatistics = nullptr;
 }
 
@@ -275,7 +275,7 @@ void NetworkSession::invalidateAndCancel()
 
 void NetworkSession::destroyPrivateClickMeasurementStore(CompletionHandler<void()>&& completionHandler)
 {
-    m_privateClickMeasurement->destroyStoreForTesting(WTFMove(completionHandler));
+    m_privateClickMeasurement->destroyStoreForTesting(WTF::move(completionHandler));
 }
 
 void NetworkSession::setTrackingPreventionEnabled(bool enabled)
@@ -346,12 +346,12 @@ void NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet
     }
     domains.domainsToEnforceSameSiteStrictFor.clear();
 
-    m_networkProcess->deleteAndRestrictWebsiteDataForRegistrableDomains(m_sessionID, dataTypes, WTFMove(domains), WTFMove(completionHandler));
+    m_networkProcess->deleteAndRestrictWebsiteDataForRegistrableDomains(m_sessionID, dataTypes, WTF::move(domains), WTF::move(completionHandler));
 }
 
 void NetworkSession::registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType> dataTypes, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
-    m_networkProcess->registrableDomainsWithWebsiteData(m_sessionID, dataTypes, WTFMove(completionHandler));
+    m_networkProcess->registrableDomainsWithWebsiteData(m_sessionID, dataTypes, WTF::move(completionHandler));
 }
 
 void NetworkSession::setShouldDowngradeReferrerForTesting(bool enabled)
@@ -385,7 +385,7 @@ void NetworkSession::setFirstPartyHostCNAMEDomain(String&& firstPartyHost, WebCo
     ASSERT(!firstPartyHost.isEmpty() && !cnameDomain.isEmpty() && firstPartyHost != cnameDomain.string());
     if (firstPartyHost.isEmpty() || cnameDomain.isEmpty() || firstPartyHost == cnameDomain.string())
         return;
-    m_firstPartyHostCNAMEDomains.add(WTFMove(firstPartyHost), WTFMove(cnameDomain));
+    m_firstPartyHostCNAMEDomains.add(WTF::move(firstPartyHost), WTF::move(cnameDomain));
 }
 
 std::optional<WebCore::RegistrableDomain> NetworkSession::firstPartyHostCNAMEDomain(const String& firstPartyHost)
@@ -412,7 +412,7 @@ void NetworkSession::setFirstPartyHostIPAddress(const String& firstPartyHost, co
         return;
 
     if (auto address = WebCore::IPAddress::fromString(addressString))
-        m_firstPartyHostIPAddresses.set(firstPartyHost, WTFMove(*address));
+        m_firstPartyHostIPAddresses.set(firstPartyHost, WTF::move(*address));
 }
 
 std::optional<WebCore::IPAddress> NetworkSession::firstPartyHostIPAddress(const String& firstPartyHost)
@@ -432,19 +432,19 @@ void NetworkSession::storePrivateClickMeasurement(WebCore::PrivateClickMeasureme
     if (m_isRunningEphemeralMeasurementTest)
         unattributedPrivateClickMeasurement.setEphemeral(WebCore::PCM::AttributionEphemeral::Yes);
     if (unattributedPrivateClickMeasurement.isEphemeral() == WebCore::PCM::AttributionEphemeral::Yes) {
-        m_ephemeralMeasurement = WTFMove(unattributedPrivateClickMeasurement);
+        m_ephemeralMeasurement = WTF::move(unattributedPrivateClickMeasurement);
         return;
     }
 
     if (unattributedPrivateClickMeasurement.isSKAdNetworkAttribution())
-        return donateToSKAdNetwork(WTFMove(unattributedPrivateClickMeasurement));
+        return donateToSKAdNetwork(WTF::move(unattributedPrivateClickMeasurement));
 
-    m_privateClickMeasurement->storeUnattributed(WTFMove(unattributedPrivateClickMeasurement), [] { });
+    m_privateClickMeasurement->storeUnattributed(WTF::move(unattributedPrivateClickMeasurement), [] { });
 }
 
 void NetworkSession::handlePrivateClickMeasurementConversion(WebCore::PCM::AttributionTriggerData&& attributionTriggerData, const URL& requestURL, const WebCore::ResourceRequest& redirectRequest, String&& attributedBundleIdentifier)
 {
-    String appBundleID = WTFMove(attributedBundleIdentifier);
+    String appBundleID = WTF::move(attributedBundleIdentifier);
 #if PLATFORM(COCOA)
     if (appBundleID.isEmpty())
         appBundleID = applicationBundleIdentifier();
@@ -472,16 +472,16 @@ void NetworkSession::handlePrivateClickMeasurementConversion(WebCore::PCM::Attri
             return;
 
         // Insert ephemeral measurement right before attribution.
-        m_privateClickMeasurement->storeUnattributed(WTFMove(ephemeralMeasurement), [weakThis = WeakPtr { *this }, attributionTriggerData = WTFMove(attributionTriggerData), requestURL, redirectDomain = WTFMove(redirectDomain), firstPartyForCookies = WTFMove(firstPartyForCookies), appBundleID = WTFMove(appBundleID)] () mutable {
+        m_privateClickMeasurement->storeUnattributed(WTF::move(ephemeralMeasurement), [weakThis = WeakPtr { *this }, attributionTriggerData = WTF::move(attributionTriggerData), requestURL, redirectDomain = WTF::move(redirectDomain), firstPartyForCookies = WTF::move(firstPartyForCookies), appBundleID = WTF::move(appBundleID)] () mutable {
             CheckedPtr checkedThis = weakThis.get();
             if (!checkedThis)
                 return;
-            checkedThis->m_privateClickMeasurement->handleAttribution(WTFMove(attributionTriggerData), requestURL, WTFMove(redirectDomain), firstPartyForCookies, appBundleID);
+            checkedThis->m_privateClickMeasurement->handleAttribution(WTF::move(attributionTriggerData), requestURL, WTF::move(redirectDomain), firstPartyForCookies, appBundleID);
         });
         return;
     }
 
-    m_privateClickMeasurement->handleAttribution(WTFMove(attributionTriggerData), requestURL, RegistrableDomain(redirectRequest.url()), redirectRequest.firstPartyForCookies(), appBundleID);
+    m_privateClickMeasurement->handleAttribution(WTF::move(attributionTriggerData), requestURL, RegistrableDomain(redirectRequest.url()), redirectRequest.firstPartyForCookies(), appBundleID);
 }
 
 void NetworkSession::simulatePrivateClickMeasurementConversion(int priority, int triggerData, const URL& sourceURL, const URL& destinationURL)
@@ -496,24 +496,24 @@ void NetworkSession::simulatePrivateClickMeasurementConversion(int priority, int
     WebCore::PCM::AttributionTriggerData attributionTriggerData;
     attributionTriggerData.data = triggerData;
     attributionTriggerData.priority = priority;
-    handlePrivateClickMeasurementConversion(WTFMove(attributionTriggerData), sourceURL, request, { });
+    handlePrivateClickMeasurementConversion(WTF::move(attributionTriggerData), sourceURL, request, { });
 }
 
 void NetworkSession::dumpPrivateClickMeasurement(CompletionHandler<void(String)>&& completionHandler)
 {
-    m_privateClickMeasurement->toStringForTesting(WTFMove(completionHandler));
+    m_privateClickMeasurement->toStringForTesting(WTF::move(completionHandler));
 }
 
 void NetworkSession::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
-    m_privateClickMeasurement->clear(WTFMove(completionHandler));
+    m_privateClickMeasurement->clear(WTF::move(completionHandler));
     m_ephemeralMeasurement = std::nullopt;
     m_isRunningEphemeralMeasurementTest = false;
 }
 
 void NetworkSession::clearPrivateClickMeasurementForRegistrableDomain(WebCore::RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    m_privateClickMeasurement->clearForRegistrableDomain(WTFMove(domain), WTFMove(completionHandler));
+    m_privateClickMeasurement->clearForRegistrableDomain(WTF::move(domain), WTF::move(completionHandler));
 }
 
 void NetworkSession::setPrivateClickMeasurementOverrideTimerForTesting(bool value)
@@ -523,22 +523,22 @@ void NetworkSession::setPrivateClickMeasurementOverrideTimerForTesting(bool valu
 
 void NetworkSession::markAttributedPrivateClickMeasurementsAsExpiredForTesting(CompletionHandler<void()>&& completionHandler)
 {
-    m_privateClickMeasurement->markAttributedPrivateClickMeasurementsAsExpiredForTesting(WTFMove(completionHandler));
+    m_privateClickMeasurement->markAttributedPrivateClickMeasurementsAsExpiredForTesting(WTF::move(completionHandler));
 }
 
 void NetworkSession::setPrivateClickMeasurementTokenPublicKeyURLForTesting(URL&& url)
 {
-    m_privateClickMeasurement->setTokenPublicKeyURLForTesting(WTFMove(url));
+    m_privateClickMeasurement->setTokenPublicKeyURLForTesting(WTF::move(url));
 }
 
 void NetworkSession::setPrivateClickMeasurementTokenSignatureURLForTesting(URL&& url)
 {
-    m_privateClickMeasurement->setTokenSignatureURLForTesting(WTFMove(url));
+    m_privateClickMeasurement->setTokenSignatureURLForTesting(WTF::move(url));
 }
 
 void NetworkSession::setPrivateClickMeasurementAttributionReportURLsForTesting(URL&& sourceURL, URL&& destinationURL)
 {
-    m_privateClickMeasurement->setAttributionReportURLsForTesting(WTFMove(sourceURL), WTFMove(destinationURL));
+    m_privateClickMeasurement->setAttributionReportURLsForTesting(WTF::move(sourceURL), WTF::move(destinationURL));
 }
 
 void NetworkSession::markPrivateClickMeasurementsAsExpiredForTesting()
@@ -554,7 +554,7 @@ void NetworkSession::setPrivateClickMeasurementEphemeralMeasurementForTesting(bo
 // FIXME: Switch to non-mocked test data once the right cryptography library is available in open source.
 void NetworkSession::setPCMFraudPreventionValuesForTesting(String&& unlinkableToken, String&& secretToken, String&& signature, String&& keyID)
 {
-    m_privateClickMeasurement->setPCMFraudPreventionValuesForTesting(WTFMove(unlinkableToken), WTFMove(secretToken), WTFMove(signature), WTFMove(keyID));
+    m_privateClickMeasurement->setPCMFraudPreventionValuesForTesting(WTF::move(unlinkableToken), WTF::move(secretToken), WTF::move(signature), WTF::move(keyID));
 }
 
 void NetworkSession::setPrivateClickMeasurementDebugMode(bool enabled)
@@ -601,14 +601,14 @@ void NetworkSession::setPrivateClickMeasurementAppBundleIDForTesting(String&& ap
         WTFLogAlways("isRunningTest() returned false. appBundleID is %s.", appBundleID.isEmpty() ? "empty" : appBundleID.utf8().data());
     RELEASE_ASSERT(isRunningTest(applicationBundleIdentifier()));
 #endif
-    m_privateClickMeasurement->setPrivateClickMeasurementAppBundleIDForTesting(WTFMove(appBundleIDForTesting));
+    m_privateClickMeasurement->setPrivateClickMeasurementAppBundleIDForTesting(WTF::move(appBundleIDForTesting));
 }
 
 void NetworkSession::addKeptAliveLoad(Ref<NetworkResourceLoader>&& loader)
 {
     ASSERT(m_sessionID == loader->sessionID());
     ASSERT(!m_keptAliveLoads.contains(loader));
-    m_keptAliveLoads.add(WTFMove(loader));
+    m_keptAliveLoads.add(WTF::move(loader));
 }
 
 void NetworkSession::removeKeptAliveLoad(NetworkResourceLoader& loader)
@@ -620,12 +620,12 @@ void NetworkSession::removeKeptAliveLoad(NetworkResourceLoader& loader)
 
 Ref<NetworkSession::CachedNetworkResourceLoader> NetworkSession::CachedNetworkResourceLoader::create(Ref<NetworkResourceLoader>&& loader)
 {
-    return adoptRef(*new NetworkSession::CachedNetworkResourceLoader(WTFMove(loader)));
+    return adoptRef(*new NetworkSession::CachedNetworkResourceLoader(WTF::move(loader)));
 }
 
 NetworkSession::CachedNetworkResourceLoader::CachedNetworkResourceLoader(Ref<NetworkResourceLoader>&& loader)
     : m_expirationTimer(*this, &CachedNetworkResourceLoader::expirationTimerFired)
-    , m_loader(WTFMove(loader))
+    , m_loader(WTF::move(loader))
 {
     m_expirationTimer.startOneShot(cachedNetworkResourceLoaderLifetime);
 }
@@ -651,7 +651,7 @@ void NetworkSession::addLoaderAwaitingWebProcessTransfer(Ref<NetworkResourceLoad
     ASSERT(m_sessionID == loader->sessionID());
     auto identifier = loader->identifier();
     ASSERT(!m_loadersAwaitingWebProcessTransfer.contains(identifier));
-    m_loadersAwaitingWebProcessTransfer.add(identifier, CachedNetworkResourceLoader::create(WTFMove(loader)));
+    m_loadersAwaitingWebProcessTransfer.add(identifier, CachedNetworkResourceLoader::create(WTF::move(loader)));
 }
 
 RefPtr<NetworkResourceLoader> NetworkSession::takeLoaderAwaitingWebProcessTransfer(NetworkResourceLoadIdentifier identifier)
@@ -760,7 +760,7 @@ SWServer& NetworkSession::ensureSWServer()
         // If there's not, then where did this PAL::SessionID come from?
         ASSERT(m_sessionID.isEphemeral() || !path.isEmpty());
         auto inspectable = m_inspectionForServiceWorkersAllowed ? ServiceWorkerIsInspectable::Yes : ServiceWorkerIsInspectable::No;
-        m_swServer = SWServer::create(*this, makeUniqueRef<WebSWOriginStore>(), info.processTerminationDelayEnabled, WTFMove(path), m_sessionID, shouldRunServiceWorkersOnMainThreadForTesting(), m_networkProcess->parentProcessHasServiceWorkerEntitlement(), overrideServiceWorkerRegistrationCountTestingValue(), inspectable);
+        m_swServer = SWServer::create(*this, makeUniqueRef<WebSWOriginStore>(), info.processTerminationDelayEnabled, WTF::move(path), m_sessionID, shouldRunServiceWorkersOnMainThreadForTesting(), m_networkProcess->parentProcessHasServiceWorkerEntitlement(), overrideServiceWorkerRegistrationCountTestingValue(), inspectable);
     }
     return *m_swServer;
 }
@@ -777,13 +777,13 @@ bool NetworkSession::hasServiceWorkerDatabasePath() const
 
 void NetworkSession::requestBackgroundFetchPermission(const ClientOrigin& origin, CompletionHandler<void(bool)>&& callback)
 {
-    m_networkProcess->requestBackgroundFetchPermission(m_sessionID, origin, WTFMove(callback));
+    m_networkProcess->requestBackgroundFetchPermission(m_sessionID, origin, WTF::move(callback));
 }
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 void NetworkSession::setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit)
 {
-    m_bytesPerSecondLimit = WTFMove(bytesPerSecondLimit);
+    m_bytesPerSecondLimit = WTF::move(bytesPerSecondLimit);
 
     m_dataTaskSet.forEach([&] (auto& task) {
         task.setEmulatedConditions(m_bytesPerSecondLimit);
@@ -837,13 +837,13 @@ void NetworkSession::recordHTTPSConnectionTiming(const NetworkLoadMetrics& metri
 
 void NetworkSession::softUpdate(ServiceWorkerJobData&& jobData, bool shouldRefreshCache, WebCore::ResourceRequest&& request, CompletionHandler<void(WebCore::WorkerFetchResult&&)>&& completionHandler)
 {
-    m_softUpdateLoaders.add(ServiceWorkerSoftUpdateLoader::create(*this, WTFMove(jobData), shouldRefreshCache, WTFMove(request), WTFMove(completionHandler)));
+    m_softUpdateLoaders.add(ServiceWorkerSoftUpdateLoader::create(*this, WTF::move(jobData), shouldRefreshCache, WTF::move(request), WTF::move(completionHandler)));
 }
 
 void NetworkSession::createContextConnection(const WebCore::Site& site, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(!site.isEmpty());
-    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::ServiceWorker, site, requestingProcessIdentifier, serviceWorkerPageIdentifier, m_sessionID }, [completionHandler = WTFMove(completionHandler)] (auto) mutable {
+    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::ServiceWorker, site, requestingProcessIdentifier, serviceWorkerPageIdentifier, m_sessionID }, [completionHandler = WTF::move(completionHandler)] (auto) mutable {
         completionHandler();
     }, 0);
 }
@@ -851,7 +851,7 @@ void NetworkSession::createContextConnection(const WebCore::Site& site, std::opt
 void NetworkSession::appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetAppBoundDomains { m_sessionID }, WTFMove(completionHandler), 0);
+    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetAppBoundDomains { m_sessionID }, WTF::move(completionHandler), 0);
 #else
     completionHandler({ });
 #endif
@@ -864,7 +864,7 @@ void NetworkSession::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier w
         return;
     }
 
-    m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), LoadedWebArchive::No, [] { });
+    m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTF::move(firstPartyForCookies), LoadedWebArchive::No, [] { });
 }
 
 RefPtr<SWRegistrationStore> NetworkSession::createRegistrationStore(WebCore::SWServer& server)
@@ -899,32 +899,32 @@ Ref<BackgroundFetchStoreImpl> NetworkSession::ensureProtectedBackgroundFetchStor
 
 void NetworkSession::getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->getAllBackgroundFetchIdentifiers(WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->getAllBackgroundFetchIdentifiers(WTF::move(callback));
 }
 
 void NetworkSession::getBackgroundFetchState(const String& identifier, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->getBackgroundFetchState(identifier, WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->getBackgroundFetchState(identifier, WTF::move(callback));
 }
 
 void NetworkSession::abortBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->abortBackgroundFetch(identifier, WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->abortBackgroundFetch(identifier, WTF::move(callback));
 }
 
 void NetworkSession::pauseBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->pauseBackgroundFetch(identifier, WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->pauseBackgroundFetch(identifier, WTF::move(callback));
 }
 
 void NetworkSession::resumeBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->resumeBackgroundFetch(identifier, WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->resumeBackgroundFetch(identifier, WTF::move(callback));
 }
 
 void NetworkSession::clickBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
 {
-    ensureProtectedBackgroundFetchStore()->clickBackgroundFetch(identifier, WTFMove(callback));
+    ensureProtectedBackgroundFetchStore()->clickBackgroundFetch(identifier, WTF::move(callback));
 }
 
 void NetworkSession::setInspectionForServiceWorkersAllowed(bool inspectable)
@@ -940,7 +940,7 @@ void NetworkSession::setInspectionForServiceWorkersAllowed(bool inspectable)
 
 void NetworkSession::setPersistedDomains(HashSet<WebCore::RegistrableDomain>&& domains)
 {
-    m_persistedDomains = WTFMove(domains);
+    m_persistedDomains = WTF::move(domains);
 
     if (RefPtr resourceLoadStatistics = m_resourceLoadStatistics)
         resourceLoadStatistics->setPersistedDomains(m_persistedDomains);
@@ -969,7 +969,7 @@ Ref<WebCore::ResourceMonitorThrottlerHolder> NetworkSession::protectedResourceMo
 
 void NetworkSession::clearResourceMonitorThrottlerData(CompletionHandler<void()>&& completionHandler)
 {
-    protectedResourceMonitorThrottler()->clearAllData(WTFMove(completionHandler));
+    protectedResourceMonitorThrottler()->clearAllData(WTF::move(completionHandler));
 }
 
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -160,7 +160,7 @@ public:
     std::optional<WebCore::RegistrableDomain> firstPartyHostCNAMEDomain(const String& firstPartyHost);
     void setFirstPartyHostIPAddress(const String& firstPartyHost, const String& addressString);
     std::optional<WebCore::IPAddress> firstPartyHostIPAddress(const String& firstPartyHost);
-    void setThirdPartyCNAMEDomainForTesting(WebCore::RegistrableDomain&& domain) { m_thirdPartyCNAMEDomainForTesting = WTFMove(domain); };
+    void setThirdPartyCNAMEDomainForTesting(WebCore::RegistrableDomain&& domain) { m_thirdPartyCNAMEDomainForTesting = WTF::move(domain); };
     std::optional<WebCore::RegistrableDomain> thirdPartyCNAMEDomainForTesting() const { return m_thirdPartyCNAMEDomainForTesting; }
     void resetFirstPartyDNSData();
     void destroyResourceLoadStatistics(CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -87,12 +87,12 @@ Ref<NetworkConnectionToWebProcess> NetworkSocketChannel::protectedConnectionToWe
 
 void NetworkSocketChannel::sendString(std::span<const uint8_t> message, CompletionHandler<void()>&& callback)
 {
-    protectedSocket()->sendString(message, WTFMove(callback));
+    protectedSocket()->sendString(message, WTF::move(callback));
 }
 
 void NetworkSocketChannel::sendData(std::span<const uint8_t> data, CompletionHandler<void()>&& callback)
 {
-    protectedSocket()->sendData(data, WTFMove(callback));
+    protectedSocket()->sendData(data, WTF::move(callback));
 }
 
 void NetworkSocketChannel::finishClosingIfPossible()
@@ -139,7 +139,7 @@ void NetworkSocketChannel::didClose(unsigned short code, const String& reason)
 
 void NetworkSocketChannel::didReceiveMessageError(String&& errorMessage)
 {
-    m_errorMessage = WTFMove(errorMessage);
+    m_errorMessage = WTF::move(errorMessage);
     m_errorTimer.startOneShot(NetworkProcess::randomClosedPortDelay());
 }
 

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -46,7 +46,7 @@ void Connection::newConnectionWasInitialized() const
 
 static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
-    auto xpcData = encoderToXPCData(WTFMove(encoder));
+    auto xpcData = encoderToXPCData(WTF::move(encoder));
     // FIXME: This is a false positive. <rdar://164843889>
     SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
@@ -57,7 +57,7 @@ static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::En
 
 bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder) const
 {
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
     Daemon::Connection::send(dictionary.get());
 
     return true;
@@ -65,8 +65,8 @@ bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& 
 
 bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
 {
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
-    Daemon::Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
+    Daemon::Connection::sendWithReply(dictionary.get(), [completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY)
             return completionHandler(nullptr);
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -47,14 +47,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkNotificationManager);
 
 Ref<NetworkNotificationManager> NetworkNotificationManager::create(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration, NetworkProcess& networkProcess)
 {
-    return adoptRef(*new NetworkNotificationManager(webPushMachServiceName, WTFMove(configuration), networkProcess));
+    return adoptRef(*new NetworkNotificationManager(webPushMachServiceName, WTF::move(configuration), networkProcess));
 }
 
 NetworkNotificationManager::NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration, NetworkProcess& networkProcess)
     : m_networkProcess(networkProcess)
 {
     if (!webPushMachServiceName.isEmpty())
-        m_connection = WebPushD::Connection::create(webPushMachServiceName.utf8(), WTFMove(configuration));
+        m_connection = WebPushD::Connection::create(webPushMachServiceName.utf8(), WTF::move(configuration));
 }
 
 void NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin(const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& completionHandler)
@@ -65,27 +65,27 @@ void NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin(const S
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetPushAndNotificationsEnabledForOrigin(origin.toString(), enabled), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetPushAndNotificationsEnabledForOrigin(origin.toString(), enabled), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getPendingPushMessage(CompletionHandler<void(const std::optional<WebPushMessage>&)>&& completionHandler)
 {
-    CompletionHandler<void(std::optional<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (auto&& message) mutable {
+    CompletionHandler<void(std::optional<WebPushMessage>&&)> replyHandler = [completionHandler = WTF::move(completionHandler)] (auto&& message) mutable {
         RELEASE_LOG(Push, "Done getting %u push messages", message ? 1 : 0);
-        completionHandler(WTFMove(message));
+        completionHandler(WTF::move(message));
     };
 
-    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), WTFMove(replyHandler));
+    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), WTF::move(replyHandler));
 }
 
 void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
 {
-    CompletionHandler<void(Vector<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<WebPushMessage>&& messages) mutable {
+    CompletionHandler<void(Vector<WebPushMessage>&&)> replyHandler = [completionHandler = WTF::move(completionHandler)] (Vector<WebPushMessage>&& messages) mutable {
         LOG(Push, "Done getting %u push messages", (unsigned)messages.size());
-        completionHandler(WTFMove(messages));
+        completionHandler(WTF::move(messages));
     };
 
-    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessages(), WTFMove(replyHandler));
+    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessages(), WTF::move(replyHandler));
 }
 
 void NetworkNotificationManager::showNotification(const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
@@ -96,12 +96,12 @@ void NetworkNotificationManager::showNotification(const WebCore::NotificationDat
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::ShowNotification { notification, notificationResources }, WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::ShowNotification { notification, notificationResources }, WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
 {
-    showNotification(notification, WTFMove(notificationResources), WTFMove(completionHandler));
+    showNotification(notification, WTF::move(notificationResources), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&& completionHandler)
@@ -112,7 +112,7 @@ void NetworkNotificationManager::getNotifications(const URL& registrationURL, co
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetNotifications { registrationURL, tag }, WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetNotifications { registrationURL, tag }, WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::cancelNotification(WebCore::SecurityOriginData&& origin, const WTF::UUID& notificationID)
@@ -121,7 +121,7 @@ void NetworkNotificationManager::cancelNotification(WebCore::SecurityOriginData&
     if (!connection)
         return;
 
-    connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification { WTFMove(origin), notificationID });
+    connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification { WTF::move(origin), notificationID });
 }
 
 void NetworkNotificationManager::clearNotifications(const Vector<WTF::UUID>&)
@@ -144,7 +144,7 @@ void NetworkNotificationManager::requestPermission(WebCore::SecurityOriginData&&
         return completionHandler(false);
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission { WTFMove(origin) }, WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission { WTF::move(origin) }, WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
@@ -164,7 +164,7 @@ void NetworkNotificationManager::subscribeToPushService(URL&& scopeURL, Vector<u
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SubscribeToPushService(WTFMove(scopeURL), WTFMove(applicationServerKey)), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SubscribeToPushService(WTF::move(scopeURL), WTF::move(applicationServerKey)), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::unsubscribeFromPushService(URL&& scopeURL, std::optional<PushSubscriptionIdentifier> pushSubscriptionIdentifier, CompletionHandler<void(Expected<bool, WebCore::ExceptionData>&&)>&& completionHandler)
@@ -175,7 +175,7 @@ void NetworkNotificationManager::unsubscribeFromPushService(URL&& scopeURL, std:
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::UnsubscribeFromPushService(WTFMove(scopeURL), pushSubscriptionIdentifier), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::UnsubscribeFromPushService(WTF::move(scopeURL), pushSubscriptionIdentifier), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getPushSubscription(URL&& scopeURL, CompletionHandler<void(Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&&)>&& completionHandler)
@@ -186,7 +186,7 @@ void NetworkNotificationManager::getPushSubscription(URL&& scopeURL, CompletionH
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushSubscription(WTFMove(scopeURL)), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushSubscription(WTF::move(scopeURL)), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::incrementSilentPushCount(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& completionHandler)
@@ -197,7 +197,7 @@ void NetworkNotificationManager::incrementSilentPushCount(WebCore::SecurityOrigi
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::IncrementSilentPushCount(WTFMove(origin)), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::IncrementSilentPushCount(WTF::move(origin)), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&& completionHandler)
@@ -208,7 +208,7 @@ void NetworkNotificationManager::removeAllPushSubscriptions(CompletionHandler<vo
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RemoveAllPushSubscriptions(), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RemoveAllPushSubscriptions(), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& completionHandler)
@@ -219,7 +219,7 @@ void NetworkNotificationManager::removePushSubscriptionsForOrigin(WebCore::Secur
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RemovePushSubscriptionsForOrigin(WTFMove(origin)), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RemovePushSubscriptionsForOrigin(WTF::move(origin)), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler)
@@ -230,7 +230,7 @@ void NetworkNotificationManager::getAppBadgeForTesting(CompletionHandler<void(st
         return;
     }
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAppBadgeForTesting(), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAppBadgeForTesting(), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::setServiceWorkerIsBeingInspected(const URL& scopeURL, bool isInspected)
@@ -247,17 +247,17 @@ static void getPushPermissionStateImpl(WebPushD::Connection* connection, WebCore
     if (!connection)
         return completionHandler(WebCore::PushPermissionState::Denied);
 
-    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WTFMove(origin)), WTFMove(completionHandler));
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WTF::move(origin)), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-    getPushPermissionStateImpl(protectedConnection().get(), WTFMove(origin), WTFMove(completionHandler));
+    getPushPermissionStateImpl(protectedConnection().get(), WTF::move(origin), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getPermissionStateSync(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-    getPushPermissionStateImpl(protectedConnection().get(), WTFMove(origin), WTFMove(completionHandler));
+    getPushPermissionStateImpl(protectedConnection().get(), WTF::move(origin), WTF::move(completionHandler));
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkNotificationManager::sharedPreferencesForWebProcess(const IPC::Connection& connection) const

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -39,12 +39,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
 
 Ref<Connection> Connection::create(CString&& machServiceName, WebPushDaemonConnectionConfiguration&& configuration)
 {
-    return adoptRef(*new Connection(WTFMove(machServiceName), WTFMove(configuration)));
+    return adoptRef(*new Connection(WTF::move(machServiceName), WTF::move(configuration)));
 }
 
 Connection::Connection(CString&& machServiceName, WebPushDaemonConnectionConfiguration&& configuration)
-    : Daemon::ConnectionToMachService<ConnectionTraits>(WTFMove(machServiceName))
-    , m_configuration(WTFMove(configuration))
+    : Daemon::ConnectionToMachService<ConnectionTraits>(WTF::move(machServiceName))
+    , m_configuration(WTF::move(configuration))
 {
     LOG(Push, "Creating WebPushD connection to mach service: %s", this->machServiceName().data());
 }

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -47,18 +47,18 @@ public:
 
     static void create(NetworkProcess& networkProcess, PAL::SessionID sessionID, NetworkResourceLoadParameters&& networkResourceLoadParameters, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&& completionHandler)
     {
-        Ref pingLoad = adoptRef(*new PingLoad(networkProcess, sessionID, WTFMove(networkResourceLoadParameters), WTFMove(completionHandler)));
+        Ref pingLoad = adoptRef(*new PingLoad(networkProcess, sessionID, WTF::move(networkResourceLoadParameters), WTF::move(completionHandler)));
 
         // Keep the load alive until didFinish.
-        pingLoad->m_selfReference = WTFMove(pingLoad);
+        pingLoad->m_selfReference = WTF::move(pingLoad);
     }
 
     static void create(NetworkConnectionToWebProcess& networkConnectionToWebProcess, NetworkResourceLoadParameters&& networkResourceLoadParameters, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&& completionHandler)
     {
-        Ref pingLoad = adoptRef(*new PingLoad(networkConnectionToWebProcess, WTFMove(networkResourceLoadParameters), WTFMove(completionHandler)));
+        Ref pingLoad = adoptRef(*new PingLoad(networkConnectionToWebProcess, WTF::move(networkResourceLoadParameters), WTF::move(completionHandler)));
 
         // Keep the load alive until didFinish.
-        pingLoad->m_selfReference = WTFMove(pingLoad);
+        pingLoad->m_selfReference = WTF::move(pingLoad);
     }
 
     ~PingLoad();

--- a/Source/WebKit/NetworkProcess/PreconnectTask.cpp
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.cpp
@@ -41,11 +41,11 @@ using namespace WebCore;
 
 Ref<PreconnectTask> PreconnectTask::create(NetworkSession& networkSession, NetworkLoadParameters&& parameters)
 {
-    return adoptRef(*new PreconnectTask(networkSession, WTFMove(parameters)));
+    return adoptRef(*new PreconnectTask(networkSession, WTF::move(parameters)));
 }
 
 PreconnectTask::PreconnectTask(NetworkSession& networkSession, NetworkLoadParameters&& parameters)
-    : m_networkLoad(NetworkLoad::create(*this, WTFMove(parameters), networkSession))
+    : m_networkLoad(NetworkLoad::create(*this, WTF::move(parameters), networkSession))
 {
     RELEASE_LOG(Network, "%p - PreconnectTask::PreconnectTask()", this);
 
@@ -54,14 +54,14 @@ PreconnectTask::PreconnectTask(NetworkSession& networkSession, NetworkLoadParame
 
 void PreconnectTask::setH2PingCallback(const URL& url, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&& completionHandler)
 {
-    m_networkLoad->setH2PingCallback(url, WTFMove(completionHandler));
+    m_networkLoad->setH2PingCallback(url, WTF::move(completionHandler));
 }
 
 void PreconnectTask::start(CompletionHandler<void(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&)>&& completionHandler, Seconds timeout)
 {
     RELEASE_LOG(Network, "%p - PreconnectTask::start() timeout=%g", this, timeout.value());
     // Keep `this` alive until completion of the network load.
-    m_completionHandler = [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& metrics) mutable {
+    m_completionHandler = [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& metrics) mutable {
         if (completionHandler)
             completionHandler(error, metrics);
     };
@@ -84,7 +84,7 @@ void PreconnectTask::willSendRedirectedRequest(ResourceRequest&&, ResourceReques
     url.setProtocol("https"_s);
     ASSERT(redirectRequest.url() == url);
 #endif
-    completionHandler(WTFMove(redirectRequest));
+    completionHandler(WTF::move(redirectRequest));
 }
 
 void PreconnectTask::didReceiveResponse(ResourceResponse&& response, PrivateRelayed, ResponseCompletionHandler&& completionHandler)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.cpp
@@ -32,11 +32,11 @@ namespace WebKit::PCM {
 
 Ref<Connection> Connection::create(CString&& machServiceName, NetworkSession& networkSession)
 {
-    return adoptRef(*new Connection(WTFMove(machServiceName), networkSession));
+    return adoptRef(*new Connection(WTF::move(machServiceName), networkSession));
 }
 
 Connection::Connection(CString&& machServiceName, NetworkSession& networkSession)
-    : Daemon::ConnectionToMachService<ConnectionTraits>(WTFMove(machServiceName))
+    : Daemon::ConnectionToMachService<ConnectionTraits>(WTF::move(machServiceName))
     , m_networkSession(networkSession)
 {
 }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -311,12 +311,12 @@ std::pair<std::optional<WebCore::PCM::AttributionSecondsUntilSendData>, DebugInf
     if (previouslyUnattributed) {
         // Always convert the pending attribution and remove it from the unattributed map.
         removeUnattributed(*previouslyUnattributed);
-        secondsUntilSend = previouslyUnattributed.value().attributeAndGetEarliestTimeToSend(WTFMove(attributionTriggerData), isRunningTest);
+        secondsUntilSend = previouslyUnattributed.value().attributeAndGetEarliestTimeToSend(WTF::move(attributionTriggerData), isRunningTest);
 
         // We should always have a valid secondsUntilSend value for a previouslyUnattributed value because there can be no previous attribution with a higher priority.
         if (!secondsUntilSend.hasValidSecondsUntilSendValues()) {
             ASSERT_NOT_REACHED();
-            return { std::nullopt, WTFMove(debugInfo) };
+            return { std::nullopt, WTF::move(debugInfo) };
         }
 
         RELEASE_LOG_INFO(PrivateClickMeasurement, "Converted a stored ad click with attribution trigger data: %u and priority: %u.", data, priority);
@@ -324,7 +324,7 @@ std::pair<std::optional<WebCore::PCM::AttributionSecondsUntilSendData>, DebugInf
 
         // If there is no previous attribution, or the new attribution has higher priority, insert/update the database.
         if (!previouslyAttributed || previouslyUnattributed.value().hasHigherPriorityThan(*previouslyAttributed)) {
-            insertPrivateClickMeasurement(WTFMove(*previouslyUnattributed), PrivateClickMeasurementAttributionType::Attributed);
+            insertPrivateClickMeasurement(WTF::move(*previouslyUnattributed), PrivateClickMeasurementAttributionType::Attributed);
 
             RELEASE_LOG_INFO(PrivateClickMeasurement, "Replaced a previously converted ad click with a new one with attribution data: %u and priority: %u because it had higher priority.", data, priority);
             debugInfo.messages.append({ MessageLevel::Info, makeString("[Private Click Measurement] Replaced a previously converted ad click with a new one with attribution trigger data: '"_s, data, "' and priority: '"_s, priority, "' because it had higher priority."_s) });
@@ -333,11 +333,11 @@ std::pair<std::optional<WebCore::PCM::AttributionSecondsUntilSendData>, DebugInf
         // If we have no new attribution, re-attribute the old one to respect the new priority, but only if this report has
         // not been sent to the source or destination site yet.
         if (!previouslyAttributed.value().hasPreviouslyBeenReported()) {
-            auto secondsUntilSend = previouslyAttributed.value().attributeAndGetEarliestTimeToSend(WTFMove(attributionTriggerData), isRunningTest);
+            auto secondsUntilSend = previouslyAttributed.value().attributeAndGetEarliestTimeToSend(WTF::move(attributionTriggerData), isRunningTest);
             if (!secondsUntilSend.hasValidSecondsUntilSendValues())
-                return { std::nullopt, WTFMove(debugInfo) };
+                return { std::nullopt, WTF::move(debugInfo) };
 
-            insertPrivateClickMeasurement(WTFMove(*previouslyAttributed), PrivateClickMeasurementAttributionType::Attributed);
+            insertPrivateClickMeasurement(WTF::move(*previouslyAttributed), PrivateClickMeasurementAttributionType::Attributed);
 
             RELEASE_LOG_INFO(PrivateClickMeasurement, "Re-converted an ad click with a new one with attribution trigger data: %u and priority: %u because it had higher priority.", data, priority);
             debugInfo.messages.append({ MessageLevel::Info, makeString("[Private Click Measurement] Re-converted an ad click with a new one with attribution trigger data: '"_s, data, "' and priority: '"_s, priority, "'' because it had higher priority."_s) });
@@ -345,9 +345,9 @@ std::pair<std::optional<WebCore::PCM::AttributionSecondsUntilSendData>, DebugInf
     }
 
     if (!secondsUntilSend.hasValidSecondsUntilSendValues())
-        return { std::nullopt, WTFMove(debugInfo) };
+        return { std::nullopt, WTF::move(debugInfo) };
 
-    return { secondsUntilSend, WTFMove(debugInfo) };
+    return { secondsUntilSend, WTF::move(debugInfo) };
 }
 
 void Database::removeUnattributed(WebCore::PrivateClickMeasurement& attribution)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp
@@ -37,7 +37,7 @@ DebugInfo DebugInfo::isolatedCopy() const &
 
 DebugInfo DebugInfo::isolatedCopy() &&
 {
-    return { crossThreadCopy(WTFMove(messages)) };
+    return { crossThreadCopy(WTF::move(messages)) };
 }
 
 DebugInfo::Message DebugInfo::Message::isolatedCopy() const &
@@ -47,7 +47,7 @@ DebugInfo::Message DebugInfo::Message::isolatedCopy() const &
 
 DebugInfo::Message DebugInfo::Message::isolatedCopy() &&
 {
-    return { messageLevel, WTFMove(message).isolatedCopy() };
+    return { messageLevel, WTF::move(message).isolatedCopy() };
 }
 
 } // namespace WebKit::PCM

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
@@ -39,7 +39,7 @@ void EphemeralStore::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurem
 {
     ASSERT(attribution.isEphemeral() == WebCore::PCM::AttributionEphemeral::Yes);
     ASSERT_UNUSED(type, type == PrivateClickMeasurementAttributionType::Unattributed);
-    m_clickMeasurement = WTFMove(attribution);
+    m_clickMeasurement = WTF::move(attribution);
     completionHandler();
 }
 
@@ -53,15 +53,15 @@ void EphemeralStore::attributePrivateClickMeasurement(WebCore::PCM::SourceSite&&
 {
     DebugInfo debugInfo;
     if (!m_clickMeasurement)
-        return completionHandler(std::nullopt, WTFMove(debugInfo));
+        return completionHandler(std::nullopt, WTF::move(debugInfo));
 
     if (m_clickMeasurement->sourceSite() != sourceSite || m_clickMeasurement->destinationSite() != destinationSite)
-        return completionHandler(std::nullopt, WTFMove(debugInfo));
+        return completionHandler(std::nullopt, WTF::move(debugInfo));
 
     if (!applicationBundleIdentifier.isEmpty() && m_clickMeasurement->sourceApplicationBundleID() != applicationBundleIdentifier)
-        return completionHandler(std::nullopt, WTFMove(debugInfo));
+        return completionHandler(std::nullopt, WTF::move(debugInfo));
 
-    completionHandler(m_clickMeasurement->attributeAndGetEarliestTimeToSend(WTFMove(attributionTriggerData), isLayoutTest), WTFMove(debugInfo));
+    completionHandler(m_clickMeasurement->attributeAndGetEarliestTimeToSend(WTF::move(attributionTriggerData), isLayoutTest), WTF::move(debugInfo));
 }
 
 void EphemeralStore::privateClickMeasurementToStringForTesting(CompletionHandler<void(String)>&& completionHandler) const
@@ -146,8 +146,8 @@ void EphemeralStore::clearSentAttribution(WebCore::PrivateClickMeasurement&& att
         return;
     }
 
-    attributionToClear.setTimesToSend(WTFMove(timesToSend));
-    m_clickMeasurement = WTFMove(attributionToClear);
+    attributionToClear.setTimesToSend(WTF::move(timesToSend));
+    m_clickMeasurement = WTF::move(attributionToClear);
 }
 
 void EphemeralStore::close(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -203,7 +203,7 @@ void handlePCMMessage(std::span<const uint8_t> encodedMessage)
     if (!arguments) [[unlikely]]
         return;
 
-    IPC::callMemberFunction(&daemonManagerSingleton(), Info::MemberFunction, WTFMove(*arguments));
+    IPC::callMemberFunction(&daemonManagerSingleton(), Info::MemberFunction, WTF::move(*arguments));
 }
 
 static void handlePCMMessageSetDebugModeIsEnabled(const Daemon::Connection& connection, std::span<const uint8_t> encodedMessage)
@@ -236,11 +236,11 @@ void handlePCMMessageWithReply(std::span<const uint8_t> encodedMessage, Completi
     if (!arguments) [[unlikely]]
         return;
 
-    typename Info::Reply completionHandler { [replySender = WTFMove(replySender)] (auto&&... args) mutable {
+    typename Info::Reply completionHandler { [replySender = WTF::move(replySender)] (auto&&... args) mutable {
         replySender(Info::encodeReply(args...));
     }};
 
-    IPC::callMemberFunction(&daemonManagerSingleton(), Info::MemberFunction, WTFMove(*arguments), WTFMove(completionHandler));
+    IPC::callMemberFunction(&daemonManagerSingleton(), Info::MemberFunction, WTF::move(*arguments), WTF::move(completionHandler));
 }
 
 void doDailyActivityInManager()
@@ -253,16 +253,16 @@ void decodeMessageAndSendToManager(const Daemon::Connection& connection, Message
     ASSERT(messageTypeSendsReply(messageType) == !!replySender);
     switch (messageType) {
     case PCM::MessageType::StoreUnattributed:
-        handlePCMMessageWithReply<MessageInfo::storeUnattributed>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::storeUnattributed>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::HandleAttribution:
         handlePCMMessage<MessageInfo::handleAttribution>(encodedMessage);
         break;
     case PCM::MessageType::Clear:
-        handlePCMMessageWithReply<MessageInfo::clear>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::clear>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::ClearForRegistrableDomain:
-        handlePCMMessageWithReply<MessageInfo::clearForRegistrableDomain>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::clearForRegistrableDomain>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::SetDebugModeIsEnabled:
         handlePCMMessageSetDebugModeIsEnabled(connection, encodedMessage);
@@ -271,7 +271,7 @@ void decodeMessageAndSendToManager(const Daemon::Connection& connection, Message
         handlePCMMessage<MessageInfo::migratePrivateClickMeasurementFromLegacyStorage>(encodedMessage);
         break;
     case PCM::MessageType::ToStringForTesting:
-        handlePCMMessageWithReply<MessageInfo::toStringForTesting>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::toStringForTesting>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::SetOverrideTimerForTesting:
         handlePCMMessage<MessageInfo::setOverrideTimerForTesting>(encodedMessage);
@@ -289,7 +289,7 @@ void decodeMessageAndSendToManager(const Daemon::Connection& connection, Message
         handlePCMMessage<MessageInfo::markAllUnattributedAsExpiredForTesting>(encodedMessage);
         break;
     case PCM::MessageType::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting:
-        handlePCMMessageWithReply<MessageInfo::markAttributedPrivateClickMeasurementsAsExpiredForTesting>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::markAttributedPrivateClickMeasurementsAsExpiredForTesting>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::SetPCMFraudPreventionValuesForTesting:
         handlePCMMessage<MessageInfo::setPCMFraudPreventionValuesForTesting>(encodedMessage);
@@ -301,7 +301,7 @@ void decodeMessageAndSendToManager(const Daemon::Connection& connection, Message
         handlePCMMessage<MessageInfo::setPrivateClickMeasurementAppBundleIDForTesting>(encodedMessage);
         break;
     case PCM::MessageType::DestroyStoreForTesting:
-        handlePCMMessageWithReply<MessageInfo::destroyStoreForTesting>(encodedMessage, WTFMove(replySender));
+        handlePCMMessageWithReply<MessageInfo::destroyStoreForTesting>(encodedMessage, WTF::move(replySender));
         break;
     case PCM::MessageType::AllowTLSCertificateChainForLocalPCMTesting:
         handlePCMMessage<MessageInfo::allowTLSCertificateChainForLocalPCMTesting>(encodedMessage);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
@@ -57,7 +57,7 @@ template<> struct ReplyCaller<String> {
         decoder >> string;
         if (!string)
             return completionHandler({ });
-        completionHandler(WTFMove(*string));
+        completionHandler(WTF::move(*string));
     }
 };
 
@@ -66,9 +66,9 @@ void ManagerProxy::sendMessageWithReply(CompletionHandler<void(ReplyArgs...)>&& 
 {
     Daemon::Encoder encoder;
     encoder.encode(std::forward<Args>(args)...);
-    m_connection->sendWithReply(messageType, encoder.takeBuffer(), [completionHandler = WTFMove(completionHandler)] (auto replyBuffer) mutable {
-        Daemon::Decoder decoder(WTFMove(replyBuffer));
-        ReplyCaller<ReplyArgs...>::callReply(WTFMove(decoder), WTFMove(completionHandler));
+    m_connection->sendWithReply(messageType, encoder.takeBuffer(), [completionHandler = WTF::move(completionHandler)] (auto replyBuffer) mutable {
+        Daemon::Decoder decoder(WTF::move(replyBuffer));
+        ReplyCaller<ReplyArgs...>::callReply(WTF::move(decoder), WTF::move(completionHandler));
     });
 }
 
@@ -83,7 +83,7 @@ ManagerProxy::ManagerProxy(const String& machServiceName, NetworkSession& networ
 
 void ManagerProxy::storeUnattributed(WebCore::PrivateClickMeasurement&& pcm, CompletionHandler<void()>&& completionHandler)
 {
-    sendMessageWithReply<MessageType::StoreUnattributed>(WTFMove(completionHandler), pcm);
+    sendMessageWithReply<MessageType::StoreUnattributed>(WTF::move(completionHandler), pcm);
 }
 
 void ManagerProxy::handleAttribution(WebCore::PCM::AttributionTriggerData&& triggerData, const URL& requestURL, WebCore::RegistrableDomain&& redirectDomain, const URL& firstPartyURL, const ApplicationBundleIdentifier& applicationBundleIdentifier)
@@ -93,12 +93,12 @@ void ManagerProxy::handleAttribution(WebCore::PCM::AttributionTriggerData&& trig
 
 void ManagerProxy::clear(CompletionHandler<void()>&& completionHandler)
 {
-    sendMessageWithReply<MessageType::Clear>(WTFMove(completionHandler));
+    sendMessageWithReply<MessageType::Clear>(WTF::move(completionHandler));
 }
 
 void ManagerProxy::clearForRegistrableDomain(WebCore::RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    sendMessageWithReply<MessageType::ClearForRegistrableDomain>(WTFMove(completionHandler), domain);
+    sendMessageWithReply<MessageType::ClearForRegistrableDomain>(WTF::move(completionHandler), domain);
 }
 
 void ManagerProxy::setDebugModeIsEnabled(bool enabled)
@@ -113,7 +113,7 @@ void ManagerProxy::migratePrivateClickMeasurementFromLegacyStorage(WebCore::Priv
 
 void ManagerProxy::toStringForTesting(CompletionHandler<void(String)>&& completionHandler) const
 {
-    sendMessageWithReply<MessageType::ToStringForTesting>(WTFMove(completionHandler));
+    sendMessageWithReply<MessageType::ToStringForTesting>(WTF::move(completionHandler));
 }
 
 void ManagerProxy::setOverrideTimerForTesting(bool value)
@@ -143,7 +143,7 @@ void ManagerProxy::markAllUnattributedAsExpiredForTesting()
 
 void ManagerProxy::markAttributedPrivateClickMeasurementsAsExpiredForTesting(CompletionHandler<void()>&& completionHandler)
 {
-    sendMessageWithReply<MessageType::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting>(WTFMove(completionHandler));
+    sendMessageWithReply<MessageType::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting>(WTF::move(completionHandler));
 }
 
 void ManagerProxy::setPCMFraudPreventionValuesForTesting(String&& unlinkableToken, String&& secretToken, String&& signature, String&& keyID)
@@ -163,7 +163,7 @@ void ManagerProxy::setPrivateClickMeasurementAppBundleIDForTesting(ApplicationBu
 
 void ManagerProxy::destroyStoreForTesting(CompletionHandler<void()>&& completionHandler)
 {
-    sendMessageWithReply<MessageType::DestroyStoreForTesting>(WTFMove(completionHandler));
+    sendMessageWithReply<MessageType::DestroyStoreForTesting>(WTF::move(completionHandler));
 }
 
 void ManagerProxy::allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo& certificateInfo)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -64,7 +64,7 @@ XPCObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType message
 {
     // FIXME: This is a false positive. <rdar://164843889>
     SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
-    addVersionAndEncodedMessageToDictionary(WTFMove(message), dictionary.get());
+    addVersionAndEncodedMessageToDictionary(WTF::move(message), dictionary.get());
     xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;
 }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -127,7 +127,7 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
     setPCMDataCarriedOnRequest(pcmDataCarried, request.get());
 
     auto identifier = LoadTaskIdentifier::generate();
-    RetainPtr task = [statelessSessionWithoutRedirectsSingleton() dataTaskWithRequest:request.get() completionHandler:makeBlockPtr([callback = WTFMove(callback), identifier](NSData *data, NSURLResponse *response, NSError *error) mutable {
+    RetainPtr task = [statelessSessionWithoutRedirectsSingleton() dataTaskWithRequest:request.get() completionHandler:makeBlockPtr([callback = WTF::move(callback), identifier](NSData *data, NSURLResponse *response, NSError *error) mutable {
         taskMap().remove(identifier);
         if (error)
             return callback(error.localizedDescription, { });

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementXPCUtilities.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementXPCUtilities.mm
@@ -36,7 +36,7 @@ void addVersionAndEncodedMessageToDictionary(Vector<uint8_t>&& message, xpc_obje
 {
     ASSERT(xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY);
     xpc_dictionary_set_uint64(dictionary, PCM::protocolVersionKey, PCM::protocolVersionValue);
-    xpc_dictionary_set_value(dictionary, PCM::protocolEncodedMessageKey, vectorToXPCData(WTFMove(message)).get());
+    xpc_dictionary_set_value(dictionary, PCM::protocolEncodedMessageKey, vectorToXPCData(WTF::move(message)).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -97,7 +97,7 @@ template<typename Message> bool ServiceWorkerDownloadTask::sendToServiceWorker(M
 
 void ServiceWorkerDownloadTask::dispatch(Function<void()>&& function)
 {
-    serviceWorkerDownloadTaskQueueSingleton().dispatch([protectedThis = Ref { *this }, function = WTFMove(function)] {
+    serviceWorkerDownloadTaskQueueSingleton().dispatch([protectedThis = Ref { *this }, function = WTF::move(function)] {
         function();
     });
 }
@@ -147,7 +147,7 @@ void ServiceWorkerDownloadTask::setPendingDownloadLocation(const WTF::String& fi
     NetworkDataTask::setPendingDownloadLocation(filename, { }, allowOverwrite);
 
     ASSERT(!m_sandboxExtension);
-    m_sandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+    m_sandboxExtension = SandboxExtension::create(WTF::move(sandboxExtensionHandle));
     if (RefPtr sandboxExtension = m_sandboxExtension)
         sandboxExtension->consume();
 
@@ -232,7 +232,7 @@ void ServiceWorkerDownloadTask::didFinish()
         if (RefPtr download = m_networkProcess->checkedDownloadManager()->download(*m_pendingDownloadID)) {
 #if HAVE(MODERN_DOWNLOADPROGRESS)
             if (RefPtr sandboxExtension = std::exchange(m_sandboxExtension, nullptr))
-                download->setSandboxExtension(WTFMove(sandboxExtension));
+                download->setSandboxExtension(WTF::move(sandboxExtension));
 #endif
             download->didFinish();
         }
@@ -246,7 +246,7 @@ void ServiceWorkerDownloadTask::didFail(ResourceError&& error)
 {
     ASSERT(!isMainRunLoop());
 
-    didFailDownload(WTFMove(error));
+    didFailDownload(WTF::move(error));
 }
 
 void ServiceWorkerDownloadTask::didFailDownload(std::optional<ResourceError>&& error)
@@ -255,7 +255,7 @@ void ServiceWorkerDownloadTask::didFailDownload(std::optional<ResourceError>&& e
 
     m_downloadFile = { };
 
-    callOnMainRunLoop([this, protectedThis = Ref { *this }, error = crossThreadCopy(WTFMove(error))] {
+    callOnMainRunLoop([this, protectedThis = Ref { *this }, error = crossThreadCopy(WTF::move(error))] {
         if (m_state == State::Completed)
             return;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -82,7 +82,7 @@ public:
     WebCore::FetchIdentifier fetchIdentifier() const { return m_fetchIdentifier; }
     std::optional<WebCore::ServiceWorkerIdentifier> serviceWorkerIdentifier() const { return m_serviceWorkerIdentifier; }
 
-    WebCore::ResourceRequest takeRequest() { return WTFMove(m_currentRequest); }
+    WebCore::ResourceRequest takeRequest() { return WTF::move(m_currentRequest); }
 
     void cannotHandle();
     void contextClosed();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -46,12 +46,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerSoftUpdateLoader);
 
 Ref<ServiceWorkerSoftUpdateLoader> ServiceWorkerSoftUpdateLoader::create(NetworkSession& session, WebCore::ServiceWorkerJobData&& jobData, bool shouldRefreshCache, WebCore::ResourceRequest&& request, Handler&& completionHandler)
 {
-    return adoptRef(*new ServiceWorkerSoftUpdateLoader(session, WTFMove(jobData), shouldRefreshCache, WTFMove(request), WTFMove(completionHandler)));
+    return adoptRef(*new ServiceWorkerSoftUpdateLoader(session, WTF::move(jobData), shouldRefreshCache, WTF::move(request), WTF::move(completionHandler)));
 }
 
 ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& session, ServiceWorkerJobData&& jobData, bool shouldRefreshCache, ResourceRequest&& request, Handler&& completionHandler)
-    : m_completionHandler(WTFMove(completionHandler))
-    , m_jobData(WTFMove(jobData))
+    : m_completionHandler(WTF::move(completionHandler))
+    , m_jobData(WTF::move(jobData))
     , m_session(session)
 {
     ASSERT(!request.isConditional());
@@ -76,7 +76,7 @@ ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& ses
 
             request.setCachePolicy(ResourceRequestCachePolicy::RefreshAnyCacheData);
             if (entry) {
-                m_cacheEntry = WTFMove(entry);
+                m_cacheEntry = WTF::move(entry);
 
                 String eTag = m_cacheEntry->response().httpHeaderField(HTTPHeaderName::ETag);
                 if (!eTag.isEmpty())
@@ -86,11 +86,11 @@ ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& ses
                 if (!lastModified.isEmpty())
                     request.setHTTPHeaderField(HTTPHeaderName::IfModifiedSince, lastModified);
             }
-            loadFromNetwork(CheckedRef { *m_session }.get(), WTFMove(request));
+            loadFromNetwork(CheckedRef { *m_session }.get(), WTF::move(request));
         });
         return;
     }
-    loadFromNetwork(session, WTFMove(request));
+    loadFromNetwork(session, WTF::move(request));
 }
 
 ServiceWorkerSoftUpdateLoader::~ServiceWorkerSoftUpdateLoader()
@@ -104,7 +104,7 @@ void ServiceWorkerSoftUpdateLoader::fail(ResourceError&& error)
     if (!m_completionHandler)
         return;
 
-    m_completionHandler(workerFetchError(WTFMove(error)));
+    m_completionHandler(workerFetchError(WTF::move(error)));
     didComplete();
 }
 
@@ -112,7 +112,7 @@ void ServiceWorkerSoftUpdateLoader::loadWithCacheEntry(NetworkCache::Entry& entr
 {
     auto error = processResponse(entry.response());
     if (!error.isNull()) {
-        fail(WTFMove(error));
+        fail(WTF::move(error));
         return;
     }
 
@@ -128,8 +128,8 @@ void ServiceWorkerSoftUpdateLoader::loadFromNetwork(NetworkSession& session, Res
     parameters.contentSniffingPolicy = ContentSniffingPolicy::DoNotSniffContent;
     parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
     parameters.needsCertificateInfo = true;
-    parameters.request = WTFMove(request);
-    Ref networkLoad = NetworkLoad::create(*this, WTFMove(parameters), session);
+    parameters.request = WTF::move(request);
+    Ref networkLoad = NetworkLoad::create(*this, WTF::move(parameters), session);
     m_networkLoad = networkLoad.copyRef();
     networkLoad->start();
 
@@ -154,7 +154,7 @@ void ServiceWorkerSoftUpdateLoader::didReceiveResponse(ResourceResponse&& respon
     }
     auto error = processResponse(response);
     if (!error.isNull()) {
-        fail(WTFMove(error));
+        fail(WTF::move(error));
         completionHandler(PolicyAction::Ignore);
         return;
     }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -88,7 +88,7 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
     auto handle = m_store->createSharedMemoryHandle();
     if (!handle)
         return;
-    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(WTFMove(*handle)));
+    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(WTF::move(*handle)));
 }
 
 void WebSWOriginStore::didInvalidateSharedMemory()

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -58,7 +58,7 @@ void WebSWRegistrationStore::clearAll(CompletionHandler<void()>&& callback)
     m_updateTimer.stop();
 
     if (RefPtr manager = m_manager.get())
-        manager->clearServiceWorkerRegistrations(WTFMove(callback));
+        manager->clearServiceWorkerRegistrations(WTF::move(callback));
     else
         callback();
 }
@@ -68,13 +68,13 @@ void WebSWRegistrationStore::flushChanges(CompletionHandler<void()>&& callback)
     if (m_updateTimer.isActive())
         m_updateTimer.stop();
 
-    updateToStorage(WTFMove(callback));
+    updateToStorage(WTF::move(callback));
 }
 
 void WebSWRegistrationStore::closeFiles(CompletionHandler<void()>&& callback)
 {
     if (RefPtr manager = m_manager.get())
-        manager->closeServiceWorkerRegistrationFiles(WTFMove(callback));
+        manager->closeServiceWorkerRegistrationFiles(WTF::move(callback));
     else
         callback();
 }
@@ -82,7 +82,7 @@ void WebSWRegistrationStore::closeFiles(CompletionHandler<void()>&& callback)
 void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& callback)
 {
     if (RefPtr manager = m_manager.get())
-        manager->importServiceWorkerRegistrations(WTFMove(callback));
+        manager->importServiceWorkerRegistrations(WTF::move(callback));
     else
         callback(std::nullopt);
 }
@@ -119,7 +119,7 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
         if (!registation)
             registrationsToDelete.append(key);
         else
-            registrationsToUpdate.append(WTFMove(*registation));
+            registrationsToUpdate.append(WTF::move(*registation));
     }
     m_updates.clear();
 
@@ -127,16 +127,16 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
     if (!manager)
         return callback();
 
-    manager->updateServiceWorkerRegistrations(WTFMove(registrationsToUpdate), WTFMove(registrationsToDelete), [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
+    manager->updateServiceWorkerRegistrations(WTF::move(registrationsToUpdate), WTF::move(registrationsToDelete), [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& result) mutable {
         ASSERT(RunLoop::isMain());
 
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !protectedThis->m_server || !result)
             return callback();
 
-        auto allScripts = WTFMove(result.value());
+        auto allScripts = WTF::move(result.value());
         for (auto&& scripts : allScripts)
-            protectedThis->protectedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTFMove(scripts.mainScript), WTFMove(scripts.importedScripts));
+            protectedThis->protectedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTF::move(scripts.mainScript), WTF::move(scripts.importedScripts));
 
         callback();
     });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -148,7 +148,7 @@ void WebSWServerConnection::resolveUnregistrationJobInClient(ServiceWorkerJobIde
         }
 
         auto scopeURL = registrationKey.scope();
-        checkedSession->notificationManager().unsubscribeFromPushService(WTFMove(scopeURL), std::nullopt, [completionHandler = WTFMove(completionHandler), unregistrationResult](auto&&) mutable {
+        checkedSession->notificationManager().unsubscribeFromPushService(WTF::move(scopeURL), std::nullopt, [completionHandler = WTF::move(completionHandler), unregistrationResult](auto&&) mutable {
             completionHandler(unregistrationResult);
         });
 
@@ -233,9 +233,9 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
 
     auto ancestorOrigins = map(parameters.frameAncestorOrigins, [](auto& origin) { return origin->toString(); });
     auto advancedPrivacyProtections = server->advancedPrivacyProtectionsFromClient(registration.key().clientOrigin());
-    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, advancedPrivacyProtections, false, false, 0, WTFMove(ancestorOrigins) };
+    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, advancedPrivacyProtections, false, false, 0, WTF::move(ancestorOrigins) };
 
-    registerServiceWorkerClientInternal(ClientOrigin { registration.key().topOrigin(), SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url()) }, WTFMove(data), registration.identifier(), request.httpUserAgent(), WebCore::SWServer::IsBeingCreatedClient::Yes);
+    registerServiceWorkerClientInternal(ClientOrigin { registration.key().topOrigin(), SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url()) }, WTF::move(data), registration.identifier(), request.httpUserAgent(), WebCore::SWServer::IsBeingCreatedClient::Yes);
 }
 
 RefPtr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(NetworkResourceLoader& loader, const ResourceRequest& request)
@@ -339,7 +339,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
             server->createContextConnection(worker->topSite(), worker->serviceWorkerPageIdentifier());
 
         auto identifier = *task->serviceWorkerIdentifier();
-        server->runServiceWorkerIfNecessary(identifier, [weakThis = WTFMove(weakThis), task = WTFMove(task)](auto* contextConnection) mutable {
+        server->runServiceWorkerIfNecessary(identifier, [weakThis = WTF::move(weakThis), task = WTF::move(task)](auto* contextConnection) mutable {
             if (!task)
                 return;
 
@@ -359,7 +359,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
         });
     };
 
-    worker.whenActivated(WTFMove(runServerWorkerAndStartFetch));
+    worker.whenActivated(WTF::move(runServerWorkerAndStartFetch));
 }
 
 void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier destinationIdentifier, MessageWithMessagePorts&& message, const ServiceWorkerOrClientIdentifier& sourceIdentifier)
@@ -385,9 +385,9 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
         return;
 
     // It's possible this specific worker cannot be re-run (e.g. its registration has been removed)
-    server->runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTFMove(message), sourceData = WTFMove(*sourceData)](auto* contextConnection) mutable {
+    server->runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTF::move(message), sourceData = WTF::move(*sourceData)](auto* contextConnection) mutable {
         if (contextConnection)
-            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), WTFMove(sourceData) });
+            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTF::move(message), WTF::move(sourceData) });
     });
 }
 
@@ -405,7 +405,7 @@ void WebSWServerConnection::scheduleJobInServer(ServiceWorkerJobData&& jobData)
     ASSERT(identifier() == jobData.connectionIdentifier());
 
     if (RefPtr server = this->server())
-        server->scheduleJob(WTFMove(jobData));
+        server->scheduleJob(WTF::move(jobData));
 }
 
 URL WebSWServerConnection::clientURLFromIdentifier(ServiceWorkerOrClientIdentifier contextIdentifier)
@@ -449,9 +449,9 @@ void WebSWServerConnection::scheduleUnregisterJobInServer(ServiceWorkerJobIdenti
         return completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "Client is unknown"_s }));
 
     ASSERT(!m_unregisterJobs.contains(jobIdentifier));
-    m_unregisterJobs.add(jobIdentifier, WTFMove(completionHandler));
+    m_unregisterJobs.add(jobIdentifier, WTF::move(completionHandler));
 
-    server->scheduleUnregisterJob(ServiceWorkerJobDataIdentifier { identifier(), jobIdentifier }, *registration, contextIdentifier, WTFMove(clientURL));
+    server->scheduleUnregisterJob(ServiceWorkerJobDataIdentifier { identifier(), jobIdentifier }, *registration, contextIdentifier, WTF::move(clientURL));
 }
 
 void WebSWServerConnection::postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const SecurityOriginData& sourceOrigin)
@@ -480,7 +480,7 @@ void WebSWServerConnection::whenRegistrationReady(const WebCore::SecurityOriginD
 {
     checkTopOrigin(topOrigin);
 
-    SWServer::Connection::whenRegistrationReady(topOrigin, clientURL, WTFMove(callback));
+    SWServer::Connection::whenRegistrationReady(topOrigin, clientURL, WTF::move(callback));
 }
 
 void WebSWServerConnection::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(const Vector<ServiceWorkerRegistrationData>&)>&& callback)
@@ -498,7 +498,7 @@ void WebSWServerConnection::registerServiceWorkerClient(WebCore::ClientOrigin&& 
     MESSAGE_CHECK(data.identifier.processIdentifier() == identifier());
     checkTopOrigin(clientOrigin.topOrigin);
 
-    registerServiceWorkerClientInternal(WTFMove(clientOrigin), WTFMove(data), controllingServiceWorkerRegistrationIdentifier, WTFMove(userAgent), SWServer::IsBeingCreatedClient::No);
+    registerServiceWorkerClientInternal(WTF::move(clientOrigin), WTF::move(data), controllingServiceWorkerRegistrationIdentifier, WTF::move(userAgent), SWServer::IsBeingCreatedClient::No);
 }
 
 void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientOrigin&& clientOrigin, ServiceWorkerClientData&& data, const std::optional<ServiceWorkerRegistrationIdentifier>& controllingServiceWorkerRegistrationIdentifier, String&& userAgent, WebCore::SWServer::IsBeingCreatedClient isBeingCreatedClient)
@@ -528,7 +528,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
             send(Messages::WebSWClientConnection::PostMessageToServiceWorkerClient { data.identifier, pendingMessage.message, pendingMessage.sourceData, pendingMessage.sourceOrigin }, 0);
     }
 
-    server->registerServiceWorkerClient(WTFMove(clientOrigin), WTFMove(data), controllingServiceWorkerRegistrationIdentifier, WTFMove(userAgent), isBeingCreatedClient);
+    server->registerServiceWorkerClient(WTF::move(clientOrigin), WTF::move(data), controllingServiceWorkerRegistrationIdentifier, WTF::move(userAgent), isBeingCreatedClient);
 
     if (!m_isThrottleable)
         updateThrottleState();
@@ -647,13 +647,13 @@ void WebSWServerConnection::subscribeToPushService(WebCore::ServiceWorkerRegistr
         return;
     }
 
-    session->notificationManager().subscribeToPushService(registration->scopeURLWithoutFragment(), WTFMove(applicationServerKey), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), registrableDomain = RegistrableDomain(registration->data().scopeURL)] (Expected<PushSubscriptionData, ExceptionData>&& result) mutable {
+    session->notificationManager().subscribeToPushService(registration->scopeURLWithoutFragment(), WTF::move(applicationServerKey), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), registrableDomain = RegistrableDomain(registration->data().scopeURL)] (Expected<PushSubscriptionData, ExceptionData>&& result) mutable {
         if (RefPtr resourceLoadStatistics = weakThis && weakThis->session() ? weakThis->session()->resourceLoadStatistics() : nullptr; result && resourceLoadStatistics) {
-            return resourceLoadStatistics->setMostRecentWebPushInteractionTime(WTFMove(registrableDomain), [result = WTFMove(result), completionHandler = WTFMove(completionHandler)] () mutable {
-                completionHandler(WTFMove(result));
+            return resourceLoadStatistics->setMostRecentWebPushInteractionTime(WTF::move(registrableDomain), [result = WTF::move(result), completionHandler = WTF::move(completionHandler)] () mutable {
+                completionHandler(WTF::move(result));
             });
         }
-        completionHandler(WTFMove(result));
+        completionHandler(WTF::move(result));
     });
 #endif
 }
@@ -684,7 +684,7 @@ void WebSWServerConnection::unsubscribeFromPushService(WebCore::ServiceWorkerReg
         return;
     }
 
-    session->notificationManager().unsubscribeFromPushService(registration->scopeURLWithoutFragment(), subscriptionIdentifier, WTFMove(completionHandler));
+    session->notificationManager().unsubscribeFromPushService(registration->scopeURLWithoutFragment(), subscriptionIdentifier, WTF::move(completionHandler));
 #endif
 }
 
@@ -713,7 +713,7 @@ void WebSWServerConnection::getPushSubscription(WebCore::ServiceWorkerRegistrati
         return;
     }
 
-    session->notificationManager().getPushSubscription(registration->scopeURLWithoutFragment(), WTFMove(completionHandler));
+    session->notificationManager().getPushSubscription(registration->scopeURLWithoutFragment(), WTF::move(completionHandler));
 #endif
 }
 
@@ -742,7 +742,7 @@ void WebSWServerConnection::getPushPermissionState(WebCore::ServiceWorkerRegistr
         return;
     }
 
-    session->notificationManager().getPermissionState(SecurityOriginData::fromURL( registration->scopeURLWithoutFragment()), [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState state) mutable {
+    session->notificationManager().getPermissionState(SecurityOriginData::fromURL( registration->scopeURLWithoutFragment()), [completionHandler = WTF::move(completionHandler)](WebCore::PushPermissionState state) mutable {
         completionHandler(static_cast<uint8_t>(state));
     });
 #endif
@@ -765,7 +765,7 @@ void WebSWServerConnection::terminateWorkerFromClient(ServiceWorkerIdentifier se
     RefPtr worker = server->workerByID(serviceWorkerIdentifier);
     if (!worker)
         return callback();
-    worker->terminate(WTFMove(callback));
+    worker->terminate(WTF::move(callback));
 }
 
 void WebSWServerConnection::whenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier identifier, CompletionHandler<void()>&& completionHandler)
@@ -773,7 +773,7 @@ void WebSWServerConnection::whenServiceWorkerIsTerminatedForTesting(WebCore::Ser
     RefPtr worker = SWServerWorker::existingWorkerForIdentifier(identifier);
     if (!worker || worker->isNotRunning())
         return completionHandler();
-    worker->whenTerminated(WTFMove(completionHandler));
+    worker->whenTerminated(WTF::move(completionHandler));
 }
 
 PAL::SessionID WebSWServerConnection::sessionID() const
@@ -793,7 +793,7 @@ CheckedPtr<NetworkSession> WebSWServerConnection::checkedSession()
 
 template<typename U> void WebSWServerConnection::sendToContextProcess(WebCore::SWServerToContextConnection& connection, U&& message)
 {
-    Ref { downcast<WebSWServerToContextConnection>(connection) }->send(WTFMove(message));
+    Ref { downcast<WebSWServerToContextConnection>(connection) }->send(WTF::move(message));
 }
 
 void WebSWServerConnection::fetchTaskTimedOut(ServiceWorkerIdentifier serviceWorkerIdentifier)
@@ -852,7 +852,7 @@ void WebSWServerConnection::setNavigationPreloadHeaderValue(WebCore::ServiceWork
         callback(ExceptionData { ExceptionCode::InvalidStateError, "No registration"_s });
         return;
     }
-    callback(registration->setNavigationPreloadHeaderValue(WTFMove(headerValue)));
+    callback(registration->setNavigationPreloadHeaderValue(WTF::move(headerValue)));
 }
 
 void WebSWServerConnection::getNavigationPreloadState(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrNavigationPreloadStateCallback&& callback)
@@ -872,7 +872,7 @@ void WebSWServerConnection::getNavigationPreloadState(WebCore::ServiceWorkerRegi
 
 void WebSWServerConnection::focusServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<ServiceWorkerClientData>&&)>&& callback)
 {
-    sendWithAsyncReply(Messages::WebSWClientConnection::FocusServiceWorkerClient { clientIdentifier }, WTFMove(callback));
+    sendWithAsyncReply(Messages::WebSWClientConnection::FocusServiceWorkerClient { clientIdentifier }, WTF::move(callback));
 }
 
 void WebSWServerConnection::transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader& loader, WebCore::SWServerRegistration& registration, const WebCore::ResourceRequest& request)
@@ -909,7 +909,7 @@ void WebSWServerConnection::retrieveRecordResponseBody(WebCore::BackgroundFetchR
             protectedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyEnd(callbackIdentifier, result.error()));
             return;
         }
-        protectedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyChunk(callbackIdentifier, IPC::SharedBufferReference(WTFMove(result.value()))));
+        protectedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyChunk(callbackIdentifier, IPC::SharedBufferReference(WTF::move(result.value()))));
     });
 }
 
@@ -928,7 +928,7 @@ void WebSWServerConnection::addCookieChangeSubscriptions(WebCore::ServiceWorkerR
         return;
     }
 
-    registration->addCookieChangeSubscriptions(WTFMove(subscriptions));
+    registration->addCookieChangeSubscriptions(WTF::move(subscriptions));
     callback({ });
 }
 
@@ -947,7 +947,7 @@ void WebSWServerConnection::removeCookieChangeSubscriptions(WebCore::ServiceWork
         return;
     }
 
-    registration->removeCookieChangeSubscriptions(WTFMove(subscriptions));
+    registration->removeCookieChangeSubscriptions(WTF::move(subscriptions));
     callback({ });
 }
 
@@ -976,7 +976,7 @@ void WebSWServerConnection::addRoutes(WebCore::ServiceWorkerRegistrationIdentifi
         callback(makeUnexpected(WebCore::ExceptionData { ExceptionCode::TypeError, "Internal error"_s }));
         return;
     }
-    server->addRoutes(registrationIdentifier, WTFMove(routes), WTFMove(callback));
+    server->addRoutes(registrationIdentifier, WTF::move(routes), WTF::move(callback));
 }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
@@ -988,7 +988,7 @@ void WebSWServerConnection::getNotifications(const URL& registrationURL, const S
         return;
     }
 
-    session->notificationManager().getNotifications(registrationURL, tag, WTFMove(completionHandler));
+    session->notificationManager().getNotifications(registrationURL, tag, WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -89,7 +89,7 @@ WebCore::Site WebSharedWorker::topSite() const
 
 void WebSharedWorker::setFetchResult(WebCore::WorkerFetchResult&& fetchResult)
 {
-    m_fetchResult = WTFMove(fetchResult);
+    m_fetchResult = WTF::move(fetchResult);
 }
 
 void WebSharedWorker::didCreateContextConnection(WebSharedWorkerServerToContextConnection& contextConnection)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -84,7 +84,7 @@ public:
     void markAsRunning() { m_isRunning = true; }
 
     const WebCore::WorkerInitializationData& initializationData() const { return m_initializationData; }
-    void setInitializationData(WebCore::WorkerInitializationData&& initializationData) { m_initializationData = WTFMove(initializationData); }
+    void setInitializationData(WebCore::WorkerInitializationData&& initializationData) { m_initializationData = WTF::move(initializationData); }
 
     const WebCore::WorkerFetchResult& fetchResult() const { return m_fetchResult; }
     void setFetchResult(WebCore::WorkerFetchResult&&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -93,7 +93,7 @@ void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& share
                     RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::requestSharedWorker: Failed to connect to existing shared worker %" PRIu64 ", will create a new one instead.", sharedWorkerIdentifier.toUInt64());
                     if (auto it = checkedThis->m_sharedWorkers.find(sharedWorkerKey); it != checkedThis->m_sharedWorkers.end() && it->value->identifier() == sharedWorkerIdentifier)
                         checkedThis->m_sharedWorkers.remove(it);
-                    checkedThis->requestSharedWorker(WTFMove(sharedWorkerKey), sharedWorkerObjectIdentifier, WTFMove(port), WTFMove(workerOptions));
+                    checkedThis->requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, WTF::move(port), WTF::move(workerOptions));
                 });
             }
         }
@@ -113,7 +113,7 @@ void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& share
         RefPtr sharedWorker = weakSharedWorker.get();
         CheckedPtr checkedThis = weakThis.get();
         if (checkedThis && sharedWorker)
-            checkedThis->didFinishFetchingSharedWorkerScript(*sharedWorker, WTFMove(fetchResult), WTFMove(initializationData));
+            checkedThis->didFinishFetchingSharedWorkerScript(*sharedWorker, WTF::move(fetchResult), WTF::move(initializationData));
     });
 }
 
@@ -131,8 +131,8 @@ void WebSharedWorkerServer::didFinishFetchingSharedWorkerScript(WebSharedWorker&
         return;
     }
 
-    sharedWorker.setInitializationData(WTFMove(initializationData));
-    sharedWorker.setFetchResult(WTFMove(fetchResult));
+    sharedWorker.setInitializationData(WTF::move(initializationData));
+    sharedWorker.setFetchResult(WTF::move(fetchResult));
 
     if (RefPtr connection = m_contextConnections.get(sharedWorker.topRegistrableDomain()))
         sharedWorker.launch(*connection);
@@ -264,7 +264,7 @@ void WebSharedWorkerServer::addConnection(Ref<WebSharedWorkerServerConnection>&&
     auto processIdentifier = connection->webProcessIdentifier();
     RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::addConnection(%p): processIdentifier=%" PRIu64, connection.ptr(), processIdentifier.toUInt64());
     ASSERT(!m_connections.contains(processIdentifier));
-    m_connections.add(processIdentifier, WTFMove(connection));
+    m_connections.add(processIdentifier, WTF::move(connection));
 }
 
 void WebSharedWorkerServer::removeConnection(WebCore::ProcessIdentifier processIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -96,7 +96,7 @@ void WebSharedWorkerServerConnection::requestSharedWorker(WebCore::SharedWorkerK
     MESSAGE_CHECK(sharedWorkerKey.name == workerOptions.name);
     CONNECTION_RELEASE_LOG("requestSharedWorker: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
     if (CheckedPtr session = this->session())
-        session->ensureSharedWorkerServer().requestSharedWorker(WTFMove(sharedWorkerKey), sharedWorkerObjectIdentifier, WTFMove(port), WTFMove(workerOptions));
+        session->ensureSharedWorkerServer().requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, WTF::move(port), WTF::move(workerOptions));
 }
 
 void WebSharedWorkerServerConnection::sharedWorkerObjectIsGoingAway(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
@@ -126,7 +126,7 @@ void WebSharedWorkerServerConnection::resumeForBackForwardCache(WebCore::SharedW
 void WebSharedWorkerServerConnection::fetchScriptInClient(const WebSharedWorker& sharedWorker, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&& completionHandler)
 {
     CONNECTION_RELEASE_LOG("fetchScriptInClient: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
-    sendWithAsyncReply(Messages::WebSharedWorkerObjectConnection::FetchScriptInClient { sharedWorker.url(), sharedWorkerObjectIdentifier, sharedWorker.workerOptions() }, WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebSharedWorkerObjectConnection::FetchScriptInClient { sharedWorker.url(), sharedWorkerObjectIdentifier, sharedWorker.workerOptions() }, WTF::move(completionHandler));
 }
 
 void WebSharedWorkerServerConnection::notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const WebCore::ResourceError& error)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -136,7 +136,7 @@ void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorke
                     swOldConnection->unregisterServiceWorkerClient(*contextIdentifier);
                     if (RefPtr swNewConnection = connection->swConnection()) {
                         clientData->serviceWorkerClientData.identifier = *initializationData.clientIdentifier;
-                        swNewConnection->registerServiceWorkerClient(WTFMove(clientData->clientOrigin), WTFMove(clientData->serviceWorkerClientData), clientData->controllingServiceWorkerRegistrationIdentifier, WTFMove(clientData->userAgent));
+                        swNewConnection->registerServiceWorkerClient(WTF::move(clientData->clientOrigin), WTF::move(clientData->serviceWorkerClientData), clientData->controllingServiceWorkerRegistrationIdentifier, WTF::move(clientData->userAgent));
                     }
                 }
             }
@@ -161,7 +161,7 @@ void WebSharedWorkerServerToContextConnection::resumeSharedWorker(WebCore::Share
 void WebSharedWorkerServerToContextConnection::postConnectEvent(const WebSharedWorker& sharedWorker, const WebCore::TransferredMessagePort& port, CompletionHandler<void(bool)>&& completionHandler)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("postConnectEvent: sharedWorkerIdentifier=%" PRIu64, sharedWorker.identifier().toUInt64());
-    sendWithAsyncReply(Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent { sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin }, WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent { sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin }, WTF::move(completionHandler));
 }
 
 void WebSharedWorkerServerToContextConnection::terminateSharedWorker(const WebSharedWorker& sharedWorker)

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
@@ -70,12 +70,12 @@ void AsyncRevalidation::staleWhileRevalidateEnding()
 
 Ref<AsyncRevalidation> AsyncRevalidation::create(Cache& cache, const GlobalFrameID& frameID, const WebCore::ResourceRequest& request, std::unique_ptr<NetworkCache::Entry>&& entry, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, CompletionHandler<void(Result)>&& handler)
 {
-    return adoptRef(*new AsyncRevalidation(cache, frameID, request, WTFMove(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTFMove(handler)));
+    return adoptRef(*new AsyncRevalidation(cache, frameID, request, WTF::move(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTF::move(handler)));
 }
 
 AsyncRevalidation::AsyncRevalidation(Cache& cache, const GlobalFrameID& frameID, const WebCore::ResourceRequest& request, std::unique_ptr<NetworkCache::Entry>&& entry, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, CompletionHandler<void(Result)>&& handler)
     : m_timer(*this, &AsyncRevalidation::staleWhileRevalidateEnding)
-    , m_completionHandler(WTFMove(handler))
+    , m_completionHandler(WTF::move(handler))
 {
     auto key = entry->key();
     auto revalidationRequest = constructRevalidationRequest(key, request, *entry.get());
@@ -91,7 +91,7 @@ AsyncRevalidation::AsyncRevalidation(Cache& cache, const GlobalFrameID& frameID,
         if (m_completionHandler)
             m_completionHandler(revalidatedEntry ? Result::Success : Result::Failure);
     };
-    lazyInitialize(m_load, SpeculativeLoad::create(cache, frameID, WTFMove(revalidationRequest), WTFMove(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTFMove(loadRevalidationCompletionHandler)));
+    lazyInitialize(m_load, SpeculativeLoad::create(cache, frameID, WTF::move(revalidationRequest), WTF::move(entry), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTF::move(loadRevalidationCompletionHandler)));
 }
 
 } // namespace NetworkCache

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.cpp
@@ -66,7 +66,7 @@ void CacheStorageEngineConnection::open(WebCore::ClientOrigin&& origin, String&&
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::open(*session, WTFMove(origin), WTFMove(cacheName), [callback = WTFMove(callback), sessionID = this->sessionID()](auto& result) mutable {
+    Engine::open(*session, WTF::move(origin), WTF::move(cacheName), [callback = WTF::move(callback), sessionID = this->sessionID()](auto& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("open", "cache identifier is %" PRIu64, [](const auto& value) { return value.identifier.object().toUInt64(); });
         callback(result);
     });
@@ -79,7 +79,7 @@ void CacheStorageEngineConnection::remove(WebCore::DOMCacheIdentifier cacheIdent
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::remove(*session, cacheIdentifier, [callback = WTFMove(callback), sessionID = this->sessionID()](auto& result) mutable {
+    Engine::remove(*session, cacheIdentifier, [callback = WTF::move(callback), sessionID = this->sessionID()](auto& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("caches", "removed cache %d", [](const auto& value) { return value; });
         callback(result);
     });
@@ -92,9 +92,9 @@ void CacheStorageEngineConnection::caches(WebCore::ClientOrigin&& origin, uint64
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::retrieveCaches(*session, WTFMove(origin), updateCounter, [callback = WTFMove(callback), origin, sessionID = this->sessionID()](auto&& result) mutable {
+    Engine::retrieveCaches(*session, WTF::move(origin), updateCounter, [callback = WTF::move(callback), origin, sessionID = this->sessionID()](auto&& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("caches", "caches size is %lu", [](const auto& value) { return value.infos.size(); });
-        callback(WTFMove(result));
+        callback(WTF::move(result));
     });
 }
 
@@ -105,9 +105,9 @@ void CacheStorageEngineConnection::retrieveRecords(WebCore::DOMCacheIdentifier c
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::retrieveRecords(*session, cacheIdentifier, WTFMove(options), [callback = WTFMove(callback), sessionID = this->sessionID()](auto&& result) mutable {
+    Engine::retrieveRecords(*session, cacheIdentifier, WTF::move(options), [callback = WTF::move(callback), sessionID = this->sessionID()](auto&& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("retrieveRecords", "records size is %lu", [](const auto& value) { return value.size(); });
-        callback(WTFMove(result));
+        callback(WTF::move(result));
     });
 }
 
@@ -118,9 +118,9 @@ void CacheStorageEngineConnection::deleteMatchingRecords(WebCore::DOMCacheIdenti
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::deleteMatchingRecords(*session, cacheIdentifier, WTFMove(request), WTFMove(options), [callback = WTFMove(callback), sessionID = this->sessionID()](auto&& result) mutable {
+    Engine::deleteMatchingRecords(*session, cacheIdentifier, WTF::move(request), WTF::move(options), [callback = WTF::move(callback), sessionID = this->sessionID()](auto&& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("deleteMatchingRecords", "deleted %lu records",  [](const auto& value) { return value.size(); });
-        callback(WTFMove(result));
+        callback(WTF::move(result));
     });
 }
 
@@ -131,9 +131,9 @@ void CacheStorageEngineConnection::putRecords(WebCore::DOMCacheIdentifier cacheI
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    Engine::putRecords(*session, cacheIdentifier, WTFMove(records), [callback = WTFMove(callback), sessionID = this->sessionID()](auto&& result) mutable {
+    Engine::putRecords(*session, cacheIdentifier, WTF::move(records), [callback = WTF::move(callback), sessionID = this->sessionID()](auto&& result) mutable {
         CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("putRecords", "put %lu records",  [](const auto& value) { return value.size(); });
-        callback(WTFMove(result));
+        callback(WTF::move(result));
     });
 }
 
@@ -184,7 +184,7 @@ void CacheStorageEngineConnection::clearMemoryRepresentation(WebCore::ClientOrig
     if (!session)
         return completionHandler(WebCore::DOMCacheEngine::Error::Internal);
 
-    Engine::clearMemoryRepresentation(*session, WTFMove(origin), WTFMove(completionHandler));
+    Engine::clearMemoryRepresentation(*session, WTF::move(origin), WTF::move(completionHandler));
 }
 
 void CacheStorageEngineConnection::engineRepresentation(CompletionHandler<void(String&&)>&& completionHandler)
@@ -193,7 +193,7 @@ void CacheStorageEngineConnection::engineRepresentation(CompletionHandler<void(S
     if (!session)
         return completionHandler({ });
 
-    Engine::representation(*session, WTFMove(completionHandler));
+    Engine::representation(*session, WTF::move(completionHandler));
 }
 
 PAL::SessionID CacheStorageEngineConnection::sessionID() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -176,7 +176,7 @@ public:
         Markable<UseDecision> useDecision;
 
         RetrieveInfo isolatedCopy() && { return {
-            crossThreadCopy(WTFMove(url)),
+            crossThreadCopy(WTF::move(url)),
             startTime,
             completionTime,
             priority,

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
@@ -52,39 +52,39 @@ std::optional<WebKit::NetworkCache::Key> Coder<WebKit::NetworkCache::Key>::decod
     decoder >> partition;
     if (!partition)
         return std::nullopt;
-    key.m_partition = WTFMove(*partition);
+    key.m_partition = WTF::move(*partition);
 
     std::optional<String> type;
     decoder >> type;
     if (!type)
         return std::nullopt;
-    key.m_type = WTFMove(*type);
+    key.m_type = WTF::move(*type);
 
     std::optional<String> identifier;
     decoder >> identifier;
     if (!identifier)
         return std::nullopt;
-    key.m_identifier = WTFMove(*identifier);
+    key.m_identifier = WTF::move(*identifier);
 
     std::optional<String> range;
     decoder >> range;
     if (!range)
         return std::nullopt;
-    key.m_range = WTFMove(*range);
+    key.m_range = WTF::move(*range);
 
     std::optional<WebKit::NetworkCache::Key::HashType> hash;
     decoder >> hash;
     if (!hash)
         return std::nullopt;
-    key.m_hash = WTFMove(*hash);
+    key.m_hash = WTF::move(*hash);
 
     std::optional<WebKit::NetworkCache::Key::HashType> partitionHash;
     decoder >> partitionHash;
     if (!partitionHash)
         return std::nullopt;
-    key.m_partitionHash = WTFMove(*partitionHash);
+    key.m_partitionHash = WTF::move(*partitionHash);
 
-    return { WTFMove(key) };
+    return { WTF::move(key) };
 }
 
 void Coder<WebKit::NetworkCache::SubresourceInfo>::encodeForPersistence(WTF::Persistence::Encoder& encoder, const WebKit::NetworkCache::SubresourceInfo& instance)
@@ -128,7 +128,7 @@ std::optional<WebKit::NetworkCache::SubresourceInfo> Coder<WebKit::NetworkCache:
         return std::nullopt;
 
     if (*isTransient)
-        return WebKit::NetworkCache::SubresourceInfo(WTFMove(*key), *lastSeen, *firstSeen);
+        return WebKit::NetworkCache::SubresourceInfo(WTF::move(*key), *lastSeen, *firstSeen);
 
     std::optional<bool> isSameSite;
     decoder >> isSameSite;
@@ -155,7 +155,7 @@ std::optional<WebKit::NetworkCache::SubresourceInfo> Coder<WebKit::NetworkCache:
     if (!priority)
         return std::nullopt;
 
-    return WebKit::NetworkCache::SubresourceInfo(WTFMove(*key), *lastSeen, *firstSeen, *isSameSite, *isAppInitiated, WTFMove(*firstPartyForCookies), WTFMove(*requestHeaders), *priority);
+    return WebKit::NetworkCache::SubresourceInfo(WTF::move(*key), *lastSeen, *firstSeen, *isSameSite, *isAppInitiated, WTF::move(*firstPartyForCookies), WTF::move(*requestHeaders), *priority);
 }
 
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -41,7 +41,7 @@ namespace NetworkCache {
 
 #if !USE(GLIB) && USE(CURL)
 Data::Data(Vector<uint8_t>&& data)
-    : Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTFMove(data) })
+    : Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTF::move(data) })
 {
 }
 #elif !PLATFORM(COCOA)
@@ -57,10 +57,10 @@ Data Data::mapToFile(const String& path) const
     auto applyData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& applier) {
         apply(applier);
     };
-    auto mappedFile = FileSystem::mapToFile(path, size(), WTFMove(applyData), &handle);
+    auto mappedFile = FileSystem::mapToFile(path, size(), WTF::move(applyData), &handle);
     if (!mappedFile)
         return { };
-    return Data::adoptMap(WTFMove(mappedFile), WTFMove(handle));
+    return Data::adoptMap(WTF::move(mappedFile), WTF::move(handle));
 }
 
 Data mapFile(const String& path)
@@ -80,7 +80,7 @@ Data mapFile(const String& path)
     if (!mappedFile)
         return { };
 
-    return Data::adoptMap(WTFMove(*mappedFile), WTFMove(handle));
+    return Data::adoptMap(WTF::move(*mappedFile), WTF::move(handle));
 }
 
 SHA1::Digest computeSHA1(const Data& data, const Salt& salt)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -43,13 +43,13 @@ Data::Data(std::span<const uint8_t> data)
 }
 
 Data::Data(OSObjectPtr<dispatch_data_t>&& dispatchData, Backing backing)
-    : m_dispatchData(WTFMove(dispatchData))
+    : m_dispatchData(WTF::move(dispatchData))
     , m_isMap(backing == Backing::Map && dispatch_data_get_size(m_dispatchData.get()))
 {
 }
 
 Data::Data(Vector<uint8_t>&& data)
-    : Data(makeDispatchData(WTFMove(data)).get(), Backing::Buffer)
+    : Data(makeDispatchData(WTF::move(data)).get(), Backing::Buffer)
 {
 }
 
@@ -116,7 +116,7 @@ Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::FileHan
     auto bodyMap = adoptOSObject(dispatch_data_create(span.data(), span.size(), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [span] {
         munmap(span.data(), span.size());
     }));
-    return { WTFMove(bodyMap), Data::Backing::Map };
+    return { WTF::move(bodyMap), Data::Backing::Map };
 }
 
 RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -39,7 +39,7 @@ Data::Data(std::span<const uint8_t> data)
 }
 
 Data::Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
-    : m_buffer(Box<Variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(WTFMove(data)))
+    : m_buffer(Box<Variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(WTF::move(data)))
     , m_isMap(std::holds_alternative<FileSystem::MappedFileData>(*m_buffer))
 {
 }
@@ -47,7 +47,7 @@ Data::Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
 Data Data::empty()
 {
     Vector<uint8_t> buffer;
-    return { WTFMove(buffer) };
+    return { WTF::move(buffer) };
 }
 
 std::span<const uint8_t> Data::span() const
@@ -102,7 +102,7 @@ Data concatenate(const Data& a, const Data& b)
     Vector<uint8_t> buffer(a.size() + b.size());
     memcpySpan(buffer.mutableSpan(), a.span());
     memcpySpan(buffer.mutableSpan().subspan(a.size()), b.span());
-    return Data(WTFMove(buffer));
+    return Data(WTF::move(buffer));
 }
 
 Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::FileHandle&& fileHandle)
@@ -110,7 +110,7 @@ Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::FileHan
     ASSERT(mappedFile);
     fileHandle = { };
 
-    return { WTFMove(mappedFile) };
+    return { WTF::move(mappedFile) };
 }
 
 #if ENABLE(SHAREABLE_RESOURCE) && OS(WINDOWS)
@@ -123,7 +123,7 @@ RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const
     if (!newHandle)
         return nullptr;
 
-    return WebCore::SharedMemory::map({ WTFMove(newHandle), size() }, WebCore::SharedMemory::Protection::ReadOnly);
+    return WebCore::SharedMemory::map({ WTF::move(newHandle), size() }, WebCore::SharedMemory::Protection::ReadOnly);
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -54,8 +54,8 @@ Data::Data(std::span<const uint8_t> data)
 }
 
 Data::Data(GRefPtr<GBytes>&& buffer, FileSystem::FileHandle&& fileHandle)
-    : m_buffer(WTFMove(buffer))
-    , m_fileHandle(Box<FileSystem::FileHandle>::create(WTFMove(fileHandle)))
+    : m_buffer(WTF::move(buffer))
+    , m_fileHandle(Box<FileSystem::FileHandle>::create(WTF::move(fileHandle)))
     , m_isMap(m_buffer && g_bytes_get_size(m_buffer.get()) && m_fileHandle->isValid())
 {
 }
@@ -136,8 +136,8 @@ Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::FileHan
     auto* map = mappedFile.span().data();
     ASSERT(map);
     ASSERT(map != MAP_FAILED);
-    MapWrapper* wrapper = new MapWrapper { WTFMove(mappedFile) };
-    return { adoptGRef(g_bytes_new_with_free_func(map, size, reinterpret_cast<GDestroyNotify>(deleteMapWrapper), wrapper)), WTFMove(fileHandle) };
+    MapWrapper* wrapper = new MapWrapper { WTF::move(mappedFile) };
+    return { adoptGRef(g_bytes_new_with_free_func(map, size, reinterpret_cast<GDestroyNotify>(deleteMapWrapper), wrapper)), WTF::move(fileHandle) };
 }
 
 RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -45,7 +45,7 @@ Entry::Entry(const Key& key, const WebCore::ResourceResponse& response, PrivateR
     , m_timeStamp(WallTime::now())
     , m_response(response)
     , m_varyingRequestHeaders(varyingRequestHeaders)
-    , m_buffer(WTFMove(buffer))
+    , m_buffer(WTF::move(buffer))
     , m_privateRelayed(privateRelayed)
 {
     ASSERT(m_key.type() == "Resource"_s);
@@ -124,7 +124,7 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
     decoder >> response;
     if (!response)
         return nullptr;
-    entry->m_response = WTFMove(*response);
+    entry->m_response = WTF::move(*response);
     entry->m_response.setSource(WebCore::ResourceResponse::Source::DiskCache);
 
     std::optional<bool> hasVaryingRequestHeaders;
@@ -137,7 +137,7 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
         decoder >> varyingRequestHeaders;
         if (!varyingRequestHeaders)
             return nullptr;
-        entry->m_varyingRequestHeaders = WTFMove(*varyingRequestHeaders);
+        entry->m_varyingRequestHeaders = WTF::move(*varyingRequestHeaders);
     }
 
     std::optional<uint8_t> isRedirectAndPrivateRelayed;
@@ -154,14 +154,14 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
         decoder >> resourceRequest;
         if (!resourceRequest)
             return nullptr;
-        entry->m_redirectRequest = WTFMove(*resourceRequest);
+        entry->m_redirectRequest = WTF::move(*resourceRequest);
     }
 
     std::optional<std::optional<Seconds>> maxAgeCap;
     decoder >> maxAgeCap;
     if (!maxAgeCap)
         return nullptr;
-    entry->m_maxAgeCap = WTFMove(*maxAgeCap);
+    entry->m_maxAgeCap = WTF::move(*maxAgeCap);
 
     if (!decoder.verifyChecksum()) {
         LOG(NetworkCache, "(NetworkProcess) checksum verification failure\n");
@@ -185,7 +185,7 @@ void Entry::initializeBufferFromStorageRecord() const
 {
 #if ENABLE(SHAREABLE_RESOURCE)
     if (auto handle = shareableResourceHandle()) {
-        m_buffer = WTFMove(*handle).tryWrapInSharedBuffer();
+        m_buffer = WTF::move(*handle).tryWrapInSharedBuffer();
         if (m_buffer)
             return;
     }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -96,13 +96,13 @@ IOChannel::~IOChannel()
 void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
     bool didCallCompletionHandler = false;
-    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
+    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
 
         Data data { OSObjectPtr<dispatch_data_t> { fileData } };
-        completionHandler(WTFMove(data), error);
+        completionHandler(WTF::move(data), error);
         didCallCompletionHandler = true;
     }).get());
 }
@@ -110,7 +110,7 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
 void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
     RetainPtr dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler)](bool done, dispatch_data_t, int error) mutable {
         if (!done) {
             RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
             return;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
@@ -58,7 +58,7 @@ IOChannel::~IOChannel()
 
 void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
-    queue->dispatch([this, protectedThis = Ref { *this }, offset, size, completionHandler = WTFMove(completionHandler)] {
+    queue->dispatch([this, protectedThis = Ref { *this }, offset, size, completionHandler = WTF::move(completionHandler)] {
         m_lock.lock();
 
         auto fileSize = m_fileDescriptor.size();
@@ -74,14 +74,14 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
         auto bytesRead = m_fileDescriptor.read(buffer.mutableSpan());
         m_lock.unlock();
 
-        auto data = Data(WTFMove(buffer));
-        completionHandler(WTFMove(data), bytesRead ? 0 : -1);
+        auto data = Data(WTF::move(buffer));
+        completionHandler(WTF::move(data), bytesRead ? 0 : -1);
     });
 }
 
 void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    queue->dispatch([this, protectedThis = Ref { *this }, offset, data, completionHandler = WTFMove(completionHandler)] {
+    queue->dispatch([this, protectedThis = Ref { *this }, offset, data, completionHandler = WTF::move(completionHandler)] {
         int err = 0;
         {
             Locker locker { m_lock };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -90,10 +90,10 @@ public:
     static String partitionToPartitionHashAsString(const String& partition, const Salt&);
 
     Key isolatedCopy() && { return {
-        crossThreadCopy(WTFMove(m_partition)),
-        crossThreadCopy(WTFMove(m_type)),
-        crossThreadCopy(WTFMove(m_identifier)),
-        crossThreadCopy(WTFMove(m_range)),
+        crossThreadCopy(WTF::move(m_partition)),
+        crossThreadCopy(WTF::move(m_type)),
+        crossThreadCopy(WTF::move(m_identifier)),
+        crossThreadCopy(WTF::move(m_range)),
         m_hash,
         m_partitionHash
     }; }
@@ -114,10 +114,10 @@ private:
     HashType computePartitionHash(const Salt&) const;
     static HashType partitionToPartitionHash(const String& partition, const Salt&);
     Key(String&& partition, String&& type, String&& identifier, String&& range, HashType hash, HashType partitionHash)
-        : m_partition(WTFMove(partition))
-        , m_type(WTFMove(type))
-        , m_identifier(WTFMove(identifier))
-        , m_range(WTFMove(range))
+        : m_partition(WTF::move(partition))
+        , m_type(WTF::move(type))
+        , m_identifier(WTF::move(identifier))
+        , m_range(WTF::move(range))
         , m_hash(hash)
         , m_partitionHash(partitionHash) { }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -46,21 +46,21 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculativeLoad);
 
 Ref<SpeculativeLoad> SpeculativeLoad::create(Cache& cache, const GlobalFrameID& globalFrameID, const ResourceRequest& request, std::unique_ptr<NetworkCache::Entry> cacheEntryForValidation, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, RevalidationCompletionHandler&& completionHandler)
 {
-    return adoptRef(*new SpeculativeLoad(cache, globalFrameID, request, WTFMove(cacheEntryForValidation), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTFMove(completionHandler)));
+    return adoptRef(*new SpeculativeLoad(cache, globalFrameID, request, WTF::move(cacheEntryForValidation), isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections, WTF::move(completionHandler)));
 }
 
 SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameID, const ResourceRequest& request, std::unique_ptr<NetworkCache::Entry> cacheEntryForValidation, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, RevalidationCompletionHandler&& completionHandler)
     : m_cache(cache)
-    , m_completionHandler(WTFMove(completionHandler))
+    , m_completionHandler(WTF::move(completionHandler))
     , m_originalRequest(request)
     , m_bufferedDataForCache(SharedBuffer::create())
-    , m_cacheEntry(WTFMove(cacheEntryForValidation))
+    , m_cacheEntry(WTF::move(cacheEntryForValidation))
 {
     ASSERT(!m_cacheEntry || m_cacheEntry->needsValidation());
 
     CheckedPtr networkSession = m_cache->networkProcess().networkSession(m_cache->sessionID());
     if (!networkSession) {
-        RunLoop::mainSingleton().dispatch([completionHandler = WTFMove(m_completionHandler)]() mutable {
+        RunLoop::mainSingleton().dispatch([completionHandler = WTF::move(m_completionHandler)]() mutable {
             completionHandler(nullptr);
         });
         return;
@@ -77,7 +77,7 @@ SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameI
     parameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     parameters.allowPrivacyProxy = allowPrivacyProxy;
     parameters.advancedPrivacyProtections = advancedPrivacyProtections;
-    Ref networkLoad = NetworkLoad::create(*this, WTFMove(parameters), *networkSession);
+    Ref networkLoad = NetworkLoad::create(*this, WTF::move(parameters), *networkSession);
     m_networkLoad = networkLoad.copyRef();
     networkLoad->startWithScheduling();
 }
@@ -179,7 +179,7 @@ void SpeculativeLoad::didComplete()
     if (m_cacheEntry)
         m_cacheEntry->setNeedsValidation(false);
 
-    m_completionHandler(WTFMove(m_cacheEntry));
+    m_completionHandler(WTF::move(m_cacheEntry));
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -72,7 +72,7 @@ public:
         : m_identifier(Storage::ReadOperationIdentifier::generate())
         , m_key(key)
         , m_priority(priority)
-        , m_completionHandler(WTFMove(completionHandler))
+        , m_completionHandler(WTF::move(completionHandler))
     {
         ASSERT(isMainRunLoop());
         ASSERT(m_completionHandler);
@@ -170,7 +170,7 @@ bool Storage::ReadOperation::finish()
     if (m_record.body.isNull())
         m_record = { };
 
-    return m_completionHandler(WTFMove(m_record), m_timings);
+    return m_completionHandler(WTF::move(m_record), m_timings);
 }
 
 void Storage::ReadOperation::finishReadRecord(Record&& record, MonotonicTime recordIOStartTime, MonotonicTime recordIOEndTime)
@@ -182,9 +182,9 @@ void Storage::ReadOperation::finishReadRecord(Record&& record, MonotonicTime rec
     if (m_blobBodyHash) {
         // Body should not be stored in both blob storage and record storage.
         ASSERT(record.body.isNull());
-        record.body = WTFMove(m_record.body);
+        record.body = WTF::move(m_record.body);
     }
-    m_record = WTFMove(record);
+    m_record = WTF::move(record);
     m_timings.recordIOStartTime = recordIOStartTime;
     m_timings.recordIOEndTime = recordIOEndTime;
 }
@@ -197,8 +197,8 @@ void Storage::ReadOperation::finishReadBlob(BlobStorage::Blob&& blob, MonotonicT
     if (blob.data.isNull())
         return;
 
-    m_record.body = WTFMove(blob.data);
-    m_blobBodyHash = WTFMove(blob.hash);
+    m_record.body = WTF::move(blob.data);
+    m_blobBodyHash = WTF::move(blob.hash);
     m_timings.blobIOStartTime = blobIOStartTime;
     m_timings.blobIOEndTime = blobIOEndTime;
 }
@@ -209,7 +209,7 @@ public:
     WriteOperation(const Record& record, MappedBodyHandler&& mappedBodyHandler)
         : m_identifier(Storage::WriteOperationIdentifier::generate())
         , m_record(record)
-        , m_mappedBodyHandler(WTFMove(mappedBodyHandler))
+        , m_mappedBodyHandler(WTF::move(mappedBodyHandler))
     {
         ASSERT(isMainRunLoop());
     }
@@ -242,7 +242,7 @@ public:
     static Ref<TraverseOperation> create(Storage::TraverseHandler&& handler)
     {
         ASSERT(isMainRunLoop());
-        return adoptRef(*new TraverseOperation(WTFMove(handler)));
+        return adoptRef(*new TraverseOperation(WTF::move(handler)));
     }
 
     void invokeHandler(const Storage::Record* record, const Storage::RecordInfo& info)
@@ -280,7 +280,7 @@ public:
 
 private:
     explicit TraverseOperation(Storage::TraverseHandler&& handler)
-        : m_handler(WTFMove(handler))
+        : m_handler(WTF::move(handler))
     { }
 
     Storage::TraverseHandler m_handler;
@@ -509,7 +509,7 @@ void Storage::synchronize()
 
         LOG(NetworkCacheStorage, "(NetworkProcess) cache synchronization completed size=%zu recordCount=%u", recordsSize, recordCount);
 
-        RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, recordFilter = WTFMove(recordFilter), blobFilter = WTFMove(blobFilter), recordsSize]() mutable {
+        RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, recordFilter = WTF::move(recordFilter), blobFilter = WTF::move(blobFilter), recordsSize]() mutable {
             for (auto& recordFilterKey : m_recordFilterHashesAddedDuringSynchronization)
                 recordFilter->add(recordFilterKey);
             m_recordFilterHashesAddedDuringSynchronization.clear();
@@ -518,8 +518,8 @@ void Storage::synchronize()
                 blobFilter->add(hash);
             m_blobFilterHashesAddedDuringSynchronization.clear();
 
-            m_recordFilter = WTFMove(recordFilter);
-            m_blobFilter = WTFMove(blobFilter);
+            m_recordFilter = WTF::move(recordFilter);
+            m_blobFilter = WTF::move(blobFilter);
             m_approximateRecordsSize = recordsSize;
             m_synchronizationInProgress = false;
             if (m_mode == Mode::AvoidRandomness)
@@ -604,49 +604,49 @@ WARN_UNUSED_RETURN static bool decodeRecordMetaData(RecordMetaData& metaData, co
         decoder >> cacheStorageVersion;
         if (!cacheStorageVersion)
             return false;
-        metaData.cacheStorageVersion = WTFMove(*cacheStorageVersion);
+        metaData.cacheStorageVersion = WTF::move(*cacheStorageVersion);
 
         std::optional<Key> key;
         decoder >> key;
         if (!key)
             return false;
-        metaData.key = WTFMove(*key);
+        metaData.key = WTF::move(*key);
 
         std::optional<WallTime> timeStamp;
         decoder >> timeStamp;
         if (!timeStamp)
             return false;
-        metaData.timeStamp = WTFMove(*timeStamp);
+        metaData.timeStamp = WTF::move(*timeStamp);
 
         std::optional<SHA1::Digest> headerHash;
         decoder >> headerHash;
         if (!headerHash)
             return false;
-        metaData.headerHash = WTFMove(*headerHash);
+        metaData.headerHash = WTF::move(*headerHash);
 
         std::optional<uint64_t> headerSize;
         decoder >> headerSize;
         if (!headerSize)
             return false;
-        metaData.headerSize = WTFMove(*headerSize);
+        metaData.headerSize = WTF::move(*headerSize);
 
         std::optional<SHA1::Digest> bodyHash;
         decoder >> bodyHash;
         if (!bodyHash)
             return false;
-        metaData.bodyHash = WTFMove(*bodyHash);
+        metaData.bodyHash = WTF::move(*bodyHash);
 
         std::optional<uint64_t> bodySize;
         decoder >> bodySize;
         if (!bodySize)
             return false;
-        metaData.bodySize = WTFMove(*bodySize);
+        metaData.bodySize = WTF::move(*bodySize);
 
         std::optional<bool> isBodyInline;
         decoder >> isBodyInline;
         if (!isBodyInline)
             return false;
-        metaData.isBodyInline = WTFMove(*isBodyInline);
+        metaData.isBodyInline = WTF::move(*isBodyInline);
 
         if (!decoder.verifyChecksum())
             return false;
@@ -702,10 +702,10 @@ Storage::Record Storage::readRecord(const Data& recordData)
     }
 
     return Record {
-        WTFMove(metaData.key),
+        WTF::move(metaData.key),
         metaData.timeStamp,
-        WTFMove(headerData),
-        WTFMove(bodyData),
+        WTF::move(headerData),
+        WTF::move(bodyData),
         metaData.bodyHash
     };
 }
@@ -739,7 +739,7 @@ std::optional<BlobStorage::Blob> Storage::storeBodyAsBlob(WriteOperationIdentifi
 
     addWriteOperationActivity(identifier);
 
-    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, blob = WTFMove(blob), identifier] {
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, blob = WTF::move(blob), identifier] {
         assertIsMainThread();
 
         auto* writeOperation = m_activeWriteOperations.get(identifier);
@@ -825,11 +825,11 @@ void Storage::remove(const Vector<Key>& keys, CompletionHandler<void()>&& comple
         return key;
     });
 
-    serialBackgroundIOQueue().dispatch([this, protectedThis = Ref { *this }, keysToRemove = WTFMove(keysToRemove), completionHandler = WTFMove(completionHandler)] () mutable {
+    serialBackgroundIOQueue().dispatch([this, protectedThis = Ref { *this }, keysToRemove = WTF::move(keysToRemove), completionHandler = WTF::move(completionHandler)] () mutable {
         for (auto& key : keysToRemove)
             deleteFiles(key);
 
-        RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
+        RunLoop::mainSingleton().dispatch(WTF::move(completionHandler));
     });
 }
 
@@ -843,7 +843,7 @@ void Storage::deleteFiles(const Key& key)
 
 void Storage::updateFileModificationTime(String&& path)
 {
-    serialBackgroundIOQueue().dispatch([path = WTFMove(path).isolatedCopy()] {
+    serialBackgroundIOQueue().dispatch([path = WTF::move(path).isolatedCopy()] {
         updateFileModificationTimeIfNeeded(path);
     });
 }
@@ -854,7 +854,7 @@ void Storage::dispatchReadOperation(std::unique_ptr<ReadOperation> readOperation
 
     auto& readOperation = *readOperationPtr;
     auto identifier = readOperation.identifier();
-    m_activeReadOperations.add(identifier, WTFMove(readOperationPtr));
+    m_activeReadOperations.add(identifier, WTF::move(readOperationPtr));
     auto key = readOperation.key();
     auto recordPath = recordPathForKey(key);
     auto blobPath = mayContainBlob(key) ? blobPathForKey(key) : String { };
@@ -872,7 +872,7 @@ void Storage::dispatchReadOperation(std::unique_ptr<ReadOperation> readOperation
         m_readOperationTimeoutTimer.startOneShot(readTimeout);
     }
 
-    ioQueue().dispatch([this, protectedThis = Ref { *this }, identifier, recordPath = crossThreadCopy(WTFMove(recordPath)), blobPath = crossThreadCopy(WTFMove(blobPath))]() mutable {
+    ioQueue().dispatch([this, protectedThis = Ref { *this }, identifier, recordPath = crossThreadCopy(WTF::move(recordPath)), blobPath = crossThreadCopy(WTF::move(blobPath))]() mutable {
         readRecordFromData(identifier, MonotonicTime::now(), FileSystem::readEntireFile(recordPath));
         readBlobIfNecessary(identifier, blobPath);
     });
@@ -882,14 +882,14 @@ void Storage::readRecordFromData(Storage::ReadOperationIdentifier identifier, Mo
 {
     Record record;
     if (data)
-        record = readRecord(WTFMove(*data));
+        record = readRecord(WTF::move(*data));
 
     auto recordIOEndTime = MonotonicTime::now();
-    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, identifier, recordIOStartTime, recordIOEndTime, record = crossThreadCopy(WTFMove(record))]() mutable {
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, identifier, recordIOStartTime, recordIOEndTime, record = crossThreadCopy(WTF::move(record))]() mutable {
         auto* readOperation = m_activeReadOperations.get(identifier);
         RELEASE_ASSERT(readOperation);
 
-        readOperation->finishReadRecord(WTFMove(record), recordIOStartTime, recordIOEndTime);
+        readOperation->finishReadRecord(WTF::move(record), recordIOStartTime, recordIOEndTime);
         if (readOperation->canFinish())
             finishReadOperation(identifier);
     });
@@ -903,11 +903,11 @@ void Storage::readBlobIfNecessary(Storage::ReadOperationIdentifier identifier, c
     auto blobIOStartTime = MonotonicTime::now();
     auto blob = m_blobStorage.get(blobPath);
     auto blobIOEndTime = MonotonicTime::now();
-    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, identifier, blob = WTFMove(blob), blobIOStartTime, blobIOEndTime]() mutable {
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, identifier, blob = WTF::move(blob), blobIOStartTime, blobIOEndTime]() mutable {
         auto* readOperation = m_activeReadOperations.get(identifier);
         RELEASE_ASSERT(readOperation);
 
-        readOperation->finishReadBlob(WTFMove(blob), blobIOStartTime, blobIOEndTime);
+        readOperation->finishReadBlob(WTF::move(blob), blobIOStartTime, blobIOEndTime);
         if (readOperation->canFinish())
             finishReadOperation(identifier);
     });
@@ -972,8 +972,8 @@ template <class T> bool retrieveFromMemory(const T& operations, const Key& key, 
     for (auto& operation : operations) {
         if (operation->record().key == key) {
             LOG(NetworkCacheStorage, "(NetworkProcess) found write operation in progress");
-            RunLoop::mainSingleton().dispatch([record = operation->record(), completionHandler = WTFMove(completionHandler)] () mutable {
-                completionHandler(WTFMove(record), { });
+            RunLoop::mainSingleton().dispatch([record = operation->record(), completionHandler = WTF::move(completionHandler)] () mutable {
+                completionHandler(WTF::move(record), { });
             });
             return true;
         }
@@ -1007,13 +1007,13 @@ void Storage::dispatchWriteOperation(std::unique_ptr<WriteOperation> writeOperat
 
     auto& writeOperation = *writeOperationPtr;
     auto identifier = writeOperation.identifier();
-    m_activeWriteOperations.add(identifier, WTFMove(writeOperationPtr));
+    m_activeWriteOperations.add(identifier, WTF::move(writeOperationPtr));
 
     auto record = writeOperation.record();
     // This was added already when starting the store but filter might have been wiped.
     addToRecordFilter(record.key);
 
-    backgroundIOQueue().dispatch([this, protectedThis = Ref { *this }, identifier, record = crossThreadCopy(WTFMove(record))]() mutable {
+    backgroundIOQueue().dispatch([this, protectedThis = Ref { *this }, identifier, record = crossThreadCopy(WTF::move(record))]() mutable {
         auto recordDirectoryPath = recordDirectoryPathForKey(record.key);
         auto recordPath = recordPathForKey(record.key);
         FileSystem::makeAllDirectories(recordDirectoryPath);
@@ -1083,10 +1083,10 @@ void Storage::retrieve(const Key& key, unsigned priority, RetrieveCompletionHand
     if (retrieveFromMemory(m_activeWriteOperations.values(), key, completionHandler))
         return;
 
-    auto readOperation = makeUnique<ReadOperation>(key, priority, WTFMove(completionHandler));
+    auto readOperation = makeUnique<ReadOperation>(key, priority, WTF::move(completionHandler));
     readOperation->updateForStart(m_readOperationDispatchCount);
 
-    m_pendingReadOperations.enqueue(WTFMove(readOperation));
+    m_pendingReadOperations.enqueue(WTF::move(readOperation));
     dispatchPendingReadOperations();
 }
 
@@ -1098,8 +1098,8 @@ void Storage::store(const Record& record, MappedBodyHandler&& mappedBodyHandler)
     if (!m_capacity)
         return;
 
-    auto writeOperation = makeUnique<WriteOperation>(record, WTFMove(mappedBodyHandler));
-    m_pendingWriteOperations.prepend(WTFMove(writeOperation));
+    auto writeOperation = makeUnique<WriteOperation>(record, WTF::move(mappedBodyHandler));
+    m_pendingWriteOperations.prepend(WTF::move(writeOperation));
 
     // Add key to the filter already here as we do lookups from the pending operations too.
     addToRecordFilter(record.key);
@@ -1116,8 +1116,8 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
     ASSERT(RunLoop::isMain());
     ASSERT(traverseHandler);
 
-    auto traverseOperation = TraverseOperation::create(WTFMove(traverseHandler));
-    ioQueue().dispatch([this, protectedThis = Ref { *this }, traverseOperation = WTFMove(traverseOperation), flags, rootPath = crossThreadCopy(rootPath), type = crossThreadCopy(type)]() mutable {
+    auto traverseOperation = TraverseOperation::create(WTF::move(traverseHandler));
+    ioQueue().dispatch([this, protectedThis = Ref { *this }, traverseOperation = WTF::move(traverseOperation), flags, rootPath = crossThreadCopy(rootPath), type = crossThreadCopy(type)]() mutable {
         traverseRecordsFiles(rootPath, type, [this, protectedThis, expectedType = type, flags, traverseOperation](const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath) {
             ASSERT(type == expectedType || expectedType.isEmpty());
             if (isBlob)
@@ -1133,7 +1133,7 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
                 bodyShareCount = m_blobStorage.shareCount(blobPathForRecordPath(recordPath));
 
             traverseOperation->waitAndIncrementActivityCount();
-            auto channel = IOChannel::open(WTFMove(recordPath), IOChannel::Type::Read);
+            auto channel = IOChannel::open(WTF::move(recordPath), IOChannel::Type::Read);
             channel->read(0, std::numeric_limits<size_t>::max(), WorkQueue::mainSingleton(), [this, protectedThis, traverseOperation, worth, bodyShareCount](auto fileData, int) {
                 RecordMetaData metaData;
                 Data headerData;
@@ -1158,7 +1158,7 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
         });
 
         traverseOperation->waitUntilActivitiesFinished();
-        RunLoop::mainSingleton().dispatch([traverseOperation = WTFMove(traverseOperation)]() mutable {
+        RunLoop::mainSingleton().dispatch([traverseOperation = WTF::move(traverseOperation)]() mutable {
             // Invoke with nullptr to indicate this is the last record.
             traverseOperation->invokeHandler(nullptr, { });
         });
@@ -1167,14 +1167,14 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
 
 void Storage::traverse(const String& type, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
 {
-    traverseWithinRootPath(recordsPathIsolatedCopy(), type, flags, WTFMove(traverseHandler));
+    traverseWithinRootPath(recordsPathIsolatedCopy(), type, flags, WTF::move(traverseHandler));
 }
 
 void Storage::traverse(const String& type, const String& partition, OptionSet<TraverseFlag> flags, TraverseHandler&& traverseHandler)
 {
     auto partitionHashAsString = Key::partitionToPartitionHashAsString(partition, salt());
     auto rootPath = FileSystem::pathByAppendingComponent(recordsPathIsolatedCopy(), partitionHashAsString);
-    traverseWithinRootPath(rootPath, type, flags, WTFMove(traverseHandler));
+    traverseWithinRootPath(rootPath, type, flags, WTF::move(traverseHandler));
 }
 
 void Storage::setCapacity(size_t capacity)
@@ -1208,7 +1208,7 @@ void Storage::clear(String&& type, WallTime modifiedSinceTime, CompletionHandler
         m_blobFilter->clear();
     m_approximateRecordsSize = 0;
 
-    ioQueue().dispatch([this, protectedThis = Ref { *this }, modifiedSinceTime, completionHandler = WTFMove(completionHandler), type = WTFMove(type).isolatedCopy()] () mutable {
+    ioQueue().dispatch([this, protectedThis = Ref { *this }, modifiedSinceTime, completionHandler = WTF::move(completionHandler), type = WTF::move(type).isolatedCopy()] () mutable {
         auto recordsPath = this->recordsPathIsolatedCopy();
         traverseRecordsFiles(recordsPath, type, [modifiedSinceTime](const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath) {
             auto filePath = FileSystem::pathByAppendingComponent(recordDirectoryPath, fileName);
@@ -1225,7 +1225,7 @@ void Storage::clear(String&& type, WallTime modifiedSinceTime, CompletionHandler
         // This cleans unreferenced blobs.
         m_blobStorage.synchronize();
 
-        RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
+        RunLoop::mainSingleton().dispatch(WTF::move(completionHandler));
     });
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -71,7 +71,7 @@ public:
         {
         }
         Record isolatedCopy() const & { return { crossThreadCopy(key), timeStamp, header, body, bodyHash }; }
-        Record isolatedCopy() && { return { crossThreadCopy(WTFMove(key)), timeStamp, WTFMove(header), WTFMove(body), WTFMove(bodyHash) }; }
+        Record isolatedCopy() && { return { crossThreadCopy(WTF::move(key)), timeStamp, WTF::move(header), WTF::move(body), WTF::move(bodyHash) }; }
         bool isNull() const { return key.isNull(); }
 
         Key key;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<SubresourcesEntry> SubresourcesEntry::decodeStorageRecord(const 
     decoder >> subresources;
     if (!subresources)
         return nullptr;
-    entry->m_subresources = WTFMove(*subresources);
+    entry->m_subresources = WTF::move(*subresources);
 
     if (!decoder.verifyChecksum()) {
         LOG(NetworkCache, "(NetworkProcess) checksum verification failure\n");
@@ -128,7 +128,7 @@ static Vector<SubresourceInfo> makeSubresourceInfoVector(const Vector<std::uniqu
 }
 
 SubresourcesEntry::SubresourcesEntry(Key&& key, const Vector<std::unique_ptr<SubresourceLoad>>& subresourceLoads)
-    : m_key(WTFMove(key))
+    : m_key(WTF::move(key))
     , m_timeStamp(WallTime::now())
     , m_subresources(makeSubresourceInfoVector(subresourceLoads, nullptr))
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
@@ -36,19 +36,19 @@ class SubresourceInfo {
     WTF_MAKE_TZONE_ALLOCATED(SubresourceInfo);
 public:
     SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen)
-        : m_key(WTFMove(key))
+        : m_key(WTF::move(key))
         , m_lastSeen(lastSeen)
         , m_firstSeen(firstSeen)
         , m_isTransient(true) { }
     SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen, bool isSameSite, bool isAppInitiated, URL&& firstPartyForCookies, WebCore::HTTPHeaderMap&& requestHeaders, WebCore::ResourceLoadPriority priority)
-        : m_key(WTFMove(key))
+        : m_key(WTF::move(key))
         , m_lastSeen(lastSeen)
         , m_firstSeen(firstSeen)
         , m_isTransient(false)
         , m_isSameSite(isSameSite)
         , m_isAppInitiated(isAppInitiated)
-        , m_firstPartyForCookies(WTFMove(firstPartyForCookies))
-        , m_requestHeaders(WTFMove(requestHeaders))
+        , m_firstPartyForCookies(WTF::move(firstPartyForCookies))
+        , m_requestHeaders(WTF::move(requestHeaders))
         , m_priority(priority) { }
     SubresourceInfo(const Key&, const WebCore::ResourceRequest&, const SubresourceInfo* previousInfo);
 

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -34,14 +34,14 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PrefetchCache);
 
 PrefetchCache::Entry::Entry(WebCore::ResourceResponse&& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& buffer)
-    : response(WTFMove(response))
+    : response(WTF::move(response))
     , privateRelayed(privateRelayed)
-    , buffer(WTFMove(buffer))
+    , buffer(WTF::move(buffer))
 {
 }
 
 PrefetchCache::Entry::Entry(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& redirectRequest)
-    : response(WTFMove(redirectResponse)), redirectRequest(WTFMove(redirectRequest))
+    : response(WTF::move(redirectResponse)), redirectRequest(WTF::move(redirectRequest))
 {
 }
 
@@ -81,7 +81,7 @@ void PrefetchCache::store(const URL& requestURL, WebCore::ResourceResponse&& res
 {
     if (!m_sessionPrefetches)
         m_sessionPrefetches = makeUnique<PrefetchEntriesMap>();
-    auto addResult = m_sessionPrefetches->add(requestURL, makeUnique<PrefetchCache::Entry>(WTFMove(response), privateRelayed, WTFMove(buffer)));
+    auto addResult = m_sessionPrefetches->add(requestURL, makeUnique<PrefetchCache::Entry>(WTF::move(response), privateRelayed, WTF::move(buffer)));
     // Limit prefetches for same url to 1.
     if (!addResult.isNewEntry)
         return;
@@ -95,7 +95,7 @@ void PrefetchCache::storeRedirect(const URL& requestUrl, WebCore::ResourceRespon
     if (!m_sessionPrefetches)
         m_sessionPrefetches = makeUnique<PrefetchEntriesMap>();
     redirectRequest.clearPurpose();
-    m_sessionPrefetches->set(requestUrl, makeUnique<PrefetchCache::Entry>(WTFMove(redirectResponse), WTFMove(redirectRequest)));
+    m_sessionPrefetches->set(requestUrl, makeUnique<PrefetchCache::Entry>(WTF::move(redirectResponse), WTF::move(redirectRequest)));
     m_sessionExpirationList.append(std::make_tuple(requestUrl, WallTime::now()));
     if (!m_expirationTimer.isActive())
         m_expirationTimer.startOneShot(expirationTimeout);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -213,8 +213,8 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
         m_clearCacheDispatchGroup = adoptOSObject(dispatch_group_create());
 
     RetainPtr group = m_clearCacheDispatchGroup.get();
-    dispatch_group_async(group.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
-        auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    dispatch_group_async(group.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTF::move(completionHandler)] () mutable {
+        auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
         forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
             if (RefPtr cache = session.cache())
                 cache->clear(modifiedSince, [aggregator] () { });
@@ -232,16 +232,16 @@ void NetworkProcess::setSharedHTTPCookieStorage(const Vector<uint8_t>& identifie
 
 void NetworkProcess::flushCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    platformFlushCookies(sessionID, WTFMove(completionHandler));
+    platformFlushCookies(sessionID, WTF::move(completionHandler));
 }
 
 void saveCookies(NSHTTPCookieStorage *cookieStorage, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     ASSERT(cookieStorage);
-    [cookieStorage _saveCookies:makeBlockPtr([completionHandler = WTFMove(completionHandler)]() mutable {
+    [cookieStorage _saveCookies:makeBlockPtr([completionHandler = WTF::move(completionHandler)]() mutable {
         // CFNetwork may call the completion block on a background queue, so we need to redispatch to the main thread.
-        RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
+        RunLoop::mainSingleton().dispatch(WTF::move(completionHandler));
     }).get()];
 }
 
@@ -253,7 +253,7 @@ void NetworkProcess::platformFlushCookies(PAL::SessionID sessionID, CompletionHa
         return completionHandler();
 
     RetainPtr cookieStorage = networkStorageSession->nsCookieStorage();
-    saveCookies(cookieStorage.get(), WTFMove(completionHandler));
+    saveCookies(cookieStorage.get(), WTF::move(completionHandler));
 }
 
 const String& NetworkProcess::uiProcessBundleIdentifier() const
@@ -267,7 +267,7 @@ const String& NetworkProcess::uiProcessBundleIdentifier() const
 #if PLATFORM(IOS_FAMILY)
 void NetworkProcess::setBackupExclusionPeriodForTesting(PAL::SessionID sessionID, Seconds period, CompletionHandler<void()>&& completionHandler)
 {
-    auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     if (CheckedPtr session = networkSession(sessionID))
         session->storageManager().setBackupExclusionPeriodForTesting(period, [callbackAggregator] { });
 }
@@ -289,7 +289,7 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
     if (!session)
         return;
 
-    session->setProxyConfigData(WTFMove(proxyConfigurations));
+    session->setProxyConfigData(WTF::move(proxyConfigurations));
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -417,7 +417,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 
         WebCore::ResourceResponse resourceResponse(response);
 
-        networkDataTask->willPerformHTTPRedirection(WTFMove(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
+        networkDataTask->willPerformHTTPRedirection(WTF::move(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
 #if !LOG_DISABLED
             LOG(NetworkSession, "%zu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
@@ -429,7 +429,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
         });
     } else if (RefPtr webSocketTask = [self existingWebSocketTask:task]) {
         WebCore::ResourceResponse resourceResponse(response);
-        webSocketTask->willPerformHTTPRedirection(WTFMove(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](auto&& request) {
+        webSocketTask->willPerformHTTPRedirection(WTF::move(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](auto&& request) {
 #if !LOG_DISABLED
             LOG(NetworkSession, "%zu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
@@ -470,7 +470,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
         WebCore::ResourceResponse synthesizedResponse = WebCore::synthesizeRedirectResponseIfNecessary(retainPtr([task currentRequest]).get(), request, nil);
         RetainPtr origin = [request valueForHTTPHeaderField:@"Origin"] ?: @"*";
         synthesizedResponse.setHTTPHeaderField(WebCore::HTTPHeaderName::AccessControlAllowOrigin, origin.get());
-        networkDataTask->willPerformHTTPRedirection(WTFMove(synthesizedResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
+        networkDataTask->willPerformHTTPRedirection(WTF::move(synthesizedResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
 #if !LOG_DISABLED
             LOG(NetworkSession, "%zu _schemeUpgraded completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
@@ -488,7 +488,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 
 static inline void processServerTrustEvaluation(NetworkSessionCocoa& session, SessionWrapper& sessionWrapper, NSURLAuthenticationChallenge *challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, NetworkDataTaskCocoa::TaskIdentifier taskIdentifier, NetworkDataTaskCocoa* networkDataTask, CompletionHandler<void(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential)>&& completionHandler)
 {
-    session.continueDidReceiveChallenge(sessionWrapper, challenge, negotiatedLegacyTLS, taskIdentifier, networkDataTask, [completionHandler = WTFMove(completionHandler), secTrust = retainPtr(challenge.protectionSpace.serverTrust)] (WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
+    session.continueDidReceiveChallenge(sessionWrapper, challenge, negotiatedLegacyTLS, taskIdentifier, networkDataTask, [completionHandler = WTF::move(completionHandler), secTrust = retainPtr(challenge.protectionSpace.serverTrust)] (WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
         // FIXME: UIProcess should send us back non nil credentials but the credential IPC encoder currently only serializes ns credentials for username/password.
         if (disposition == WebKit::AuthenticationChallengeDisposition::UseCredential && !credential.nsCredential()) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust: secTrust.get()]);
@@ -596,13 +596,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                 auto strongSelf = weakSelf.get();
                 if (!strongSelf || !strongSelf->_sessionWrapper)
                     return completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
-                auto task = WTFMove(networkDataTask);
+                auto task = WTF::move(networkDataTask);
                 CheckedPtr session = sessionCocoa.get();
                 if (trustResult == noErr || !session) {
                     completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
                     return;
                 }
-                processServerTrustEvaluation(*session, CheckedRef { *strongSelf->_sessionWrapper }, challenge, negotiatedLegacyTLS, taskIdentifier, task.get(), WTFMove(completionHandler));
+                processServerTrustEvaluation(*session, CheckedRef { *strongSelf->_sessionWrapper }, challenge, negotiatedLegacyTLS, taskIdentifier, task.get(), WTF::move(completionHandler));
             });
             [NSURLSession _strictTrustEvaluate:challenge queue:retainPtr([NSOperationQueue mainQueue].underlyingQueue).get() completionHandler:decisionHandler.get()];
             return;
@@ -800,7 +800,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
             [retainPtr(m.get().request.allHTTPHeaderFields) enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSString *value, BOOL *) {
                 requestHeaders.set(String(name), String(value));
             }];
-            additionalMetrics->requestHeaders = WTFMove(requestHeaders);
+            additionalMetrics->requestHeaders = WTF::move(requestHeaders);
 
             uint64_t requestHeaderBytesSent = 0;
             uint64_t responseHeaderBytesReceived = 0;
@@ -816,7 +816,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
 
             additionalMetrics->isProxyConnection = m.get().proxyConnection;
 
-            networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector = WTFMove(additionalMetrics);
+            networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector = WTF::move(additionalMetrics);
         }
         networkLoadMetrics.responseBodyBytesReceived = m.get().countOfResponseBodyBytesReceived;
         networkLoadMetrics.responseBodyDecodedSize = m.get().countOfResponseBodyBytesAfterDecoding;
@@ -834,7 +834,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
         ASSERT(RunLoop::isMain());
 
         WebCore::ResourceResponse resourceResponse(response);
-        networkDataTask->didReceiveInformationalResponse(WTFMove(resourceResponse));
+        networkDataTask->didReceiveInformationalResponse(WTF::move(resourceResponse));
     }
 }
 
@@ -887,8 +887,8 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
         resourceResponse.disableLazyInitialization();
 
         resourceResponse.setDeprecatedNetworkLoadMetrics(WebCore::copyTimingData(taskMetrics.get(), networkDataTask->networkLoadMetrics()));
-        resourceResponse.setProxyName(WTFMove(proxyName));
-        networkDataTask->didReceiveResponse(WTFMove(resourceResponse), negotiatedLegacyTLS, privateRelayed, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](WebCore::PolicyAction policyAction) {
+        resourceResponse.setProxyName(WTF::move(proxyName));
+        networkDataTask->didReceiveResponse(WTF::move(resourceResponse), negotiatedLegacyTLS, privateRelayed, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](WebCore::PolicyAction policyAction) {
 #if !LOG_DISABLED
             LOG(NetworkSession, "%zu didReceiveResponse completionHandler (%s)", taskIdentifier, toString(policyAction).characters());
 #else
@@ -952,7 +952,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
     networkDataTask->transferSandboxExtensionToDownload(download);
     ASSERT(FileSystem::fileExists(networkDataTask->pendingDownloadLocation()));
     download->didCreateDestination(networkDataTask->pendingDownloadLocation());
-    downloadManager->dataTaskBecameDownloadTask(downloadID, WTFMove(download));
+    downloadManager->dataTaskBecameDownloadTask(downloadID, WTF::move(download));
 
     RELEASE_ASSERT(!_sessionWrapper->downloadMap.contains(downloadTask.taskIdentifier));
     _sessionWrapper->downloadMap.add(downloadTask.taskIdentifier, downloadID);
@@ -1601,7 +1601,7 @@ void NetworkSessionCocoa::clearCredentials(WallTime modifiedSince)
 static CompletionHandler<void(WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential)> createChallengeCompletionHandler(Ref<NetworkProcess>&& networkProcess, PAL::SessionID sessionID,  const WebCore::AuthenticationChallenge& challenge, const String& partition, uint64_t taskIdentifier, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&& completionHandler)
  {
     WebCore::AuthenticationChallenge authenticationChallenge { challenge };
-    return [completionHandler = WTFMove(completionHandler), networkProcess = WTFMove(networkProcess), sessionID, authenticationChallenge, taskIdentifier, partition](WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
+    return [completionHandler = WTF::move(completionHandler), networkProcess = WTF::move(networkProcess), sessionID, authenticationChallenge, taskIdentifier, partition](WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
 #if !LOG_DISABLED
         LOG(NetworkSession, "%llu didReceiveChallenge completionHandler %hhu", taskIdentifier, disposition);
 #else
@@ -1628,15 +1628,15 @@ void NetworkSessionCocoa::continueDidReceiveChallenge(SessionWrapper& sessionWra
 {
     if (!networkDataTask) {
         if (RefPtr webSocketTask = sessionWrapper.webSocketDataTaskMap.get(taskIdentifier).get()) {
-            auto challengeCompletionHandler = createChallengeCompletionHandler(networkProcess(), sessionID(), challenge, webSocketTask->partition(), 0, WTFMove(completionHandler));
-            networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask->webPageProxyID(), !webSocketTask->topOrigin().isNull() ? &webSocketTask->topOrigin() : nullptr, challenge, negotiatedLegacyTLS, WTFMove(challengeCompletionHandler));
+            auto challengeCompletionHandler = createChallengeCompletionHandler(networkProcess(), sessionID(), challenge, webSocketTask->partition(), 0, WTF::move(completionHandler));
+            networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask->webPageProxyID(), !webSocketTask->topOrigin().isNull() ? &webSocketTask->topOrigin() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(challengeCompletionHandler));
             return;
         }
         if (auto downloadID = sessionWrapper.downloadMap.getOptional(taskIdentifier)) {
             if (RefPtr download = networkProcess().checkedDownloadManager()->download(*downloadID)) {
                 WebCore::AuthenticationChallenge authenticationChallenge { challenge };
                 // Received an authentication challenge for a download being resumed.
-                download->didReceiveChallenge(authenticationChallenge, WTFMove(completionHandler));
+                download->didReceiveChallenge(authenticationChallenge, WTF::move(completionHandler));
                 return;
             }
         }
@@ -1645,13 +1645,13 @@ void NetworkSessionCocoa::continueDidReceiveChallenge(SessionWrapper& sessionWra
         return;
     }
 
-    auto challengeCompletionHandler = createChallengeCompletionHandler(networkProcess(), sessionID(), challenge, networkDataTask->partition(), taskIdentifier, WTFMove(completionHandler));
+    auto challengeCompletionHandler = createChallengeCompletionHandler(networkProcess(), sessionID(), challenge, networkDataTask->partition(), taskIdentifier, WTF::move(completionHandler));
     if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes
         && fastServerTrustEvaluationEnabled()
         && !networkDataTask->isTopLevelNavigation())
         return challengeCompletionHandler(AuthenticationChallengeDisposition::Cancel, { });
 
-    networkDataTask->didReceiveChallenge(WebCore::AuthenticationChallenge { challenge }, negotiatedLegacyTLS, WTFMove(challengeCompletionHandler));
+    networkDataTask->didReceiveChallenge(WebCore::AuthenticationChallenge { challenge }, negotiatedLegacyTLS, WTF::move(challengeCompletionHandler));
 }
 
 DMFWebsitePolicyMonitor *NetworkSessionCocoa::deviceManagementPolicyMonitor()
@@ -1721,7 +1721,7 @@ RefPtr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageProxyIdent
     // Use NSIntegerMax instead of 2^63 - 1 for 32-bit systems.
     task.get().maximumMessageSize = NSIntegerMax;
 
-    return WebSocketTask::create(channel, webPageProxyID, frameID, pageID, sessionSet, request, clientOrigin, WTFMove(task), storedCredentialsPolicy);
+    return WebSocketTask::create(channel, webPageProxyID, frameID, pageID, sessionSet, request, clientOrigin, WTF::move(task), storedCredentialsPolicy);
 }
 
 void NetworkSessionCocoa::addWebSocketTask(WebPageProxyIdentifier webPageProxyID, WebSocketTask& task)
@@ -1772,7 +1772,7 @@ public:
 
     static Ref<BlobDataTaskClient> create(WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, NetworkSessionCocoa& session, IPC::Connection* connection, DataTaskIdentifier identifier)
     {
-        return adoptRef(*new BlobDataTaskClient(WTFMove(request), topOrigin, session, connection, identifier));
+        return adoptRef(*new BlobDataTaskClient(WTF::move(request), topOrigin, session, connection, identifier));
     }
 
     void cancel() { m_task->cancel(); }
@@ -1798,7 +1798,7 @@ private:
     {
         if (!m_connection)
             return completionHandler(WebCore::PolicyAction::Ignore);
-        m_connection->sendWithAsyncReply(Messages::NetworkProcessProxy::DataTaskDidReceiveResponse(m_identifier, response), [completionHandler = WTFMove(completionHandler)] (bool allowed) mutable {
+        m_connection->sendWithAsyncReply(Messages::NetworkProcessProxy::DataTaskDidReceiveResponse(m_identifier, response), [completionHandler = WTF::move(completionHandler)] (bool allowed) mutable {
             completionHandler(allowed ? WebCore::PolicyAction::Use : WebCore::PolicyAction::Ignore);
         });
     }
@@ -1838,29 +1838,29 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
 
         static void create(NetworkSession& networkSession, Ref<NetworkProcess>&& networkProcess, WebPageProxyIdentifier pageID, const NetworkLoadParameters& loadParameters, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&&)>&& completionHandler)
         {
-            Ref client = adoptRef(*new Client(networkSession, WTFMove(networkProcess), pageID, loadParameters, maximumBytesFromNetwork, WTFMove(completionHandler)));
+            Ref client = adoptRef(*new Client(networkSession, WTF::move(networkProcess), pageID, loadParameters, maximumBytesFromNetwork, WTF::move(completionHandler)));
 
             // Keep the load alive until didCompleteWithError.
-            client->m_selfReference = WTFMove(client);
+            client->m_selfReference = WTF::move(client);
         }
 
     private:
         Client(NetworkSession& networkSession, Ref<NetworkProcess>&& networkProcess, WebPageProxyIdentifier pageID, const NetworkLoadParameters& loadParameters, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&&)>&& completionHandler)
-            : m_networkProcess(WTFMove(networkProcess))
+            : m_networkProcess(WTF::move(networkProcess))
             , m_url(loadParameters.request.url())
             , m_sessionID(networkSession.sessionID())
             , m_pageID(pageID)
             , m_maximumBytesFromNetwork(maximumBytesFromNetwork)
             , m_dataTask(NetworkDataTask::create(networkSession, *this, loadParameters))
-            , m_completionHandler(WTFMove(completionHandler))
+            , m_completionHandler(WTF::move(completionHandler))
         {
             m_dataTask->resume();
         }
 
-        void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler) final { completionHandler(WTFMove(request)); }
+        void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler) final { completionHandler(WTF::move(request)); }
         void didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler) final
         {
-            m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, m_pageID, nullptr, challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+            m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, m_pageID, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
         }
         void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler) final
         {
@@ -1902,16 +1902,16 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
     };
 
     NetworkLoadParameters loadParameters;
-    loadParameters.request = WTFMove(request);
+    loadParameters.request = WTF::move(request);
     // Client manages its own lifetime, derefing itself when its purpose has been fulfilled.
-    Client::create(*this, networkProcess(), pageID, loadParameters, maximumBytesFromNetwork, WTFMove(completionHandler));
+    Client::create(*this, networkProcess(), pageID, loadParameters, maximumBytesFromNetwork, WTF::move(completionHandler));
 }
 
 void NetworkSessionCocoa::dataTaskWithRequest(WebPageProxyIdentifier pageID, WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, CompletionHandler<void(DataTaskIdentifier)>&& completionHandler)
 {
     auto identifier = DataTaskIdentifier::generate();
     if (request.url().protocolIsBlob()) {
-        m_blobDataTasksForAPI.add(identifier, BlobDataTaskClient::create(WTFMove(request), topOrigin, *this, networkProcess().protectedParentProcessConnection().get(), identifier));
+        m_blobDataTasksForAPI.add(identifier, BlobDataTaskClient::create(WTF::move(request), topOrigin, *this, networkProcess().protectedParentProcessConnection().get(), identifier));
         return completionHandler(identifier);
     }
 
@@ -2120,7 +2120,7 @@ void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8
         if (requiresHTTPProtocols(nwProxyConfig.get()))
             recreateSessions = true;
 
-        m_nwProxyConfigs.append(WTFMove(nwProxyConfig));
+        m_nwProxyConfigs.append(WTF::move(nwProxyConfig));
     }
 
     if (recreateSessions) {
@@ -2230,7 +2230,7 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
         }
     };
 
-    bool result = [usageFeed performNetworkDomainsActionWithOptions:options reply:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSDictionary *reply, NSError *error) mutable {
+    bool result = [usageFeed performNetworkDomainsActionWithOptions:options reply:makeBlockPtr([completionHandler = WTF::move(completionHandler)](NSDictionary *reply, NSError *error) mutable {
         if (error)
             RELEASE_LOG_DEBUG(NetworkSession, "Error deleting network domain data %" PUBLIC_LOG_STRING, error.localizedDescription.UTF8String);
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -403,7 +403,7 @@ void NetworkTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& re
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
     updateTaskWithStoragePartitionIdentifier(request);
 #endif
-    completionHandler(WTFMove(request));
+    completionHandler(WTF::move(request));
 }
 
 ShouldRelaxThirdPartyCookieBlocking NetworkTaskCocoa::shouldRelaxThirdPartyCookieBlocking() const

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -45,17 +45,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketTask);
 
 Ref<WebSocketTask> WebSocketTask::create(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
-    return adoptRef(*new WebSocketTask(channel, webProxyPageID, frameID, pageID, WTFMove(sessionSet), request, clientOrigin, WTFMove(task), storedCredentialsPolicy));
+    return adoptRef(*new WebSocketTask(channel, webProxyPageID, frameID, pageID, WTF::move(sessionSet), request, clientOrigin, WTF::move(task), storedCredentialsPolicy));
 }
 
 WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
     : NetworkTaskCocoa(*channel.session())
     , m_channel(channel)
-    , m_task(WTFMove(task))
+    , m_task(WTF::move(task))
     , m_webProxyPageID(webProxyPageID)
     , m_frameID(frameID)
     , m_pageID(pageID)
-    , m_sessionSet(WTFMove(sessionSet))
+    , m_sessionSet(WTF::move(sessionSet))
     , m_partition(request.cachePartition())
     , m_storedCredentialsPolicy(storedCredentialsPolicy)
 {
@@ -103,7 +103,7 @@ void WebSocketTask::readNextMessage()
             if (!protectedThis->m_receivedDidConnect) {
                 ResourceResponse response { [protectedThis->m_task response] };
                 if (!response.isNull())
-                    channel->didReceiveHandshakeResponse(WTFMove(response));
+                    channel->didReceiveHandshakeResponse(WTF::move(response));
             }
 
             channel->didReceiveMessageError([error localizedDescription]);
@@ -159,7 +159,7 @@ void WebSocketTask::sendString(std::span<const uint8_t> utf8String, CompletionHa
         return;
     }
     auto message = adoptNS([[NSURLSessionWebSocketMessage alloc] initWithString:text.get()]);
-    [m_task sendMessage:message.get() completionHandler:makeBlockPtr([callback = WTFMove(callback)](NSError * _Nullable) mutable {
+    [m_task sendMessage:message.get() completionHandler:makeBlockPtr([callback = WTF::move(callback)](NSError * _Nullable) mutable {
         callback();
     }).get()];
 }
@@ -168,7 +168,7 @@ void WebSocketTask::sendData(std::span<const uint8_t> data, CompletionHandler<vo
 {
     RetainPtr nsData = toNSData(data);
     auto message = adoptNS([[NSURLSessionWebSocketMessage alloc] initWithData:nsData.get()]);
-    [m_task sendMessage:message.get() completionHandler:makeBlockPtr([callback = WTFMove(callback)](NSError * _Nullable) mutable {
+    [m_task sendMessage:message.get() completionHandler:makeBlockPtr([callback = WTF::move(callback)](NSError * _Nullable) mutable {
         callback();
     }).get()];
 }

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -80,7 +80,7 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
         blockCookies();
     restrictRequestReferrerToOriginIfNeeded(request);
 
-    m_curlRequest = createCurlRequest(WTFMove(request));
+    m_curlRequest = createCurlRequest(WTF::move(request));
     if (!m_initialCredential.isEmpty()) {
         m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
         m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
@@ -165,7 +165,7 @@ void NetworkDataTaskCurl::curlDidReceiveResponse(CurlRequest& request, CurlRespo
     m_response = ResourceResponse(receivedResponse);
 
     updateNetworkLoadMetrics(receivedResponse.networkLoadMetrics);
-    m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTFMove(receivedResponse.networkLoadMetrics)));
+    m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTF::move(receivedResponse.networkLoadMetrics)));
 
     handleCookieHeaders(request.resourceRequest(), receivedResponse);
 
@@ -229,7 +229,7 @@ void NetworkDataTaskCurl::curlDidComplete(CurlRequest&, NetworkLoadMetrics&& net
 
     updateNetworkLoadMetrics(networkLoadMetrics);
 
-    m_client->didCompleteWithError({ }, WTFMove(networkLoadMetrics));
+    m_client->didCompleteWithError({ }, WTF::move(networkLoadMetrics));
 }
 
 void NetworkDataTaskCurl::curlDidFailWithError(CurlRequest& request, ResourceError&& resourceError, CertificateInfo&& certificateInfo)
@@ -349,7 +349,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
     ResourceRequest request = m_firstRequest;
     if (!redirectedURL.hasFragmentIdentifier() && request.url().hasFragmentIdentifier())
         redirectedURL.setFragmentIdentifier(request.url().fragmentIdentifier());
-    request.setURL(WTFMove(redirectedURL));
+    request.setURL(WTF::move(redirectedURL));
 
     m_hasCrossOriginRedirect = m_hasCrossOriginRedirect || !SecurityOrigin::create(m_response.url())->canRequest(request.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 
@@ -396,7 +396,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
     if (!m_blockingCookies && shouldBlockCookies(request))
         blockCookies();
     auto response = ResourceResponse(m_response);
-    m_client->willPerformHTTPRedirection(WTFMove(response), WTFMove(request), [this, protectedThis = Ref { *this }, didChangeCredential](const ResourceRequest& newRequest) {
+    m_client->willPerformHTTPRedirection(WTF::move(response), WTF::move(request), [this, protectedThis = Ref { *this }, didChangeCredential](const ResourceRequest& newRequest) {
         if (newRequest.isNull() || m_state == State::Canceling)
             return;
 
@@ -405,7 +405,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
 
         auto requestCopy = newRequest;
         restrictRequestReferrerToOriginIfNeeded(requestCopy);
-        m_curlRequest = createCurlRequest(WTFMove(requestCopy));
+        m_curlRequest = createCurlRequest(WTF::move(requestCopy));
         if (didChangeCredential && !m_initialCredential.isEmpty()) {
             m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
             m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
@@ -527,7 +527,7 @@ void NetworkDataTaskCurl::restartWithCredential(const ProtectionSpace& protectio
     auto shouldDisableServerTrustEvaluation = protectionSpace.authenticationScheme() == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested || m_curlRequest->isServerTrustEvaluationDisabled();
     m_curlRequest->cancel();
 
-    m_curlRequest = createCurlRequest(WTFMove(previousRequest), RequestStatus::ReusedRequest);
+    m_curlRequest = createCurlRequest(WTF::move(previousRequest), RequestStatus::ReusedRequest);
     m_curlRequest->setAuthenticationScheme(protectionSpace.authenticationScheme());
     m_curlRequest->setUserPass(credential.user(), credential.password());
     if (shouldDisableServerTrustEvaluation)
@@ -608,7 +608,7 @@ void NetworkDataTaskCurl::setTimingAllowFailedFlag()
 
 void NetworkDataTaskCurl::setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)
 {
-    NetworkDataTask::setPendingDownloadLocation(filename, WTFMove(sandboxExtensionHandle), allowOverwrite);
+    NetworkDataTask::setPendingDownloadLocation(filename, WTF::move(sandboxExtensionHandle), allowOverwrite);
     m_allowOverwriteDownload = allowOverwrite;
 }
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
@@ -49,7 +49,7 @@ void NetworkProcess::allowSpecificHTTPSCertificateForHost(PAL::SessionID, const 
 
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
 {
-    auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
     forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
         if (auto* cache = session.cache())
             cache->clear(modifiedSince, [aggregator] () { });

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -73,7 +73,7 @@ RefPtr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdenti
 
 void NetworkSessionCurl::didReceiveChallenge(WebSocketTask& webSocketTask, WebCore::AuthenticationChallenge&& challenge, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&& challengeCompletionHandler)
 {
-    networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask.webPageProxyID(), !webSocketTask.topOrigin().isNull() ? &webSocketTask.topOrigin() : nullptr, challenge, NegotiatedLegacyTLS::No, WTFMove(challengeCompletionHandler));
+    networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask.webPageProxyID(), !webSocketTask.topOrigin().isNull() ? &webSocketTask.topOrigin() : nullptr, challenge, NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -152,7 +152,7 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
         memcpy(handshakeMessage.get() + handshakeMessageLength - 2, "\r\n", 2);
     }
 
-    m_scheduler.send(m_streamID, WTFMove(handshakeMessage), handshakeMessageLength);
+    m_scheduler.send(m_streamID, WTF::move(handshakeMessage), handshakeMessageLength);
 }
 
 void WebSocketTask::didReceiveData(WebCore::CurlStreamID, const WebCore::SharedBuffer& buffer)
@@ -256,16 +256,16 @@ void WebSocketTask::didFail(WebCore::CurlStreamID, CURLcode errorCode, WebCore::
         RELEASE_ASSERT(m_state == State::Connecting);
         destructStream();
 
-        tryServerTrustEvaluation({ m_request.url(), WTFMove(certificateInfo), WebCore::ResourceError(errorCode, m_request.url()) }, WTFMove(reason));
+        tryServerTrustEvaluation({ m_request.url(), WTF::move(certificateInfo), WebCore::ResourceError(errorCode, m_request.url()) }, WTF::move(reason));
         return;
     }
 
-    didFail(WTFMove(reason));
+    didFail(WTF::move(reason));
 }
 
 void WebSocketTask::tryServerTrustEvaluation(WebCore::AuthenticationChallenge&& challenge, String&& errorReason)
 {
-    networkSession()->didReceiveChallenge(*this, WTFMove(challenge), [this, errorReason = WTFMove(errorReason)](WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
+    networkSession()->didReceiveChallenge(*this, WTF::move(challenge), [this, errorReason = WTF::move(errorReason)](WebKit::AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) mutable {
         if (disposition == AuthenticationChallengeDisposition::UseCredential && !credential.isEmpty()) {
             auto localhostAlias = WebCore::CurlStream::LocalhostAlias::Disable;
             if (networkSession() && networkSession()->networkProcess().localhostAliasesForTesting().contains<StringViewHashTranslator>(m_request.url().host()))
@@ -273,7 +273,7 @@ void WebSocketTask::tryServerTrustEvaluation(WebCore::AuthenticationChallenge&& 
 
             m_streamID = m_scheduler.createStream(m_request.url(), *this, WebCore::CurlStream::ServerTrustEvaluation::Disable, localhostAlias);
         } else
-            didFail(WTFMove(errorReason));
+            didFail(WTF::move(errorReason));
     });
 }
 
@@ -449,7 +449,7 @@ bool WebSocketTask::sendFrame(WebCore::WebSocketFrame::OpCode opCode, std::span<
     auto buffer = makeUniqueArray<uint8_t>(frameData.size());
     memcpySpan(unsafeMakeSpan(buffer.get(), frameData.size()), frameData.span());
 
-    m_scheduler.send(m_streamID, WTFMove(buffer), frameData.size());
+    m_scheduler.send(m_streamID, WTF::move(buffer), frameData.size());
     return true;
 }
 
@@ -469,7 +469,7 @@ void WebSocketTask::didFail(String&& reason)
     m_hasContinuousFrame = false;
     m_continuousFrameData.clear();
 
-    protectedChannel()->didReceiveMessageError(WTFMove(reason));
+    protectedChannel()->didReceiveMessageError(WTF::move(reason));
     didClose(WebCore::ThreadableWebSocketChannel::CloseEventCode::CloseEventCodeAbnormalClosure, { });
 }
 

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
@@ -80,8 +80,8 @@ void DNSCache::update(const CString& host, Vector<GRefPtr<GInetAddress>>&& addre
 {
     Locker locker { m_lock };
     auto& map = mapForType(type);
-    CachedResponse response = { WTFMove(addressList), MonotonicTime::now() + expireInterval };
-    auto addResult = map.set(host, WTFMove(response));
+    CachedResponse response = { WTF::move(addressList), MonotonicTime::now() + expireInterval };
+    auto addResult = map.set(host, WTF::move(response));
     if (addResult.isNewEntry)
         pruneResponsesInMap(map);
     m_expiredTimer.startOneShot(expireInterval);

--- a/Source/WebKit/NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
+++ b/Source/WebKit/NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
@@ -87,7 +87,7 @@ void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdenti
     }).iterator->value.append(name);
 
     Ref connection = m_connection.get();
-    auto request = makeUnique<PendingRegistrationRequest>(connection.get(), WTFMove(name), ipAddress, sessionID(), WTFMove(completionHandler));
+    auto request = makeUnique<PendingRegistrationRequest>(connection.get(), WTF::move(name), ipAddress, sessionID(), WTF::move(completionHandler));
 
     request->cancellable = m_cancellable;
 

--- a/Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp
+++ b/Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp
@@ -236,6 +236,6 @@ GResolver* webkitCachedResolverNew(GRefPtr<GResolver>&& wrappedResolver)
     g_return_val_if_fail(wrappedResolver, nullptr);
 
     auto* resolver = WEBKIT_CACHED_RESOLVER(g_object_new(WEBKIT_TYPE_CACHED_RESOLVER, nullptr));
-    resolver->priv->wrappedResolver = WTFMove(wrappedResolver);
+    resolver->priv->wrappedResolver = WTF::move(wrappedResolver);
     return G_RESOLVER(resolver);
 }

--- a/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
+++ b/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
@@ -184,7 +184,7 @@ GResolver* webkitOverridingResolverNew(GRefPtr<GResolver>&& wrappedResolver, con
     auto* resolver = WEBKIT_OVERRIDING_RESOLVER(g_object_new(WEBKIT_TYPE_OVERRIDING_RESOLVER, nullptr));
     resolver->priv->ipv4LoopbackAddress = adoptGRef(g_inet_address_new_loopback(G_SOCKET_FAMILY_IPV4));
     resolver->priv->ipv6LoopbackAddress = adoptGRef(g_inet_address_new_loopback(G_SOCKET_FAMILY_IPV6));
-    resolver->priv->wrappedResolver = WTFMove(wrappedResolver);
+    resolver->priv->wrappedResolver = WTF::move(wrappedResolver);
     resolver->priv->localhostAliases = localhostAliases;
     return G_RESOLVER(resolver);
 }

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -57,7 +57,7 @@ UIViewController *NetworkConnectionToWebProcess::paymentCoordinatorPresentingVie
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
 void NetworkConnectionToWebProcess::getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&& completionHandler)
 {
-    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetWindowSceneAndBundleIdentifierForPaymentPresentation(webPageProxyIdentifier), WTFMove(completionHandler));
+    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetWindowSceneAndBundleIdentifierForPaymentPresentation(webPageProxyIdentifier), WTF::move(completionHandler));
 }
 
 void NetworkConnectionToWebProcess::notifyWillPresentPaymentUI(WebPageProxyIdentifier webPageProxyIdentifier)
@@ -68,7 +68,7 @@ void NetworkConnectionToWebProcess::notifyWillPresentPaymentUI(WebPageProxyIdent
 
 void NetworkConnectionToWebProcess::getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetPaymentCoordinatorEmbeddingUserAgent { webPageProxyIdentifier }, WTFMove(completionHandler));
+    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetPaymentCoordinatorEmbeddingUserAgent { webPageProxyIdentifier }, WTF::move(completionHandler));
 }
 
 CocoaWindow *NetworkConnectionToWebProcess::paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const

--- a/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
@@ -51,7 +51,7 @@ void NetworkConnectionToWebProcess::updateActivePages(String&& overrideDisplayNa
 #if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
         // In this case, the WebContent process has not been checked in with Launch Services yet.
         // We store the display name, and set it after checkin has completed.
-        m_pendingDisplayName = WTFMove(overrideDisplayName);
+        m_pendingDisplayName = WTF::move(overrideDisplayName);
 #endif
         return;
     }
@@ -125,13 +125,13 @@ void NetworkConnectionToWebProcess::checkInWebProcess(const CoreIPCAuditToken& a
         NSDictionary *dictionary = (__bridge NSDictionary *)result;
         RELEASE_LOG(Process, "Launch Services checkin completed, result = %{public}@, error = %{public}@", dictionary, (__bridge NSError *)error);
 
-        callOnMainRunLoop([weakThis = WTFMove(weakThis), auditToken = WTFMove(auditToken)] mutable {
+        callOnMainRunLoop([weakThis = WTF::move(weakThis), auditToken = WTF::move(auditToken)] mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
             if (protectedThis->m_pendingDisplayName.isNull())
                 return;
-            protectedThis->updateActivePages(std::exchange(protectedThis->m_pendingDisplayName, String()), { }, WTFMove(auditToken));
+            protectedThis->updateActivePages(std::exchange(protectedThis->m_pendingDisplayName, String()), { }, WTF::move(auditToken));
         });
     });
 

--- a/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
+++ b/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
@@ -85,7 +85,7 @@ static std::optional<SecItemResponseData> sendSecItemRequest(SecItemRequestData:
 
         globalNetworkProcess()->protectedParentProcessConnection()->sendWithAsyncReply(Messages::SecItemShimProxy::SecItemRequest(SecItemRequestData(requestType, cfQuery.get(), cfAttributesToMatch.get())), [&](auto reply) {
             if (reply)
-                response = WTFMove(*reply);
+                response = WTF::move(*reply);
 
             semaphore.signal();
         });

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -171,7 +171,7 @@ void NetworkProcess::allowSpecificHTTPSCertificateForHost(PAL::SessionID session
 
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
 {
-    auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
     forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
         if (auto* cache = session.cache())
             cache->clear(modifiedSince, [aggregator] () { });

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -88,7 +88,7 @@ void NetworkSessionSoup::setCookiePersistentStorage(const String& storagePath, S
         jar = adoptGRef(soup_cookie_jar_db_new(storagePath.utf8().data(), FALSE));
         break;
     }
-    storageSession->setCookieStorage(WTFMove(jar));
+    storageSession->setCookieStorage(WTF::move(jar));
 
     m_networkSession->setCookieJar(storageSession->cookieStorage());
 }

--- a/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
@@ -188,8 +188,8 @@ webkit_directory_input_stream_class_init(WebKitDirectoryInputStreamClass* klass)
 GRefPtr<GInputStream> webkitDirectoryInputStreamNew(GRefPtr<GFileEnumerator>&& enumerator, CString&& uri)
 {
     auto* stream = WEBKIT_DIRECTORY_INPUT_STREAM(g_object_new(WEBKIT_TYPE_DIRECTORY_INPUT_STREAM, nullptr));
-    stream->priv->enumerator = WTFMove(enumerator);
-    stream->priv->uri = WTFMove(uri);
+    stream->priv->enumerator = WTF::move(enumerator);
+    stream->priv->uri = WTF::move(uri);
     stream->priv->buffer = adoptGRef(webkitDirectoryInputStreamCreateHeader(stream));
 
     return adoptGRef(G_INPUT_STREAM((stream)));

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -102,14 +102,14 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
                 return;
             }
             if (connection)
-                task->didConnect(WTFMove(connection));
+                task->didConnect(WTF::move(connection));
             else
                 task->didFail(String::fromUTF8(error->message));
         }, this);
 
     g_signal_connect(msg, "starting", G_CALLBACK(+[](SoupMessage* msg, WebSocketTask* task) {
         task->m_request.updateFromSoupMessageHeaders(soup_message_get_request_headers(msg));
-        task->protectedChannel()->didSendHandshakeRequest(WTFMove(task->m_request));
+        task->protectedChannel()->didSendHandshakeRequest(WTF::move(task->m_request));
     }), this);
 }
 
@@ -146,7 +146,7 @@ String WebSocketTask::acceptedExtensions() const
 
 void WebSocketTask::didConnect(GRefPtr<SoupWebsocketConnection>&& connection)
 {
-    m_connection = WTFMove(connection);
+    m_connection = WTF::move(connection);
 
     // Use the same maximum payload length as WebKit internal implementation for backwards compatibility.
     static const uint64_t maxPayloadLength = UINT64_C(0x7FFFFFFFFFFFFFFF);
@@ -203,7 +203,7 @@ void WebSocketTask::didFail(String&& errorMessage)
         g_signal_handlers_disconnect_by_data(m_handshakeMessage.get(), this);
         m_handshakeMessage = nullptr;
     }
-    channel->didReceiveMessageError(WTFMove(errorMessage));
+    channel->didReceiveMessageError(WTF::move(errorMessage));
     if (!m_connection) {
         didClose(SOUP_WEBSOCKET_CLOSE_ABNORMAL, { });
         return;
@@ -283,7 +283,7 @@ void WebSocketTask::resume()
 
 void WebSocketTask::delayFailTimerFired()
 {
-    didFail(WTFMove(m_delayErrorMessage));
+    didFail(WTF::move(m_delayErrorMessage));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -44,7 +44,7 @@ struct BackgroundFetchState;
 
 class BackgroundFetchStoreImpl :  public WebCore::BackgroundFetchStore {
 public:
-    static Ref<BackgroundFetchStoreImpl> create(ThreadSafeWeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server) { return adoptRef(*new BackgroundFetchStoreImpl(WTFMove(manager), WTFMove(server))); }
+    static Ref<BackgroundFetchStoreImpl> create(ThreadSafeWeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server) { return adoptRef(*new BackgroundFetchStoreImpl(WTF::move(manager), WTF::move(server))); }
     ~BackgroundFetchStoreImpl();
 
     void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
@@ -44,7 +44,7 @@ public:
 
     static Ref<BackgroundFetchStoreManager> create(const String& path, Ref<WTF::WorkQueue>&& taskQueue, QuotaCheckFunction&& quotaCheckFunction)
     {
-        return adoptRef(*new BackgroundFetchStoreManager(path, WTFMove(taskQueue), WTFMove(quotaCheckFunction)));
+        return adoptRef(*new BackgroundFetchStoreManager(path, WTF::move(taskQueue), WTF::move(quotaCheckFunction)));
     }
     ~BackgroundFetchStoreManager();
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -106,14 +106,14 @@ struct StoredRecordInformation {
 
 Ref<CacheStorageDiskStore> CacheStorageDiskStore::create(const String& cacheName, const String& path, Ref<WorkQueue>&& queue)
 {
-    return adoptRef(*new CacheStorageDiskStore(cacheName, path, WTFMove(queue)));
+    return adoptRef(*new CacheStorageDiskStore(cacheName, path, WTF::move(queue)));
 }
 
 CacheStorageDiskStore::CacheStorageDiskStore(const String& cacheName, const String& path, Ref<WorkQueue>&& queue)
     : m_cacheName(cacheName)
     , m_path(path)
     , m_salt(valueOrDefault(FileSystem::readOrMakeSalt(saltFilePath())))
-    , m_callbackQueue(WTFMove(queue))
+    , m_callbackQueue(WTF::move(queue))
     , m_ioQueue(WorkQueue::create("com.apple.WebKit.CacheStorageCache"_s))
 {
     ASSERT(!m_cacheName.isEmpty());
@@ -163,49 +163,49 @@ static std::optional<RecordMetaData> decodeRecordMetaData(std::span<const uint8_
     decoder >> cacheStorageVersion;
     if (!cacheStorageVersion)
         return std::nullopt;
-    metaData.cacheStorageVersion = WTFMove(*cacheStorageVersion);
+    metaData.cacheStorageVersion = WTF::move(*cacheStorageVersion);
 
     std::optional<NetworkCache::Key> key;
     decoder >> key;
     if (!key)
         return std::nullopt;
-    metaData.key = WTFMove(*key);
+    metaData.key = WTF::move(*key);
 
     std::optional<WallTime> timeStamp;
     decoder >> timeStamp;
     if (!timeStamp)
         return std::nullopt;
-    metaData.timeStamp = WTFMove(*timeStamp);
+    metaData.timeStamp = WTF::move(*timeStamp);
 
     std::optional<SHA1::Digest> headerHash;
     decoder >> headerHash;
     if (!headerHash)
         return std::nullopt;
-    metaData.headerHash = WTFMove(*headerHash);
+    metaData.headerHash = WTF::move(*headerHash);
 
     std::optional<uint64_t> headerSize;
     decoder >> headerSize;
     if (!headerSize)
         return std::nullopt;
-    metaData.headerSize = WTFMove(*headerSize);
+    metaData.headerSize = WTF::move(*headerSize);
 
     std::optional<SHA1::Digest> bodyHash;
     decoder >> bodyHash;
     if (!bodyHash)
         return std::nullopt;
-    metaData.bodyHash = WTFMove(*bodyHash);
+    metaData.bodyHash = WTF::move(*bodyHash);
 
     std::optional<uint64_t> bodySize;
     decoder >> bodySize;
     if (!bodySize)
         return std::nullopt;
-    metaData.bodySize = WTFMove(*bodySize);
+    metaData.bodySize = WTF::move(*bodySize);
 
     std::optional<bool> isBodyInline;
     decoder >> isBodyInline;
     if (!isBodyInline)
         return std::nullopt;
-    metaData.isBodyInline = WTFMove(*isBodyInline);
+    metaData.isBodyInline = WTF::move(*isBodyInline);
 
     if (!decoder.verifyChecksum())
         return std::nullopt;
@@ -273,12 +273,12 @@ static std::optional<RecordHeader> decodeRecordHeader(std::span<const uint8_t> h
         *insertionTime,
         *size,
         *requestHeadersGuard,
-        WTFMove(*request),
-        WTFMove(options),
-        WTFMove(*referrer),
+        WTF::move(*request),
+        WTF::move(options),
+        WTF::move(*referrer),
         *responseHeadersGuard,
-        WTFMove(*responseData),
-        WTFMove(*responseBodySize)
+        WTF::move(*responseData),
+        WTF::move(*responseBodySize)
     };
 }
 
@@ -304,9 +304,9 @@ static std::optional<StoredRecordInformation> readRecordInfoFromFileData(const F
 
     auto key = metaData->key;
     auto url = header->request.url();
-    CacheStorageRecordInformation info { WTFMove(key), header->insertionTime, 0, 0, header->responseBodySize, WTFMove(url), false, { } };
+    CacheStorageRecordInformation info { WTF::move(key), header->insertionTime, 0, 0, header->responseBodySize, WTF::move(url), false, { } };
     info.updateVaryHeaders(header->request, header->responseData);
-    return StoredRecordInformation { info, WTFMove(*metaData), WTFMove(*header) };
+    return StoredRecordInformation { info, WTF::move(*metaData), WTF::move(*header) };
 }
 
 std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(std::span<const uint8_t> buffer, FileSystem::MappedFileData&& blobBuffer)
@@ -333,7 +333,7 @@ std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(
         if (!blobBuffer)
             return std::nullopt;
 
-        auto sharedBuffer = WebCore::SharedBuffer::create(WTFMove(blobBuffer));
+        auto sharedBuffer = WebCore::SharedBuffer::create(WTF::move(blobBuffer));
         if (storedInfo->metaData.bodyHash != computeSHA1(sharedBuffer->span(), m_salt))
             return std::nullopt;
 
@@ -343,12 +343,12 @@ std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(
     if (!responseBody)
         return std::nullopt;
 
-    return CacheStorageRecord { storedInfo->info, storedInfo->header.requestHeadersGuard, storedInfo->header.request, storedInfo->header.options, storedInfo->header.referrer, storedInfo->header.responseHeadersGuard, WTFMove(storedInfo->header.responseData), storedInfo->header.responseBodySize, WTFMove(*responseBody) };
+    return CacheStorageRecord { storedInfo->info, storedInfo->header.requestHeadersGuard, storedInfo->header.request, storedInfo->header.options, storedInfo->header.referrer, storedInfo->header.responseHeadersGuard, WTF::move(storedInfo->header.responseData), storedInfo->header.responseBodySize, WTF::move(*responseBody) };
 }
 
 void CacheStorageDiskStore::readAllRecordInfosInternal(ReadAllRecordInfosCallback&& callback)
 {
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordsDirectory = recordsDirectoryPath().isolatedCopy(), cacheName = m_cacheName.isolatedCopy(), salt = m_salt, callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordsDirectory = recordsDirectoryPath().isolatedCopy(), cacheName = m_cacheName.isolatedCopy(), salt = m_salt, callback = WTF::move(callback)]() mutable {
         Vector<CacheStorageRecordInformation> recordInfos;
         auto partitionNames = FileSystem::listDirectory(recordsDirectory);
         for (auto& partitionName : partitionNames) {
@@ -364,29 +364,29 @@ void CacheStorageDiskStore::readAllRecordInfosInternal(ReadAllRecordInfosCallbac
                     continue;
 
                 if (auto storedRecordInfo = readRecordInfoFromFileData(salt, fileData->span()))
-                    recordInfos.append(WTFMove(storedRecordInfo->info));
+                    recordInfos.append(WTF::move(storedRecordInfo->info));
             }
         }
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), recordInfos = crossThreadCopy(WTFMove(recordInfos)), callback = WTFMove(callback)]() mutable {
-            callback(WTFMove(recordInfos));
+        m_callbackQueue->dispatch([protectedThis = WTF::move(protectedThis), recordInfos = crossThreadCopy(WTF::move(recordInfos)), callback = WTF::move(callback)]() mutable {
+            callback(WTF::move(recordInfos));
         });
     });
 }
 
 void CacheStorageDiskStore::readAllRecordInfos(ReadAllRecordInfosCallback&& callback)
 {
-    readAllRecordInfosInternal(WTFMove(callback));
+    readAllRecordInfosInternal(WTF::move(callback));
 }
 
 void CacheStorageDiskStore::readRecordsInternal(const Vector<CacheStorageRecordInformation>& recordInfos, ReadRecordsCallback&& callback)
 {
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, directory = crossThreadCopy(recordsDirectoryPath()), recordInfos = crossThreadCopy(recordInfos), callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, directory = crossThreadCopy(recordsDirectoryPath()), recordInfos = crossThreadCopy(recordInfos), callback = WTF::move(callback)]() mutable {
         Vector<std::optional<CacheStorageRecord>> records;
         for (auto& recordInfo : recordInfos) {
             auto recordFile = recordFilePathWithDirectory(directory, recordInfo.key());
             auto fileData = valueOrDefault(FileSystem::mapFile(recordFile, FileSystem::MappedFileMode::Private));
             auto blobData = !fileData.size() ? FileSystem::MappedFileData { } : valueOrDefault(FileSystem::mapFile(recordBlobFilePath(recordFile), FileSystem::MappedFileMode::Private));
-            auto record = readRecordFromFileData(fileData.span(), WTFMove(blobData));
+            auto record = readRecordFromFileData(fileData.span(), WTF::move(blobData));
             if (!record) {
                 RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readRecordsInternal fails to decode record from file", this);
                 records.append(std::nullopt);
@@ -405,18 +405,18 @@ void CacheStorageDiskStore::readRecordsInternal(const Vector<CacheStorageRecordI
 
             record->info.setIdentifier(recordInfo.identifier());
             record->info.setUpdateResponseCounter(recordInfo.updateResponseCounter());
-            records.append(WTFMove(record));
+            records.append(WTF::move(record));
         }
 
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), records = crossThreadCopy(WTFMove(records)), callback = WTFMove(callback)]() mutable {
-            callback(WTFMove(records));
+        m_callbackQueue->dispatch([protectedThis = WTF::move(protectedThis), records = crossThreadCopy(WTF::move(records)), callback = WTF::move(callback)]() mutable {
+            callback(WTF::move(records));
         });
     });
 }
 
 void CacheStorageDiskStore::readRecords(const Vector<CacheStorageRecordInformation>& recordInfos, ReadRecordsCallback&& callback)
 {
-    readRecordsInternal(recordInfos, WTFMove(callback));
+    readRecordsInternal(recordInfos, WTF::move(callback));
 }
 
 void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
@@ -425,7 +425,7 @@ void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInforma
         return recordFilePath(recordInfo.key());
     });
 
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTF::move(recordFiles)), callback = WTF::move(callback)]() mutable {
         bool result = true;
         for (auto recordFile : recordFiles) {
             FileSystem::deleteFile(recordBlobFilePath(recordFile));
@@ -435,8 +435,8 @@ void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInforma
                 result = false;
         }
 
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), result, callback = WTFMove(callback)]() mutable {
-            callback(WTFMove(result));
+        m_callbackQueue->dispatch([protectedThis = WTF::move(protectedThis), result, callback = WTF::move(callback)]() mutable {
+            callback(WTF::move(result));
         });
     });
 }
@@ -514,15 +514,15 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
         auto bodyHash = computeSHA1(bodyData.span(), m_salt);
         bool shouldCreateBlob = shouldStoreBodyAsBlob(bodyData);
         auto recordInfoKey = record.info.key();
-        auto headerData = encodeRecordHeader(WTFMove(record));
+        auto headerData = encodeRecordHeader(WTF::move(record));
         auto recordData = encodeRecord(recordInfoKey, headerData, !shouldCreateBlob, bodyData, bodyHash, m_salt);
-        recordDatas.append(WTFMove(recordData));
+        recordDatas.append(WTF::move(recordData));
         if (!shouldCreateBlob)
             bodyData = { };
-        recordBlobDatas.append(WTFMove(bodyData));
+        recordBlobDatas.append(WTF::move(bodyData));
     }
 
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), recordDatas = crossThreadCopy(WTFMove(recordDatas)), recordBlobDatas = crossThreadCopy(WTFMove(recordBlobDatas)), callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTF::move(recordFiles)), recordDatas = crossThreadCopy(WTF::move(recordDatas)), recordBlobDatas = crossThreadCopy(WTF::move(recordBlobDatas)), callback = WTF::move(callback)]() mutable {
         bool result = true;
         // FIXME: we should probably stop writing and revert changes when result becomes false.
         for (size_t index = 0; index < recordFiles.size(); ++index) {
@@ -540,8 +540,8 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
                 result = false;
         }
 
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), result, callback = WTFMove(callback)]() mutable {
-            callback(WTFMove(result));
+        m_callbackQueue->dispatch([protectedThis = WTF::move(protectedThis), result, callback = WTF::move(callback)]() mutable {
+            callback(WTF::move(result));
         });
     });
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -56,7 +56,7 @@ void CacheStorageMemoryStore::readRecords(const Vector<CacheStorageRecordInforma
             return std::nullopt;
         return copyCacheStorageRecord(*iterator->value);
     });
-    return callback(WTFMove(result));
+    return callback(WTF::move(result));
 }
 
 void CacheStorageMemoryStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
@@ -70,7 +70,7 @@ void CacheStorageMemoryStore::deleteRecords(const Vector<CacheStorageRecordInfor
 void CacheStorageMemoryStore::writeRecords(Vector<CacheStorageRecord>&& records, WriteRecordsCallback&& callback)
 {
     for (auto&& record : records)
-        m_records.set(record.info.identifier(), makeUnique<CacheStorageRecord>(WTFMove(record)));
+        m_records.set(record.info.identifier(), makeUnique<CacheStorageRecord>(WTF::move(record)));
 
     callback(true);
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
@@ -29,14 +29,14 @@
 namespace WebKit {
 
 CacheStorageRecordInformation::CacheStorageRecordInformation(NetworkCache::Key&& key, double insertionTime, uint64_t identifier, uint64_t updateResponseCounter, uint64_t size, URL&& url, bool hasVaryStar, HashMap<String, String>&& varyHeaders)
-    : m_key(WTFMove(key))
+    : m_key(WTF::move(key))
     , m_insertionTime(insertionTime)
     , m_identifier(identifier)
     , m_updateResponseCounter(updateResponseCounter)
     , m_size(size)
-    , m_url(WTFMove(url))
+    , m_url(WTF::move(url))
     , m_hasVaryStar(hasVaryStar)
-    , m_varyHeaders(WTFMove(varyHeaders))
+    , m_varyHeaders(WTF::move(varyHeaders))
 {
 }
 
@@ -62,14 +62,14 @@ void CacheStorageRecordInformation::updateVaryHeaders(const WebCore::ResourceReq
 CacheStorageRecordInformation CacheStorageRecordInformation::isolatedCopy() &&
 {
     return {
-        crossThreadCopy(WTFMove(m_key)),
+        crossThreadCopy(WTF::move(m_key)),
         m_insertionTime,
         m_identifier,
         m_updateResponseCounter,
         m_size,
-        crossThreadCopy(WTFMove(m_url)),
+        crossThreadCopy(WTF::move(m_url)),
         m_hasVaryStar,
-        crossThreadCopy(WTFMove(m_varyHeaders))
+        crossThreadCopy(WTF::move(m_varyHeaders))
     };
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -80,23 +80,23 @@ struct CacheStorageRecord {
         , options(options)
         , referrer(referrer)
         , responseHeadersGuard(responseHeadersGuard)
-        , responseData(WTFMove(responseData))
+        , responseData(WTF::move(responseData))
         , responseBodySize(responseBodySize)
-        , responseBody(WTFMove(responseBody))
+        , responseBody(WTF::move(responseBody))
     {
     }
 
     CacheStorageRecord isolatedCopy() && {
         return {
-            crossThreadCopy(WTFMove(info)),
+            crossThreadCopy(WTF::move(info)),
             requestHeadersGuard,
-            crossThreadCopy(WTFMove(request)),
-            crossThreadCopy(WTFMove(options)),
-            crossThreadCopy(WTFMove(referrer)),
+            crossThreadCopy(WTF::move(request)),
+            crossThreadCopy(WTF::move(options)),
+            crossThreadCopy(WTF::move(referrer)),
             responseHeadersGuard,
-            crossThreadCopy(WTFMove(responseData)),
+            crossThreadCopy(WTF::move(responseData)),
             responseBodySize,
-            WebCore::DOMCacheEngine::isolatedResponseBody(WTFMove(responseBody))
+            WebCore::DOMCacheEngine::isolatedResponseBody(WTF::move(responseBody))
         };
     }
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -66,14 +66,14 @@ RefPtr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSystemStorag
     if (!canAccess)
         return nullptr;
 
-    return adoptRef(*new FileSystemStorageHandle(manager, type, WTFMove(path), WTFMove(name)));
+    return adoptRef(*new FileSystemStorageHandle(manager, type, WTF::move(path), WTF::move(name)));
 }
 
 FileSystemStorageHandle::FileSystemStorageHandle(FileSystemStorageManager& manager, Type type, String&& path, String&& name)
     : m_manager(manager)
     , m_type(type)
-    , m_path(WTFMove(path))
-    , m_name(WTFMove(name))
+    , m_path(WTF::move(path))
+    , m_name(WTF::move(name))
 {
     ASSERT(!m_path.isEmpty());
 }
@@ -130,17 +130,17 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
         return makeUnexpected(FileSystemStorageError::InvalidName);
 
     auto path = FileSystem::pathByAppendingComponent(m_path, name);
-    return manager->createHandle(connection, type, WTFMove(path), WTFMove(name), createIfNecessary);
+    return manager->createHandle(connection, type, WTF::move(path), WTF::move(name), createIfNecessary);
 }
 
 Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystemStorageHandle::getFileHandle(IPC::Connection::UniqueID connection, String&& name, bool createIfNecessary)
 {
-    return requestCreateHandle(connection, FileSystemStorageHandle::Type::File, WTFMove(name), createIfNecessary);
+    return requestCreateHandle(connection, FileSystemStorageHandle::Type::File, WTF::move(name), createIfNecessary);
 }
 
 Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystemStorageHandle::getDirectoryHandle(IPC::Connection::UniqueID connection, String&& name, bool createIfNecessary)
 {
-    return requestCreateHandle(connection, FileSystemStorageHandle::Type::Directory, WTFMove(name), createIfNecessary);
+    return requestCreateHandle(connection, FileSystemStorageHandle::Type::Directory, WTF::move(name), createIfNecessary);
 }
 
 std::optional<FileSystemStorageError> FileSystemStorageHandle::removeEntry(const String& name, bool deleteRecursively)
@@ -210,14 +210,14 @@ Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> FileSystemStora
     if (!handle)
         return makeUnexpected(FileSystemStorageError::Unknown);
 
-    auto ipcHandle = IPC::SharedFileHandle::create(WTFMove(handle));
+    auto ipcHandle = IPC::SharedFileHandle::create(WTF::move(handle));
     if (!ipcHandle)
         return makeUnexpected(FileSystemStorageError::BackendNotSupported);
 
     ASSERT(!m_activeSyncAccessHandle);
     m_activeSyncAccessHandle = SyncAccessHandleInfo { WebCore::FileSystemSyncAccessHandleIdentifier::generate() };
     uint64_t initialCapacity = valueOrDefault(FileSystem::fileSize(m_path));
-    return FileSystemSyncAccessHandleInfo { m_activeSyncAccessHandle->identifier, WTFMove(*ipcHandle), initialCapacity };
+    return FileSystemSyncAccessHandleInfo { m_activeSyncAccessHandle->identifier, WTF::move(*ipcHandle), initialCapacity };
 }
 
 std::optional<FileSystemStorageError> FileSystemStorageHandle::closeSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
@@ -259,7 +259,7 @@ Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError
     if (!activeWritableFile)
         return makeUnexpected(FileSystemStorageError::Unknown);
 
-    m_activeWritableFiles.add(streamIdentifier, FileHandleWithPath { WTFMove(activeWritableFile), WTFMove(path) });
+    m_activeWritableFiles.add(streamIdentifier, FileHandleWithPath { WTF::move(activeWritableFile), WTF::move(path) });
     return streamIdentifier;
 }
 
@@ -384,7 +384,7 @@ void FileSystemStorageHandle::executeCommandForWritable(WebCore::FileSystemWrita
         return;
     }
 
-    manager->requestSpace(*spaceRequired, [weakThis = WeakPtr { *this }, streamIdentifier, type, position, size, dataBytes = Vector<uint8_t>(dataBytes), completionHandler = WTFMove(completionHandler)](bool granted) mutable {
+    manager->requestSpace(*spaceRequired, [weakThis = WeakPtr { *this }, streamIdentifier, type, position, size, dataBytes = Vector<uint8_t>(dataBytes), completionHandler = WTF::move(completionHandler)](bool granted) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler(FileSystemStorageError::Unknown);
@@ -421,7 +421,7 @@ Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::getHan
 Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError> FileSystemStorageHandle::getHandle(IPC::Connection::UniqueID connection, String&& name)
 {
     bool createIfNecessary = false;
-    auto result = requestCreateHandle(connection, FileSystemStorageHandle::Type::Any, WTFMove(name), createIfNecessary);
+    auto result = requestCreateHandle(connection, FileSystemStorageHandle::Type::Any, WTF::move(name), createIfNecessary);
     if (!result)
         return makeUnexpected(result.error());
 
@@ -506,7 +506,7 @@ void FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle(WebCore::Fil
     else
         newCapacity = defaultCapacityStep * ((newCapacity / defaultCapacityStep) + 1);
 
-    manager->requestSpace(newCapacity - currentCapacity, [weakThis = WeakPtr { *this }, accessHandleIdentifier, newCapacity, completionHandler = WTFMove(completionHandler)](bool granted) mutable {
+    manager->requestSpace(newCapacity - currentCapacity, [weakThis = WeakPtr { *this }, accessHandleIdentifier, newCapacity, completionHandler = WTF::move(completionHandler)](bool granted) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler(std::nullopt);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -37,13 +37,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageManager);
 
 Ref<FileSystemStorageManager> FileSystemStorageManager::create(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
 {
-    return adoptRef(*new FileSystemStorageManager(WTFMove(path), registry, WTFMove(quotaCheckFunction)));
+    return adoptRef(*new FileSystemStorageManager(WTF::move(path), registry, WTF::move(quotaCheckFunction)));
 }
 
 FileSystemStorageManager::FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
-    : m_path(WTFMove(path))
+    : m_path(WTF::move(path))
     , m_registry(registry)
-    , m_quotaCheckFunction(WTFMove(quotaCheckFunction))
+    , m_quotaCheckFunction(WTF::move(quotaCheckFunction))
 {
     ASSERT(!RunLoop::isMain());
 }
@@ -98,7 +98,7 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
         }
     }
 
-    RefPtr newHandle = FileSystemStorageHandle::create(*this, type, WTFMove(path), WTFMove(name));
+    RefPtr newHandle = FileSystemStorageHandle::create(*this, type, WTF::move(path), WTF::move(name));
     if (!newHandle)
         return makeUnexpected(FileSystemStorageError::Unknown);
     auto newHandleIdentifier = newHandle->identifier();
@@ -107,7 +107,7 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
     }).iterator->value.add(newHandleIdentifier);
     if (RefPtr registry = m_registry.get())
         registry->registerHandle(newHandleIdentifier, *newHandle);
-    m_handles.add(newHandleIdentifier, WTFMove(newHandle));
+    m_handles.add(newHandleIdentifier, WTF::move(newHandle));
     return newHandleIdentifier;
 }
 
@@ -230,7 +230,7 @@ void FileSystemStorageManager::close()
 
 void FileSystemStorageManager::requestSpace(uint64_t size, CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_quotaCheckFunction(size, WTFMove(completionHandler));
+    m_quotaCheckFunction(size, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -199,7 +199,7 @@ bool IDBStorageManager::migrateOriginData(const String& oldOriginDirectory, cons
 IDBStorageManager::IDBStorageManager(const String& path, IDBStorageRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
     : m_path(path)
     , m_registry(registry)
-    , m_quotaCheckFunction(WTFMove(quotaCheckFunction))
+    , m_quotaCheckFunction(WTF::move(quotaCheckFunction))
 {
 }
 
@@ -281,7 +281,7 @@ Vector<WebCore::IDBDatabaseNameAndVersion> IDBStorageManager::getAllDatabaseName
             visitedDatabasePaths.add(path);
 
         if (auto nameAndVersion = database->nameAndVersion())
-            result.append(WTFMove(*nameAndVersion));
+            result.append(WTF::move(*nameAndVersion));
     }
 
     auto databaseIdentifiers = FileSystem::listDirectory(m_path);
@@ -292,7 +292,7 @@ Vector<WebCore::IDBDatabaseNameAndVersion> IDBStorageManager::getAllDatabaseName
             continue;
 
         if (auto nameAndVersion = WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile(databasePath))
-            result.append(WTFMove(*nameAndVersion));
+            result.append(WTF::move(*nameAndVersion));
     }
 
     return result;
@@ -347,7 +347,7 @@ std::unique_ptr<WebCore::IDBServer::IDBBackingStore> IDBStorageManager::createBa
 
 void IDBStorageManager::requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_quotaCheckFunction(size, WTFMove(completionHandler));
+    m_quotaCheckFunction(size, WTF::move(completionHandler));
 }
 
 void IDBStorageManager::handleLowMemoryWarning()

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -54,7 +54,7 @@ void IDBStorageRegistry::removeConnectionToClient(IPC::Connection::UniqueID conn
     auto allConnectionsToClient = std::exchange(m_connectionsToClient, { });
     for (auto& [identifier, connectionToClient] : allConnectionsToClient) {
         if (connectionToClient->ipcConnection() != connection) {
-            m_connectionsToClient.add(identifier, WTFMove(connectionToClient));
+            m_connectionsToClient.add(identifier, WTF::move(connectionToClient));
             continue;
         }
         connectionToClient->connectionToClient().connectionToClientClosed();

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -198,7 +198,7 @@ StorageAreaBase& LocalStorageManager::ensureLocalStorageArea(const WebCore::Clie
     if (!m_localStorageArea) {
         RefPtr<StorageAreaBase> storage;
         if (!m_path.isEmpty())
-            storage = SQLiteStorageArea::create(localStorageQuotaInBytes, origin, m_path, WTFMove(workQueue));
+            storage = SQLiteStorageArea::create(localStorageQuotaInBytes, origin, m_path, WTF::move(workQueue));
         else
             storage = MemoryStorageArea::create(origin, StorageAreaBase::StorageType::Local);
 
@@ -211,7 +211,7 @@ StorageAreaBase& LocalStorageManager::ensureLocalStorageArea(const WebCore::Clie
 
 StorageAreaIdentifier LocalStorageManager::connectToLocalStorageArea(IPC::Connection::UniqueID connection, StorageAreaMapIdentifier sourceIdentifier, const WebCore::ClientOrigin& origin, Ref<WorkQueue>&& workQueue)
 {
-    Ref localStorageArea = ensureLocalStorageArea(origin, WTFMove(workQueue));
+    Ref localStorageArea = ensureLocalStorageArea(origin, WTF::move(workQueue));
     ASSERT(m_path.isEmpty() || is<SQLiteStorageArea>(localStorageArea));
     localStorageArea->addListener(connection, sourceIdentifier);
     return localStorageArea->identifier();
@@ -274,15 +274,15 @@ bool LocalStorageManager::setStorageMap(WebCore::ClientOrigin clientOrigin, Hash
     bool succeeded = true;
 
     if (clientOrigin.topOrigin == clientOrigin.clientOrigin) {
-        Ref localStorageArea = ensureLocalStorageArea(clientOrigin, WTFMove(workQueue));
+        Ref localStorageArea = ensureLocalStorageArea(clientOrigin, WTF::move(workQueue));
         for (auto& [key, value] : storageMap) {
-            if (!localStorageArea->setItem({ }, { }, WTFMove(key), WTFMove(value), { }))
+            if (!localStorageArea->setItem({ }, { }, WTF::move(key), WTF::move(value), { }))
                 succeeded = false;
         }
     } else {
         Ref transientStorageArea = ensureTransientLocalStorageArea(clientOrigin);
         for (auto& [key, value] : storageMap) {
-            if (!transientStorageArea->setItem({ }, { }, WTFMove(key), WTFMove(value), { }))
+            if (!transientStorageArea->setItem({ }, { }, WTF::move(key), WTF::move(value), { }))
                 succeeded = false;
         }
     }

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
@@ -37,16 +37,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OriginQuotaManager);
 
 Ref<OriginQuotaManager> OriginQuotaManager::create(Parameters&& parameters, GetUsageFunction&& getUsageFunction)
 {
-    return adoptRef(*new OriginQuotaManager(WTFMove(parameters), WTFMove(getUsageFunction)));
+    return adoptRef(*new OriginQuotaManager(WTF::move(parameters), WTF::move(getUsageFunction)));
 }
 
 OriginQuotaManager::OriginQuotaManager(Parameters&& parameters, GetUsageFunction&& getUsageFunction)
     : m_quota(parameters.quota)
     , m_standardReportedQuota(parameters.standardReportedQuota)
     , m_initialQuota(parameters.quota)
-    , m_getUsageFunction(WTFMove(getUsageFunction))
-    , m_increaseQuotaFunction(WTFMove(parameters.increaseQuotaFunction))
-    , m_notifySpaceGrantedFunction(WTFMove(parameters.notifySpaceGrantedFunction))
+    , m_getUsageFunction(WTF::move(getUsageFunction))
+    , m_increaseQuotaFunction(WTF::move(parameters.increaseQuotaFunction))
+    , m_notifySpaceGrantedFunction(WTF::move(parameters.notifySpaceGrantedFunction))
 {
     ASSERT(m_quota);
 }
@@ -65,7 +65,7 @@ uint64_t OriginQuotaManager::usage()
 
 void OriginQuotaManager::requestSpace(uint64_t spaceRequested, RequestCallback&& callback)
 {
-    m_requests.append(OriginQuotaManager::Request { spaceRequested, WTFMove(callback), std::nullopt });
+    m_requests.append(OriginQuotaManager::Request { spaceRequested, WTF::move(callback), std::nullopt });
     handleRequests();
 }
 
@@ -165,8 +165,8 @@ void OriginQuotaManager::updateParametersForTesting(Parameters&& parameters)
 {
     m_quota = parameters.quota;
     m_standardReportedQuota = parameters.standardReportedQuota;
-    m_increaseQuotaFunction = WTFMove(parameters.increaseQuotaFunction);
-    m_notifySpaceGrantedFunction = WTFMove(parameters.notifySpaceGrantedFunction);
+    m_increaseQuotaFunction = WTF::move(parameters.increaseQuotaFunction);
+    m_notifySpaceGrantedFunction = WTF::move(parameters.notifySpaceGrantedFunction);
     m_initialQuota = m_quota;
     m_quotaCountdown = 0;
     m_usage = std::nullopt;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -216,7 +216,7 @@ String OriginStorageManager::StorageBucket::typeStoragePath(StorageType type) co
 FileSystemStorageManager& OriginStorageManager::StorageBucket::fileSystemStorageManager(FileSystemStorageHandleRegistry& registry, FileSystemStorageManager::QuotaCheckFunction&& quotaCheckFunction)
 {
     if (!m_fileSystemStorageManager)
-        m_fileSystemStorageManager = FileSystemStorageManager::create(typeStoragePath(StorageType::FileSystem), registry, WTFMove(quotaCheckFunction));
+        m_fileSystemStorageManager = FileSystemStorageManager::create(typeStoragePath(StorageType::FileSystem), registry, WTF::move(quotaCheckFunction));
 
     return *m_fileSystemStorageManager;
 }
@@ -240,7 +240,7 @@ SessionStorageManager& OriginStorageManager::StorageBucket::sessionStorageManage
 IDBStorageManager& OriginStorageManager::StorageBucket::idbStorageManager(IDBStorageRegistry& registry, IDBStorageManager::QuotaCheckFunction&& quotaCheckFunction)
 {
     if (!m_idbStorageManager)
-        m_idbStorageManager = makeUnique<IDBStorageManager>(resolvedIDBStoragePath(), registry, WTFMove(quotaCheckFunction));
+        m_idbStorageManager = makeUnique<IDBStorageManager>(resolvedIDBStoragePath(), registry, WTF::move(quotaCheckFunction));
 
     return *m_idbStorageManager;
 }
@@ -251,7 +251,7 @@ CacheStorageManager& OriginStorageManager::StorageBucket::cacheStorageManager(Ca
         std::optional<WebCore::ClientOrigin> optionalOrigin;
         if (m_level < UnifiedOriginStorageLevel::Standard)
             optionalOrigin = origin;
-        m_cacheStorageManager = CacheStorageManager::create(resolvedCacheStoragePath(), registry, optionalOrigin, WTFMove(quotaCheckFunction), WTFMove(queue));
+        m_cacheStorageManager = CacheStorageManager::create(resolvedCacheStoragePath(), registry, optionalOrigin, WTF::move(quotaCheckFunction), WTF::move(queue));
     }
 
     return *m_cacheStorageManager;
@@ -260,7 +260,7 @@ CacheStorageManager& OriginStorageManager::StorageBucket::cacheStorageManager(Ca
 BackgroundFetchStoreManager& OriginStorageManager::StorageBucket::backgroundFetchManager(Ref<WorkQueue>&& queue, BackgroundFetchStoreManager::QuotaCheckFunction&& quotaCheckFunction)
 {
     if (!m_backgroundFetchManager)
-        m_backgroundFetchManager = BackgroundFetchStoreManager::create(resolvedBackgroundFetchStoragePath(), WTFMove(queue), WTFMove(quotaCheckFunction));
+        m_backgroundFetchManager = BackgroundFetchStoreManager::create(resolvedBackgroundFetchStoragePath(), WTF::move(queue), WTF::move(quotaCheckFunction));
 
     return *m_backgroundFetchManager;
 }
@@ -646,15 +646,15 @@ Ref<OriginQuotaManager> OriginStorageManager::createQuotaManager(OriginQuotaMana
         return IDBStorageManager::idbStorageSize(idbStoragePath) + CacheStorageManager::cacheStorageSize(cacheStoragePath) + fileSystemStorageSize;
     };
 
-    return OriginQuotaManager::create(WTFMove(parameters), WTFMove(getUsageFunction));
+    return OriginQuotaManager::create(WTF::move(parameters), WTF::move(getUsageFunction));
 }
 
 OriginStorageManager::OriginStorageManager(OriginQuotaManager::Parameters&& parameters, String&& path, String&& customLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel level)
-    : m_path(WTFMove(path))
-    , m_customLocalStoragePath(WTFMove(customLocalStoragePath))
-    , m_customIDBStoragePath(WTFMove(customIDBStoragePath))
-    , m_customCacheStoragePath(WTFMove(customCacheStoragePath))
-    , m_quotaManager(createQuotaManager(WTFMove(parameters)))
+    : m_path(WTF::move(path))
+    , m_customLocalStoragePath(WTF::move(customLocalStoragePath))
+    , m_customIDBStoragePath(WTF::move(customIDBStoragePath))
+    , m_customCacheStoragePath(WTF::move(customCacheStoragePath))
+    , m_quotaManager(createQuotaManager(WTF::move(parameters)))
     , m_level(level)
 {
     ASSERT(!RunLoop::isMain());
@@ -693,7 +693,7 @@ FileSystemStorageManager& OriginStorageManager::fileSystemStorageManager(FileSys
         if (!strongReference)
             return completionHandler(false);
 
-        strongReference->requestSpace(spaceRequested, [completionHandler = WTFMove(completionHandler)](auto decision) mutable {
+        strongReference->requestSpace(spaceRequested, [completionHandler = WTF::move(completionHandler)](auto decision) mutable {
             completionHandler(decision == OriginQuotaManager::Decision::Grant);
         });
     });
@@ -731,7 +731,7 @@ IDBStorageManager& OriginStorageManager::idbStorageManager(IDBStorageRegistry& r
         if (!strongReference)
             return completionHandler(false);
 
-        strongReference->requestSpace(spaceRequested, [completionHandler = WTFMove(completionHandler)](auto decision) mutable {
+        strongReference->requestSpace(spaceRequested, [completionHandler = WTF::move(completionHandler)](auto decision) mutable {
             completionHandler(decision == OriginQuotaManager::Decision::Grant);
         });
     });
@@ -758,24 +758,24 @@ CacheStorageManager& OriginStorageManager::cacheStorageManager(CacheStorageRegis
         if (!quotaManager.get())
             return completionHandler(false);
 
-        quotaManager.get()->requestSpace(spaceRequested, [completionHandler = WTFMove(completionHandler)](auto decision) mutable {
+        quotaManager.get()->requestSpace(spaceRequested, [completionHandler = WTF::move(completionHandler)](auto decision) mutable {
             completionHandler(decision == OriginQuotaManager::Decision::Grant);
         });
-    }, WTFMove(queue));
+    }, WTF::move(queue));
 }
 
 Ref<CacheStorageManager> OriginStorageManager::protectedCacheStorageManager(CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, Ref<WorkQueue>&& queue)
 {
-    return cacheStorageManager(registry, origin, WTFMove(queue));
+    return cacheStorageManager(registry, origin, WTF::move(queue));
 }
 
 BackgroundFetchStoreManager& OriginStorageManager::backgroundFetchManager(Ref<WorkQueue>&& queue)
 {
-    return defaultBucket().backgroundFetchManager(WTFMove(queue), [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {
+    return defaultBucket().backgroundFetchManager(WTF::move(queue), [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {
         if (!quotaManager.get())
             return completionHandler(false);
 
-        quotaManager.get()->requestSpace(spaceRequested, [completionHandler = WTFMove(completionHandler)](auto decision) mutable {
+        quotaManager.get()->requestSpace(spaceRequested, [completionHandler = WTF::move(completionHandler)](auto decision) mutable {
             completionHandler(decision == OriginQuotaManager::Decision::Grant);
         });
     });

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -72,13 +72,13 @@ ASCIILiteral SQLiteStorageArea::statementString(StatementType type) const
 
 Ref<SQLiteStorageArea> SQLiteStorageArea::create(unsigned quota, const WebCore::ClientOrigin& origin, const String& path, Ref<WorkQueue>&& workQueue)
 {
-    return adoptRef(*new SQLiteStorageArea(quota, origin, path, WTFMove(workQueue)));
+    return adoptRef(*new SQLiteStorageArea(quota, origin, path, WTF::move(workQueue)));
 }
 
 SQLiteStorageArea::SQLiteStorageArea(unsigned quota, const WebCore::ClientOrigin& origin, const String& path, Ref<WorkQueue>&& workQueue)
     : StorageAreaBase(quota, origin)
     , m_path(path)
-    , m_queue(WTFMove(workQueue))
+    , m_queue(WTF::move(workQueue))
     , m_cachedStatements(static_cast<size_t>(StatementType::Invalid))
 {
     assertIsCurrent(m_queue.get());
@@ -246,7 +246,7 @@ WebCore::SQLiteStatementAutoResetScope SQLiteStorageArea::cachedStatement(Statem
     auto index = static_cast<uint8_t>(type);
     if (!m_cachedStatements[index]) {
         if (auto result = checkedDatabase()->prepareStatement(statementString(type)))
-            m_cachedStatements[index] = WTFMove(result);
+            m_cachedStatements[index] = WTF::move(result);
     }
 
     return WebCore::SQLiteStatementAutoResetScope { m_cachedStatements[index].get() };
@@ -359,7 +359,7 @@ HashMap<String, String> SQLiteStorageArea::allItems()
             String value = statement->columnBlobAsString(1);
             if (!key.isNull() && !value.isNull()) {
                 items.add(key, value);
-                updateCacheIfNeeded(WTFMove(key), WTFMove(value));
+                updateCacheIfNeeded(WTF::move(key), WTF::move(value));
             }
 
             result = statement->step();

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
@@ -81,7 +81,7 @@ StorageAreaIdentifier SessionStorageManager::addStorageArea(Ref<MemoryStorageAre
     auto identifier = storageArea->identifier();
     m_registry->registerStorageArea(identifier, storageArea);
     m_storageAreasByNamespace.add(namespaceIdentifier, identifier);
-    m_storageAreas.add(identifier, WTFMove(storageArea));
+    m_storageAreas.add(identifier, WTF::move(storageArea));
 
     return identifier;
 }
@@ -155,7 +155,7 @@ bool SessionStorageManager::setStorageMap(StorageNamespaceIdentifier storageName
 
     bool succeeded = true;
     for (auto& [key, value] : storageMap) {
-        if (!storageArea->setItem({ }, { }, WTFMove(key), WTFMove(value), { }))
+        if (!storageArea->setItem({ }, { }, WTF::move(key), WTF::move(value), { }))
             succeeded = false;
     }
 

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -46,8 +46,8 @@ LibWebRTCSocketClient::LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier 
     : m_identifier(identifier)
     , m_type(type)
     , m_rtcProvider(rtcProvider)
-    , m_socket(WTFMove(socket))
-    , m_connection(WTFMove(connection))
+    , m_socket(WTF::move(socket))
+    , m_connection(WTF::move(connection))
 {
     ASSERT(m_socket);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -43,11 +43,11 @@ namespace WebKit {
 #define MDNS_RELEASE_LOG_IN_CALLBACK(sessionID, fmt, ...) RELEASE_LOG(Network, "NetworkMDNSRegister callback - " fmt, ##__VA_ARGS__)
 
 NetworkMDNSRegister::PendingRegistrationRequest::PendingRegistrationRequest(Ref<NetworkConnectionToWebProcess>&& connection, String&& name, String address, PAL::SessionID sessionID, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&& completionHandler)
-    : connection(WTFMove(connection))
-    , name(WTFMove(name))
-    , address(WTFMove(address))
+    : connection(WTF::move(connection))
+    , name(WTF::move(name))
+    , address(WTF::move(address))
     , sessionID(sessionID)
-    , completionHandler(WTFMove(completionHandler))
+    , completionHandler(WTF::move(completionHandler))
 {
 }
 
@@ -155,8 +155,8 @@ void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdenti
 
     auto identifier = PendingRegistrationRequestIdentifier::generate();
     Ref connection = m_connection.get();
-    auto pendingRequest = makeUnique<PendingRegistrationRequest>(connection.get(), WTFMove(name), ipAddress, sessionID(), WTFMove(completionHandler));
-    auto addResult = pendingRegistrationRequestMap().add(identifier, WTFMove(pendingRequest));
+    auto pendingRequest = makeUnique<PendingRegistrationRequest>(connection.get(), WTF::move(name), ipAddress, sessionID(), WTF::move(completionHandler));
+    auto addResult = pendingRegistrationRequestMap().add(identifier, WTF::move(pendingRequest));
     DNSRecordRef record { nullptr };
     auto error = DNSServiceRegisterRecord(service,
         &record,

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -88,20 +88,20 @@ private:
 class IPAddressCallbackAggregator final : public ThreadSafeRefCounted<IPAddressCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
 public:
     using Callback = CompletionHandler<void(RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&, HashMap<String, RTCNetwork>&&)>;
-    static Ref<IPAddressCallbackAggregator> create(Callback&& callback) { return adoptRef(*new IPAddressCallbackAggregator(WTFMove(callback))); }
+    static Ref<IPAddressCallbackAggregator> create(Callback&& callback) { return adoptRef(*new IPAddressCallbackAggregator(WTF::move(callback))); }
 
     ~IPAddressCallbackAggregator()
     {
-        m_callback(WTFMove(m_ipv4), WTFMove(m_ipv6), WTFMove(m_networkMap));
+        m_callback(WTF::move(m_ipv4), WTF::move(m_ipv6), WTF::move(m_networkMap));
     }
 
-    void setIPv4(RTCNetwork::IPAddress&& ipv4) { m_ipv4 = WTFMove(ipv4); }
-    void setIPv6(RTCNetwork::IPAddress&& ipv6) { m_ipv6 = WTFMove(ipv6); }
-    void setNetworkMap(HashMap<String, RTCNetwork>&& networkMap) { m_networkMap = crossThreadCopy(WTFMove(networkMap)); }
+    void setIPv4(RTCNetwork::IPAddress&& ipv4) { m_ipv4 = WTF::move(ipv4); }
+    void setIPv6(RTCNetwork::IPAddress&& ipv6) { m_ipv6 = WTF::move(ipv6); }
+    void setNetworkMap(HashMap<String, RTCNetwork>&& networkMap) { m_networkMap = crossThreadCopy(WTF::move(networkMap)); }
 
 private:
     explicit IPAddressCallbackAggregator(Callback&& callback)
-        : m_callback(WTFMove(callback))
+        : m_callback(WTF::move(callback))
     {
     }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
@@ -105,18 +105,18 @@ webrtc::AdapterType NetworkRTCSharedMonitor::adapterTypeFromInterfaceName(const 
 void NetworkRTCSharedMonitor::updateNetworks()
 {
     auto aggregator = IPAddressCallbackAggregator::create([] (auto&& ipv4, auto&& ipv6, auto&& networkList) mutable {
-        NetworkRTCSharedMonitor::singleton().onGatheredNetworks(WTFMove(ipv4), WTFMove(ipv6), WTFMove(networkList));
+        NetworkRTCSharedMonitor::singleton().onGatheredNetworks(WTF::move(ipv4), WTF::move(ipv6), WTF::move(networkList));
     });
     Ref protectedQueue = m_queue;
     protectedQueue->dispatch([aggregator] {
         bool useIPv4 = true;
         if (auto address = NetworkRTCMonitor::getDefaultIPAddress(useIPv4))
-            aggregator->setIPv4(WTFMove(*address));
+            aggregator->setIPv4(WTF::move(*address));
     });
     protectedQueue->dispatch([aggregator] {
         bool useIPv4 = false;
         if (auto address = NetworkRTCMonitor::getDefaultIPAddress(useIPv4))
-            aggregator->setIPv6(WTFMove(*address));
+            aggregator->setIPv6(WTF::move(*address));
     });
     protectedQueue->dispatch([aggregator] {
         aggregator->setNetworkMap(NetworkRTCMonitor::gatherNetworkMap());
@@ -127,9 +127,9 @@ void NetworkRTCSharedMonitor::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, R
 {
     if (!m_didReceiveResults) {
         m_didReceiveResults = true;
-        m_networkMap = WTFMove(networkMap);
-        m_ipv4 = WTFMove(ipv4);
-        m_ipv6 = WTFMove(ipv6);
+        m_networkMap = WTF::move(networkMap);
+        m_ipv4 = WTF::move(ipv4);
+        m_ipv6 = WTF::move(ipv6);
 
         for (auto& network : m_networkMap.values())
             network.id = ++m_networkLastIndex;
@@ -152,11 +152,11 @@ void NetworkRTCSharedMonitor::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, R
         if (!didChange && (ipv4.isUnspecified() || NetworkRTCMonitor::isEqual(ipv4, m_ipv4)) && (ipv6.isUnspecified() || NetworkRTCMonitor::isEqual(ipv6, m_ipv6)))
             return;
 
-        m_networkMap = WTFMove(networkMap);
+        m_networkMap = WTF::move(networkMap);
         if (!ipv4.isUnspecified())
-            m_ipv4 = WTFMove(ipv4);
+            m_ipv4 = WTF::move(ipv4);
         if (!ipv6.isUnspecified())
-            m_ipv6 = WTFMove(ipv6);
+            m_ipv6 = WTF::move(ipv6);
     }
     RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::onGatheredNetworks - networks changed");
 

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -44,7 +44,7 @@ void RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess(NetworkCon
     m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID(), sharedPreferences = connectionToWebProcess.sharedPreferencesForWebProcessValue()]() mutable {
         ASSERT(!m_webProcessConnections.contains(identifier));
         m_webProcessConnections.add(identifier, connectionID);
-        m_sharedPreferencesForConnections.add(connectionID, WTFMove(sharedPreferences));
+        m_sharedPreferencesForConnections.add(connectionID, WTF::move(sharedPreferences));
     });
     connectionToWebProcess.connection().addWorkQueueMessageReceiver(Messages::RTCDataChannelRemoteManagerProxy::messageReceiverName(), m_queue, *this);
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -56,19 +56,19 @@ uint64_t NetworkTransportSession::messageSenderDestinationID() const
 void NetworkTransportSession::streamSendBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
     if (RefPtr stream = m_streams.get(identifier))
-        stream->sendBytes(bytes, withFin, WTFMove(completionHandler));
+        stream->sendBytes(bytes, withFin, WTF::move(completionHandler));
     else
         completionHandler(WebCore::Exception { WebCore::ExceptionCode::InvalidStateError });
 }
 
 void NetworkTransportSession::receiveDatagram(std::span<const uint8_t> datagram, bool withFin, std::optional<WebCore::Exception>&& exception)
 {
-    send(Messages::WebTransportSession::ReceiveDatagram(datagram, withFin, WTFMove(exception)));
+    send(Messages::WebTransportSession::ReceiveDatagram(datagram, withFin, WTF::move(exception)));
 }
 
 void NetworkTransportSession::streamReceiveBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception>&& exception)
 {
-    send(Messages::WebTransportSession::StreamReceiveBytes(identifier, bytes, withFin, WTFMove(exception)));
+    send(Messages::WebTransportSession::StreamReceiveBytes(identifier, bytes, withFin, WTF::move(exception)));
 }
 
 void NetworkTransportSession::streamReceiveError(WebCore::WebTransportStreamIdentifier identifier, uint64_t errorCode)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportStreamCocoa.mm
@@ -74,7 +74,7 @@ void NetworkTransportStream::sendBytes(std::span<const uint8_t> data, bool withF
         weakThis = WeakPtr { *this },
         withFin = withFin,
         bytesSent = data.size(),
-        completionHandler = WTFMove(completionHandler)
+        completionHandler = WTF::move(completionHandler)
     ] (nw_error_t error) mutable {
         RefPtr protectedThis = weakThis.get();
         if (error) {

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -199,7 +199,7 @@ template<typename T> struct ArgumentCoder<std::optional<T>> {
             auto value = decoder.template decode<T>();
             if (!value)
                 return std::nullopt;
-            SUPPRESS_UNCHECKED_ARG return std::optional<std::optional<T>>(WTFMove(*value));
+            SUPPRESS_UNCHECKED_ARG return std::optional<std::optional<T>>(WTF::move(*value));
         }
         return std::optional<std::optional<T>>(std::optional<T>(std::nullopt));
     }
@@ -228,7 +228,7 @@ template<typename T> struct ArgumentCoder<Box<T>> {
             auto value = decoder.template decode<T>();
             if (!value)
                 return std::nullopt;
-            return std::optional<Box<T>>(Box<T>::create(WTFMove(*value)));
+            return std::optional<Box<T>>(Box<T>::create(WTF::move(*value)));
         }
         return std::optional<Box<T>>(Box<T>(nullptr));
     }
@@ -253,7 +253,7 @@ template<typename T, typename U> struct ArgumentCoder<std::pair<T, U>> {
         if (!second)
             return std::nullopt;
 
-        SUPPRESS_UNCHECKED_ARG return std::make_optional<std::pair<T, U>>(WTFMove(*first), WTFMove(*second));
+        SUPPRESS_UNCHECKED_ARG return std::make_optional<std::pair<T, U>>(WTF::move(*first), WTF::move(*second));
     }
 };
 
@@ -323,7 +323,7 @@ template<typename T> struct ArgumentCoder<std::unique_ptr<T>> {
             auto object = decoder.template decode<T>();
             if (!object)
                 return std::nullopt;
-            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::unique_ptr<T>>(makeUnique<T>(WTFMove(*object)));
+            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::unique_ptr<T>>(makeUnique<T>(WTF::move(*object)));
         }
         return std::make_optional<std::unique_ptr<T>>();
     }
@@ -343,7 +343,7 @@ template<typename T> struct ArgumentCoder<UniqueRef<T>> {
         auto object = decoder.template decode<T>();
         if (!object)
             return std::nullopt;
-        return makeUniqueRef<T>(WTFMove(*object));
+        return makeUniqueRef<T>(WTF::move(*object));
     }
 };
 
@@ -373,10 +373,10 @@ template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
             auto optional = decoder.template decode<std::tuple_element_t<index, std::tuple<Elements...>>>();
             if (!optional)
                 return std::nullopt;
-            return decode(decoder, WTFMove(decodedObjects)..., WTFMove(optional));
+            return decode(decoder, WTF::move(decodedObjects)..., WTF::move(optional));
         } else {
             static_assert((std::is_same_v<DecodedTypes, Elements> && ...));
-            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::tuple<Elements...>>(*WTFMove(decodedObjects)...);
+            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::tuple<Elements...>>(*WTF::move(decodedObjects)...);
         }
     }
 };
@@ -400,7 +400,7 @@ template<typename KeyType, typename ValueType> struct ArgumentCoder<WTF::KeyValu
         if (!value)
             return std::nullopt;
 
-        return std::make_optional<WTF::KeyValuePair<KeyType, ValueType>>(WTFMove(*key), WTFMove(*value));
+        return std::make_optional<WTF::KeyValuePair<KeyType, ValueType>>(WTF::move(*key), WTF::move(*value));
     }
 };
 
@@ -425,10 +425,10 @@ template<typename T, size_t size> struct ArgumentCoder<std::array<T, size>> {
             auto optional = decoder.template decode<T>();
             if (!optional)
                 return std::nullopt;
-            return decode(decoder, WTFMove(decodedObjects)..., WTFMove(optional));
+            return decode(decoder, WTF::move(decodedObjects)..., WTF::move(optional));
         } else {
             static_assert((std::is_same_v<DecodedTypes, T> && ...));
-            return std::array<T, size> { *WTFMove(decodedObjects)... };
+            return std::array<T, size> { *WTF::move(decodedObjects)... };
         }
     }
 };
@@ -448,7 +448,7 @@ template<typename Key, typename T, Key lastValue> struct ArgumentCoder<Enumerate
         if (!array)
             return std::nullopt;
 
-        return std::make_optional<EnumeratedArray<Key, T, lastValue>>(WTFMove(*array));
+        return std::make_optional<EnumeratedArray<Key, T, lastValue>>(WTF::move(*array));
     }
 };
 
@@ -482,7 +482,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
                 auto element = decoder.template decode<T>();
                 if (!element)
                     return std::nullopt;
-                vector.append(WTFMove(*element));
+                vector.append(WTF::move(*element));
             }
             return vector;
         }
@@ -491,7 +491,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
             auto element = decoder.template decode<T>();
             if (!element)
                 return std::nullopt;
-            SUPPRESS_UNCHECKED_ARG vector.append(WTFMove(*element));
+            SUPPRESS_UNCHECKED_ARG vector.append(WTF::move(*element));
         }
         vector.shrinkToFit();
         return vector;
@@ -553,9 +553,9 @@ template<typename T> struct FixedVectorArgumentCoder<false, T> {
             auto element = decoder.template decode<T>();
             if (!element)
                 return std::nullopt;
-            mutableVector.append(WTFMove(*element));
+            mutableVector.append(WTF::move(*element));
         }
-        return std::make_optional<FixedVector<T>>(WTFMove(mutableVector));
+        return std::make_optional<FixedVector<T>>(WTF::move(mutableVector));
     }
 };
 
@@ -611,7 +611,7 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
             if (!HashMapType::isValidKey(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (!hashMap.add(WTFMove(*key), WTFMove(*value)).isNewEntry) [[unlikely]] {
+            if (!hashMap.add(WTF::move(*key), WTF::move(*value)).isNewEntry) [[unlikely]] {
                 // The hash map already has the specified key, bail.
                 return std::nullopt;
             }
@@ -648,7 +648,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename Hash
             if (!HashSetType::isValidValue(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (!hashSet.add(WTFMove(*key)).isNewEntry) [[unlikely]] {
+            if (!hashSet.add(WTF::move(*key)).isNewEntry) [[unlikely]] {
                 // The hash set already has the specified key, bail.
                 return std::nullopt;
             }
@@ -697,7 +697,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
             }
         }
 
-        return WTFMove(tempHashCountedSet);
+        return WTF::move(tempHashCountedSet);
     }
 };
 
@@ -719,11 +719,11 @@ template<typename ValueType, typename ErrorType> struct ArgumentCoder<Expected<V
     {
         if (!expected.has_value()) {
             encoder << false;
-            encoder << WTFMove(expected.error());
+            encoder << WTF::move(expected.error());
             return;
         }
         encoder << true;
-        encoder << WTFMove(expected.value());
+        encoder << WTF::move(expected.value());
     }
 
     template<typename Decoder>
@@ -738,13 +738,13 @@ template<typename ValueType, typename ErrorType> struct ArgumentCoder<Expected<V
             if (!value)
                 return std::nullopt;
 
-            return std::make_optional<Expected<ValueType, ErrorType>>(WTFMove(*value));
+            return std::make_optional<Expected<ValueType, ErrorType>>(WTF::move(*value));
         }
 
         auto error = decoder.template decode<ErrorType>();
         if (!error)
             return std::nullopt;
-        return std::make_optional<Expected<ValueType, ErrorType>>(makeUnexpected(WTFMove(*error)));
+        return std::make_optional<Expected<ValueType, ErrorType>>(makeUnexpected(WTF::move(*error)));
     }
 };
 
@@ -772,7 +772,7 @@ template<typename ErrorType> struct ArgumentCoder<Expected<void, ErrorType>> {
         auto error = decoder.template decode<ErrorType>();
         if (!error)
             return std::nullopt;
-        return std::make_optional<Expected<void, ErrorType>>(makeUnexpected(WTFMove(*error)));
+        return std::make_optional<Expected<void, ErrorType>>(makeUnexpected(WTF::move(*error)));
     }
 };
 
@@ -821,7 +821,7 @@ template<typename... Types> struct ArgumentCoder<Variant<Types...>> {
                 auto optional = decoder.template decode<typename WTF::VariantAlternativeT<index, Variant<Types...>>>();
                 if (!optional)
                     return std::nullopt;
-                return std::make_optional<Variant<Types...>>(WTF::InPlaceIndex<index>, WTFMove(*optional));
+                return std::make_optional<Variant<Types...>>(WTF::InPlaceIndex<index>, WTF::move(*optional));
             }
             return decode(decoder, std::make_index_sequence<index + 1> { }, i);
         } else
@@ -871,7 +871,7 @@ template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Trai
         if (!value) [[unlikely]]
             return std::nullopt;
 
-        return WTF::Markable<T, Traits>(WTFMove(*value));
+        return WTF::Markable<T, Traits>(WTF::move(*value));
     }
 };
 

--- a/Source/WebKit/Platform/IPC/ConnectionHandle.h
+++ b/Source/WebKit/Platform/IPC/ConnectionHandle.h
@@ -52,19 +52,19 @@ public:
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     ConnectionHandle(UnixFileDescriptor&& inHandle)
-        : m_handle(WTFMove(inHandle))
+        : m_handle(WTF::move(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
     WARN_UNUSED_RETURN int release() { return m_handle.release(); }
 #elif OS(WINDOWS)
     ConnectionHandle(Win32Handle&& inHandle)
-        : m_handle(WTFMove(inHandle))
+        : m_handle(WTF::move(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
     WARN_UNUSED_RETURN HANDLE leak() { return m_handle.leak(); }
 #elif OS(DARWIN)
     ConnectionHandle(MachSendRight&& sendRight)
-        : m_handle(WTFMove(sendRight))
+        : m_handle(WTF::move(sendRight))
     { }
     explicit operator bool() const { return MACH_PORT_VALID(m_handle.sendRight()); }
     WARN_UNUSED_RETURN mach_port_t leakSendRight() { return m_handle.leakSendRight(); }

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -89,7 +89,7 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
     auto trust = adoptCF(SecTrustDeserialize(adoptCF(CFDataCreate(nullptr, bytes.data(), bytes.size())).get(), nullptr));
     if (!trust)
         return std::nullopt;
-    return WebCore::CertificateInfo(WTFMove(trust));
+    return WebCore::CertificateInfo(WTF::move(trust));
 #else
     return WebCore::CertificateInfo();
 #endif
@@ -106,7 +106,7 @@ template<> struct Coder<WebCore::PCM::SourceSite> {
         decoder >> registrableDomain;
         if (!registrableDomain)
             return std::nullopt;
-        return { WebCore::PCM::SourceSite { WTFMove(*registrableDomain) } };
+        return { WebCore::PCM::SourceSite { WTF::move(*registrableDomain) } };
     }
 };
 
@@ -121,7 +121,7 @@ template<> struct Coder<WebCore::PCM::AttributionDestinationSite> {
         decoder >> registrableDomain;
         if (!registrableDomain)
             return std::nullopt;
-        return { WebCore::PCM::AttributionDestinationSite { WTFMove(*registrableDomain) } };
+        return { WebCore::PCM::AttributionDestinationSite { WTF::move(*registrableDomain) } };
     }
 };
 
@@ -136,7 +136,7 @@ template<> struct Coder<WebCore::PCM::EphemeralNonce> {
         decoder >> nonce;
         if (!nonce)
             return std::nullopt;
-        return { WebCore::PCM::EphemeralNonce { WTFMove(*nonce) } };
+        return { WebCore::PCM::EphemeralNonce { WTF::move(*nonce) } };
     }
 };
 
@@ -158,7 +158,7 @@ template<> struct Coder<WebCore::PCM::AttributionTimeToSendData> {
         if (!destinationEarliestTimeToSend)
             return std::nullopt;
 
-        return { { WTFMove(*sourceEarliestTimeToSend), WTFMove(*destinationEarliestTimeToSend) } };
+        return { { WTF::move(*sourceEarliestTimeToSend), WTF::move(*destinationEarliestTimeToSend) } };
     }
 };
 
@@ -229,16 +229,16 @@ std::optional<WebCore::PrivateClickMeasurement> Coder<WebCore::PrivateClickMeasu
         return std::nullopt;
 
     return { {
-        WTFMove(*sourceID),
-        WTFMove(*sourceSite),
-        WTFMove(*destinationSite),
-        WTFMove(*timeOfAdClick),
-        WTFMove(*isEphemeral),
-        WTFMove(*adamID),
-        WTFMove(*attributionTriggerData),
-        WTFMove(*timesToSend),
-        WTFMove(*ephemeralSourceNonce),
-        WTFMove(*sourceApplicationBundleID),
+        WTF::move(*sourceID),
+        WTF::move(*sourceSite),
+        WTF::move(*destinationSite),
+        WTF::move(*timeOfAdClick),
+        WTF::move(*isEphemeral),
+        WTF::move(*adamID),
+        WTF::move(*attributionTriggerData),
+        WTF::move(*timesToSend),
+        WTF::move(*ephemeralSourceNonce),
+        WTF::move(*sourceApplicationBundleID),
     } };
 }
 
@@ -285,12 +285,12 @@ std::optional<WebCore::PCM::AttributionTriggerData> Coder<WebCore::PCM::Attribut
         return std::nullopt;
 
     return { {
-        WTFMove(*data),
-        WTFMove(*priority),
-        WTFMove(*wasSent),
-        WTFMove(*sourceRegistrableDomain),
-        WTFMove(*ephemeralDestinationNonce),
-        WTFMove(*destinationSite),
+        WTF::move(*data),
+        WTF::move(*priority),
+        WTF::move(*wasSent),
+        WTF::move(*sourceRegistrableDomain),
+        WTF::move(*ephemeralDestinationNonce),
+        WTF::move(*destinationSite),
         // destinationUnlinkableToken and destinationSecretToken are not serialized.
     } };
 }
@@ -307,7 +307,7 @@ std::optional<WebCore::RegistrableDomain> Coder<WebCore::RegistrableDomain, void
     if (!host)
         return std::nullopt;
 
-    return { WebCore::RegistrableDomain::fromRawString(WTFMove(*host)) };
+    return { WebCore::RegistrableDomain::fromRawString(WTF::move(*host)) };
 }
 
 }

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -88,7 +88,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
             decoder >> element;
             if (!element)
                 return std::nullopt;
-            vector.append(WTFMove(*element));
+            vector.append(WTF::move(*element));
         }
         vector.shrinkToFit();
         return vector;
@@ -127,7 +127,7 @@ template<> struct Coder<WTF::URL> {
         decoder >> string;
         if (!string)
             return std::nullopt;
-        return { WTF::URL(WTFMove(*string)) };
+        return { WTF::URL(WTF::move(*string)) };
     }
 };
 

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -47,7 +47,7 @@ public:
 #if PLATFORM(COCOA)
     static Ref<Connection> create(XPCObjectPtr<xpc_connection_t>&& connection)
     {
-        return adoptRef(*new Connection(WTFMove(connection)));
+        return adoptRef(*new Connection(WTF::move(connection)));
     }
 #endif
 
@@ -64,7 +64,7 @@ protected:
 
 #if PLATFORM(COCOA)
     explicit Connection(XPCObjectPtr<xpc_connection_t>&& connection)
-        : m_connection(WTFMove(connection)) { }
+        : m_connection(WTF::move(connection)) { }
 #endif
 
     virtual void initializeConnectionIfNeeded() const { }
@@ -93,7 +93,7 @@ public:
 
 protected:
     explicit ConnectionToMachService(CString&& machServiceName)
-        : m_machServiceName(WTFMove(machServiceName))
+        : m_machServiceName(WTF::move(machServiceName))
     { }
 
 private:

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, Vector
 {
     auto bufferCopy = copyBuffer(buffer);
     auto bufferCopySpan = bufferCopy.span();
-    return Decoder::create(bufferCopySpan, [bufferCopy = WTFMove(bufferCopy)](auto) { }, WTFMove(attachments)); // NOLINT
+    return Decoder::create(bufferCopySpan, [bufferCopy = WTF::move(bufferCopy)](auto) { }, WTF::move(attachments)); // NOLINT
 }
 
 std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeallocator, Vector<Attachment>&& attachments)
@@ -65,7 +65,7 @@ std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, Buffer
         RELEASE_LOG_FAULT(IPC, "Decoder::create() called with a null buffer (buffer size: %lu)", buffer.size_bytes());
         return nullptr;
     }
-    auto decoder = std::unique_ptr<Decoder>(new Decoder(buffer, WTFMove(bufferDeallocator), WTFMove(attachments)));
+    auto decoder = std::unique_ptr<Decoder>(new Decoder(buffer, WTF::move(bufferDeallocator), WTF::move(attachments)));
     if (!decoder->isValid())
         return nullptr;
     return decoder;
@@ -74,8 +74,8 @@ std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, Buffer
 Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeallocator, Vector<Attachment>&& attachments)
     : m_buffer { buffer }
     , m_bufferPosition { m_buffer.begin() }
-    , m_bufferDeallocator { WTFMove(bufferDeallocator) }
-    , m_attachments { WTFMove(attachments) }
+    , m_bufferDeallocator { WTF::move(bufferDeallocator) }
+    , m_attachments { WTF::move(attachments) }
 {
     if (reinterpret_cast<uintptr_t>(m_buffer.data()) % alignof(uint64_t)) [[unlikely]] {
         markInvalid();
@@ -85,12 +85,12 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
     auto messageFlags = decode<OptionSet<MessageFlags>>();
     if (!messageFlags) [[unlikely]]
         return;
-    m_messageFlags = WTFMove(*messageFlags);
+    m_messageFlags = WTF::move(*messageFlags);
 
     auto messageName = decode<MessageName>();
     if (!messageName) [[unlikely]]
         return;
-    m_messageName = WTFMove(*messageName);
+    m_messageName = WTF::move(*messageName);
 
     auto destinationID = decode<uint64_t>();
     if (!destinationID) [[unlikely]]
@@ -100,7 +100,7 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
         markInvalid();
         return;
     }
-    m_destinationID = WTFMove(*destinationID);
+    m_destinationID = WTF::move(*destinationID);
     if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
         if (!syncRequestID) [[unlikely]]
@@ -124,7 +124,7 @@ Decoder::Decoder(std::span<const uint8_t> stream, uint64_t destinationID)
     auto messageName = decode<MessageName>();
     if (!messageName) [[unlikely]]
         return;
-    m_messageName = WTFMove(*messageName);
+    m_messageName = WTF::move(*messageName);
     if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
         if (!syncRequestID) [[unlikely]]
@@ -162,7 +162,7 @@ bool Decoder::shouldMaintainOrderingWithAsyncMessages() const
 #if PLATFORM(MAC)
 void Decoder::setImportanceAssertion(ImportanceAssertion&& assertion)
 {
-    m_importanceAssertion = WTFMove(assertion);
+    m_importanceAssertion = WTF::move(assertion);
 }
 #endif
 
@@ -176,7 +176,7 @@ std::unique_ptr<Decoder> Decoder::unwrapForTesting(Decoder& decoder)
     if (!wrappedMessage)
         return nullptr;
 
-    auto wrappedDecoder = Decoder::create(*wrappedMessage, WTFMove(attachments));
+    auto wrappedDecoder = Decoder::create(*wrappedMessage, WTF::move(attachments));
     wrappedDecoder->setIsAllowedWhenWaitingForSyncReplyOverride(true);
     return wrappedDecoder;
 }

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -132,7 +132,7 @@ public:
     {
         auto buffer = std::exchange(m_buffer, { });
         if (m_bufferDeallocator && !buffer.empty())
-            m_bufferDeallocator(WTFMove(buffer));
+            m_bufferDeallocator(WTF::move(buffer));
     }
 
     template<typename T>

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -98,8 +98,8 @@ void Encoder::wrapForTesting(UniqueRef<Encoder>&& original)
 
     auto attachments = original->releaseAttachments();
     reserve(attachments.size());
-    for (auto&& attachment : WTFMove(attachments))
-        addAttachment(WTFMove(attachment));
+    for (auto&& attachment : WTF::move(attachments))
+        addAttachment(WTF::move(attachment));
 }
 
 static inline size_t roundUpToAlignment(size_t value, size_t alignment)
@@ -121,7 +121,7 @@ void Encoder::reserve(size_t size)
     RELEASE_ASSERT(newBuffer);
     memcpySpan(newBuffer.mutableSpan(), span());
 
-    m_outOfLineBuffer = WTFMove(newBuffer);
+    m_outOfLineBuffer = WTF::move(newBuffer);
 }
 
 void Encoder::encodeHeader()
@@ -172,7 +172,7 @@ std::span<const uint8_t> Encoder::capacityBuffer() const
 
 void Encoder::addAttachment(Attachment&& attachment)
 {
-    m_attachments.append(WTFMove(attachment));
+    m_attachments.append(WTF::move(attachment));
 }
 
 Vector<Attachment> Encoder::releaseAttachments()

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -87,7 +87,7 @@ public:
 
     Encoder& operator<<(Attachment&& attachment)
     {
-        addAttachment(WTFMove(attachment));
+        addAttachment(WTF::move(attachment));
         return *this;
     }
 

--- a/Source/WebKit/Platform/IPC/FormDataReference.h
+++ b/Source/WebKit/Platform/IPC/FormDataReference.h
@@ -36,14 +36,14 @@ class FormDataReference {
 public:
     FormDataReference() = default;
     explicit FormDataReference(RefPtr<WebCore::FormData>&& data)
-        : m_data(WTFMove(data))
+        : m_data(WTF::move(data))
     {
     }
 
     FormDataReference(RefPtr<WebCore::FormData>&&, Vector<WebKit::SandboxExtensionHandle>&&);
 
     RefPtr<WebCore::FormData> data() const { return m_data.get(); }
-    RefPtr<WebCore::FormData> takeData() { return WTFMove(m_data); }
+    RefPtr<WebCore::FormData> takeData() { return WTF::move(m_data); }
 
     Vector<WebKit::SandboxExtensionHandle> sandboxExtensionHandles() const;
 
@@ -52,9 +52,9 @@ private:
 };
 
 inline FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<WebKit::SandboxExtensionHandle>&& sandboxExtensionHandles)
-    : m_data(WTFMove(data))
+    : m_data(WTF::move(data))
 {
-    WebKit::SandboxExtension::consumePermanently(WTFMove(sandboxExtensionHandles));
+    WebKit::SandboxExtension::consumePermanently(WTF::move(sandboxExtensionHandles));
 }
 
 inline Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensionHandles() const
@@ -66,7 +66,7 @@ inline Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensio
         if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
             const String& path = fileData->filename;
             if (auto handle = WebKit::SandboxExtension::createHandle(path, WebKit::SandboxExtension::Type::ReadOnly))
-                return { WTFMove(*handle) };
+                return { WTF::move(*handle) };
         }
         return std::nullopt;
     });

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -51,7 +51,7 @@ public:
 #if PLATFORM(COCOA)
     void signal();
 
-    MachSendRight takeSendRight() { return WTFMove(m_sendRight); }
+    MachSendRight takeSendRight() { return WTF::move(m_sendRight); }
 #else
     void signal()
     {
@@ -68,11 +68,11 @@ private:
 
 #if PLATFORM(COCOA)
     Signal(MachSendRight&& sendRight)
-        : m_sendRight(WTFMove(sendRight))
+        : m_sendRight(WTF::move(sendRight))
     { }
 #else
     Signal(Semaphore&& semaphore)
-        : m_semaphore(WTFMove(semaphore))
+        : m_semaphore(WTF::move(semaphore))
     { }
 #endif
 
@@ -90,14 +90,14 @@ public:
 #if PLATFORM(COCOA)
     ~Event();
     Event(Event&& other)
-        : m_receiveRight(WTFMove(other.m_receiveRight))
+        : m_receiveRight(WTF::move(other.m_receiveRight))
     {
         other.m_receiveRight = MACH_PORT_NULL;
     }
 
     Event& operator=(Event&& other)
     {
-        m_receiveRight = WTFMove(other.m_receiveRight);
+        m_receiveRight = WTF::move(other.m_receiveRight);
         other.m_receiveRight = MACH_PORT_NULL;
         return *this;
     }
@@ -128,7 +128,7 @@ private:
     { }
 #else
     Event(Semaphore&& semaphore)
-        : m_semaphore(WTFMove(semaphore))
+        : m_semaphore(WTF::move(semaphore))
     { }
 #endif
 
@@ -153,7 +153,7 @@ inline std::optional<EventSignalPair> createEventSignalPair()
 #else
     Semaphore signal(event.m_fd.duplicate());
 #endif
-    return EventSignalPair { Event { WTFMove(event) }, Signal { WTFMove(signal) } };
+    return EventSignalPair { Event { WTF::move(event) }, Signal { WTF::move(signal) } };
 }
 #endif
 

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -153,14 +153,14 @@ std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObje
         return std::nullopt;
 
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto jsValue = jsValueForDecodedArgumentValue(globalObject, WTFMove(*value));
+    auto jsValue = jsValueForDecodedArgumentValue(globalObject, WTF::move(*value));
     RETURN_IF_EXCEPTION(scope, std::nullopt);
     if (jsValue.isEmpty()) {
         // Create array buffers out of types we don't recognize.
         auto span = decoder.span().subspan(startingBufferOffset, decoder.currentBufferOffset() - startingBufferOffset);
         auto arrayBuffer = JSC::ArrayBuffer::create(span);
         if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
-            jsValue = JSC::JSArrayBuffer::create(Ref { globalObject->vm() }, structure, WTFMove(arrayBuffer));
+            jsValue = JSC::JSArrayBuffer::create(Ref { globalObject->vm() }, structure, WTF::move(arrayBuffer));
         RETURN_IF_EXCEPTION(scope, std::nullopt);
     }
     array->putDirectIndex(globalObject, currentIndex, jsValue);

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
@@ -33,16 +33,16 @@ void MessageReceiveQueueMap::addImpl(StoreType&& queue, const ReceiverMatcher& m
 {
     if (!matcher.receiverName) {
         ASSERT(!m_anyReceiverQueue);
-        m_anyReceiverQueue = WTFMove(queue);
+        m_anyReceiverQueue = WTF::move(queue);
         return;
     }
     uint8_t receiverName = static_cast<uint8_t>(*matcher.receiverName);
     if (!matcher.destinationID.has_value()) {
-        auto result = m_anyIDQueues.add(receiverName, WTFMove(queue));
+        auto result = m_anyIDQueues.add(receiverName, WTF::move(queue));
         ASSERT_UNUSED(result, result.isNewEntry);
         return;
     }
-    auto result = m_queues.add(std::make_pair(receiverName, *matcher.destinationID), WTFMove(queue));
+    auto result = m_queues.add(std::make_pair(receiverName, *matcher.destinationID), WTF::move(queue));
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -37,7 +37,7 @@ enum class ReceiverName : uint8_t;
 class MessageReceiveQueueMap {
 public:
     void add(MessageReceiveQueue& queue, const ReceiverMatcher& matcher) { addImpl(StoreType(&queue), matcher); }
-    void add(std::unique_ptr<MessageReceiveQueue>&& queue, const ReceiverMatcher& matcher) { addImpl(StoreType(WTFMove(queue)), matcher); }
+    void add(std::unique_ptr<MessageReceiveQueue>&& queue, const ReceiverMatcher& matcher) { addImpl(StoreType(WTF::move(queue)), matcher); }
     void remove(const ReceiverMatcher&);
 
     MessageReceiveQueue* get(const Decoder&) const;

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -45,8 +45,8 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_dispatcher.dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = Ref { m_receiver.get() }]() mutable {
-            connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
+        m_dispatcher.dispatch([connection = Ref { connection }, message = WTF::move(message), receiver = Ref { m_receiver.get() }]() mutable {
+            connection->dispatchMessageReceiverMessage(receiver.get(), WTF::move(message));
         });
     }
 private:
@@ -66,8 +66,8 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_queue->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
-            connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
+        m_queue->dispatch([connection = Ref { connection }, message = WTF::move(message), receiver = m_receiver]() mutable {
+            connection->dispatchMessageReceiverMessage(receiver.get(), WTF::move(message));
         });
     }
 private:

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -37,7 +37,7 @@ bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOpti
     RefPtr connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
-    return connection->sendMessage(WTFMove(encoder), sendOptions) == Error::NoError;
+    return connection->sendMessage(WTF::move(encoder), sendOptions) == Error::NoError;
 }
 
 bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncReplyHandler replyHandler, OptionSet<SendOption> sendOptions)
@@ -45,7 +45,7 @@ bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, Asyn
     RefPtr connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
-    return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;
+    return connection->sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(replyHandler), sendOptions) == Error::NoError;
 }
 
 bool MessageSender::performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&) const

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -36,7 +36,7 @@ template<typename MessageType> inline bool MessageSender::send(MessageType&& mes
     static_assert(!MessageType::isSync);
     auto encoder = makeUniqueRef<Encoder>(MessageType::name(), destinationID);
     message.encode(encoder.get());
-    return sendMessage(WTFMove(encoder), options);
+    return sendMessage(WTF::move(encoder), options);
 }
 
 template<typename MessageType> inline auto MessageSender::sendSync(MessageType&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> options) -> SendSyncResult<MessageType>
@@ -54,7 +54,7 @@ template<typename MessageType, typename C> inline std::optional<AsyncReplyID> Me
     message.encode(encoder.get());
     auto asyncHandler = Connection::makeAsyncReplyHandler<MessageType>(std::forward<C>(completionHandler));
     auto replyID = asyncHandler.replyID;
-    if (sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(asyncHandler), options))
+    if (sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(asyncHandler), options))
         return replyID;
     return std::nullopt;
 }
@@ -65,7 +65,7 @@ template<typename MessageType> inline bool MessageSender::sendWithoutUsingIPCCon
     SUPPRESS_FORWARD_DECL_ARG auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());
     message.encode(encoder.get());
 
-    return performSendWithoutUsingIPCConnection(WTFMove(encoder));
+    return performSendWithoutUsingIPCConnection(WTF::move(encoder));
 }
 
 template<typename T, typename C>
@@ -84,7 +84,7 @@ static void callReplyWithoutUsingConnection(Decoder& decoder, C&& completionHand
         completionHandler();
     else {
         if (auto arguments = decoder.template decode<typename T::ReplyArguments>())
-            return std::apply(std::forward<C>(completionHandler), WTFMove(*arguments));
+            return std::apply(std::forward<C>(completionHandler), WTF::move(*arguments));
         cancelReplyWithoutUsingConnection<T>(std::forward<C>(completionHandler));
     }
 }
@@ -97,12 +97,12 @@ template<typename MessageType, typename C> inline bool MessageSender::sendWithAs
 
     auto asyncHandler = [completionHandler = std::forward<C>(completionHandler)] (Decoder* decoder) mutable {
         if (decoder && decoder->isValid())
-            callReplyWithoutUsingConnection<MessageType>(*decoder, WTFMove(completionHandler));
+            callReplyWithoutUsingConnection<MessageType>(*decoder, WTF::move(completionHandler));
         else
-            cancelReplyWithoutUsingConnection<MessageType>(WTFMove(completionHandler));
+            cancelReplyWithoutUsingConnection<MessageType>(WTF::move(completionHandler));
     };
 
-    SUPPRESS_FORWARD_DECL_ARG return performSendWithAsyncReplyWithoutUsingIPCConnection(WTFMove(encoder), WTFMove(asyncHandler));
+    SUPPRESS_FORWARD_DECL_ARG return performSendWithAsyncReplyWithoutUsingIPCConnection(WTF::move(encoder), WTF::move(asyncHandler));
 }
 
 template<typename MessageType> inline bool MessageSender::send(MessageType&& message)

--- a/Source/WebKit/Platform/IPC/ScopedActiveMessageReceiveQueue.h
+++ b/Source/WebKit/Platform/IPC/ScopedActiveMessageReceiveQueue.h
@@ -46,7 +46,7 @@ public:
     ScopedActiveMessageReceiveQueue() = default;
     template <typename U>
     ScopedActiveMessageReceiveQueue(U&& object)
-        : m_object(WTFMove(object))
+        : m_object(WTF::move(object))
     {
     }
     ScopedActiveMessageReceiveQueue(ScopedActiveMessageReceiveQueue&& other)
@@ -80,9 +80,9 @@ private:
         object->stopListeningForIPC(object.releaseNonNull());
     }
     template<typename U>
-    static auto stopListeningForIPCAndRelease(U& object) -> decltype(object->stopListeningForIPC(WTFMove(object)), void())
+    static auto stopListeningForIPCAndRelease(U& object) -> decltype(object->stopListeningForIPC(WTF::move(object)), void())
     {
-        object->stopListeningForIPC(WTFMove(object));
+        object->stopListeningForIPC(WTF::move(object));
     }
     template<typename U>
     static auto stopListeningForIPCAndRelease(U& object) -> decltype(object->stopListeningForIPC(), void())

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -48,12 +48,12 @@ SharedBufferReference::SharedBufferReference(std::optional<SerializableBuffer>&&
     if (!serializableBuffer->handle)
         return;
 
-    auto sharedMemoryBuffer = SharedMemory::map(WTFMove(*serializableBuffer->handle), SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryBuffer = SharedMemory::map(WTF::move(*serializableBuffer->handle), SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer || sharedMemoryBuffer->size() < serializableBuffer->size)
         return;
 
     m_size = serializableBuffer->size;
-    m_memory = WTFMove(sharedMemoryBuffer);
+    m_memory = WTF::move(sharedMemoryBuffer);
 }
 
 auto SharedBufferReference::serializableBuffer() const -> std::optional<SerializableBuffer>

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.h
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.h
@@ -40,16 +40,16 @@ public:
 
     explicit SharedBufferReference(RefPtr<WebCore::FragmentedSharedBuffer>&& buffer)
         : m_size(buffer ? buffer->size() : 0)
-        , m_buffer(WTFMove(buffer)) { }
+        , m_buffer(WTF::move(buffer)) { }
     explicit SharedBufferReference(Ref<WebCore::FragmentedSharedBuffer>&& buffer)
         : m_size(buffer->size())
-        , m_buffer(WTFMove(buffer)) { }
+        , m_buffer(WTF::move(buffer)) { }
     explicit SharedBufferReference(RefPtr<WebCore::SharedBuffer>&& buffer)
         : m_size(buffer ? buffer->size() : 0)
-        , m_buffer(WTFMove(buffer)) { }
+        , m_buffer(WTF::move(buffer)) { }
     explicit SharedBufferReference(Ref<WebCore::SharedBuffer>&& buffer)
         : m_size(buffer->size())
-        , m_buffer(WTFMove(buffer)) { }
+        , m_buffer(WTF::move(buffer)) { }
     explicit SharedBufferReference(const WebCore::FragmentedSharedBuffer& buffer)
         : m_size(buffer.size())
         , m_buffer(const_cast<WebCore::FragmentedSharedBuffer*>(&buffer)) { }
@@ -87,7 +87,7 @@ public:
 private:
     SharedBufferReference(Ref<WebCore::SharedMemory>&& memory, size_t size)
         : m_size(size)
-        , m_memory(WTFMove(memory)) { }
+        , m_memory(WTF::move(memory)) { }
 
     size_t m_size { 0 };
     mutable RefPtr<WebCore::FragmentedSharedBuffer> m_buffer;

--- a/Source/WebKit/Platform/IPC/SharedFileHandle.h
+++ b/Source/WebKit/Platform/IPC/SharedFileHandle.h
@@ -47,7 +47,7 @@ public:
 
 private:
     explicit SharedFileHandle(FileSystem::FileHandle&& handle)
-        : m_handle(WTFMove(handle))
+        : m_handle(WTF::move(handle))
     {
     }
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -83,18 +83,18 @@ std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnecti
     // For Connection, "client" means the connection which was established by receiving it through IPC and creating IPC::Connection out from the identifier.
     // The "Client" in StreamClientConnection means the party that mostly does sending, e.g. untrusted party.
     // The "Server" in StreamServerConnection means the party that mostly does receiving, e.g. the trusted party which holds the destination object to communicate with.
-    auto dedicatedConnection = Connection::createServerConnection(WTFMove(connectionIdentifiers->server));
-    auto clientConnection = adoptRef(*new StreamClientConnection(WTFMove(dedicatedConnection), WTFMove(*buffer), defaultTimeoutDuration));
+    auto dedicatedConnection = Connection::createServerConnection(WTF::move(connectionIdentifiers->server));
+    auto clientConnection = adoptRef(*new StreamClientConnection(WTF::move(dedicatedConnection), WTF::move(*buffer), defaultTimeoutDuration));
     StreamServerConnection::Handle serverHandle {
-        WTFMove(connectionIdentifiers->client),
+        WTF::move(connectionIdentifiers->client),
         clientConnection->m_buffer.createHandle()
     };
-    return StreamClientConnection::StreamConnectionPair { WTFMove(clientConnection), WTFMove(serverHandle) };
+    return StreamClientConnection::StreamConnectionPair { WTF::move(clientConnection), WTF::move(serverHandle) };
 }
 
 StreamClientConnection::StreamClientConnection(Ref<Connection> connection, StreamClientConnectionBuffer&& buffer, Seconds defaultTimeoutDuration)
-    : m_connection(WTFMove(connection))
-    , m_buffer(WTFMove(buffer))
+    : m_connection(WTF::move(connection))
+    , m_buffer(WTF::move(buffer))
     , m_defaultTimeoutDuration(defaultTimeoutDuration)
 {
 }
@@ -106,7 +106,7 @@ StreamClientConnection::~StreamClientConnection()
 
 void StreamClientConnection::setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait)
 {
-    m_buffer.setSemaphores(WTFMove(wakeUp), WTFMove(clientWait));
+    m_buffer.setSemaphores(WTF::move(wakeUp), WTF::move(clientWait));
 }
 
 bool StreamClientConnection::hasSemaphores() const
@@ -130,7 +130,7 @@ Error StreamClientConnection::flushSentMessages()
 {
     auto timeout = defaultTimeout();
     wakeUpServer(WakeUpServer::Yes);
-    return m_connection->flushSentMessages(WTFMove(timeout));
+    return m_connection->flushSentMessages(WTF::move(timeout));
 }
 
 void StreamClientConnection::invalidate()

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -88,7 +88,7 @@ inline std::optional<StreamClientConnectionBuffer> StreamClientConnectionBuffer:
 }
 
 inline StreamClientConnectionBuffer::StreamClientConnectionBuffer(Ref<WebCore::SharedMemory> memory)
-    : StreamConnectionBuffer(WTFMove(memory))
+    : StreamConnectionBuffer(WTF::move(memory))
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(sharedMemorySizeIsValid(m_sharedMemory->size()));
 
@@ -211,7 +211,7 @@ inline size_t StreamClientConnectionBuffer::toLimit(ClientLimit clientLimit) con
 
 inline void StreamClientConnectionBuffer::setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait)
 {
-    m_semaphores = { WTFMove(wakeUp), WTFMove(clientWait) };
+    m_semaphores = { WTF::move(wakeUp), WTF::move(clientWait) };
     m_semaphores->wakeUp.signal();
 }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -32,7 +32,7 @@ namespace IPC {
 
 StreamConnectionBuffer::StreamConnectionBuffer(Ref<WebCore::SharedMemory>&& memory)
     : m_dataSize(memory->size() - headerSize())
-    , m_sharedMemory(WTFMove(memory))
+    , m_sharedMemory(WTF::move(memory))
 {
     ASSERT(sharedMemorySizeIsValid(m_sharedMemory->size()));
 }
@@ -44,7 +44,7 @@ StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
     auto handle = Ref { m_sharedMemory }->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
     if (!handle)
         CRASH();
-    return { WTFMove(*handle) };
+    return { WTF::move(*handle) };
 }
 
 std::span<uint8_t> StreamConnectionBuffer::headerForTesting()

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -53,7 +53,7 @@ void StreamConnectionWorkQueue::dispatch(WTF::Function<void()>&& function)
         // not dispatched as a function.
         if (m_shouldQuit)
             return;
-        m_functions.append(WTFMove(function));
+        m_functions.append(WTF::move(function));
         if (!m_shouldQuit && !m_processingThread) {
             startProcessingThread();
             return;
@@ -93,7 +93,7 @@ void StreamConnectionWorkQueue::stopAndWaitForCompletion(NOESCAPE WTF::Function<
     RefPtr<Thread> processingThread;
     {
         Locker locker { m_lock };
-        m_cleanupFunction = WTFMove(cleanupFunction);
+        m_cleanupFunction = WTF::move(cleanupFunction);
         processingThread = m_processingThread;
         m_shouldQuit = true;
     }
@@ -123,7 +123,7 @@ void StreamConnectionWorkQueue::startProcessingThread()
                 WTF::Function<void()> cleanup = nullptr;
                 {
                     Locker locker { m_lock };
-                    cleanup = WTFMove(m_cleanupFunction);
+                    cleanup = WTF::move(m_cleanupFunction);
 
                 }
                 if (cleanup)
@@ -133,7 +133,7 @@ void StreamConnectionWorkQueue::startProcessingThread()
             m_wakeUpSemaphore.wait();
         }
     };
-    m_processingThread = Thread::create(m_name, WTFMove(task), ThreadType::Graphics, Thread::QOS::UserInteractive);
+    m_processingThread = Thread::create(m_name, WTF::move(task), ThreadType::Graphics, Thread::QOS::UserInteractive);
 }
 
 void StreamConnectionWorkQueue::processStreams()
@@ -152,7 +152,7 @@ void StreamConnectionWorkQueue::processStreams()
             connections = m_connections;
         }
         for (auto& function : functions)
-            WTFMove(function)();
+            WTF::move(function)();
 
         hasMoreToProcess = false;
         for (auto& connection : connections)

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -35,23 +35,23 @@ namespace IPC {
 
 RefPtr<StreamServerConnection> StreamServerConnection::tryCreate(Handle&& handle, const StreamServerConnectionParameters& params)
 {
-    auto buffer = StreamServerConnectionBuffer::map(WTFMove(handle.buffer));
+    auto buffer = StreamServerConnectionBuffer::map(WTF::move(handle.buffer));
     if (!buffer)
         return { };
 
-    auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(handle.outOfStreamConnection) });
+    auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(handle.outOfStreamConnection) });
 
 #if ENABLE(IPC_TESTING_API)
     if (params.ignoreInvalidMessageForTesting)
         connection->setIgnoreInvalidMessageForTesting();
 #endif
 
-    return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer)));
+    return adoptRef(*new StreamServerConnection(WTF::move(connection), WTF::move(*buffer)));
 }
 
 StreamServerConnection::StreamServerConnection(Ref<Connection> connection, StreamServerConnectionBuffer&& stream)
-    : m_connection(WTFMove(connection))
-    , m_buffer(WTFMove(stream))
+    : m_connection(WTF::move(connection))
+    , m_buffer(WTF::move(stream))
 {
 }
 
@@ -107,7 +107,7 @@ void StreamServerConnection::enqueueMessage(Connection&, UniqueRef<Decoder>&& me
 {
     {
         Locker locker { m_outOfStreamMessagesLock };
-        m_outOfStreamMessages.append(WTFMove(message));
+        m_outOfStreamMessages.append(WTF::move(message));
     }
     ASSERT(m_workQueue);
     protectedWorkQueue()->wakeUp();
@@ -218,7 +218,7 @@ bool StreamServerConnection::processStreamMessage(Decoder& decoder, StreamMessag
     if (decoder.isSyncMessage()) {
         result = m_buffer.releaseAll();
         if (m_syncReplyToDispatch)
-            protectedConnection()->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)));
+            protectedConnection()->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTF::move(m_syncReplyToDispatch)));
     } else
         result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -42,8 +42,8 @@ class StreamConnectionWorkQueue;
 struct StreamServerConnectionHandle {
     WTF_MAKE_NONCOPYABLE(StreamServerConnectionHandle);
     StreamServerConnectionHandle(Connection::Handle&& connection, StreamConnectionBuffer::Handle&& bufferHandle)
-        : outOfStreamConnection(WTFMove(connection))
-        , buffer(WTFMove(bufferHandle))
+        : outOfStreamConnection(WTF::move(connection))
+        , buffer(WTF::move(bufferHandle))
     { }
     StreamServerConnectionHandle(StreamServerConnectionHandle&&) = default;
     StreamServerConnectionHandle& operator=(StreamServerConnectionHandle&&) = default;
@@ -196,7 +196,7 @@ void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequest
     } else {
         // Asynchronously replying from the current thread is supported. Note: This is not thread safe,
         // as any other thread might execute before the buffer release.
-        m_connection->sendSyncReply(WTFMove(encoder));
+        m_connection->sendSyncReply(WTF::move(encoder));
     }
 }
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -59,7 +59,7 @@ private:
 
 inline std::optional<StreamServerConnectionBuffer> StreamServerConnectionBuffer::map(Handle&& handle)
 {
-    auto sharedMemory = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadWrite);
+    auto sharedMemory = WebCore::SharedMemory::map(WTF::move(handle), WebCore::SharedMemory::Protection::ReadWrite);
     if (!sharedMemory) [[unlikely]]
         return std::nullopt;
     return StreamServerConnectionBuffer { sharedMemory.releaseNonNull() };

--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -76,7 +76,7 @@ public:
     std::optional<String> release(size_t maxCopySizeInBytes = transferAsMappingSize - 1) &&;
 
     // Release the string via copy.
-    std::optional<String> releaseToCopy() && { return WTFMove(*this).release(std::numeric_limits<size_t>::max()); };
+    std::optional<String> releaseToCopy() && { return WTF::move(*this).release(std::numeric_limits<size_t>::max()); };
 
     IPCData toIPCData() const LIFETIME_BOUND;
 
@@ -117,7 +117,7 @@ inline std::optional<TransferString> TransferString::create(StringView string)
 }
 
 inline TransferString::TransferString(String&& string)
-    : m_storage(WTFMove(string))
+    : m_storage(WTF::move(string))
 {
 }
 
@@ -129,18 +129,18 @@ inline std::optional<TransferString> TransferString::create(NSString *string)
 #endif
 
 inline TransferString::TransferString(SharedSpan8&& handle)
-    : m_storage(WTFMove(handle))
+    : m_storage(WTF::move(handle))
 {
 }
 
 inline TransferString::TransferString(SharedSpan16&& handle)
-    : m_storage(WTFMove(handle))
+    : m_storage(WTF::move(handle))
 {
 }
 
 inline TransferString::TransferString(IPCData&& data)
 {
-    WTF::switchOn(WTFMove(data),
+    WTF::switchOn(WTF::move(data),
         [&](std::monostate) {
             m_storage = String { };
         },
@@ -151,10 +151,10 @@ inline TransferString::TransferString(IPCData&& data)
             m_storage = String { characters };
         },
         [&](SharedSpan8 handle) {
-            m_storage = WTFMove(handle);
+            m_storage = WTF::move(handle);
         },
         [&](SharedSpan16 handle) {
-            m_storage = WTFMove(handle);
+            m_storage = WTF::move(handle);
         }
     );
 }

--- a/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.cpp
+++ b/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.cpp
@@ -33,7 +33,7 @@ std::optional<UnixFileDescriptor> ArgumentCoder<UnixFileDescriptor>::decode(Deco
 {
     if (auto attachment = decoder.takeLastAttachment()) {
         if (holdsAlternative<UnixFileDescriptor>(attachment.value()))
-            return { WTFMove(get<UnixFileDescriptor>(attachment.value())) };
+            return { WTF::move(get<UnixFileDescriptor>(attachment.value())) };
     }
     return std::nullopt;
 }
@@ -45,14 +45,14 @@ void ArgumentCoder<RefPtr<AHardwareBuffer>>::encode(Encoder& encoder, const RefP
 
 void ArgumentCoder<RefPtr<AHardwareBuffer>>::encode(Encoder& encoder, RefPtr<AHardwareBuffer>&& buffer)
 {
-    encoder.addAttachment(WTFMove(buffer));
+    encoder.addAttachment(WTF::move(buffer));
 }
 
 std::optional<RefPtr<AHardwareBuffer>> ArgumentCoder<RefPtr<AHardwareBuffer>>::decode(Decoder& decoder)
 {
     if (auto attachment = decoder.takeLastAttachment()) {
         if (holdsAlternative<RefPtr<AHardwareBuffer>>(attachment.value()))
-            return { WTFMove(get<RefPtr<AHardwareBuffer>>(attachment.value())) };
+            return { WTF::move(get<RefPtr<AHardwareBuffer>>(attachment.value())) };
     }
     return std::nullopt;
 }

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -54,7 +54,7 @@ void Connection::sendWithReply(xpc_object_t message, CompletionHandler<void(xpc_
 
     ASSERT(m_connection.get());
     ASSERT(xpc_get_type(message) == XPC_TYPE_DICTIONARY);
-    xpc_connection_send_message_with_reply(m_connection.get(), message, mainDispatchQueueSingleton(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    xpc_connection_send_message_with_reply(m_connection.get(), message, mainDispatchQueueSingleton(), makeBlockPtr([completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         ASSERT(RunLoop::isMain());
         completionHandler(reply);
     }).get());
@@ -94,7 +94,7 @@ template<typename Traits>
 void ConnectionToMachService<Traits>::send(typename Traits::MessageType messageType, EncodedMessage&& message) const
 {
     initializeConnectionIfNeeded();
-    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
+    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTF::move(message));
     Connection::send(dictionary.get());
 }
 
@@ -104,8 +104,8 @@ void ConnectionToMachService<Traits>::sendWithReply(typename Traits::MessageType
     ASSERT(RunLoop::isMain());
     initializeConnectionIfNeeded();
 
-    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
-    Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTF::move(message));
+    Connection::sendWithReply(dictionary.get(), [completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
             if (reply == XPC_ERROR_CONNECTION_INTERRUPTED)
                 LOG_ERROR("ConnectionToMachService::sendWithReply: connection is interrupted");

--- a/Source/WebKit/Platform/IPC/cocoa/SharedFileHandleCocoa.cpp
+++ b/Source/WebKit/Platform/IPC/cocoa/SharedFileHandleCocoa.cpp
@@ -37,7 +37,7 @@ namespace IPC {
 
 std::optional<SharedFileHandle> SharedFileHandle::create(FileSystem::FileHandle&& handle)
 {
-    return SharedFileHandle { WTFMove(handle) };
+    return SharedFileHandle { WTF::move(handle) };
 }
 
 SharedFileHandle::SharedFileHandle(MachSendRight&& fileport)

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -92,7 +92,7 @@ std::optional<EventSignalPair> createEventSignalPair()
     auto sendRight = MachSendRight::createFromReceiveRight(listeningPort);
     requestNoSenderNotifications(listeningPort);
 
-    return EventSignalPair { Event { listeningPort }, Signal { WTFMove(sendRight) } };
+    return EventSignalPair { Event { listeningPort }, Signal { WTF::move(sendRight) } };
 }
 
 Event::~Event()

--- a/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
@@ -37,13 +37,13 @@ Semaphore::Semaphore()
 }
 
 Semaphore::Semaphore(Semaphore&& other)
-    : m_sendRight(WTFMove(other.m_sendRight))
+    : m_sendRight(WTF::move(other.m_sendRight))
     , m_semaphore(std::exchange(other.m_semaphore, SEMAPHORE_NULL))
 {
 }
 
 Semaphore::Semaphore(MachSendRight&& sendRight)
-    : m_sendRight(WTFMove(sendRight))
+    : m_sendRight(WTF::move(sendRight))
     , m_semaphore(m_sendRight.sendRight())
 {
     ASSERT(m_sendRight);
@@ -58,7 +58,7 @@ Semaphore& Semaphore::operator=(Semaphore&& other)
 {
     if (this != &other) {
         destroy();
-        m_sendRight = WTFMove(other.m_sendRight);
+        m_sendRight = WTF::move(other.m_sendRight);
         m_semaphore = std::exchange(other.m_semaphore, SEMAPHORE_NULL);
     }
 

--- a/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.cpp
@@ -39,7 +39,7 @@ void ArgumentCoder<UnixFileDescriptor>::encode(Encoder& encoder, const UnixFileD
 
 void ArgumentCoder<UnixFileDescriptor>::encode(Encoder& encoder, UnixFileDescriptor&& fd)
 {
-    encoder.addAttachment(WTFMove(fd));
+    encoder.addAttachment(WTF::move(fd));
 }
 
 #if !OS(ANDROID)

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -99,7 +99,7 @@ int Connection::socketDescriptor() const
 
 void Connection::platformInitialize(Identifier&& identifier)
 {
-    m_socketDescriptor = WTFMove(identifier.handle);
+    m_socketDescriptor = WTF::move(identifier.handle);
     m_readBuffer.reserveInitialCapacity(messageMaxSize);
     m_fileDescriptors.reserveInitialCapacity(attachmentMaxAmount);
 }
@@ -178,8 +178,8 @@ bool Connection::processMessage()
             return false;
         }
 
-        auto handle = WebCore::SharedMemory::Handle { WTFMove(fd), messageInfo.bodySize() };
-        oolMessageBody = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadOnly);
+        auto handle = WebCore::SharedMemory::Handle { WTF::move(fd), messageInfo.bodySize() };
+        oolMessageBody = WebCore::SharedMemory::map(WTF::move(handle), WebCore::SharedMemory::Protection::ReadOnly);
         if (!oolMessageBody) {
             ASSERT_NOT_REACHED();
             return false;
@@ -192,12 +192,12 @@ bool Connection::processMessage()
     if (messageInfo.isBodyOutOfLine())
         messageBody = oolMessageBody->mutableSpan();
 
-    auto decoder = Decoder::create(messageBody.first(messageInfo.bodySize()), WTFMove(attachments));
+    auto decoder = Decoder::create(messageBody.first(messageInfo.bodySize()), WTF::move(attachments));
     ASSERT(decoder);
     if (!decoder)
         return false;
 
-    processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
+    processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTF::move(decoder)));
 
     if (m_readBuffer.size() > messageLength) {
         memmoveSpan(m_readBuffer.mutableSpan(), m_readBuffer.subspan(messageLength));
@@ -380,7 +380,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
             return false;
     }
 
-    return sendOutputMessage(WTFMove(outputMessage));
+    return sendOutputMessage(WTF::move(outputMessage));
 }
 
 bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
@@ -478,7 +478,7 @@ bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
 
 #if OS(ANDROID)
     RELEASE_ASSERT(m_outgoingHardwareBuffers.isEmpty());
-    m_outgoingHardwareBuffers = WTFMove(hardwareBuffers);
+    m_outgoingHardwareBuffers = WTF::move(hardwareBuffers);
     return sendOutgoingHardwareBuffers();
 #else
     return true;
@@ -541,7 +541,7 @@ bool Connection::receiveIncomingHardwareBuffers()
         if (!result) {
             m_pendingIncomingHardwareBufferCount--;
             auto hardwareBuffer = adoptRef(buffer);
-            m_incomingHardwareBuffers.append(WTFMove(hardwareBuffer));
+            m_incomingHardwareBuffers.append(WTF::move(hardwareBuffer));
             continue;
         }
 
@@ -565,7 +565,7 @@ bool Connection::receiveIncomingHardwareBuffers()
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {
     SocketPair socketPair = createPlatformConnection(SOCKET_TYPE);
-    return { { Identifier { WTFMove(socketPair.server) }, ConnectionHandle { WTFMove(socketPair.client) } } };
+    return { { Identifier { WTF::move(socketPair.server) }, ConnectionHandle { WTF::move(socketPair.client) } } };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
@@ -45,7 +45,7 @@ Semaphore::Semaphore()
 }
 
 Semaphore::Semaphore(UnixFileDescriptor&& fd)
-    : m_fd(WTFMove(fd))
+    : m_fd(WTF::move(fd))
 { }
 
 Semaphore::Semaphore(Semaphore&&) = default;

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -111,8 +111,8 @@ public:
     }
 
     UnixMessage(UnixMessage&& other)
-        : m_attachments(WTFMove(other.m_attachments))
-        , m_messageInfo(WTFMove(other.m_messageInfo))
+        : m_attachments(WTF::move(other.m_attachments))
+        , m_messageInfo(WTF::move(other.m_messageInfo))
     {
         if (other.m_bodyOwned) {
             std::swap(m_body, other.m_body);
@@ -142,7 +142,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void appendAttachment(Attachment&& attachment)
     {
-        m_attachments.append(WTFMove(attachment));
+        m_attachments.append(WTF::move(attachment));
     }
 
     bool setBodyOutOfLine()

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -146,7 +146,7 @@ void Connection::readEventHandler()
             ASSERT(decoder);
             if (!decoder)
                 return;
-            processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
+            processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTF::move(decoder)));
         }
 
         // Find out the size of the next message in the pipe (if there is one) so that we can read
@@ -317,7 +317,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
 void Connection::EventListener::open(Function<void()>&& handler)
 {
-    m_handler = WTFMove(handler);
+    m_handler = WTF::move(handler);
 
     memset(&m_state, 0, sizeof(m_state));
     m_state.hEvent = ::CreateEventW(0, FALSE, FALSE, 0);

--- a/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
@@ -38,7 +38,7 @@ Semaphore::Semaphore()
 }
 
 Semaphore::Semaphore(Win32Handle&& handle)
-    : m_semaphoreHandle(WTFMove(handle))
+    : m_semaphoreHandle(WTF::move(handle))
 {
 }
 
@@ -53,7 +53,7 @@ Semaphore& Semaphore::operator=(Semaphore&& other)
 {
     if (this != &other) {
         destroy();
-        m_semaphoreHandle = WTFMove(other.m_semaphoreHandle);
+        m_semaphoreHandle = WTF::move(other.m_semaphoreHandle);
     }
 
     return *this;

--- a/Source/WebKit/Platform/LogClient.h
+++ b/Source/WebKit/Platform/LogClient.h
@@ -85,7 +85,7 @@ void LogClient::send(T&& message)
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     Locker locker { m_lock };
 #endif
-    m_connection->send(WTFMove(message), identifier());
+    m_connection->send(WTF::move(message), identifier());
 }
 
 }

--- a/Source/WebKit/Platform/cf/ModuleCF.cpp
+++ b/Source/WebKit/Platform/cf/ModuleCF.cpp
@@ -41,7 +41,7 @@ bool Module::load()
     if (!CFBundleLoadExecutable(bundle.get()))
         return false;
 
-    m_bundle = WTFMove(bundle);
+    m_bundle = WTF::move(bundle);
     return true;
 }
 

--- a/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
+++ b/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
@@ -127,8 +127,8 @@ void TextExtractionFilter::shouldFilter(const String& text, CompletionHandler<vo
     if (text.length() <= chunkSize)
         return completionHandler(false);
 
-    m_modelQueue->dispatch([protectedThis = Ref { *this }, text = text.isolatedCopy(), completionHandler = WTFMove(completionHandler)] mutable {
-        RunLoop::mainSingleton().dispatch([completionHandler = WTFMove(completionHandler), result = protectedThis->shouldFilter(text)] mutable {
+    m_modelQueue->dispatch([protectedThis = Ref { *this }, text = text.isolatedCopy(), completionHandler = WTF::move(completionHandler)] mutable {
+        RunLoop::mainSingleton().dispatch([completionHandler = WTF::move(completionHandler), result = protectedThis->shouldFilter(text)] mutable {
             completionHandler(result);
         });
     });

--- a/Source/WebKit/Platform/cocoa/AssertionCapability.mm
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.mm
@@ -35,11 +35,11 @@
 namespace WebKit {
 
 AssertionCapability::AssertionCapability(String environmentIdentifier, String domain, String name, Function<void()>&& willInvalidateFunction, Function<void()>&& didInvalidateFunction)
-    : m_environmentIdentifier { WTFMove(environmentIdentifier) }
-    , m_domain { WTFMove(domain) }
-    , m_name { WTFMove(name) }
-    , m_willInvalidateBlock { willInvalidateFunction ? makeBlockPtr(WTFMove(willInvalidateFunction)) : nullptr }
-    , m_didInvalidateBlock { didInvalidateFunction ? makeBlockPtr(WTFMove(didInvalidateFunction)) : nullptr }
+    : m_environmentIdentifier { WTF::move(environmentIdentifier) }
+    , m_domain { WTF::move(domain) }
+    , m_name { WTF::move(name) }
+    , m_willInvalidateBlock { willInvalidateFunction ? makeBlockPtr(WTF::move(willInvalidateFunction)) : nullptr }
+    , m_didInvalidateBlock { didInvalidateFunction ? makeBlockPtr(WTF::move(didInvalidateFunction)) : nullptr }
 {
     RELEASE_LOG(Process, "AssertionCapability::AssertionCapability: taking assertion %{public}s", m_name.utf8().data());
     if (m_name == "Suspended"_s)

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -444,7 +444,7 @@ void callAfterRandomDelay(Function<void()>&& completionHandler)
 {
     // Random delay between 100 and 500 milliseconds.
     auto delay = Seconds::fromMilliseconds(100) + Seconds::fromMilliseconds((static_cast<double>(arc4random()) / static_cast<double>(UINT32_MAX)) * 400);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), makeBlockPtr(WTFMove(completionHandler)).get());
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), makeBlockPtr(WTF::move(completionHandler)).get());
 }
 
 NSDate *toAPI(const WallTime& time)

--- a/Source/WebKit/Platform/cocoa/CocoaImage.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaImage.mm
@@ -52,7 +52,7 @@ std::pair<RetainPtr<NSData>, RetainPtr<CFStringRef>> transcodeWithPreferredMIMET
     auto preferredTypeIdentifier = RetainPtr { (__bridge CFStringRef)[UTType typeWithMIMEType:bridge_cast(preferredMIMEType) conformingToType:UTTypeImage].identifier };
     if (WebCore::isSupportedImageType(preferredTypeIdentifier.get())) {
         if (auto data = transcode(image, preferredTypeIdentifier.get()); [data length])
-            return { WTFMove(data), WTFMove(preferredTypeIdentifier) };
+            return { WTF::move(data), WTF::move(preferredTypeIdentifier) };
     }
 
     return { nil, nil };

--- a/Source/WebKit/Platform/cocoa/ExtensionCapability.h
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapability.h
@@ -51,7 +51,7 @@ public:
 
 protected:
     ExtensionCapability() = default;
-    void setPlatformCapability(PlatformCapability&& capability) { m_platformCapability = WTFMove(capability); }
+    void setPlatformCapability(PlatformCapability&& capability) { m_platformCapability = WTF::move(capability); }
 
 private:
     PlatformCapability m_platformCapability;

--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
@@ -44,13 +44,13 @@ static void platformInvalidate(const PlatformGrant& platformGrant)
 }
 
 ExtensionCapabilityGrant::ExtensionCapabilityGrant(String environmentIdentifier)
-    : m_environmentIdentifier { WTFMove(environmentIdentifier) }
+    : m_environmentIdentifier { WTF::move(environmentIdentifier) }
 {
 }
 
 ExtensionCapabilityGrant::ExtensionCapabilityGrant(String&& environmentIdentifier, PlatformGrant&& platformGrant)
-    : m_environmentIdentifier { WTFMove(environmentIdentifier) }
-    , m_platformGrant { WTFMove(platformGrant) }
+    : m_environmentIdentifier { WTF::move(environmentIdentifier) }
+    , m_platformGrant { WTF::move(platformGrant) }
 {
 }
 
@@ -62,8 +62,8 @@ ExtensionCapabilityGrant::~ExtensionCapabilityGrant()
 ExtensionCapabilityGrant ExtensionCapabilityGrant::isolatedCopy() &&
 {
     return {
-        crossThreadCopy(WTFMove(m_environmentIdentifier)),
-        WTFMove(m_platformGrant)
+        crossThreadCopy(WTF::move(m_environmentIdentifier)),
+        WTF::move(m_platformGrant)
     };
 }
 
@@ -79,7 +79,7 @@ bool ExtensionCapabilityGrant::isValid() const
 
 void ExtensionCapabilityGrant::setPlatformGrant(PlatformGrant&& platformGrant)
 {
-    platformInvalidate(std::exchange(m_platformGrant, WTFMove(platformGrant)));
+    platformInvalidate(std::exchange(m_platformGrant, WTF::move(platformGrant)));
 }
 
 void ExtensionCapabilityGrant::invalidate()

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -189,7 +189,7 @@ WTF::MachSendRightAnnotated LayerHostingContext::sendRightAnnotated() const
         sendRight = MachSendRight::adopt(copiedPort);
         dataRepresentation = data;
     }];
-    return { WTFMove(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };
+    return { WTF::move(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };
 }
 
 RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::createHostingUpdateCoordinator(WTF::MachSendRightAnnotated&& sendRightAnnotated)
@@ -210,7 +210,7 @@ WTF::MachSendRightAnnotated LayerHostingContext::fence(BELayerHierarchyHostingTr
         sendRight = MachSendRight::adopt(copiedPort);
         dataRepresentation = data;
     }];
-    return { WTFMove(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };
+    return { WTF::move(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };
 }
 
 RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(WTF::MachSendRightAnnotated&& sendRightAnnotated)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -49,7 +49,7 @@ void LayerHostingContextManager::requestHostingContext(LayerHostingContextCallba
         return;
     }
 
-    m_layerHostingContextRequests.append(WTFMove(completionHandler));
+    m_layerHostingContextRequests.append(WTF::move(completionHandler));
 }
 
 void LayerHostingContextManager::setInitialVideoLayerSize(const WebCore::FloatSize& size)
@@ -102,7 +102,7 @@ void LayerHostingContextManager::setVideoLayerSizeFenced(const WebCore::FloatSiz
 #if USE(EXTENSIONKIT)
 #if ENABLE(MACH_PORT_LAYER_HOSTING)
         auto sendRightAnnotatedCopy = sendRightAnnotated;
-        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTFMove(sendRightAnnotatedCopy));
+        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTF::move(sendRightAnnotatedCopy));
 #else
         hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(sendRightAnnotated.sendRight.sendRight());
 #endif // ENABLE(MACH_PORT_LAYER_HOSTING)

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -45,11 +45,11 @@ static RetainPtr<BEMediaEnvironment> createMediaEnvironment(const URL& webPageUR
 
 Ref<MediaCapability> MediaCapability::create(URL&& url)
 {
-    return adoptRef(*new MediaCapability(WTFMove(url)));
+    return adoptRef(*new MediaCapability(WTF::move(url)));
 }
 
 MediaCapability::MediaCapability(URL&& webPageURL)
-    : m_webPageURL { WTFMove(webPageURL) }
+    : m_webPageURL { WTF::move(webPageURL) }
     , m_mediaEnvironment { createMediaEnvironment(m_webPageURL) }
 {
     setPlatformCapability([BEProcessCapability mediaPlaybackAndCaptureWithEnvironment:m_mediaEnvironment.get()]);

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -81,25 +81,25 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const
 
 #if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
 MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, CoreIPCAVOutputContext&& context, std::optional<WTF::UUID>&& identifier)
-    : m_deviceName { WTFMove(deviceName) }
+    : m_deviceName { WTF::move(deviceName) }
     , m_hasActiveRoute { hasActiveRoute }
     , m_supportsRemoteVideoPlayback { supportsRemoteVideoPlayback }
     , m_targetType { targetType }
     , m_state { state }
-    , m_context { WTFMove(context) }
-    , m_identifier { WTFMove(identifier) }
+    , m_context { WTF::move(context) }
+    , m_identifier { WTF::move(identifier) }
 {
 }
 #else
 MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, String&& contextID, String&& contextType, std::optional<WTF::UUID>&& identifier)
-    : m_deviceName(WTFMove(deviceName))
+    : m_deviceName(WTF::move(deviceName))
     , m_hasActiveRoute(hasActiveRoute)
     , m_supportsRemoteVideoPlayback(supportsRemoteVideoPlayback)
     , m_targetType(targetType)
     , m_state(state)
-    , m_contextID(WTFMove(contextID))
-    , m_contextType(WTFMove(contextType))
-    , m_identifier { WTFMove(identifier) }
+    , m_contextID(WTF::move(contextID))
+    , m_contextType(WTF::move(contextType))
+    , m_identifier { WTF::move(identifier) }
 {
 }
 #endif
@@ -124,7 +124,7 @@ Ref<MediaPlaybackTarget> MediaPlaybackTargetContextSerialized::playbackTarget() 
     propertyList[@"AVOutputContextSerializationKeyContextType"] = m_contextType.createNSString().get();
     auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);
     auto outputContext = adoptNS([[PAL::getAVOutputContextClassSingleton() alloc] initWithCoder:unarchiver.get()]);
-    return MediaPlaybackTargetCocoa::create(WTFMove(outputContext));
+    return MediaPlaybackTargetCocoa::create(WTF::move(outputContext));
 #endif
 }
 

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.cpp
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.cpp
@@ -32,12 +32,12 @@ namespace WebKit {
 
 Ref<MediaPlaybackTargetSerialized> MediaPlaybackTargetSerialized::create(MediaPlaybackTargetContextSerialized&& context)
 {
-    return adoptRef(*new MediaPlaybackTargetSerialized(WTFMove(context)));
+    return adoptRef(*new MediaPlaybackTargetSerialized(WTF::move(context)));
 }
 
 MediaPlaybackTargetSerialized::MediaPlaybackTargetSerialized(MediaPlaybackTargetContextSerialized&& context)
     : MediaPlaybackTarget { Type::Serialized }
-    , m_context { WTFMove(context) }
+    , m_context { WTF::move(context) }
 {
 }
 

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -287,31 +287,31 @@ void PaymentAuthorizationPresenter::completePaymentMethodSelection(std::optional
 #if HAVE(PASSKIT_DISBURSEMENTS)
     bool isDisbursementRequestBasedOnSummaryItems = update->newLineItems.isEmpty() ? NO : update->newLineItems.last().disbursementLineItemType == WebCore::ApplePayLineItem::DisbursementLineItemType::Disbursement;
     if (isDisbursementRequestBasedOnSummaryItems)
-        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems)).get()]);
+        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTF::move(update->newLineItems)).get()]);
     else
 #endif
-        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems)).get()]);
+        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTF::move(update->newTotal), WTF::move(update->newLineItems)).get()]);
 #if HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
-    [paymentMethodUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
+    [paymentMethodUpdate setErrors:toNSErrors(WTF::move(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-    [paymentMethodUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
+    [paymentMethodUpdate setAvailableShippingMethods:toPKShippingMethods(WTF::move(update->newShippingMethods)).get()];
 #else
-    [paymentMethodUpdate setShippingMethods:createNSArray(WTFMove(update->newShippingMethods), [] (auto& method) {
+    [paymentMethodUpdate setShippingMethods:createNSArray(WTF::move(update->newShippingMethods), [] (auto& method) {
         return toPKShippingMethod(method);
     }).get()];
 #endif
 #endif
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)
     if (auto& recurringPaymentRequest = update->newRecurringPaymentRequest)
-        [paymentMethodUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTFMove(*recurringPaymentRequest)).get()];
+        [paymentMethodUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTF::move(*recurringPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_AUTOMATIC_RELOAD_PAYMENTS)
     if (auto& automaticReloadPaymentRequest = update->newAutomaticReloadPaymentRequest)
-        [paymentMethodUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTFMove(*automaticReloadPaymentRequest)).get()];
+        [paymentMethodUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTF::move(*automaticReloadPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_MULTI_MERCHANT_PAYMENTS)
     if (auto& multiTokenContexts = update->newMultiTokenContexts)
-        [paymentMethodUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTFMove(*multiTokenContexts)).get()];
+        [paymentMethodUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTF::move(*multiTokenContexts)).get()];
 #endif
 #if HAVE(PASSKIT_INSTALLMENTS) && ENABLE(APPLE_PAY_INSTALLMENTS)
     [paymentMethodUpdate setInstallmentGroupIdentifier:update->installmentGroupIdentifier.createNSString().get()];
@@ -319,7 +319,7 @@ void PaymentAuthorizationPresenter::completePaymentMethodSelection(std::optional
     [protectedPlatformDelegate() completePaymentMethodSelection:paymentMethodUpdate.get()];
 #if HAVE(PASSKIT_DEFERRED_PAYMENTS)
     if (auto& deferredPaymentRequest = update->newDeferredPaymentRequest)
-        [paymentMethodUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTFMove(*deferredPaymentRequest)).get()];
+        [paymentMethodUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTF::move(*deferredPaymentRequest)).get()];
 #endif
 }
 
@@ -333,7 +333,7 @@ void PaymentAuthorizationPresenter::completePaymentSession(WebCore::ApplePayPaym
     auto errors = toNSErrors(result.errors);
 
 #if HAVE(PASSKIT_PAYMENT_ORDER_DETAILS)
-    if (auto orderDetails = WTFMove(result.orderDetails)) {
+    if (auto orderDetails = WTF::move(result.orderDetails)) {
         auto platformOrderDetails = adoptNS([PAL::allocPKPaymentOrderDetailsInstance() initWithOrderTypeIdentifier:orderDetails->orderTypeIdentifier.createNSString().get() orderIdentifier:orderDetails->orderIdentifier.createNSString().get() webServiceURL:adoptNS([[NSURL alloc] initWithString:orderDetails->webServiceURL.createNSString().get()]).get() authenticationToken:orderDetails->authenticationToken.createNSString().get()]);
         [protectedPlatformDelegate() completePaymentSession:status errors:errors.get() orderDetails:platformOrderDetails.get()];
         return;
@@ -354,33 +354,33 @@ void PaymentAuthorizationPresenter::completeShippingContactSelection(std::option
     RetainPtr<PKPaymentRequestShippingContactUpdate> shippingContactUpdate;
 #if HAVE(PASSKIT_DISBURSEMENTS)
     if (update->newDisbursementRequest)
-        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems)).get()]);
+        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTF::move(update->newLineItems)).get()]);
     else
 #endif // HAVE(PASSKIT_DISBURSEMENTS)
-        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems)).get()]);
-    [shippingContactUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
+        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTF::move(update->newTotal), WTF::move(update->newLineItems)).get()]);
+    [shippingContactUpdate setErrors:toNSErrors(WTF::move(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-    [shippingContactUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
+    [shippingContactUpdate setAvailableShippingMethods:toPKShippingMethods(WTF::move(update->newShippingMethods)).get()];
 #else
-    [shippingContactUpdate setShippingMethods:createNSArray(WTFMove(update->newShippingMethods), [] (auto& method) {
+    [shippingContactUpdate setShippingMethods:createNSArray(WTF::move(update->newShippingMethods), [] (auto& method) {
         return toPKShippingMethod(method);
     }).get()];
 #endif
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)
     if (auto& recurringPaymentRequest = update->newRecurringPaymentRequest)
-        [shippingContactUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTFMove(*recurringPaymentRequest)).get()];
+        [shippingContactUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTF::move(*recurringPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_AUTOMATIC_RELOAD_PAYMENTS)
     if (auto& automaticReloadPaymentRequest = update->newAutomaticReloadPaymentRequest)
-        [shippingContactUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTFMove(*automaticReloadPaymentRequest)).get()];
+        [shippingContactUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTF::move(*automaticReloadPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_MULTI_MERCHANT_PAYMENTS)
     if (auto& multiTokenContexts = update->newMultiTokenContexts)
-        [shippingContactUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTFMove(*multiTokenContexts)).get()];
+        [shippingContactUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTF::move(*multiTokenContexts)).get()];
 #endif
 #if HAVE(PASSKIT_DEFERRED_PAYMENTS)
     if (auto& deferredPaymentRequest = update->newDeferredPaymentRequest)
-        [shippingContactUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTFMove(*deferredPaymentRequest)).get()];
+        [shippingContactUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTF::move(*deferredPaymentRequest)).get()];
 #endif
     [protectedPlatformDelegate() completeShippingContactSelection:shippingContactUpdate.get()];
 }
@@ -393,29 +393,29 @@ void PaymentAuthorizationPresenter::completeShippingMethodSelection(std::optiona
         return;
     }
 
-    auto shippingMethodUpdate = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems)).get()]);
+    auto shippingMethodUpdate = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTF::move(update->newTotal), WTF::move(update->newLineItems)).get()]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-    [shippingMethodUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
+    [shippingMethodUpdate setAvailableShippingMethods:toPKShippingMethods(WTF::move(update->newShippingMethods)).get()];
 #elif HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
-    [shippingMethodUpdate setShippingMethods:createNSArray(WTFMove(update->newShippingMethods), [] (auto& method) {
+    [shippingMethodUpdate setShippingMethods:createNSArray(WTF::move(update->newShippingMethods), [] (auto& method) {
         return toPKShippingMethod(method);
     }).get()];
 #endif
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)
     if (auto& recurringPaymentRequest = update->newRecurringPaymentRequest)
-        [shippingMethodUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTFMove(*recurringPaymentRequest)).get()];
+        [shippingMethodUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTF::move(*recurringPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_AUTOMATIC_RELOAD_PAYMENTS)
     if (auto& automaticReloadPaymentRequest = update->newAutomaticReloadPaymentRequest)
-        [shippingMethodUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTFMove(*automaticReloadPaymentRequest)).get()];
+        [shippingMethodUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTF::move(*automaticReloadPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_MULTI_MERCHANT_PAYMENTS)
     if (auto& multiTokenContexts = update->newMultiTokenContexts)
-        [shippingMethodUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTFMove(*multiTokenContexts)).get()];
+        [shippingMethodUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTF::move(*multiTokenContexts)).get()];
 #endif
 #if HAVE(PASSKIT_DEFERRED_PAYMENTS)
     if (auto& deferredPaymentRequest = update->newDeferredPaymentRequest)
-        [shippingMethodUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTFMove(*deferredPaymentRequest)).get()];
+        [shippingMethodUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTF::move(*deferredPaymentRequest)).get()];
 #endif
     [protectedPlatformDelegate() completeShippingMethodSelection:shippingMethodUpdate.get()];
 }
@@ -430,30 +430,30 @@ void PaymentAuthorizationPresenter::completeCouponCodeChange(std::optional<WebCo
         return;
     }
 
-    auto couponCodeUpdate = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems)).get()]);
-    [couponCodeUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
+    auto couponCodeUpdate = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTF::move(update->newTotal), WTF::move(update->newLineItems)).get()]);
+    [couponCodeUpdate setErrors:toNSErrors(WTF::move(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-    [couponCodeUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
+    [couponCodeUpdate setAvailableShippingMethods:toPKShippingMethods(WTF::move(update->newShippingMethods)).get()];
 #else
-    [couponCodeUpdate setShippingMethods:createNSArray(WTFMove(update->newShippingMethods), [] (auto& method) {
+    [couponCodeUpdate setShippingMethods:createNSArray(WTF::move(update->newShippingMethods), [] (auto& method) {
         return toPKShippingMethod(method);
     }).get()];
 #endif
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)
     if (auto& recurringPaymentRequest = update->newRecurringPaymentRequest)
-        [couponCodeUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTFMove(*recurringPaymentRequest)).get()];
+        [couponCodeUpdate setRecurringPaymentRequest:platformRecurringPaymentRequest(WTF::move(*recurringPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_AUTOMATIC_RELOAD_PAYMENTS)
     if (auto& automaticReloadPaymentRequest = update->newAutomaticReloadPaymentRequest)
-        [couponCodeUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTFMove(*automaticReloadPaymentRequest)).get()];
+        [couponCodeUpdate setAutomaticReloadPaymentRequest:platformAutomaticReloadPaymentRequest(WTF::move(*automaticReloadPaymentRequest)).get()];
 #endif
 #if HAVE(PASSKIT_MULTI_MERCHANT_PAYMENTS)
     if (auto& multiTokenContexts = update->newMultiTokenContexts)
-        [couponCodeUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTFMove(*multiTokenContexts)).get()];
+        [couponCodeUpdate setMultiTokenContexts:platformPaymentTokenContexts(WTF::move(*multiTokenContexts)).get()];
 #endif
 #if HAVE(PASSKIT_DEFERRED_PAYMENTS)
     if (auto& deferredPaymentRequest = update->newDeferredPaymentRequest)
-        [couponCodeUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTFMove(*deferredPaymentRequest)).get()];
+        [couponCodeUpdate setDeferredPaymentRequest:platformDeferredPaymentRequest(WTF::move(*deferredPaymentRequest)).get()];
 #endif
     [protectedPlatformDelegate() completeCouponCodeChange:couponCodeUpdate.get()];
 }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -69,14 +69,14 @@ class ListDataObserver : public RefCountedAndCanMakeWeakPtr<ListDataObserver> {
 public:
     static Ref<ListDataObserver> create(Function<void()>&& callback)
     {
-        return adoptRef(*new ListDataObserver(WTFMove(callback)));
+        return adoptRef(*new ListDataObserver(WTF::move(callback)));
     }
 
     void invokeCallback() { m_callback(); }
 
 private:
     explicit ListDataObserver(Function<void()>&& callback)
-        : m_callback { WTFMove(callback) }
+        : m_callback { WTF::move(callback) }
     {
     }
 
@@ -113,7 +113,7 @@ public:
     void setCachedListDataForTesting(BackingDataType&& data)
     {
         m_wasInitialized = true;
-        setCachedListData(WTFMove(data));
+        setCachedListData(WTF::move(data));
         // FIXME: This is a safer cpp false positive (rdar://161384112).
         SUPPRESS_FORWARD_DECL_ARG m_observers.forEach([](ListDataObserver& observer) {
             observer.invokeCallback();
@@ -127,7 +127,7 @@ protected:
 
     void setCachedListData(BackingDataType&& data)
     {
-        m_cachedListData = WTFMove(data);
+        m_cachedListData = WTF::move(data);
         didUpdateCachedListData();
     }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -115,7 +115,7 @@ Ref<ListDataObserver> ListDataControllerBase::observeUpdates(Function<void()>&& 
             });
         }]);
     }
-    Ref observer = ListDataObserver::create(WTFMove(callback));
+    Ref observer = ListDataObserver::create(WTF::move(callback));
     m_observers.add(observer.get());
     return observer;
 }
@@ -152,7 +152,7 @@ void LinkDecorationFilteringController::updateList(CompletionHandler<void()>&& c
     }
 
     static NeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
-    lookupCompletionHandlers->append(WTFMove(completionHandler));
+    lookupCompletionHandlers->append(WTF::move(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
 
@@ -167,9 +167,9 @@ void LinkDecorationFilteringController::updateList(CompletionHandler<void()>&& c
             RetainPtr rules = [data rules];
             for (WPLinkFilteringRule *rule : rules.get()) {
                 auto domain = WebCore::RegistrableDomain { URL { makeString("http://"_s, String { rule.domain }) } };
-                result.append(WebCore::LinkDecorationFilteringData { WTFMove(domain), [rule respondsToSelector:@selector(path)] ? rule.path : @"", rule.queryParameter });
+                result.append(WebCore::LinkDecorationFilteringData { WTF::move(domain), [rule respondsToSelector:@selector(path)] ? rule.path : @"", rule.queryParameter });
             }
-            setCachedListData(WTFMove(result));
+            setCachedListData(WTF::move(result));
         }
 
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
@@ -196,7 +196,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
     }
 
     static NeverDestroyed<Vector<LinkFilteringRulesCallback, 1>> lookupCallbacks;
-    lookupCallbacks->append(WTFMove(callback));
+    lookupCallbacks->append(WTF::move(callback));
     if (lookupCallbacks->size() > 1)
         return;
 
@@ -211,7 +211,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
             RetainPtr rules = [data rules];
             for (WPLinkFilteringRule *rule : rules.get()) {
                 auto domain = WebCore::RegistrableDomain { URL { makeString("http://"_s, String { rule.domain }) } };
-                result.append(WebCore::LinkDecorationFilteringData { WTFMove(domain), { }, rule.queryParameter });
+                result.append(WebCore::LinkDecorationFilteringData { WTF::move(domain), { }, rule.queryParameter });
             }
         }
 
@@ -221,7 +221,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
             if (i)
                 callback(Vector { result });
             else
-                callback(WTFMove(result));
+                callback(WTF::move(result));
         }
     }];
 }
@@ -245,7 +245,7 @@ static HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> q
         Vector<WebCore::RegistrableDomain> subFrameDomains;
         for (NSString *subFrameDomain : [quirkDomains objectForKey:topDomain])
             subFrameDomains.append(WebCore::RegistrableDomain::fromRawString(subFrameDomain));
-        map.add(WebCore::RegistrableDomain::fromRawString(String { topDomain }), WTFMove(subFrameDomains));
+        map.add(WebCore::RegistrableDomain::fromRawString(String { topDomain }), WTF::move(subFrameDomains));
     }
     return map;
 }
@@ -264,12 +264,12 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
 {
     ASSERT(RunLoop::isMain());
     if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestStorageAccessPromptQuirksData:completionHandler:)]) {
-        RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
+        RunLoop::mainSingleton().dispatch(WTF::move(completionHandler));
         return;
     }
 
     static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
-    lookupCompletionHandlers->append(WTFMove(completionHandler));
+    lookupCompletionHandlers->append(WTF::move(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
 
@@ -289,7 +289,7 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
                 else
                     result.append(WebCore::OrganizationStorageAccessPromptQuirk { quirk.name, quirkDomainsDictToMap(retainPtr(quirk.domainPairings).get()), { } });
             }
-            setCachedListData(WTFMove(result));
+            setCachedListData(WTF::move(result));
         }
 
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
@@ -306,12 +306,12 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
 {
     ASSERT(RunLoop::isMain());
     if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestStorageAccessUserAgentStringQuirksData:completionHandler:)]) {
-        RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
+        RunLoop::mainSingleton().dispatch(WTF::move(completionHandler));
         return;
     }
 
     static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
-    lookupCompletionHandlers->append(WTFMove(completionHandler));
+    lookupCompletionHandlers->append(WTF::move(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
 
@@ -326,7 +326,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
             RetainPtr quirks = [data quirks];
             for (WPStorageAccessUserAgentStringQuirk *quirk : quirks.get())
                 result.add(WebCore::RegistrableDomain::fromRawString(quirk.domain), quirk.userAgentString);
-            setCachedListData(WTFMove(result));
+            setCachedListData(WTF::move(result));
         }
 
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
@@ -391,7 +391,7 @@ void RestrictedOpenerDomainsController::update()
             restrictedOpenerTypes.add(registrableDomain, restrictedOpenerType(domainInfo.openerType));
         }
 
-        m_restrictedOpenerTypes = WTFMove(restrictedOpenerTypes);
+        m_restrictedOpenerTypes = WTF::move(restrictedOpenerTypes);
     }];
 }
 
@@ -428,7 +428,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
     }
 
     static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void(WKContentRuleList*, bool)>, 1>> lookupCompletionHandlers;
-    lookupCompletionHandlers->append(WTFMove(completionHandler));
+    lookupCompletionHandlers->append(WTF::move(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
 
@@ -452,7 +452,7 @@ void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&
     }
 
     static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void(NSString *)>, 1>> lookupCompletionHandlers;
-    lookupCompletionHandlers->append(WTFMove(completionHandler));
+    lookupCompletionHandlers->append(WTF::move(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
 
@@ -499,7 +499,7 @@ public:
     enum class CanBlock : bool { No, Yes };
 
     TrackerAddressLookupInfo(WebCore::IPAddress&& network, unsigned netMaskLength, String&& owner, String&& host, CanBlock canBlock)
-        : m_network { WTFMove(network) }
+        : m_network { WTF::move(network) }
         , m_netMaskLength { netMaskLength }
         , m_owner { owner.utf8() }
         , m_host { host.utf8() }
@@ -800,12 +800,12 @@ void ScriptTrackingPrivacyController::updateList(CompletionHandler<void()>&& com
     ASSERT(RunLoop::isMain());
 #if ENABLE(SCRIPT_TRACKING_PRIVACY_PROTECTIONS)
     if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestFingerprintingScripts:completionHandler:)]) {
-        RunLoop::mainSingleton().dispatch(WTFMove(completion));
+        RunLoop::mainSingleton().dispatch(WTF::move(completion));
         return;
     }
 
     static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void()>, 1>> pendingCompletionHandlers;
-    pendingCompletionHandlers->append(WTFMove(completion));
+    pendingCompletionHandlers->append(WTF::move(completion));
     if (pendingCompletionHandlers->size() > 1)
         return;
 
@@ -839,10 +839,10 @@ void ScriptTrackingPrivacyController::updateList(CompletionHandler<void()>&& com
                     result.thirdPartyHosts.append({ script.host, allowedCategories });
             }
         }
-        setCachedListData(WTFMove(result));
+        setCachedListData(WTF::move(result));
     }];
 #else
-    RunLoop::mainSingleton().dispatch(WTFMove(completion));
+    RunLoop::mainSingleton().dispatch(WTF::move(completion));
 #endif
 }
 

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -176,7 +176,7 @@ void PaymentAuthorizationController::present(UIViewController *, CompletionHandl
     if (!m_controller)
         return completionHandler(false);
 
-    [m_controller presentWithCompletion:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL success) mutable {
+    [m_controller presentWithCompletion:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL success) mutable {
         completionHandler(success);
     }).get()];
 }
@@ -186,7 +186,7 @@ void PaymentAuthorizationController::presentInScene(const String& sceneIdentifie
 {
     m_sceneIdentifier = sceneIdentifier;
     m_bundleIdentifier = bundleIdentifier;
-    present(nil, WTFMove(completionHandler));
+    present(nil, WTF::move(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -132,7 +132,7 @@ void VideoPresentationInterfaceLMK::invalidatePlayerViewController()
 void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     playbackSessionInterface().startObservingNowPlayingMetadata();
-    [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
+    [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (BOOL success, NSError *error) {
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
@@ -146,7 +146,7 @@ void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<vo
 void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     playbackSessionInterface().stopObservingNowPlayingMetadata();
-    [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
+    [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (BOOL success, NSError *error) {
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(nullString());
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Automatic);
@@ -168,11 +168,11 @@ void VideoPresentationInterfaceLMK::enterExternalPlayback(CompletionHandler<void
     }
 
     setupPlayerViewController();
-    m_exitExternalPlaybackHandler = WTFMove(exitHandler);
+    m_exitExternalPlaybackHandler = WTF::move(exitHandler);
     playbackSessionInterface().startObservingNowPlayingMetadata();
 
     // Puts the player into `enteringExternal` state.
-    [linearMediaPlayer() enterExternalPlaybackWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, handler = WTFMove(enterHandler)] (BOOL success, NSError *error) mutable {
+    [linearMediaPlayer() enterExternalPlaybackWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, handler = WTF::move(enterHandler)] (BOOL success, NSError *error) mutable {
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
@@ -202,7 +202,7 @@ void VideoPresentationInterfaceLMK::exitExternalPlayback()
     }
 
     playbackSessionInterface().stopObservingNowPlayingMetadata();
-    [linearMediaPlayer() exitExternalPlaybackWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, handler = WTFMove(exitHandler)] (BOOL success, NSError *error) mutable {
+    [linearMediaPlayer() exitExternalPlaybackWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, handler = WTF::move(exitHandler)] (BOOL success, NSError *error) mutable {
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(nullString());
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Automatic);

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -45,11 +45,11 @@ static constexpr ASCIILiteral endpointIdentifierKey = "video-receiver-endpoint-i
 static constexpr ASCIILiteral cacheCommandKey = "video-receiver-cache-command"_s;
 
 VideoReceiverEndpointMessage::VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier, WebCore::VideoReceiverEndpoint endpoint, WebCore::VideoReceiverEndpointIdentifier endpointIdentifier)
-    : m_processIdentifier { WTFMove(processIdentifier) }
-    , m_mediaElementIdentifier { WTFMove(mediaElementIdentifier) }
-    , m_playerIdentifier { WTFMove(playerIdentifier) }
-    , m_endpoint { WTFMove(endpoint) }
-    , m_endpointIdentifier { WTFMove(endpointIdentifier) }
+    : m_processIdentifier { WTF::move(processIdentifier) }
+    , m_mediaElementIdentifier { WTF::move(mediaElementIdentifier) }
+    , m_playerIdentifier { WTF::move(playerIdentifier) }
+    , m_endpoint { WTF::move(endpoint) }
+    , m_endpointIdentifier { WTF::move(endpointIdentifier) }
 {
     RELEASE_ASSERT(!m_endpoint || xpc_get_type(m_endpoint.get()) == XPC_TYPE_DICTIONARY);
 }
@@ -85,11 +85,11 @@ XPCObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
 }
 
 VideoReceiverSwapEndpointsMessage::VideoReceiverSwapEndpointsMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier sourceMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> sourcePlayerIdentifier, WebCore::HTMLMediaElementIdentifier destinationMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> destinationPlayerIdentifier)
-    : m_processIdentifier { WTFMove(processIdentifier) }
-    , m_sourceMediaElementIdentifier { WTFMove(sourceMediaElementIdentifier) }
-    , m_sourcePlayerIdentifier { WTFMove(sourcePlayerIdentifier) }
-    , m_destinationMediaElementIdentifier { WTFMove(destinationMediaElementIdentifier) }
-    , m_destinationPlayerIdentifier { WTFMove(destinationPlayerIdentifier) }
+    : m_processIdentifier { WTF::move(processIdentifier) }
+    , m_sourceMediaElementIdentifier { WTF::move(sourceMediaElementIdentifier) }
+    , m_sourcePlayerIdentifier { WTF::move(sourcePlayerIdentifier) }
+    , m_destinationMediaElementIdentifier { WTF::move(destinationMediaElementIdentifier) }
+    , m_destinationPlayerIdentifier { WTF::move(destinationPlayerIdentifier) }
 {
 }
 

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -109,7 +109,7 @@ static RetainPtr<PlatformDDAction> actionForMenuItem(NSMenuItem *item)
         return nil;
 
     RetainPtr<id> action = [representedObject objectForKey:@"DDAction"];
-    return dynamic_objc_cast<PlatformDDAction>(WTFMove(action));
+    return dynamic_objc_cast<PlatformDDAction>(WTF::move(action));
 }
 
 NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)

--- a/Source/WebKit/Platform/mac/StringUtilities.mm
+++ b/Source/WebKit/Platform/mac/StringUtilities.mm
@@ -62,7 +62,7 @@ RetainPtr<NSString> formattedPhoneNumberString(NSString *originalPhoneNumber)
     if (!phoneNumberString)
         phoneNumberString = adoptCF(CFPhoneNumberCopyUnformattedRepresentation(phoneNumber.get()));
 
-    return bridge_cast(WTFMove(phoneNumberString));
+    return bridge_cast(WTF::move(phoneNumberString));
 }
 
 #endif // ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -230,7 +230,7 @@ def function_parameter_requires_suppress_forward_decl(type, kind, for_reply=Fals
 
 def arguments_constructor_name(type, name):
     if type in types_that_must_be_moved():
-        return 'WTFMove(%s)' % name
+        return 'WTF::move(%s)' % name
 
     return name
 
@@ -315,7 +315,7 @@ def message_to_struct_declaration(receiver, message):
         if requires_suppress_forward_decl[i]:
             result.append('SUPPRESS_FORWARD_DECL_ARG ')
         if parameter.type in types_that_must_be_moved():
-            result.append('encoder << WTFMove(m_%s);\n' % parameter.name)
+            result.append('encoder << WTF::move(m_%s);\n' % parameter.name)
         else:
             result.append('encoder << m_%s;\n' % parameter.name)
     result.append('    }\n')
@@ -903,7 +903,7 @@ def async_message_statement(receiver, message):
     else:
         target_name = 'this'
     if receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE) and message.reply_parameters is not None and not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
-        dispatch_function_args = ['decoder', 'WTFMove(replyHandler)', target_name, '&%s' % handler_function(receiver, message)]
+        dispatch_function_args = ['decoder', 'WTF::move(replyHandler)', target_name, '&%s' % handler_function(receiver, message)]
     else:
         dispatch_function_args = ['decoder', target_name, '&%s' % handler_function(receiver, message)]
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -206,11 +206,11 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
         return std::nullopt;
     return {
         Namespace::Subnamespace::StructName {
-            WTFMove(*firstMemberName),
+            WTF::move(*firstMemberName),
 #if ENABLE(SECOND_MEMBER)
-            WTFMove(*secondMemberName),
+            WTF::move(*secondMemberName),
 #endif
-            WTFMove(*nullableTestMember)
+            WTF::move(*nullableTestMember)
         }
     };
 }
@@ -248,9 +248,9 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
         return std::nullopt;
     return {
         Namespace::OtherClass {
-            WTFMove(*a),
-            WTFMove(*b),
-            WTFMove(*dataDetectorResults)
+            WTF::move(*a),
+            WTF::move(*b),
+            WTF::move(*dataDetectorResults)
         }
     };
 }
@@ -278,7 +278,7 @@ std::optional<Namespace::ClassWithMemberPrecondition> ArgumentCoder<Namespace::C
         return std::nullopt;
     return {
         Namespace::ClassWithMemberPrecondition {
-            WTFMove(*m_pkPaymentMethod)
+            WTF::move(*m_pkPaymentMethod)
         }
     };
 }
@@ -303,9 +303,9 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
         return std::nullopt;
     return {
         Namespace::ReturnRefClass::create(
-            WTFMove(*functionCallmember1),
-            WTFMove(*functionCallmember2),
-            WTFMove(*uniqueMember)
+            WTF::move(*functionCallmember1),
+            WTF::move(*functionCallmember2),
+            WTF::move(*uniqueMember)
         )
     };
 }
@@ -335,9 +335,9 @@ std::optional<Namespace::EmptyConstructorStruct> ArgumentCoder<Namespace::EmptyC
     if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     Namespace::EmptyConstructorStruct result;
-    result.m_int = WTFMove(*m_int);
-    result.m_double = WTFMove(*m_double);
-    return { WTFMove(result) };
+    result.m_int = WTF::move(*m_int);
+    result.m_double = WTF::move(*m_double);
+    return { WTF::move(result) };
 }
 
 void ArgumentCoder<Namespace::EmptyConstructorWithIf>::encode(Encoder& encoder, const Namespace::EmptyConstructorWithIf& instance)
@@ -386,12 +386,12 @@ std::optional<Namespace::EmptyConstructorWithIf> ArgumentCoder<Namespace::EmptyC
         return std::nullopt;
     Namespace::EmptyConstructorWithIf result;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    result.m_type = WTFMove(*m_type);
+    result.m_type = WTF::move(*m_type);
 #endif
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    result.m_value = WTFMove(*m_value);
+    result.m_value = WTF::move(*m_value);
 #endif
-    return { WTFMove(result) };
+    return { WTF::move(result) };
 }
 
 void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutNamespace& instance)
@@ -415,7 +415,7 @@ std::optional<WithoutNamespace> ArgumentCoder<WithoutNamespace>::decode(Decoder&
         return std::nullopt;
     return {
         WithoutNamespace {
-            WTFMove(*a)
+            WTF::move(*a)
         }
     };
 }
@@ -455,7 +455,7 @@ std::optional<WithoutNamespaceWithAttributes> ArgumentCoder<WithoutNamespaceWith
         return std::nullopt;
     return {
         WithoutNamespaceWithAttributes {
-            WTFMove(*a)
+            WTF::move(*a)
         }
     };
 }
@@ -485,9 +485,9 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
     return {
         WebCore::InheritsFrom {
             WithoutNamespace {
-                WTFMove(*a)
+                WTF::move(*a)
             },
-            WTFMove(*b)
+            WTF::move(*b)
         }
     };
 }
@@ -525,11 +525,11 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
         WebCore::InheritanceGrandchild {
             WebCore::InheritsFrom {
                 WithoutNamespace {
-                    WTFMove(*a)
+                    WTF::move(*a)
                 },
-                WTFMove(*b)
+                WTF::move(*b)
             },
-            WTFMove(*c)
+            WTF::move(*c)
         }
     };
 }
@@ -548,7 +548,7 @@ std::optional<WTF::Seconds> ArgumentCoder<WTF::Seconds>::decode(Decoder& decoder
         return std::nullopt;
     return {
         WTF::Seconds {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -574,7 +574,7 @@ std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decod
         return std::nullopt;
     return {
         WTF::CreateUsingClass::fromDouble(
-            WTFMove(*value)
+            WTF::move(*value)
         )
     };
 }
@@ -602,10 +602,10 @@ std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::d
         return std::nullopt;
     return {
         WebCore::FloatBoxExtent {
-            WTFMove(*top),
-            WTFMove(*right),
-            WTFMove(*bottom),
-            WTFMove(*left)
+            WTF::move(*top),
+            WTF::move(*right),
+            WTF::move(*bottom),
+            WTF::move(*left)
         }
     };
 }
@@ -636,8 +636,8 @@ std::optional<SoftLinkedMember> ArgumentCoder<SoftLinkedMember>::decode(Decoder&
         return std::nullopt;
     return {
         SoftLinkedMember {
-            WTFMove(*firstMember),
-            WTFMove(*secondMember)
+            WTF::move(*firstMember),
+            WTF::move(*secondMember)
         }
     };
 }
@@ -691,27 +691,27 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
         auto result = decoder.decode<Ref<WebCore::LinearTimingFunction>>();
         if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
-        return WTFMove(*result);
+        return WTF::move(*result);
     }
     if (type == WebCore_TimingFunction_Subclass::CubicBezierTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::CubicBezierTimingFunction>>();
         if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
-        return WTFMove(*result);
+        return WTF::move(*result);
     }
 #if CONDITION
     if (type == WebCore_TimingFunction_Subclass::StepsTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::StepsTimingFunction>>();
         if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
-        return WTFMove(*result);
+        return WTF::move(*result);
     }
 #endif
     if (type == WebCore_TimingFunction_Subclass::SpringTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::SpringTimingFunction>>();
         if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
-        return WTFMove(*result);
+        return WTF::move(*result);
     }
     ASSERT_NOT_REACHED();
     return std::nullopt;
@@ -739,7 +739,7 @@ std::optional<Namespace::ConditionalCommonClass> ArgumentCoder<Namespace::Condit
         return std::nullopt;
     return {
         Namespace::ConditionalCommonClass {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -772,8 +772,8 @@ std::optional<Namespace::CommonClass> ArgumentCoder<Namespace::CommonClass>::dec
         return std::nullopt;
     return {
         Namespace::CommonClass {
-            WTFMove(*value),
-            WTFMove(*nonRefMemberWithSubclasses)
+            WTF::move(*value),
+            WTF::move(*nonRefMemberWithSubclasses)
         }
     };
 }
@@ -802,7 +802,7 @@ std::optional<Ref<Namespace::AnotherCommonClass>> ArgumentCoder<Namespace::Anoth
         return std::nullopt;
     return {
         Namespace::AnotherCommonClass::create(
-            WTFMove(*value)
+            WTF::move(*value)
         )
     };
 }
@@ -816,7 +816,7 @@ void ArgumentCoder<WebCore::MoveOnlyBaseClass>::encode(Encoder& encoder, WebCore
 {
     if (auto* subclass = dynamicDowncast<WebCore::MoveOnlyDerivedClass>(instance)) {
         encoder << WebCore_MoveOnlyBaseClass_Subclass::MoveOnlyDerivedClass;
-        encoder << WTFMove(*subclass);
+        encoder << WTF::move(*subclass);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -834,7 +834,7 @@ std::optional<WebCore::MoveOnlyBaseClass> ArgumentCoder<WebCore::MoveOnlyBaseCla
         auto result = decoder.decode<Ref<WebCore::MoveOnlyDerivedClass>>();
         if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
-        return WTFMove(*result);
+        return WTF::move(*result);
     }
     ASSERT_NOT_REACHED();
     return std::nullopt;
@@ -854,8 +854,8 @@ void ArgumentCoder<WebCore::MoveOnlyDerivedClass>::encode(Encoder& encoder, WebC
         , offsetof(WebCore::MoveOnlyDerivedClass, secondMember)
     >::value);
 
-    encoder << WTFMove(instance.firstMember);
-    encoder << WTFMove(instance.secondMember);
+    encoder << WTF::move(instance.firstMember);
+    encoder << WTF::move(instance.secondMember);
 }
 
 std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDerivedClass>::decode(Decoder& decoder)
@@ -866,8 +866,8 @@ std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDeri
         return std::nullopt;
     return {
         WebCore::MoveOnlyDerivedClass {
-            WTFMove(*firstMember),
-            WTFMove(*secondMember)
+            WTF::move(*firstMember),
+            WTF::move(*secondMember)
         }
     };
 }
@@ -879,7 +879,7 @@ std::optional<WebKit::CustomEncoded> ArgumentCoder<WebKit::CustomEncoded>::decod
         return std::nullopt;
     return {
         WebKit::CustomEncoded {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -940,27 +940,27 @@ std::optional<WebKit::LayerProperties> ArgumentCoder<WebKit::LayerProperties>::d
     result.changedProperties = *changedProperties;
     if (*changedProperties & WebKit::LayerChange::NameChanged) {
         if (auto deserialized = decoder.decode<String>())
-            result.name = WTFMove(*deserialized);
+            result.name = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
 #if ENABLE(FEATURE)
     if (*changedProperties & WebKit::LayerChange::TransformChanged) {
         if (auto deserialized = decoder.decode<std::unique_ptr<WebCore::TransformationMatrix>>())
-            result.featureEnabledMember = WTFMove(*deserialized);
+            result.featureEnabledMember = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
 #endif
     if (*changedProperties & WebKit::LayerChange::FeatureEnabledMember) {
         if (auto deserialized = decoder.decode<bool>())
-            result.bitFieldMember = WTFMove(*deserialized);
+            result.bitFieldMember = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
     if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
-    return { WTFMove(result) };
+    return { WTF::move(result) };
 }
 
 void ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::encode(Encoder& encoder, const WebKit::TemplateTest<WebKit::Fabulous>& instance)
@@ -984,7 +984,7 @@ std::optional<WebKit::TemplateTest<WebKit::Fabulous>> ArgumentCoder<WebKit::Temp
         return std::nullopt;
     return {
         WebKit::TemplateTest<WebKit::Fabulous> {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -1010,7 +1010,7 @@ std::optional<WebKit::TemplateTest<WebCore::Amazing>> ArgumentCoder<WebKit::Temp
         return std::nullopt;
     return {
         WebKit::TemplateTest<WebCore::Amazing> {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -1036,7 +1036,7 @@ std::optional<WebKit::TemplateTest<JSC::Incredible>> ArgumentCoder<WebKit::Templ
         return std::nullopt;
     return {
         WebKit::TemplateTest<JSC::Incredible> {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -1062,7 +1062,7 @@ std::optional<WebKit::TemplateTest<Testing::StorageSize>> ArgumentCoder<WebKit::
         return std::nullopt;
     return {
         WebKit::TemplateTest<Testing::StorageSize> {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -1096,7 +1096,7 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCor
     std::optional<WebCore::PlatformLayerIdentifier> layerlayerIDForEncoding { };
     if (*changedProperties & WebCore::ScrollingStateNode::Property::Layer) {
         if (auto deserialized = decoder.decode<std::optional<WebCore::PlatformLayerIdentifier>>())
-            layerlayerIDForEncoding = WTFMove(*deserialized);
+            layerlayerIDForEncoding = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
@@ -1104,10 +1104,10 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCor
         return std::nullopt;
     return {
         WebCore::ScrollingStateFrameHostingNode::create(
-            WTFMove(*scrollingNodeID),
-            WTFMove(*children),
-            WTFMove(*changedProperties),
-            WTFMove(layerlayerIDForEncoding)
+            WTF::move(*scrollingNodeID),
+            WTF::move(*children),
+            WTF::move(*changedProperties),
+            WTF::move(layerlayerIDForEncoding)
         )
     };
 }
@@ -1147,7 +1147,7 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> A
     std::optional<WebCore::PlatformLayerIdentifier> layerlayerIDForEncoding { };
     if (*changedProperties & WebCore::ScrollingStateNode::Property::Layer) {
         if (auto deserialized = decoder.decode<std::optional<WebCore::PlatformLayerIdentifier>>())
-            layerlayerIDForEncoding = WTFMove(*deserialized);
+            layerlayerIDForEncoding = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
@@ -1155,7 +1155,7 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> A
     bool otherMember { };
     if (*changedProperties & WebCore::ScrollingStateNode::Property::Other) {
         if (auto deserialized = decoder.decode<bool>())
-            otherMember = WTFMove(*deserialized);
+            otherMember = WTF::move(*deserialized);
         else
             return std::nullopt;
     }
@@ -1164,12 +1164,12 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> A
         return std::nullopt;
     return {
         WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple::create(
-            WTFMove(*scrollingNodeID),
-            WTFMove(*children),
-            WTFMove(*changedProperties),
-            WTFMove(layerlayerIDForEncoding),
-            WTFMove(otherMember),
-            WTFMove(*memberAfterTuple)
+            WTF::move(*scrollingNodeID),
+            WTF::move(*children),
+            WTF::move(*changedProperties),
+            WTF::move(layerlayerIDForEncoding),
+            WTF::move(otherMember),
+            WTF::move(*memberAfterTuple)
         )
     };
 }
@@ -1200,7 +1200,7 @@ std::optional<RequestEncodedWithBody> ArgumentCoder<RequestEncodedWithBody>::dec
         return std::nullopt;
     return {
         RequestEncodedWithBody {
-            WTFMove(*request)
+            WTF::move(*request)
         }
     };
 }
@@ -1217,8 +1217,8 @@ void ArgumentCoder<RequestEncodedWithBodyRValue>::encode(Encoder& encoder, Reque
     >::value);
 
     RefPtr requestBody = instance.request.httpBody();
-    encoder << WTFMove(instance.request);
-    encoder << IPC::FormDataReference { WTFMove(requestBody) };
+    encoder << WTF::move(instance.request);
+    encoder << IPC::FormDataReference { WTF::move(requestBody) };
 }
 
 std::optional<RequestEncodedWithBodyRValue> ArgumentCoder<RequestEncodedWithBodyRValue>::decode(Decoder& decoder)
@@ -1232,7 +1232,7 @@ std::optional<RequestEncodedWithBodyRValue> ArgumentCoder<RequestEncodedWithBody
         return std::nullopt;
     return {
         RequestEncodedWithBodyRValue {
-            WTFMove(*request)
+            WTF::move(*request)
         }
     };
 }
@@ -1340,8 +1340,8 @@ std::optional<SkFooBar> ArgumentCoder<SkFooBar>::decode(Decoder& decoder)
         return std::nullopt;
     return {
         CoreIPCSkFooBar {
-            WTFMove(*foo),
-            WTFMove(*bar)
+            WTF::move(*foo),
+            WTF::move(*bar)
         }
     };
 }
@@ -1362,7 +1362,7 @@ std::optional<WebKit::RValueWithFunctionCalls> ArgumentCoder<WebKit::RValueWithF
         return std::nullopt;
     return {
         WebKit::RValueWithFunctionCalls {
-            WTFMove(*callFunction)
+            WTF::move(*callFunction)
         }
     };
 }
@@ -1393,8 +1393,8 @@ std::optional<WebKit::RemoteVideoFrameReference> ArgumentCoder<WebKit::RemoteVid
         return std::nullopt;
     return {
         WebKit::RemoteVideoFrameReference {
-            WTFMove(*identifier),
-            WTFMove(*version)
+            WTF::move(*identifier),
+            WTF::move(*version)
         }
     };
 }
@@ -1425,8 +1425,8 @@ std::optional<WebKit::RemoteVideoFrameWriteReference> ArgumentCoder<WebKit::Remo
         return std::nullopt;
     return {
         WebKit::RemoteVideoFrameWriteReference {
-            WTFMove(*reference),
-            WTFMove(*pendingReads)
+            WTF::move(*reference),
+            WTF::move(*pendingReads)
         }
     };
 }
@@ -1453,7 +1453,7 @@ std::optional<Namespace::OuterClass> ArgumentCoder<Namespace::OuterClass>::decod
         return std::nullopt;
     return {
         Namespace::OuterClass {
-            WTFMove(*outerValue)
+            WTF::move(*outerValue)
         }
     };
 }
@@ -1482,7 +1482,7 @@ std::optional<Namespace::OtherOuterClass> ArgumentCoder<Namespace::OtherOuterCla
         return std::nullopt;
     return {
         Namespace::OtherOuterClass {
-            WTFMove(*outerValue)
+            WTF::move(*outerValue)
         }
     };
 }
@@ -1540,8 +1540,8 @@ std::optional<Ref<WebCore::AppKitControlSystemImage>> ArgumentCoder<WebCore::App
         return std::nullopt;
     return {
         WebCore::ScrollbarTrackCornerSystemImageMac::create(
-            WTFMove(*m_tintColor),
-            WTFMove(*m_useDarkAppearance)
+            WTF::move(*m_tintColor),
+            WTF::move(*m_useDarkAppearance)
         )
     };
 }
@@ -1571,10 +1571,10 @@ std::optional<WebCore::RectEdges<bool>> ArgumentCoder<WebCore::RectEdges<bool>>:
         return std::nullopt;
     return {
         WebCore::RectEdges<bool> {
-            WTFMove(*top),
-            WTFMove(*right),
-            WTFMove(*bottom),
-            WTFMove(*left)
+            WTF::move(*top),
+            WTF::move(*right),
+            WTF::move(*bottom),
+            WTF::move(*left)
         }
     };
 }
@@ -1601,7 +1601,7 @@ std::optional<WebCore::OpaqueTypeObject> ArgumentCoder<WebCore::OpaqueTypeObject
         return std::nullopt;
     return {
         WebCore::OpaqueTypeObject {
-            WTFMove(*member)
+            WTF::move(*member)
         }
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -122,8 +122,8 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(
     RetainPtr<NSString>&& AVOutputContextSerializationKeyContextID,
     RetainPtr<NSString>&& AVOutputContextSerializationKeyContextType
 )
-    : m_AVOutputContextSerializationKeyContextID(WTFMove(AVOutputContextSerializationKeyContextID))
-    , m_AVOutputContextSerializationKeyContextType(WTFMove(AVOutputContextSerializationKeyContextType))
+    : m_AVOutputContextSerializationKeyContextID(WTF::move(AVOutputContextSerializationKeyContextID))
+    , m_AVOutputContextSerializationKeyContextType(WTF::move(AVOutputContextSerializationKeyContextType))
 {
 }
 
@@ -164,13 +164,13 @@ CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(
     RetainPtr<NSDictionary>&& DictionaryKey,
     RetainPtr<NSDictionary>&& OptionalDictionaryKey
 )
-    : m_StringKey(WTFMove(StringKey))
-    , m_NumberKey(WTFMove(NumberKey))
-    , m_OptionalNumberKey(WTFMove(OptionalNumberKey))
-    , m_ArrayKey(WTFMove(ArrayKey))
-    , m_OptionalArrayKey(WTFMove(OptionalArrayKey))
-    , m_DictionaryKey(WTFMove(DictionaryKey))
-    , m_OptionalDictionaryKey(WTFMove(OptionalDictionaryKey))
+    : m_StringKey(WTF::move(StringKey))
+    , m_NumberKey(WTF::move(NumberKey))
+    , m_OptionalNumberKey(WTF::move(OptionalNumberKey))
+    , m_ArrayKey(WTF::move(ArrayKey))
+    , m_OptionalArrayKey(WTF::move(OptionalArrayKey))
+    , m_DictionaryKey(WTF::move(DictionaryKey))
+    , m_OptionalDictionaryKey(WTF::move(OptionalDictionaryKey))
 {
 }
 
@@ -235,7 +235,7 @@ RetainPtr<id> CoreIPCNSSomeFoundationType::toID() const
 CoreIPCclass NSSomeOtherFoundationType::CoreIPCclass NSSomeOtherFoundationType(
     RetainPtr<NSDictionary>&& DictionaryKey
 )
-    : m_DictionaryKey(WTFMove(DictionaryKey))
+    : m_DictionaryKey(WTF::move(DictionaryKey))
 {
 }
 
@@ -270,15 +270,15 @@ CoreIPCDDScannerResult::CoreIPCDDScannerResult(
     Vector<RetainPtr<NSData>>&& DataArrayKey,
     Vector<RetainPtr<SecTrustRef>>&& SecTrustArrayKey
 )
-    : m_StringKey(WTFMove(StringKey))
-    , m_NumberKey(WTFMove(NumberKey))
-    , m_OptionalNumberKey(WTFMove(OptionalNumberKey))
-    , m_ArrayKey(WTFMove(ArrayKey))
-    , m_OptionalArrayKey(WTFMove(OptionalArrayKey))
-    , m_DictionaryKey(WTFMove(DictionaryKey))
-    , m_OptionalDictionaryKey(WTFMove(OptionalDictionaryKey))
-    , m_DataArrayKey(WTFMove(DataArrayKey))
-    , m_SecTrustArrayKey(WTFMove(SecTrustArrayKey))
+    : m_StringKey(WTF::move(StringKey))
+    , m_NumberKey(WTF::move(NumberKey))
+    , m_OptionalNumberKey(WTF::move(OptionalNumberKey))
+    , m_ArrayKey(WTF::move(ArrayKey))
+    , m_OptionalArrayKey(WTF::move(OptionalArrayKey))
+    , m_DictionaryKey(WTF::move(DictionaryKey))
+    , m_OptionalDictionaryKey(WTF::move(OptionalDictionaryKey))
+    , m_DataArrayKey(WTF::move(DataArrayKey))
+    , m_SecTrustArrayKey(WTF::move(SecTrustArrayKey))
 {
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -602,7 +602,7 @@ public:
     static constexpr bool deferSendingIfSuspended = false;
 
     DidCreateWebProcessConnection(MachSendRight&& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
-        : m_connectionIdentifier(WTFMove(connectionIdentifier))
+        : m_connectionIdentifier(WTF::move(connectionIdentifier))
         , m_flags(flags)
     {
     }
@@ -610,7 +610,7 @@ public:
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_connectionIdentifier);
+        encoder << WTF::move(m_connectionIdentifier);
         SUPPRESS_FORWARD_DECL_ARG encoder << m_flags;
     }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -177,14 +177,14 @@ public:
     static constexpr bool isStreamBatched = false;
 
     explicit SendMachSendRight(MachSendRight&& a1)
-        : m_a1(WTFMove(a1))
+        : m_a1(WTF::move(a1))
     {
     }
 
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_a1);
+        encoder << WTF::move(m_a1);
     }
 
 private:
@@ -240,14 +240,14 @@ public:
     using ReplyArguments = std::tuple<MachSendRight>;
     using Reply = CompletionHandler<void(MachSendRight&&)>;
     explicit SendAndReceiveMachSendRight(MachSendRight&& a1)
-        : m_a1(WTFMove(a1))
+        : m_a1(WTF::move(a1))
     {
     }
 
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_a1);
+        encoder << WTF::move(m_a1);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
@@ -52,14 +52,14 @@ public:
     static constexpr bool deferSendingIfSuspended = false;
 
     explicit SendStreamServerConnection(IPC::StreamServerConnectionHandle&& handle)
-        : m_handle(WTFMove(handle))
+        : m_handle(WTF::move(handle))
     {
     }
 
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_handle);
+        encoder << WTF::move(m_handle);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -602,7 +602,7 @@ public:
     static constexpr bool deferSendingIfSuspended = false;
 
     DidCreateWebProcessConnection(MachSendRight&& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
-        : m_connectionIdentifier(WTFMove(connectionIdentifier))
+        : m_connectionIdentifier(WTF::move(connectionIdentifier))
         , m_flags(flags)
     {
     }
@@ -610,7 +610,7 @@ public:
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_connectionIdentifier);
+        encoder << WTF::move(m_connectionIdentifier);
         SUPPRESS_FORWARD_DECL_ARG encoder << m_flags;
     }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -45,11 +45,11 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
         return;
     }
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name()) {
-        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTF::move(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
         return;
     }
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name()) {
-        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTF::move(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
         return;
     }
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name()) {
@@ -57,11 +57,11 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
         return;
     }
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name()) {
-        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTF::move(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
         return;
     }
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name()) {
-        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTF::move(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
         return;
     }
     RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -108,7 +108,7 @@ std::optional<WebKit::PlatformClass> ArgumentCoder<WebKit::PlatformClass>::decod
         return std::nullopt;
     return {
         WebKit::PlatformClass {
-            WTFMove(*value)
+            WTF::move(*value)
         }
     };
 }
@@ -146,8 +146,8 @@ std::optional<WebKit::CoreIPCAVOutputContext> ArgumentCoder<WebKit::CoreIPCAVOut
         return std::nullopt;
     return {
         WebKit::CoreIPCAVOutputContext {
-            WTFMove(*AVOutputContextSerializationKeyContextID),
-            WTFMove(*AVOutputContextSerializationKeyContextType)
+            WTF::move(*AVOutputContextSerializationKeyContextID),
+            WTF::move(*AVOutputContextSerializationKeyContextType)
         }
     };
 }
@@ -226,13 +226,13 @@ std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPC
         return std::nullopt;
     return {
         WebKit::CoreIPCNSSomeFoundationType {
-            WTFMove(*StringKey),
-            WTFMove(*NumberKey),
-            WTFMove(*OptionalNumberKey),
-            WTFMove(*ArrayKey),
-            WTFMove(*OptionalArrayKey),
-            WTFMove(*DictionaryKey),
-            WTFMove(*OptionalDictionaryKey)
+            WTF::move(*StringKey),
+            WTF::move(*NumberKey),
+            WTF::move(*OptionalNumberKey),
+            WTF::move(*ArrayKey),
+            WTF::move(*OptionalArrayKey),
+            WTF::move(*DictionaryKey),
+            WTF::move(*OptionalDictionaryKey)
         }
     };
 }
@@ -261,7 +261,7 @@ std::optional<WebKit::CoreIPCclass NSSomeOtherFoundationType> ArgumentCoder<WebK
         return std::nullopt;
     return {
         WebKit::CoreIPCclass NSSomeOtherFoundationType {
-            WTFMove(*DictionaryKey)
+            WTF::move(*DictionaryKey)
         }
     };
 }
@@ -355,15 +355,15 @@ std::optional<WebKit::CoreIPCDDScannerResult> ArgumentCoder<WebKit::CoreIPCDDSca
         return std::nullopt;
     return {
         WebKit::CoreIPCDDScannerResult {
-            WTFMove(*StringKey),
-            WTFMove(*NumberKey),
-            WTFMove(*OptionalNumberKey),
-            WTFMove(*ArrayKey),
-            WTFMove(*OptionalArrayKey),
-            WTFMove(*DictionaryKey),
-            WTFMove(*OptionalDictionaryKey),
-            WTFMove(*DataArrayKey),
-            WTFMove(*SecTrustArrayKey)
+            WTF::move(*StringKey),
+            WTF::move(*NumberKey),
+            WTF::move(*OptionalNumberKey),
+            WTF::move(*ArrayKey),
+            WTF::move(*OptionalArrayKey),
+            WTF::move(*DictionaryKey),
+            WTF::move(*OptionalDictionaryKey),
+            WTF::move(*DataArrayKey),
+            WTF::move(*SecTrustArrayKey)
         }
     };
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -203,7 +203,7 @@ static bool wpeBufferDMABufTryEnsureGBMDevice(WPEBufferDMABuf* buffer)
     if (!device)
         return false;
 
-    priv->deviceFD = WTFMove(fd);
+    priv->deviceFD = WTF::move(fd);
     priv->device = device;
 
     return true;

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.cpp
@@ -44,7 +44,7 @@ struct BufferFormat {
     BufferFormat& operator=(const BufferFormat&) = delete;
     BufferFormat(BufferFormat&& other)
         : fourcc(other.fourcc)
-        , modifiers(WTFMove(other.modifiers))
+        , modifiers(WTF::move(other.modifiers))
     {
     }
 
@@ -64,7 +64,7 @@ struct BufferFormatsGroup {
     BufferFormatsGroup(BufferFormatsGroup&& other)
         : device(other.device)
         , usage(other.usage)
-        , formats(WTFMove(other.formats))
+        , formats(WTF::move(other.formats))
     {
         other.device = nullptr;
         other.usage = WPE_BUFFER_FORMAT_USAGE_RENDERING;
@@ -345,8 +345,8 @@ WPEBufferFormats* wpe_buffer_formats_builder_end(WPEBufferFormatsBuilder* builde
     g_return_val_if_fail(builder, nullptr);
 
     auto* formats = WPE_BUFFER_FORMATS(g_object_new(WPE_TYPE_BUFFER_FORMATS, nullptr));
-    formats->priv->device = WTFMove(builder->device);
-    formats->priv->groups = WTFMove(builder->groups);
+    formats->priv->device = WTF::move(builder->device);
+    formats->priv->groups = WTF::move(builder->groups);
     wpe_buffer_formats_builder_unref(builder);
 
     return formats;

--- a/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
@@ -63,7 +63,7 @@ static GUniquePtr<char> cursorsPath(const char* basePath, Vector<GUniquePtr<char
                 return !g_strcmp0(item.get(), path.get());
             });
             if (path && !exists)
-                inherited.append(WTFMove(path));
+                inherited.append(WTF::move(path));
         }
     }
 
@@ -85,11 +85,11 @@ static std::unique_ptr<CursorTheme> tryCreateTheme(const char* basePath, uint32_
 
     if (!path) {
         // If there's no cursors path, use the first inherited theme.
-        path = WTFMove(inheritedThemes[0]);
+        path = WTF::move(inheritedThemes[0]);
         inheritedThemes.removeAt(0);
     }
 
-    return makeUnique<CursorTheme>(WTFMove(path), size, WTFMove(inheritedThemes));
+    return makeUnique<CursorTheme>(WTF::move(path), size, WTF::move(inheritedThemes));
 }
 
 std::unique_ptr<CursorTheme> CursorTheme::create(const char* name, uint32_t size)
@@ -135,9 +135,9 @@ std::unique_ptr<CursorTheme> CursorTheme::create()
 }
 
 CursorTheme::CursorTheme(GUniquePtr<char>&& path, uint32_t size, Vector<GUniquePtr<char>>&& inherited)
-    : m_path(WTFMove(path))
+    : m_path(WTF::move(path))
     , m_size(size)
-    , m_inherited(WTFMove(inherited))
+    , m_inherited(WTF::move(inherited))
 {
 }
 
@@ -307,7 +307,7 @@ Vector<CursorTheme::CursorImage> CursorTheme::loadCursor(const char* name, uint3
         if (!image)
             break;
 
-        cursorImages.append(WTFMove(*image));
+        cursorImages.append(WTF::move(*image));
         if (cursorImages.size() == header->imageCount)
             break;
     }

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -271,7 +271,7 @@ WPEDisplay* wpe_display_get_default(void)
                 GUniqueOutPtr<GError> error;
                 GRefPtr<WPEDisplay> display = adoptGRef(WPE_DISPLAY(g_object_new(g_io_extension_get_type(extension), nullptr)));
                 if (wpe_display_connect(display.get(), &error.outPtr())) {
-                    s_defaultDisplay = WTFMove(display);
+                    s_defaultDisplay = WTF::move(display);
                     return;
                 }
                 g_error("Failed to connect to display of type %s: %s", extensionName, error->message);
@@ -285,7 +285,7 @@ WPEDisplay* wpe_display_get_default(void)
             auto* extension = static_cast<GIOExtension*>(i->data);
             GRefPtr<WPEDisplay> display = adoptGRef(WPE_DISPLAY(g_object_new(g_io_extension_get_type(extension), nullptr)));
             if (wpe_display_connect(display.get(), nullptr)) {
-                s_defaultDisplay = WTFMove(display);
+                s_defaultDisplay = WTF::move(display);
                 return;
             }
         }

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManagerManette.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManagerManette.cpp
@@ -42,7 +42,7 @@ WEBKIT_DEFINE_FINAL_TYPE(WPEGamepadManagerManette, wpe_gamepad_manager_manette, 
 static void wpeGamepadManagerManetteAddDevice(WPEGamepadManagerManette* manager, ManetteDevice* device)
 {
     GRefPtr<WPEGamepad> gamepad = adoptGRef(wpeGamepadManetteCreate(device));
-    auto addResult = manager->priv->devices.set(device, WTFMove(gamepad));
+    auto addResult = manager->priv->devices.set(device, WTF::move(gamepad));
     wpe_gamepad_manager_add_device(WPE_GAMEPAD_MANAGER(manager), addResult.iterator->value.get());
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -217,7 +217,7 @@ static void wpeScreenTryEnsureSyncObserver(WPEScreen* screen)
             continue;
 
         if (auto crtcIndex = findCrtc(WPE_SCREEN(screen), fd.value())) {
-            screen->priv->syncObserver = adoptGRef(wpeScreenSyncObserverDRMCreate(WTFMove(fd), *crtcIndex));
+            screen->priv->syncObserver = adoptGRef(wpeScreenSyncObserverDRMCreate(WTF::move(fd), *crtcIndex));
             if (screen->priv->syncObserver) {
                 g_debug("WPEScreen %u: Created WPEScreenSyncObserverDRM for device %s with CRTC index %u", screen->priv->id, devices[i]->nodes[DRM_NODE_PRIMARY], *crtcIndex);
                 break;

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
@@ -189,7 +189,7 @@ WPEScreenSyncObserver* wpeScreenSyncObserverDRMCreate(UnixFileDescriptor&& fd, i
         return nullptr;
 
     auto* observer = WPE_SCREEN_SYNC_OBSERVER_DRM(g_object_new(WPE_TYPE_SCREEN_SYNC_OBSERVER_DRM, nullptr));
-    observer->priv->fd = WTFMove(fd);
+    observer->priv->fd = WTF::move(fd);
     observer->priv->crtcBitmask = crtcBitmask;
     return WPE_SCREEN_SYNC_OBSERVER(observer);
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -39,8 +39,8 @@ struct SettingEntry {
     SettingEntry() = default;
 
     SettingEntry(GRefPtr<GVariant>&& defaultValue, GUniquePtr<GVariantType>&& type)
-        : defaultValue(WTFMove(defaultValue))
-        , type(WTFMove(type))
+        : defaultValue(WTF::move(defaultValue))
+        , type(WTF::move(type))
     {
     }
 
@@ -245,7 +245,7 @@ gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* k
             if (iter->value.setValue && !g_variant_compare(iter->value.setValue.get(), parsedValue.get()))
                 continue;
 
-            iter->value.setValue = WTFMove(parsedValue);
+            iter->value.setValue = WTF::move(parsedValue);
             g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(path.data()), path.data(), iter->value.setValue.get());
         }
     }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<Crtc> Crtc::create(int fd, drmModeCrtc* crtc, unsigned index)
         return nullptr;
 
     Properties props = { drmPropertyForName(fd, properties.get(), "ACTIVE"), drmPropertyForName(fd, properties.get(), "MODE_ID") };
-    return makeUnique<Crtc>(crtc, index, WTFMove(props));
+    return makeUnique<Crtc>(crtc, index, WTF::move(props));
 }
 
 Crtc::Crtc(drmModeCrtc* crtc, unsigned index, Properties&& properties)
@@ -72,7 +72,7 @@ Crtc::Crtc(drmModeCrtc* crtc, unsigned index, Properties&& properties)
     , m_width(crtc->width)
     , m_height(crtc->height)
     , m_bufferID(crtc->buffer_id)
-    , m_properties(WTFMove(properties))
+    , m_properties(WTF::move(properties))
 {
     if (crtc->mode_valid)
         m_currentMode = crtc->mode;
@@ -98,7 +98,7 @@ std::unique_ptr<Connector> Connector::create(int fd, drmModeConnector* connector
         return nullptr;
 
     Properties props = { drmPropertyForName(fd, properties.get(), "CRTC_ID"), drmPropertyForName(fd, properties.get(), "link-status") };
-    return makeUnique<Connector>(connector, WTFMove(props));
+    return makeUnique<Connector>(connector, WTF::move(props));
 }
 
 Connector::Connector(drmModeConnector* connector, Properties&& properties)
@@ -106,7 +106,7 @@ Connector::Connector(drmModeConnector* connector, Properties&& properties)
     , m_encoderID(connector->encoder_id)
     , m_widthMM(connector->mmWidth)
     , m_heightMM(connector->mmHeight)
-    , m_properties(WTFMove(properties))
+    , m_properties(WTF::move(properties))
 {
     m_modes.reserveInitialCapacity(connector->count_modes);
     for (int i = 0; i < connector->count_modes; ++i) {
@@ -159,7 +159,7 @@ std::unique_ptr<Plane> Plane::create(int fd, Type type, drmModePlane* plane, boo
                     if (modifiers.isEmpty())
                         modifiers.append(DRM_FORMAT_MOD_LINEAR);
 
-                    formats.append({ blobFormats[i], WTFMove(modifiers) });
+                    formats.append({ blobFormats[i], WTF::move(modifiers) });
                 }
             }
         }
@@ -184,14 +184,14 @@ std::unique_ptr<Plane> Plane::create(int fd, Type type, drmModePlane* plane, boo
         drmPropertyForName(fd, properties.get(), "FB_DAMAGE_CLIPS"),
         drmPropertyForName(fd, properties.get(), "IN_FENCE_FD")
     };
-    return makeUnique<Plane>(plane, WTFMove(formats), WTFMove(props));
+    return makeUnique<Plane>(plane, WTF::move(formats), WTF::move(props));
 }
 
 Plane::Plane(drmModePlane* plane, Vector<Format>&& formats, Properties&& properties)
     : m_id(plane->plane_id)
     , m_possibleCrtcs(plane->possible_crtcs)
-    , m_formats(WTFMove(formats))
-    , m_properties(WTFMove(properties))
+    , m_formats(WTF::move(formats))
+    , m_properties(WTF::move(properties))
 {
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -158,7 +158,7 @@ public:
 
     struct gbm_bo* bufferObject() const { return m_bufferObject; }
     uint32_t frameBufferID() const { return m_frameBufferID; }
-    void setFenceFD(WTF::UnixFileDescriptor&& fenceFD) { m_fenceFD = WTFMove(fenceFD); }
+    void setFenceFD(WTF::UnixFileDescriptor&& fenceFD) { m_fenceFD = WTF::move(fenceFD); }
     const WTF::UnixFileDescriptor& fenceFD() const { return m_fenceFD; }
 
 private:

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
@@ -37,7 +37,7 @@ namespace DRM {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Cursor);
 
 Cursor::Cursor(std::unique_ptr<Plane>&& plane, struct gbm_device* device, uint32_t cursorWidth, uint32_t cursorHeight)
-    : m_plane(WTFMove(plane))
+    : m_plane(WTF::move(plane))
     , m_device(device)
     , m_deviceWidth(cursorWidth)
     , m_deviceHeight(cursorHeight)

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<CursorTheme> CursorTheme::create(const char* name, uint32_t size
     if (!theme)
         return nullptr;
 
-    return makeUnique<CursorTheme>(WTFMove(theme));
+    return makeUnique<CursorTheme>(WTF::move(theme));
 }
 
 std::unique_ptr<CursorTheme> CursorTheme::create()
@@ -51,11 +51,11 @@ std::unique_ptr<CursorTheme> CursorTheme::create()
     if (!theme)
         return nullptr;
 
-    return makeUnique<CursorTheme>(WTFMove(theme));
+    return makeUnique<CursorTheme>(WTF::move(theme));
 }
 
 CursorTheme::CursorTheme(std::unique_ptr<WPE::CursorTheme>&& theme)
-    : m_theme(WTFMove(theme))
+    : m_theme(WTF::move(theme))
 {
 }
 
@@ -91,7 +91,7 @@ void CursorTheme::loadCursor(const char* name, double scale, std::optional<uint3
 
     for (auto& cursorImage : cursor) {
         images.append({ cursorImage.width * effectiveScale, cursorImage.height * effectiveScale,
-            cursorImage.hotspotX * effectiveScale, cursorImage.hotspotY * effectiveScale, WTFMove(cursorImage.pixels) });
+            cursorImage.hotspotX * effectiveScale, cursorImage.hotspotY * effectiveScale, WTF::move(cursorImage.pixels) });
     }
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
@@ -52,7 +52,7 @@ public:
     ~Seat();
 
     WPEAvailableInputDevices availableInputDevices() const;
-    void setAvailableInputDevicesChangedCallback(Function<void(WPEAvailableInputDevices)>&& callback) { m_capabilitiesChangedCallback = WTFMove(callback); }
+    void setAvailableInputDevicesChangedCallback(Function<void(WPEAvailableInputDevices)>&& callback) { m_capabilitiesChangedCallback = WTF::move(callback); }
 
     void setView(WPEView* view);
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
@@ -58,12 +58,12 @@ std::unique_ptr<Session> SessionLogind::create()
 
     GUniquePtr<char> path(g_strdup_printf("/org/freedesktop/login1/session/%s", session.get()));
     GRefPtr<GDBusProxy> sessionProxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START, nullptr, "org.freedesktop.login1", path.get(), "org.freedesktop.login1.Session", nullptr, nullptr));
-    return makeUnique<SessionLogind>(WTFMove(sessionProxy), GUniquePtr<char>(seat.release()));
+    return makeUnique<SessionLogind>(WTF::move(sessionProxy), GUniquePtr<char>(seat.release()));
 }
 
 SessionLogind::SessionLogind(GRefPtr<GDBusProxy>&& sessionProxy, GUniquePtr<char>&& seatID)
-    : m_sessionProxy(WTFMove(sessionProxy))
-    , m_seatID(WTFMove(seatID))
+    : m_sessionProxy(WTF::move(sessionProxy))
+    , m_seatID(WTF::move(seatID))
 {
     GUniqueOutPtr<GError> error;
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_sessionProxy.get(), "TakeControl", g_variant_new("(b)", FALSE),

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -156,7 +156,7 @@ static struct DisplayDevice findTargetDevice(struct udev* udev, const char* seat
             continue;
 
         auto drmDevice = createDisplayDevice(fd, filename);
-        displayDevice = { WTFMove(fd), WTFMove(drmDevice) };
+        displayDevice = { WTF::move(fd), WTF::move(drmDevice) };
         if (isBootVGA)
             return displayDevice;
     }
@@ -312,9 +312,9 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
         }
         WTF::UnixFileDescriptor unixFd(fd, WTF::UnixFileDescriptor::Adopt);
         auto drmDevice = createDisplayDevice(unixFd, deviceName);
-        displayDevice = { WTFMove(unixFd), WTFMove(drmDevice) };
+        displayDevice = { WTF::move(unixFd), WTF::move(drmDevice) };
     }
-    auto fd = WTFMove(displayDevice.fd);
+    auto fd = WTF::move(displayDevice.fd);
     if (drmSetMaster(fd.value()) == -1) {
         g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to become DRM master");
         return FALSE;
@@ -355,13 +355,13 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
         return FALSE;
     }
 
-    displayDRM->priv->session = WTFMove(session);
-    displayDRM->priv->fd = WTFMove(fd);
-    displayDRM->priv->displayDevice = WTFMove(displayDevice.drmDevice);
+    displayDRM->priv->session = WTF::move(session);
+    displayDRM->priv->fd = WTF::move(fd);
+    displayDRM->priv->displayDevice = WTF::move(displayDevice.drmDevice);
     if (!wpe_drm_device_get_render_node(displayDRM->priv->displayDevice.get()))
         displayDRM->priv->renderDevice = findFirstDeviceWithRenderNode();
     displayDRM->priv->device = device;
-    displayDRM->priv->connector = WTFMove(connector);
+    displayDRM->priv->connector = WTF::move(connector);
 
     static const auto scaleIsInBounds = [](double scale) {
         return (scale >= 0.05) && (scale <= 20.0);
@@ -383,7 +383,7 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
     int y = crtc->y();
     int width = crtc->width();
     int height = crtc->height();
-    displayDRM->priv->screen = wpeScreenDRMCreate(WTFMove(crtc), *displayDRM->priv->connector);
+    displayDRM->priv->screen = wpeScreenDRMCreate(WTF::move(crtc), *displayDRM->priv->connector);
     if (!width || !height) {
         auto* mode = wpeScreenDRMGetMode(WPE_SCREEN_DRM(displayDRM->priv->screen.get()));
         width = mode->hdisplay;
@@ -408,8 +408,8 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
     wpe_screen_set_size(displayDRM->priv->screen.get(), width / scale, height / scale);
     wpe_screen_set_scale(displayDRM->priv->screen.get(), scale);
 
-    displayDRM->priv->primaryPlane = WTFMove(primaryPlane);
-    displayDRM->priv->seat = WTFMove(seat);
+    displayDRM->priv->primaryPlane = WTF::move(primaryPlane);
+    displayDRM->priv->seat = WTF::move(seat);
     wpe_display_set_available_input_devices(WPE_DISPLAY(displayDRM), displayDRM->priv->seat->availableInputDevices());
     displayDRM->priv->seat->setAvailableInputDevicesChangedCallback([weakDisplay = GWeakPtr { displayDRM }](WPEAvailableInputDevices devices) {
         if (!weakDisplay)
@@ -418,7 +418,7 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
         wpe_display_set_available_input_devices(WPE_DISPLAY(weakDisplay.get()), devices);
     });
     if (cursorPlane)
-        displayDRM->priv->cursor = makeUnique<WPE::DRM::Cursor>(WTFMove(cursorPlane), device, displayDRM->priv->cursorWidth, displayDRM->priv->cursorHeight);
+        displayDRM->priv->cursor = makeUnique<WPE::DRM::Cursor>(WTF::move(cursorPlane), device, displayDRM->priv->cursorWidth, displayDRM->priv->cursorHeight);
 
     return TRUE;
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
@@ -65,7 +65,7 @@ static WPEScreenSyncObserver* wpeScreenDRMGetSyncObserver(WPEScreen* screen)
         if (auto* device = wpeDisplayDRMGetDisplayDevice(WPE_DISPLAY_DRM(wpe_display_get_primary()))) {
             const char* filename = wpe_drm_device_get_primary_node(device);
             if (auto fd = UnixFileDescriptor(open(filename, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt)) {
-                priv->syncObserver = adoptGRef(wpeScreenSyncObserverDRMCreate(WTFMove(fd), priv->crtc->index()));
+                priv->syncObserver = adoptGRef(wpeScreenSyncObserverDRMCreate(WTF::move(fd), priv->crtc->index()));
                 if (priv->syncObserver)
                     g_debug("WPEScreenDRM: Created WPEScreenSyncObserverDRM for device %s with CRTC index %u", filename, priv->crtc->index());
                 else
@@ -97,7 +97,7 @@ WPEScreen* wpeScreenDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&& crtc, const WPE:
 {
     auto* screen = WPE_SCREEN(g_object_new(WPE_TYPE_SCREEN_DRM, "id", crtc->id(), nullptr));
     auto* priv = WPE_SCREEN_DRM(screen)->priv;
-    priv->crtc = WTFMove(crtc);
+    priv->crtc = WTF::move(crtc);
 
     wpe_screen_set_physical_size(screen, connector.widthMM(), connector.heightMM());
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -540,7 +540,7 @@ static void wpeViewDRMDidPageFlip(WPEViewDRM* view)
     if (updateFlags.contains(UpdateFlags::BufferUpdateRequested)) {
         if (priv->committedBuffer)
             wpe_view_buffer_released(WPE_VIEW(view), priv->committedBuffer.get());
-        priv->committedBuffer = WTFMove(priv->pendingBuffer);
+        priv->committedBuffer = WTF::move(priv->pendingBuffer);
         wpe_view_buffer_rendered(WPE_VIEW(view), priv->committedBuffer.get());
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -122,7 +122,7 @@ static gpointer wpeDisplayHeadlessGetEGLDisplay(WPEDisplay* display, GError** er
 
         if (eglDisplay != EGL_NO_DISPLAY) {
             auto* priv = WPE_DISPLAY_HEADLESS(display)->priv;
-            priv->gbmDeviceFD = WTFMove(fd);
+            priv->gbmDeviceFD = WTF::move(fd);
             priv->gbmDevice = device;
             return eglDisplay;
         }
@@ -205,7 +205,7 @@ WPEDisplay* wpe_display_headless_new_for_device(const char* name, GError** error
 
     auto* display = WPE_DISPLAY_HEADLESS(wpe_display_headless_new());
     auto* priv = display->priv;
-    priv->drmDevice = WTFMove(drmDevice);
+    priv->drmDevice = WTF::move(drmDevice);
     return WPE_DISPLAY(display);
 #else
     UNUSED_PARAM(name);

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -89,7 +89,7 @@ static void wpeViewHeadlessConstructed(GObject* object)
         auto* priv = WPE_VIEW_HEADLESS(view)->priv;
         if (priv->committedBuffer)
             wpe_view_buffer_released(view, priv->committedBuffer.get());
-        priv->committedBuffer = WTFMove(priv->pendingBuffer);
+        priv->committedBuffer = WTF::move(priv->pendingBuffer);
         wpe_view_buffer_rendered(view, priv->committedBuffer.get());
 
         if (g_source_is_destroyed(priv->frameSource.get()))

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -272,7 +272,7 @@ const struct wl_registry_listener registryListener = {
         else if (interfaceName == "wl_output"_s) {
             GRefPtr<WPEScreen> screen = adoptGRef(wpeScreenWaylandCreate(name, static_cast<struct wl_output*>(wl_registry_bind(registry, name, &wl_output_interface, std::min<uint32_t>(version, 2)))));
             auto* screenPtr = screen.get();
-            priv->screens.append(WTFMove(screen));
+            priv->screens.append(WTF::move(screen));
             wpe_display_screen_added(WPE_DISPLAY(display), screenPtr);
         } else if (interfaceName == "wl_shm"_s)
             priv->wlSHM = static_cast<struct wl_shm*>(wl_registry_bind(registry, name, &wl_shm_interface, 1));

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -63,7 +63,7 @@ struct DMABufFeedback {
         FormatTable& operator=(const FormatTable&) = delete;
         FormatTable(FormatTable&& other)
         {
-            *this = WTFMove(other);
+            *this = WTF::move(other);
         }
 
         FormatTable(unsigned size, Data* data)
@@ -122,9 +122,9 @@ struct DMABufFeedback {
     DMABufFeedback& operator=(const DMABufFeedback&) = delete;
 
     DMABufFeedback(DMABufFeedback&& other)
-        : formatTable(WTFMove(other.formatTable))
-        , pendingTranche(WTFMove(other.pendingTranche))
-        , tranches(WTFMove(other.tranches))
+        : formatTable(WTF::move(other.formatTable))
+        , pendingTranche(WTF::move(other.pendingTranche))
+        , tranches(WTF::move(other.tranches))
     {
 #if USE(LIBDRM)
         memcpy(&mainDevice, &other.mainDevice, sizeof(dev_t));
@@ -176,7 +176,7 @@ struct DMABufFeedback {
         Tranche& operator=(const Tranche&) = delete;
         Tranche(Tranche&& other)
             : flags(other.flags)
-            , formats(WTFMove(other.formats))
+            , formats(WTF::move(other.formats))
         {
             other.flags = 0;
 #if USE(LIBDRM)
@@ -460,14 +460,14 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackLis
         // one. Return early and skip emitting the signal if there is no usable formats table in the end.
         if (!priv->pendingDMABufFeedback->formatTable) {
             if (priv->committedDMABufFeedback && priv->committedDMABufFeedback->formatTable)
-                priv->pendingDMABufFeedback->formatTable = WTFMove(priv->committedDMABufFeedback->formatTable);
+                priv->pendingDMABufFeedback->formatTable = WTF::move(priv->committedDMABufFeedback->formatTable);
             else {
                 priv->pendingDMABufFeedback.reset();
                 return;
             }
         }
 
-        priv->committedDMABufFeedback = WTFMove(priv->pendingDMABufFeedback);
+        priv->committedDMABufFeedback = WTF::move(priv->pendingDMABufFeedback);
         priv->preferredBufferFormats = nullptr;
         wpe_toplevel_preferred_buffer_formats_changed(toplevel);
     },
@@ -501,7 +501,7 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackLis
         if (!priv->pendingDMABufFeedback)
             return;
 
-        priv->pendingDMABufFeedback->tranches.append(WTFMove(priv->pendingDMABufFeedback->pendingTranche));
+        priv->pendingDMABufFeedback->tranches.append(WTF::move(priv->pendingDMABufFeedback->pendingTranche));
     },
     // tranche_target_device
     [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -230,7 +230,7 @@ class SharedMemoryBuffer final : public WaylandBuffer {
 public:
     SharedMemoryBuffer(WPEView* view, std::unique_ptr<WPE::WaylandSHMPool>&& pool, uint32_t offset, uint32_t width, uint32_t height, uint32_t stride)
         : WaylandBuffer(view, pool->createBuffer(offset, width, height, stride))
-        , m_wlPool(WTFMove(pool))
+        , m_wlPool(WTF::move(pool))
     {
     }
 
@@ -340,7 +340,7 @@ static SharedMemoryBuffer* sharedMemoryBufferCreate(WPEView* view, GBytes* bytes
         return nullptr;
 
     wlPool->write(WTF::span(bytes), offset);
-    return new SharedMemoryBuffer(view, WTFMove(wlPool), offset, width, height, stride);
+    return new SharedMemoryBuffer(view, WTF::move(wlPool), offset, width, height, stride);
 }
 
 static struct wl_buffer* createWaylandBufferSHM(WPEView* view, WPEBuffer* buffer, GError** error)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<WaylandCursorTheme> WaylandCursorTheme::create(const char* name,
     if (!pool)
         return nullptr;
 
-    return makeUnique<WaylandCursorTheme>(WTFMove(theme), WTFMove(pool));
+    return makeUnique<WaylandCursorTheme>(WTF::move(theme), WTF::move(pool));
 }
 
 std::unique_ptr<WaylandCursorTheme> WaylandCursorTheme::create(struct wl_shm* shm)
@@ -57,12 +57,12 @@ std::unique_ptr<WaylandCursorTheme> WaylandCursorTheme::create(struct wl_shm* sh
     if (!pool)
         return nullptr;
 
-    return makeUnique<WaylandCursorTheme>(WTFMove(theme), WTFMove(pool));
+    return makeUnique<WaylandCursorTheme>(WTF::move(theme), WTF::move(pool));
 }
 
 WaylandCursorTheme::WaylandCursorTheme(std::unique_ptr<CursorTheme>&& theme, std::unique_ptr<WaylandSHMPool>&& pool)
-    : m_theme(WTFMove(theme))
-    , m_pool(WTFMove(pool))
+    : m_theme(WTF::move(theme))
+    , m_pool(WTF::move(pool))
 {
 
 }
@@ -109,7 +109,7 @@ void WaylandCursorTheme::loadCursor(const char* name, double scale, std::optiona
             m_pool->write(cursorImage.pixels.span(), offset);
 
         image.buffer = m_pool->createBuffer(offset, image.width, image.height, image.width * 4);
-        images.append(WTFMove(image));
+        images.append(WTF::move(image));
     }
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
@@ -86,7 +86,7 @@ const struct wl_output_listener WaylandOutput::s_listener = {
 
 void WaylandOutput::addScaleObserver(WPEViewWayland* view, Function<void(WPEViewWayland*)>&& observer)
 {
-    m_scaleObservers.set(view, WTFMove(observer));
+    m_scaleObservers.set(view, WTF::move(observer));
 }
 
 void WaylandOutput::removeScaleObserver(WPEViewWayland* view)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
@@ -102,13 +102,13 @@ std::unique_ptr<WaylandSHMPool> WaylandSHMPool::create(struct wl_shm* shm, size_
     if (data == MAP_FAILED)
         return nullptr;
 
-    return makeUnique<WaylandSHMPool>(data, size, WTFMove(fd), shm);
+    return makeUnique<WaylandSHMPool>(data, size, WTF::move(fd), shm);
 }
 
 WaylandSHMPool::WaylandSHMPool(void* data, size_t size, UnixFileDescriptor&& fd, struct wl_shm* shm)
     : m_data(data)
     , m_size(size)
-    , m_fd(WTFMove(fd))
+    , m_fd(WTF::move(fd))
     , m_pool(wl_shm_create_pool(shm, m_fd.value(), m_size))
 {
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -58,7 +58,7 @@ public:
     void emitPointerEnter(WPEView*) const;
     void emitPointerLeave(WPEView*) const;
 
-    void setAvailableInputDevicesChangedCallback(Function<void(WPEAvailableInputDevices)>&& callback) { m_capabilitiesChangedCallback = WTFMove(callback); }
+    void setAvailableInputDevicesChangedCallback(Function<void(WPEAvailableInputDevices)>&& callback) { m_capabilitiesChangedCallback = WTF::move(callback); }
 
 private:
     static const struct wl_seat_listener s_listener;

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -92,7 +92,7 @@ void ApplePushServiceConnection::subscribe(const String& topic, const Vector<uin
 
     // Stash the completion handler away and look it up by id so that we can ensure it gets destructed on the main thread. If we move the handler and capture it in the Obj-C block, it might get destructed on a secondary thread since this completion block moves between different dispatch queues in the APS implementation.
     auto identifier = ++m_handlerIdentifier;
-    m_subscribeHandlers.add(identifier, WTFMove(subscribeHandler));
+    m_subscribeHandlers.add(identifier, WTF::move(subscribeHandler));
 
     [m_connection requestURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (APSURLToken *token, NSError *error) {
         RefPtr protectedThis = weakThis.get();
@@ -110,7 +110,7 @@ void ApplePushServiceConnection::unsubscribe(const String& topic, const Vector<u
 
     // See subscribe for why we stash the handler into a map.
     auto identifier = ++m_handlerIdentifier;
-    m_unsubscribeHandlers.add(identifier, WTFMove(unsubscribeHandler));
+    m_unsubscribeHandlers.add(identifier, WTF::move(unsubscribeHandler));
 
     [m_connection invalidateURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (BOOL success, NSError *error) {
         RefPtr protectedThis = weakThis.get();
@@ -144,27 +144,27 @@ Vector<String> ApplePushServiceConnection::nonWakingTopics()
 
 void ApplePushServiceConnection::setEnabledTopics(Vector<String>&& topics)
 {
-    [m_connection _setEnabledTopics:createNSArray(WTFMove(topics)).get()];
+    [m_connection _setEnabledTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setIgnoredTopics(Vector<String>&& topics)
 {
-    [m_connection _setIgnoredTopics:createNSArray(WTFMove(topics)).get()];
+    [m_connection _setIgnoredTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setOpportunisticTopics(Vector<String>&& topics)
 {
-    [m_connection _setOpportunisticTopics:createNSArray(WTFMove(topics)).get()];
+    [m_connection _setOpportunisticTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setNonWakingTopics(Vector<String>&& topics)
 {
-    [m_connection _setNonWakingTopics:createNSArray(WTFMove(topics)).get()];
+    [m_connection _setNonWakingTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setTopicLists(TopicLists&& topicLists)
 {
-    [m_connection setEnabledTopics:createNSArray(WTFMove(topicLists.enabledTopics)).get() ignoredTopics:createNSArray(WTFMove(topicLists.ignoredTopics)).get() opportunisticTopics:createNSArray(WTFMove(topicLists.opportunisticTopics)).get() nonWakingTopics:createNSArray(WTFMove(topicLists.nonWakingTopics)).get()];
+    [m_connection setEnabledTopics:createNSArray(WTF::move(topicLists.enabledTopics)).get() ignoredTopics:createNSArray(WTF::move(topicLists.ignoredTopics)).get() opportunisticTopics:createNSArray(WTF::move(topicLists.opportunisticTopics)).get() nonWakingTopics:createNSArray(WTF::move(topicLists.nonWakingTopics)).get()];
 }
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/MockPushServiceConnection.mm
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.mm
@@ -45,7 +45,7 @@ ClientKeys MockPushServiceConnection::generateClientKeys()
     auto privateKey = base64URLDecode("q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94"_s).value();
     auto secret = base64URLDecode("BTBZMqHH6r4Tts7J_aSIgg"_s).value();
 
-    return ClientKeys { P256DHKeyPair { WTFMove(publicKey), WTFMove(privateKey) }, WTFMove(secret) };
+    return ClientKeys { P256DHKeyPair { WTF::move(publicKey), WTF::move(privateKey) }, WTF::move(secret) };
 }
 
 void MockPushServiceConnection::subscribe(const String&, const Vector<uint8_t>& vapidPublicKey, SubscribeHandler&& handler)
@@ -66,15 +66,15 @@ void MockPushServiceConnection::unsubscribe(const String&, const Vector<uint8_t>
 
 void MockPushServiceConnection::setTopicLists(TopicLists&& topics)
 {
-    setEnabledTopics(WTFMove(topics.enabledTopics));
-    setIgnoredTopics(WTFMove(topics.ignoredTopics));
-    setOpportunisticTopics(WTFMove(topics.opportunisticTopics));
-    setNonWakingTopics(WTFMove(topics.nonWakingTopics));
+    setEnabledTopics(WTF::move(topics.enabledTopics));
+    setIgnoredTopics(WTF::move(topics.ignoredTopics));
+    setOpportunisticTopics(WTF::move(topics.opportunisticTopics));
+    setNonWakingTopics(WTF::move(topics.nonWakingTopics));
 }
 
 void MockPushServiceConnection::setPublicTokenForTesting(Vector<uint8_t>&& token)
 {
-    didReceivePublicToken(WTFMove(token));
+    didReceivePublicToken(WTF::move(token));
 }
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -146,7 +146,7 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
     audit_token_t peerAuditToken;
     xpc_connection_get_audit_token(connection, &peerAuditToken);
     if (bool peerHasPushInjectEntitlement = WTF::hasEntitlement(peerAuditToken, "com.apple.private.webkit.webpush.inject"_s))
-        return adoptRef(new PushClientConnection(connection, WTFMove(configuration.bundleIdentifierOverride), peerHasPushInjectEntitlement, WTFMove(configuration.pushPartitionString), WTFMove(configuration.dataStoreIdentifier), configuration.declarativeWebPushEnabled));
+        return adoptRef(new PushClientConnection(connection, WTF::move(configuration.bundleIdentifierOverride), peerHasPushInjectEntitlement, WTF::move(configuration.pushPartitionString), WTF::move(configuration.dataStoreIdentifier), configuration.declarativeWebPushEnabled));
 
 #if USE(EXTENSIONKIT)
     pid_t pid = xpc_connection_get_pid(connection);
@@ -176,7 +176,7 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
     bool hostAppHasWebPushEntitlement = hostAppHasEntitlement(hostAppAuditToken, hostAppWebPushEntitlement);
     String hostAppCodeSigningIdentifier = bundleIdentifierFromAuditToken(hostAppAuditToken);
     bool hostAppHasPushInjectEntitlement = hostAppHasEntitlement(hostAppAuditToken, "com.apple.private.webkit.webpush.inject"_s);
-    auto pushPartition = WTFMove(configuration.pushPartitionString);
+    auto pushPartition = WTF::move(configuration.pushPartitionString);
     bool hasValidPushPartition = isValidPushPartition(pushPartition);
 
     if (hostAppHasPushInjectEntitlement && !configuration.bundleIdentifierOverride.isEmpty())
@@ -199,15 +199,15 @@ RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t conne
         return nullptr;
     }
 
-    return adoptRef(new PushClientConnection(connection, WTFMove(hostAppCodeSigningIdentifier), hostAppHasPushInjectEntitlement, WTFMove(pushPartition), WTFMove(configuration.dataStoreIdentifier), configuration.declarativeWebPushEnabled));
+    return adoptRef(new PushClientConnection(connection, WTF::move(hostAppCodeSigningIdentifier), hostAppHasPushInjectEntitlement, WTF::move(pushPartition), WTF::move(configuration.dataStoreIdentifier), configuration.declarativeWebPushEnabled));
 }
 
 PushClientConnection::PushClientConnection(xpc_connection_t connection, String&& hostAppCodeSigningIdentifier, bool hostAppHasPushInjectEntitlement, String&& pushPartitionString, std::optional<WTF::UUID>&& dataStoreIdentifier, bool declarativeWebPushEnabled)
     : m_xpcConnection(connection)
-    , m_hostAppCodeSigningIdentifier(WTFMove(hostAppCodeSigningIdentifier))
+    , m_hostAppCodeSigningIdentifier(WTF::move(hostAppCodeSigningIdentifier))
     , m_hostAppHasPushInjectEntitlement(hostAppHasPushInjectEntitlement)
     , m_pushPartitionString(pushPartitionString)
-    , m_dataStoreIdentifier(WTFMove(dataStoreIdentifier))
+    , m_dataStoreIdentifier(WTF::move(dataStoreIdentifier))
     , m_declarativeWebPushEnabled(declarativeWebPushEnabled)
 {
 }
@@ -225,7 +225,7 @@ void PushClientConnection::initializeConnection(WebPushDaemonConnectionConfigura
 
 void PushClientConnection::getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&& completionHandler)
 {
-    WebPushDaemon::singleton().getPushTopicsForTesting(*this, WTFMove(completionHandler));
+    WebPushDaemon::singleton().getPushTopicsForTesting(*this, WTF::move(completionHandler));
 }
 
 std::optional<WebCore::PushSubscriptionSetIdentifier> PushClientConnection::subscriptionSetIdentifierForOrigin(const WebCore::SecurityOriginData& origin) const
@@ -266,68 +266,68 @@ void PushClientConnection::connectionClosed()
 
 void PushClientConnection::setPushAndNotificationsEnabledForOrigin(const String& originString, bool enabled, CompletionHandler<void()>&& replySender)
 {
-    WebPushDaemon::singleton().setPushAndNotificationsEnabledForOrigin(*this, originString, enabled, WTFMove(replySender));
+    WebPushDaemon::singleton().setPushAndNotificationsEnabledForOrigin(*this, originString, enabled, WTF::move(replySender));
 }
 
 void PushClientConnection::injectPushMessageForTesting(PushMessageForTesting&& message, CompletionHandler<void(const String&)>&& replySender)
 {
-    WebPushDaemon::singleton().injectPushMessageForTesting(*this, WTFMove(message), WTFMove(replySender));
+    WebPushDaemon::singleton().injectPushMessageForTesting(*this, WTF::move(message), WTF::move(replySender));
 }
 
 void PushClientConnection::injectEncryptedPushMessageForTesting(const String& message, CompletionHandler<void(bool)>&& replySender)
 {
-    WebPushDaemon::singleton().injectEncryptedPushMessageForTesting(*this, message, WTFMove(replySender));
+    WebPushDaemon::singleton().injectEncryptedPushMessageForTesting(*this, message, WTF::move(replySender));
 }
 
 void PushClientConnection::getPendingPushMessage(CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&& replySender)
 {
-    WebPushDaemon::singleton().getPendingPushMessage(*this, WTFMove(replySender));
+    WebPushDaemon::singleton().getPendingPushMessage(*this, WTF::move(replySender));
 }
 
 void PushClientConnection::getPendingPushMessages(CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender)
 {
-    WebPushDaemon::singleton().getPendingPushMessages(*this, WTFMove(replySender));
+    WebPushDaemon::singleton().getPendingPushMessages(*this, WTF::move(replySender));
 }
 
 void PushClientConnection::subscribeToPushService(URL&& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender)
 {
-    WebPushDaemon::singleton().subscribeToPushService(*this, WTFMove(scopeURL), applicationServerKey, WTFMove(replySender));
+    WebPushDaemon::singleton().subscribeToPushService(*this, WTF::move(scopeURL), applicationServerKey, WTF::move(replySender));
 }
 
 void PushClientConnection::unsubscribeFromPushService(URL&& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> identifier, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender)
 {
-    WebPushDaemon::singleton().unsubscribeFromPushService(*this, WTFMove(scopeURL), WTFMove(identifier), WTFMove(replySender));
+    WebPushDaemon::singleton().unsubscribeFromPushService(*this, WTF::move(scopeURL), WTF::move(identifier), WTF::move(replySender));
 }
 
 void PushClientConnection::getPushSubscription(URL&& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender)
 {
-    WebPushDaemon::singleton().getPushSubscription(*this, WTFMove(scopeURL), WTFMove(replySender));
+    WebPushDaemon::singleton().getPushSubscription(*this, WTF::move(scopeURL), WTF::move(replySender));
 }
 
 void PushClientConnection::incrementSilentPushCount(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& replySender)
 {
-    WebPushDaemon::singleton().incrementSilentPushCount(*this, WTFMove(origin), WTFMove(replySender));
+    WebPushDaemon::singleton().incrementSilentPushCount(*this, WTF::move(origin), WTF::move(replySender));
 }
 
 void PushClientConnection::removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&& replySender)
 {
-    WebPushDaemon::singleton().removeAllPushSubscriptions(*this, WTFMove(replySender));
+    WebPushDaemon::singleton().removeAllPushSubscriptions(*this, WTF::move(replySender));
 }
 
 void PushClientConnection::removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& replySender)
 {
-    WebPushDaemon::singleton().removePushSubscriptionsForOrigin(*this, WTFMove(origin), WTFMove(replySender));
+    WebPushDaemon::singleton().removePushSubscriptionsForOrigin(*this, WTF::move(origin), WTF::move(replySender));
 }
 
 void PushClientConnection::setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&& replySender)
 {
-    WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTFMove(replySender));
+    WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTF::move(replySender));
 }
 
 void PushClientConnection::getPushPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& replySender)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().getPushPermissionState(*this, WTFMove(origin), WTFMove(replySender));
+    WebPushDaemon::singleton().getPushPermissionState(*this, WTF::move(origin), WTF::move(replySender));
 #else
     UNUSED_PARAM(origin);
     replySender({ });
@@ -337,7 +337,7 @@ void PushClientConnection::getPushPermissionState(WebCore::SecurityOriginData&& 
 void PushClientConnection::requestPushPermission(WebCore::SecurityOriginData&& origin, CompletionHandler<void(bool)>&& replySender)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().requestPushPermission(*this, WTFMove(origin), WTFMove(replySender));
+    WebPushDaemon::singleton().requestPushPermission(*this, WTF::move(origin), WTF::move(replySender));
 #else
     UNUSED_PARAM(origin);
     replySender(false);
@@ -347,7 +347,7 @@ void PushClientConnection::requestPushPermission(WebCore::SecurityOriginData&& o
 void PushClientConnection::showNotification(const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources> notificationResources, CompletionHandler<void()>&& completionHandler)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().showNotification(*this, notificationData, notificationResources, WTFMove(completionHandler));
+    WebPushDaemon::singleton().showNotification(*this, notificationData, notificationResources, WTF::move(completionHandler));
 #else
     UNUSED_PARAM(notificationData);
     UNUSED_PARAM(notificationResources);
@@ -358,7 +358,7 @@ void PushClientConnection::showNotification(const WebCore::NotificationData& not
 void PushClientConnection::getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&& completionHandler)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().getNotifications(*this, registrationURL, tag, WTFMove(completionHandler));
+    WebPushDaemon::singleton().getNotifications(*this, registrationURL, tag, WTF::move(completionHandler));
 #else
     UNUSED_PARAM(registrationURL);
     UNUSED_PARAM(tag);
@@ -369,21 +369,21 @@ void PushClientConnection::getNotifications(const URL& registrationURL, const St
 void PushClientConnection::cancelNotification(WebCore::SecurityOriginData&& origin, const WTF::UUID& notificationID)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().cancelNotification(*this, WTFMove(origin), notificationID);
+    WebPushDaemon::singleton().cancelNotification(*this, WTF::move(origin), notificationID);
 #endif
 }
 
 void PushClientConnection::setAppBadge(WebCore::SecurityOriginData&& origin, std::optional<uint64_t> badge)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().setAppBadge(*this, WTFMove(origin), badge);
+    WebPushDaemon::singleton().setAppBadge(*this, WTF::move(origin), badge);
 #endif
 }
 
 void PushClientConnection::getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().getAppBadgeForTesting(*this, WTFMove(completionHandler));
+    WebPushDaemon::singleton().getAppBadgeForTesting(*this, WTF::move(completionHandler));
 #else
     completionHandler(std::nullopt);
 #endif
@@ -391,7 +391,7 @@ void PushClientConnection::getAppBadgeForTesting(CompletionHandler<void(std::opt
 
 void PushClientConnection::setProtocolVersionForTesting(unsigned version, CompletionHandler<void()>&& completionHandler)
 {
-    WebPushDaemon::singleton().setProtocolVersionForTesting(*this, version, WTFMove(completionHandler));
+    WebPushDaemon::singleton().setProtocolVersionForTesting(*this, version, WTF::move(completionHandler));
 }
 
 void PushClientConnection::setServiceWorkerIsBeingInspected(URL&& scopeURL, bool isInspected, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/webpushd/PushServiceConnection.mm
+++ b/Source/WebKit/webpushd/PushServiceConnection.mm
@@ -41,7 +41,7 @@ PushCrypto::ClientKeys PushServiceConnection::generateClientKeys()
 
 void PushServiceConnection::startListeningForPublicToken(Function<void(Vector<uint8_t>&&)>&& handler)
 {
-    m_publicTokenChangeHandler = WTFMove(handler);
+    m_publicTokenChangeHandler = WTF::move(handler);
 
     if (m_pendingPublicToken.isEmpty())
         return;
@@ -52,11 +52,11 @@ void PushServiceConnection::startListeningForPublicToken(Function<void(Vector<ui
 void PushServiceConnection::didReceivePublicToken(Vector<uint8_t>&& token)
 {
     if (!m_publicTokenChangeHandler) {
-        m_pendingPublicToken = WTFMove(token);
+        m_pendingPublicToken = WTF::move(token);
         return;
     }
 
-    m_publicTokenChangeHandler(WTFMove(token));
+    m_publicTokenChangeHandler(WTF::move(token));
 }
 
 void PushServiceConnection::setPublicTokenForTesting(Vector<uint8_t>&&)
@@ -65,7 +65,7 @@ void PushServiceConnection::setPublicTokenForTesting(Vector<uint8_t>&&)
 
 void PushServiceConnection::startListeningForPushMessages(IncomingPushMessageHandler&& handler)
 {
-    m_incomingPushMessageHandler = WTFMove(handler);
+    m_incomingPushMessageHandler = WTF::move(handler);
 
     if (!m_pendingPushes.size())
         return;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -111,21 +111,21 @@ void Connection::sendPushMessage(PushMessageForTesting&& message, CompletionHand
 {
     printf("Injecting push message\n");
 
-    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(WTFMove(message)), WTFMove(completionHandler));
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(WTF::move(message)), WTF::move(completionHandler));
 }
 
 void Connection::getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
     printf("Getting push permission state\n");
 
-    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(URL { scope })), WTF::move(completionHandler));
 }
 
 void Connection::requestPushPermission(const String& scope, CompletionHandler<void(bool)>&& completionHandler)
 {
     SAFE_PRINTF("Request push permission state for %s\n", scope.utf8());
 
-    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission(WebCore::SecurityOriginData::fromURL(URL { scope })), WTF::move(completionHandler));
 }
 
 void Connection::sendAuditToken()
@@ -145,14 +145,14 @@ void Connection::sendAuditToken()
     Vector<uint8_t> tokenVector;
     tokenVector.resize(32);
     memcpySpan(tokenVector.mutableSpan(), asByteSpan(token));
-    configuration.hostAppAuditTokenData = WTFMove(tokenVector);
+    configuration.hostAppAuditTokenData = WTF::move(tokenVector);
 
-    sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTFMove(configuration)));
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTF::move(configuration)));
 }
 
 static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
-    auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));
+    auto xpcData = WebKit::encoderToXPCData(WTF::move(encoder));
     // FIXME: This is a false positive. <rdar://164843889>
     SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
@@ -163,7 +163,7 @@ static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::En
 
 bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder) const
 {
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
     xpc_connection_send_message(m_connection.get(), dictionary.get());
 
     return true;
@@ -171,8 +171,8 @@ bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& 
 
 bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
 {
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
-    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
+    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
             ASSERT_NOT_REACHED();
             return completionHandler(nullptr);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -107,7 +107,7 @@ static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumera
     PushMessageForTesting pushMessage = { { }, { }, registrationURL.get(), message.get(), WebKit::WebPushD::PushMessageDisposition::Legacy };
 #endif
 
-    return makeUniqueWithoutFastMallocCheck<PushMessageForTesting>(WTFMove(pushMessage));
+    return makeUniqueWithoutFastMallocCheck<PushMessageForTesting>(WTF::move(pushMessage));
 }
 
 static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestService)
@@ -183,7 +183,7 @@ class InjectPushMessageVerb : public WebPushToolVerb {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(InjectPushMessageVerb);
 public:
     InjectPushMessageVerb(PushMessageForTesting&& message)
-        : m_pushMessage(WTFMove(message)) { }
+        : m_pushMessage(WTF::move(message)) { }
 
     void run(WebPushTool::Connection& connection) override
     {
@@ -191,7 +191,7 @@ public:
         pushMessage.targetAppCodeSigningIdentifier = connection.bundleIdentifier();
         pushMessage.pushPartitionString = connection.pushPartition();
 
-        connection.sendPushMessage(WTFMove(pushMessage), [this, bundleIdentifier = connection.bundleIdentifier(), webClipIdentifier = connection.pushPartition()](String error) mutable {
+        connection.sendPushMessage(WTF::move(pushMessage), [this, bundleIdentifier = connection.bundleIdentifier(), webClipIdentifier = connection.pushPartition()](String error) mutable {
             if (error.isEmpty())
                 SAFE_PRINTF("Successfully injected push message %s for [bundleID = %s, webClipIdentifier = %s, scope = %s]\n", m_pushMessage.payload.utf8(), bundleIdentifier.utf8(), webClipIdentifier.utf8(), m_pushMessage.registrationURL.string().utf8());
             else
@@ -274,7 +274,7 @@ int WebPushToolMain(int, char **)
                 auto pushMessage = pushMessageFromArguments(enumerator.get());
                 if (!pushMessage)
                     printUsageAndTerminate(adoptNS([[NSString alloc] initWithFormat:@"Invalid push arguments specified"]).get());
-                verb = makeUnique<InjectPushMessageVerb>(WTFMove(*pushMessage));
+                verb = makeUnique<InjectPushMessageVerb>(WTF::move(*pushMessage));
             } else if ([argument isEqualToString:@"getPushPermissionState"]) {
                 String scope { [enumerator nextObject] };
                 verb = makeUnique<GetPushPermissionStateVerb>(scope);


### PR DESCRIPTION
#### 8821409d12da845a26112393a1d6d0aeb4fb6c0f
<pre>
Use WTF::move() instead of WTFMove() macro in Source/WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=304462">https://bugs.webkit.org/show_bug.cgi?id=304462</a>

Reviewed by Darin Adler.

* Source/WebKit/*:

Canonical link: <a href="https://commits.webkit.org/304803@main">https://commits.webkit.org/304803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eb434e388a08c68e3ef7a5366bbe72029527d29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136544 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53cfe1f6-d04e-4a3e-8c87-5a29b007546a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104408 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88b7001d-aee6-4efb-a7c0-3e23765f1724) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139489 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85243 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75c5b548-b37e-4d54-9455-f04a1e5a8e37) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/135892 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4315 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4861 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147023 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8587 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28726 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/6572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8635 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8353 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/72201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->