### PR TITLE
[AutoFill Debugging] Items with a single redundant child text node are missing bounding rects

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -11,13 +11,13 @@ root
         section,aria-label='Interactive Elements'
             button,uid=…,events=[click],aria-describedby='This button does nothing',aria-label='Test button','Click Me',[…]
             'This button does nothing',[…]
-            input,'text',uid=…,placeholder='Enter text here'
+            input,'text',uid=…,[…],placeholder='Enter text here'
             uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
         section,aria-label='ARIA Labeling Examples'
             'Name Field\n\n        \nDescription',[…]
-            input,'text',uid=…,aria-labelledby='Name Field',placeholder='Your name'
+            input,'text',uid=…,[…],aria-labelledby='Name Field',placeholder='Your name'
             role='region',aria-labelledby='Description','This region is labeled by another element.',[…]
-            input,'text',uid=…,aria-labelledby='Name Field',placeholder='Full name'
+            input,'text',uid=…,[…],aria-labelledby='Name Field',placeholder='Full name'
             'User Profile',[…]
             role='group',aria-labelledby='User Profile'
                 'Username:',[…]
@@ -42,7 +42,7 @@ root
             'Link to',[…]
             subscript
                 'WebKit home page:',[…]
-                link,uid=…,url='https://webkit.org/'
+                link,uid=…,[…],url='https://webkit.org/'
     role='contentinfo'
         'Footer content with',[…]
         role='img',aria-label='copyright symbol','©',[…]


### PR DESCRIPTION
#### 2aa9a4fd0ae02725b7de8efe10f0ac581f26f562
<pre>
[AutoFill Debugging] Items with a single redundant child text node are missing bounding rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=304461">https://bugs.webkit.org/show_bug.cgi?id=304461</a>
<a href="https://rdar.apple.com/166750088">rdar://166750088</a>

Reviewed by Aditya Keerthi.

Currently, text extraction items with a single text child whose text content matches one or more
DOM attributes on the item will skip including the single text child, since it&apos;s redundant. However,
this clashes with the fact that rects in text extraction output only appear in leaf nodes (items
without any children). The end result is that rects are neither printed out in the text extraction
item parent, nor its only text child.

To fix this, we add plumbing to adjust the rect output strategy, such that we output rects on non-
leaf child items *only* in the case where the item only has one redundant text child.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:

Rebaseline an existing test to test this change.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::partsForItem):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Canonical link: <a href="https://commits.webkit.org/304748@main">https://commits.webkit.org/304748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af46c057ce658e62242270ac85fe9095773932b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144126 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8cde6fb3-61fe-4db2-a545-3cf374b4431a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104313 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7b8cfe7f-3e12-4928-b71b-72c4e357def3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85149 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0ed52d5-4fd0-4a9d-9482-d93dd0be0f6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6532 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4194 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146873 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28693 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6470 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62440 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8501 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36591 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8293 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->