### PR TITLE
Use WTF::move() instead of WTFMove() macro in Tools/

### DIFF
--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -64,11 +64,11 @@ public:
 
     void addDisallowedURL(JSStringRef url);
     const std::set<std::string>& allowedHosts() const { return m_allowedHosts; }
-    void setAllowedHosts(std::set<std::string> hosts) { m_allowedHosts = WTFMove(hosts); }
+    void setAllowedHosts(std::set<std::string> hosts) { m_allowedHosts = WTF::move(hosts); }
     bool allowAnyHTTPSCertificateForAllowedHosts() const { return m_allowAnyHTTPSCertificateForAllowedHosts; }
     void setAllowAnyHTTPSCertificateForAllowedHosts(bool allow) { m_allowAnyHTTPSCertificateForAllowedHosts = allow; }
     const std::set<std::string>& localhostAliases() const { return m_localhostAliases; }
-    void setLocalhostAliases(std::set<std::string> hosts) { m_localhostAliases = WTFMove(hosts); }
+    void setLocalhostAliases(std::set<std::string> hosts) { m_localhostAliases = WTF::move(hosts); }
     void addURLToRedirect(std::string origin, std::string destination);
     const char* redirectionDestinationForURL(const char*);
     void setPortsForUpgradingInsecureScheme(uint16_t insecurePort, uint16_t securePort) { m_portsForUpgradingInsecureScheme = { insecurePort, securePort }; }

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
@@ -133,5 +133,5 @@ RefPtr<BitmapContext> createBitmapContext(size_t pixelsWide, size_t pixelsHigh, 
         return nullptr;
     }
 
-    return BitmapContext::createByAdoptingBitmapAndContext(WTFMove(buffer), WTFMove(context));
+    return BitmapContext::createByAdoptingBitmapAndContext(WTF::move(buffer), WTF::move(context));
 }

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.h
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.h
@@ -41,7 +41,7 @@ class BitmapContext : public RefCounted<BitmapContext> {
 public:
     static Ref<BitmapContext> createByAdoptingBitmapAndContext(UniqueBitmapBuffer&& buffer, RetainPtr<CGContextRef>&& context)
     {
-        return adoptRef(*new BitmapContext(WTFMove(buffer), WTFMove(context)));
+        return adoptRef(*new BitmapContext(WTF::move(buffer), WTF::move(context)));
     }
 
     CGContextRef cgContext() const { return m_context.get(); }
@@ -52,8 +52,8 @@ public:
 private:
 
     BitmapContext(UniqueBitmapBuffer&& buffer, RetainPtr<CGContextRef>&& context)
-        : m_buffer(WTFMove(buffer))
-        , m_context(WTFMove(context))
+        : m_buffer(WTF::move(buffer))
+        , m_context(WTF::move(context))
     {
     }
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -795,9 +795,9 @@ RetainPtr<WebView> createWebViewAndOffscreenWindow()
 #else
     // Initialize the global UIViews, and set the key UIWindow to be painted.
     if (!gWebBrowserView) {
-        gWebBrowserView = WTFMove(webBrowserView);
-        gWebScrollView = WTFMove(scrollView);
-        gDrtWindow = WTFMove(drtWindow);
+        gWebBrowserView = WTF::move(webBrowserView);
+        gWebScrollView = WTF::move(scrollView);
+        gDrtWindow = WTF::move(drtWindow);
         [uiWindow makeKeyAndVisible];
         [uiWindow retain];
     }
@@ -1421,7 +1421,7 @@ static RetainPtr<NSString> dumpFramesAsText(WebFrame *frame)
     // a CFString via fromUTF8WithLatin1Fallback().createCFString() which can be appended to
     // the result without any conversion.
     if (auto utf8Result = WTF::String(innerText).tryGetUTF8()) {
-        auto string = WTFMove(utf8Result.value());
+        auto string = WTF::move(utf8Result.value());
         [result appendFormat:@"%@\n", String::fromUTF8WithLatin1Fallback(string.span()).createCFString().get()];
     } else
         [result appendString:@"\n"];
@@ -1581,7 +1581,7 @@ void setWaitToDumpWatchdog(RetainPtr<CFRunLoopTimerRef>&& timer)
 {
     ASSERT(timer);
     ASSERT(shouldSetWaitToDumpWatchdog());
-    waitToDumpWatchdog = WTFMove(timer);
+    waitToDumpWatchdog = WTF::move(timer);
     CFRunLoopAddTimer(CFRunLoopGetCurrent(), waitToDumpWatchdog.get(), kCFRunLoopCommonModes);
 }
 
@@ -1890,7 +1890,7 @@ static WTR::TestOptions testOptionsForTest(const WTR::TestCommand& command)
     WTR::merge(features, WTR::hardcodedFeaturesBasedOnPathForTest(command));
     WTR::merge(features, WTR::featureDefaultsFromTestHeaderForTest(command, WTR::TestOptions::keyTypeMapping()));
 
-    return WTR::TestOptions { WTFMove(features) };
+    return WTR::TestOptions { WTF::move(features) };
 }
 
 static void runTest(const std::string& inputLine)

--- a/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
@@ -213,7 +213,7 @@ static RetainPtr<CFStringRef> toUTI(NSString *type)
     if (!_types.contains(uti))
         return NO;
 
-    _data.set(WTFMove(uti), (__bridge CFDataRef)(data ?: [NSData data]));
+    _data.set(WTF::move(uti), (__bridge CFDataRef)(data ?: [NSData data]));
     return YES;
 }
 

--- a/Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm
+++ b/Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm
@@ -146,7 +146,7 @@
 
 - (void)reset
 {
-    auto notifications = WTFMove(_notifications);
+    auto notifications = WTF::move(_notifications);
     for (auto notification : notifications.values())
         [notification finalize];
 

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -437,7 +437,7 @@ void TestRunner::setMockGeolocationPosition(double latitude, double longitude, d
             geolocationPosition.speed = speed;
         if (providesFloorLevel)
             geolocationPosition.floorLevel = floorLevel;
-        position = adoptNS([[WebGeolocationPosition alloc] initWithGeolocationPosition:(WTFMove(geolocationPosition))]);
+        position = adoptNS([[WebGeolocationPosition alloc] initWithGeolocationPosition:(WTF::move(geolocationPosition))]);
     }
     [[MockGeolocationProvider shared] setPosition:position.get()];
 }

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -442,7 +442,7 @@ def cpp_array_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_contain
 
 
 def cpp_move_expr(expr: cpp_expr) -> cpp_expr:
-    return cpp_expr(expr.type.get_rvalue_type(), f"WTFMove({str(expr)})")
+    return cpp_expr(expr.type.get_rvalue_type(), f"WTF::move({str(expr)})")
 
 
 cpp_types: Dict[str, cpp_type] = {}
@@ -809,7 +809,7 @@ class webkit_ipc_cpp_proxy_impl(object):
                 e = cpp_expr(v.type, v.name)
                 self.out_exprs += [e]
                 self.post_call_stmts += [
-                    f"{o.name} = WTFMove({v.name});",
+                    f"{o.name} = WTF::move({v.name});",
                 ]
             elif o.type.is_span():
                 webkit_ipc_type = webkit_ipc_types[o.type]

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
@@ -76,7 +76,7 @@ class UIScriptContext : public RefCounted<UIScriptContext>, public CanMakeWeakPt
 public:
     using UIScriptControllerFactory = Ref<UIScriptController> (*)(UIScriptContext&);
 
-    static Ref<UIScriptContext> create(UIScriptContextDelegate& delegate, UIScriptControllerFactory factory) { return adoptRef(*new UIScriptContext(delegate, WTFMove(factory))); }
+    static Ref<UIScriptContext> create(UIScriptContextDelegate& delegate, UIScriptControllerFactory factory) { return adoptRef(*new UIScriptContext(delegate, WTF::move(factory))); }
 
     ~UIScriptContext();
 

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -253,7 +253,7 @@ static LayoutTestSpellChecker *swizzledInitializeTextChecker()
         }
         [finalResults setObject:resultsForWord.get() forKey:stringToCheck];
     }
-    _results = WTFMove(finalResults);
+    _results = WTF::move(finalResults);
 }
 
 #if PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -100,7 +100,7 @@ public:
         : m_group(group) { }
     bool await_ready() { return false; }
     void await_suspend(std::coroutine_handle<>);
-    Connection await_resume() { return WTFMove(*m_result); }
+    Connection await_resume() { return WTF::move(*m_result); }
 private:
     ConnectionGroup m_group;
     std::optional<Connection> m_result;
@@ -114,7 +114,7 @@ public:
         : m_connection(connection) { }
     bool await_ready() { return false; }
     void await_suspend(std::coroutine_handle<>);
-    Vector<char> await_resume() { return WTFMove(m_result); }
+    Vector<char> await_resume() { return WTF::move(m_result); }
 private:
     Connection m_connection;
     Vector<char> m_result;
@@ -126,7 +126,7 @@ public:
         : m_connection(connection) { }
     bool await_ready() { return false; }
     void await_suspend(std::coroutine_handle<>);
-    Vector<uint8_t> await_resume() { return WTFMove(m_result); }
+    Vector<uint8_t> await_resume() { return WTF::move(m_result); }
 private:
     Connection m_connection;
     Vector<uint8_t> m_result;
@@ -135,7 +135,7 @@ private:
 class SendOperation {
 public:
     SendOperation(OSObjectPtr<dispatch_data_t>&& data, const Connection& connection)
-        : m_data(WTFMove(data))
+        : m_data(WTF::move(data))
         , m_connection(connection) { }
     bool await_ready() { return false; }
     void await_suspend(std::coroutine_handle<>);

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -68,7 +68,7 @@ static OSObjectPtr<dispatch_data_t> dataFromString(String&& s)
 
 void Connection::receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler, size_t minimumSize) const
 {
-    nw_connection_receive(m_connection.get(), minimumSize, std::numeric_limits<uint32_t>::max(), makeBlockPtr([connection = *this, completionHandler = WTFMove(completionHandler)](dispatch_data_t content, nw_content_context_t, bool, nw_error_t error) mutable {
+    nw_connection_receive(m_connection.get(), minimumSize, std::numeric_limits<uint32_t>::max(), makeBlockPtr([connection = *this, completionHandler = WTF::move(completionHandler)](dispatch_data_t content, nw_content_context_t, bool, nw_error_t error) mutable {
         if (error || !content)
             return completionHandler({ });
         completionHandler(vectorFromData(content));
@@ -77,18 +77,18 @@ void Connection::receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&& compl
 
 void Connection::receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&& completionHandler, Vector<char>&& buffer) const
 {
-    receiveBytes([connection = *this, completionHandler = WTFMove(completionHandler), buffer = WTFMove(buffer)](Vector<uint8_t>&& bytes) mutable {
-        buffer.appendVector(WTFMove(bytes));
+    receiveBytes([connection = *this, completionHandler = WTF::move(completionHandler), buffer = WTF::move(buffer)](Vector<uint8_t>&& bytes) mutable {
+        buffer.appendVector(WTF::move(bytes));
         if (size_t doubleNewlineIndex = find(buffer.span(), "\r\n\r\n"_span); doubleNewlineIndex != notFound) {
             if (size_t contentLengthBeginIndex = find(buffer.span(), "Content-Length"_span); contentLengthBeginIndex != notFound) {
                 size_t contentLength = parseIntegerAllowingTrailingJunk<int>(buffer.span().subspan(contentLengthBeginIndex + strlen("Content-Length: "))).value_or(0);
                 size_t headerLength = doubleNewlineIndex + strlen("\r\n\r\n");
                 if (buffer.size() - headerLength < contentLength)
-                    return connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
+                    return connection.receiveHTTPRequest(WTF::move(completionHandler), WTF::move(buffer));
             }
-            completionHandler(WTFMove(buffer));
+            completionHandler(WTF::move(buffer));
         } else
-            connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));
+            connection.receiveHTTPRequest(WTF::move(completionHandler), WTF::move(buffer));
     });
 }
 
@@ -100,7 +100,7 @@ ReceiveHTTPRequestOperation Connection::awaitableReceiveHTTPRequest() const
 void ReceiveHTTPRequestOperation::await_suspend(std::coroutine_handle<> handle)
 {
     m_connection.receiveHTTPRequest([this, handle](Vector<char>&& result) mutable {
-        m_result = WTFMove(result);
+        m_result = WTF::move(result);
         handle();
     });
 }
@@ -113,36 +113,36 @@ ReceiveBytesOperation Connection::awaitableReceiveBytes() const
 void ReceiveBytesOperation::await_suspend(std::coroutine_handle<> handle)
 {
     m_connection.receiveBytes([this, handle](Vector<uint8_t>&& result) mutable {
-        m_result = WTFMove(result);
+        m_result = WTF::move(result);
         handle();
     });
 }
 
 void SendOperation::await_suspend(std::coroutine_handle<> handle)
 {
-    m_connection.send(WTFMove(m_data), [handle] (bool) mutable {
+    m_connection.send(WTF::move(m_data), [handle] (bool) mutable {
         handle();
     });
 }
 
 SendOperation Connection::awaitableSend(Vector<uint8_t>&& message)
 {
-    return { makeDispatchData(WTFMove(message)), *this };
+    return { makeDispatchData(WTF::move(message)), *this };
 }
 
 SendOperation Connection::awaitableSend(String&& message)
 {
-    return { dataFromString(WTFMove(message)), *this };
+    return { dataFromString(WTF::move(message)), *this };
 }
 
 SendOperation Connection::awaitableSend(OSObjectPtr<dispatch_data_t>&& data)
 {
-    return { WTFMove(data), *this };
+    return { WTF::move(data), *this };
 }
 
 void Connection::send(String&& message, CompletionHandler<void()>&& completionHandler) const
 {
-    send(dataFromString(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+    send(dataFromString(WTF::move(message)), [completionHandler = WTF::move(completionHandler)] (bool) mutable {
         if (completionHandler)
             completionHandler();
     });
@@ -150,7 +150,7 @@ void Connection::send(String&& message, CompletionHandler<void()>&& completionHa
 
 void Connection::send(Vector<uint8_t>&& message, CompletionHandler<void()>&& completionHandler) const
 {
-    send(makeDispatchData(WTFMove(message)), [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+    send(makeDispatchData(WTF::move(message)), [completionHandler = WTF::move(completionHandler)] (bool) mutable {
         if (completionHandler)
             completionHandler();
     });
@@ -158,12 +158,12 @@ void Connection::send(Vector<uint8_t>&& message, CompletionHandler<void()>&& com
 
 void Connection::sendAndReportError(Vector<uint8_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
 {
-    send(makeDispatchData(WTFMove(message)), WTFMove(completionHandler));
+    send(makeDispatchData(WTF::move(message)), WTF::move(completionHandler));
 }
 
 void Connection::send(OSObjectPtr<dispatch_data_t>&& message, CompletionHandler<void(bool)>&& completionHandler) const
 {
-    nw_connection_send(m_connection.get(), message.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTFMove(completionHandler)](nw_error_t error) mutable {
+    nw_connection_send(m_connection.get(), message.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([completionHandler = WTF::move(completionHandler)](nw_error_t error) mutable {
         if (completionHandler)
             completionHandler(!!error);
     }).get());
@@ -171,7 +171,7 @@ void Connection::send(OSObjectPtr<dispatch_data_t>&& message, CompletionHandler<
 
 void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandler)
 {
-    receiveHTTPRequest([connection = Connection(*this), connectionHandler = WTFMove(connectionHandler)] (Vector<char>&& request) mutable {
+    receiveHTTPRequest([connection = Connection(*this), connectionHandler = WTF::move(connectionHandler)] (Vector<char>&& request) mutable {
 
         auto webSocketAcceptValue = [] (const Vector<char>& request) {
             constexpr auto keyHeaderField = "Sec-WebSocket-Key: "_s;
@@ -194,13 +194,13 @@ void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandle
             { "Upgrade"_s, "websocket"_s },
             { "Connection"_s, "Upgrade"_s },
             { "Sec-WebSocket-Accept"_s, webSocketAcceptValue(request) }
-        }).serialize(HTTPResponse::IncludeContentLength::No), WTFMove(connectionHandler));
+        }).serialize(HTTPResponse::IncludeContentLength::No), WTF::move(connectionHandler));
     });
 }
 
 void Connection::terminate(CompletionHandler<void()>&& completionHandler)
 {
-    nw_connection_set_state_changed_handler(m_connection.get(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (nw_connection_state_t state, nw_error_t error) mutable {
+    nw_connection_set_state_changed_handler(m_connection.get(), makeBlockPtr([completionHandler = WTF::move(completionHandler)] (nw_connection_state_t state, nw_error_t error) mutable {
         ASSERT_UNUSED(error, !error);
         if (state == nw_connection_state_cancelled && completionHandler)
             completionHandler();
@@ -239,7 +239,7 @@ void ConnectionGroup::markAsFailed()
 Awaitable<void> ConnectionGroup::awaitableFailure()
 {
     co_return co_await AwaitableFromCompletionHandler<void> { [data = m_data] (auto completionHandler) {
-        data->failureCompletionHandler = WTFMove(completionHandler);
+        data->failureCompletionHandler = WTF::move(completionHandler);
     } };
 }
 
@@ -265,7 +265,7 @@ void ConnectionGroup::cancel()
 void ReceiveIncomingConnectionOperation::await_suspend(std::coroutine_handle<> handle)
 {
     m_group.receiveIncomingConnection([this, handle](Connection result) mutable {
-        m_result = WTFMove(result);
+        m_result = WTF::move(result);
         handle();
     });
 }
@@ -277,7 +277,7 @@ ReceiveIncomingConnectionOperation ConnectionGroup::receiveIncomingConnection() 
 
 void ConnectionGroup::receiveIncomingConnection(CompletionHandler<void(Connection)>&& connectionHandler)
 {
-    m_data->connectionHandler = WTFMove(connectionHandler);
+    m_data->connectionHandler = WTF::move(connectionHandler);
 }
 
 void ConnectionGroup::receiveIncomingConnection(Connection connection)

--- a/Tools/TestWebKitAPI/TestNotificationProvider.cpp
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.cpp
@@ -55,7 +55,7 @@ static WKDictionaryRef notificationPermissions(const void* clientInfo)
 }
 
 TestNotificationProvider::TestNotificationProvider(Vector<WKNotificationManagerRef>&& managers)
-    : m_managers(WTFMove(managers))
+    : m_managers(WTF::move(managers))
 {
     m_provider = {
         WKNotificationProviderBase { 0, this },

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -166,7 +166,7 @@ template<> struct ArgumentCoder<TestWebKitAPI::EncodingCounter> {
     }
     static void encode(Encoder& encoder, TestWebKitAPI::EncodingCounter&& counter)
     {
-        WTFMove(counter).encode(encoder);
+        WTF::move(counter).encode(encoder);
     }
 };
 
@@ -226,7 +226,7 @@ public:
         }
         case EncodingCounterTestType::MovedRValue: {
             auto object = createFunctor(counterValues);
-            m_encoder << WTFMove(object);
+            m_encoder << WTF::move(object);
 
             ASSERT_EQ(counterValues, EncodingCounter::CounterValues(0, expectedEncodingCount));
             break;
@@ -378,7 +378,7 @@ template<> struct ArgumentCoder<TestWebKitAPI::DecodingMoveCounter> {
     template<typename Encoder>
     static void encode(Encoder& encoder, TestWebKitAPI::DecodingMoveCounter&& counter)
     {
-        WTFMove(counter).encode(encoder);
+        WTF::move(counter).encode(encoder);
     }
     static std::optional<TestWebKitAPI::DecodingMoveCounter> decode(Decoder& decoder)
     {

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -42,14 +42,14 @@ struct MockTestMessageWithConnection {
     static constexpr bool replyCanDispatchOutOfOrder = false;
     static constexpr IPC::MessageName name()  { return IPC::MessageName::IPCTester_EmptyMessage; }
     MockTestMessageWithConnection(IPC::Connection::Handle&& handle)
-        : m_handle(WTFMove(handle))
+        : m_handle(WTF::move(handle))
     {
     }
 
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_handle);
+        encoder << WTF::move(m_handle);
     }
 
 private:
@@ -99,7 +99,7 @@ TEST_F(SimpleConnectionTest, CreateServerConnection)
 {
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
-    Ref<IPC::Connection> connection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
+    Ref<IPC::Connection> connection = IPC::Connection::createServerConnection(WTF::move(identifiers->server));
     connection->invalidate();
 }
 
@@ -107,7 +107,7 @@ TEST_F(SimpleConnectionTest, CreateClientConnection)
 {
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
-    Ref<IPC::Connection> connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(identifiers->client) });
+    Ref<IPC::Connection> connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(identifiers->client) });
     connection->invalidate();
 }
 
@@ -115,8 +115,8 @@ TEST_F(SimpleConnectionTest, ConnectLocalConnection)
 {
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
-    Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
-    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(identifiers->client) });
+    Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTF::move(identifiers->server));
+    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(identifiers->client) });
     serverConnection->open(m_mockServerClient);
     clientConnection->open(m_mockClientClient);
     serverConnection->invalidate();
@@ -129,7 +129,7 @@ TEST_F(SimpleConnectionTest, ClearOutgoingMessages)
     // handle pending.
     auto firstIdentifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(firstIdentifiers, std::nullopt);
-    Ref<IPC::Connection> firstServerConnection = IPC::Connection::createServerConnection(WTFMove(firstIdentifiers->server));
+    Ref<IPC::Connection> firstServerConnection = IPC::Connection::createServerConnection(WTF::move(firstIdentifiers->server));
     firstServerConnection->open(m_mockServerClient);
 
     // Create a second connection, and send the client
@@ -137,11 +137,11 @@ TEST_F(SimpleConnectionTest, ClearOutgoingMessages)
     // that it will be stored as a pending message).
     auto secondIdentifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(secondIdentifiers, std::nullopt);
-    Ref<IPC::Connection> secondServerConnection = IPC::Connection::createServerConnection(WTFMove(secondIdentifiers->server));
+    Ref<IPC::Connection> secondServerConnection = IPC::Connection::createServerConnection(WTF::move(secondIdentifiers->server));
     Ref mockSecondServerClient = MockConnectionClient::create();
     secondServerConnection->open(mockSecondServerClient);
 
-    firstServerConnection->send(MockTestMessageWithConnection { WTFMove(secondIdentifiers->client) }, 0);
+    firstServerConnection->send(MockTestMessageWithConnection { WTF::move(secondIdentifiers->client) }, 0);
 
     // Invalidate the first connection's client handle,
     // which should clear pending messages and also invalidate
@@ -274,7 +274,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingWorks)
         EXPECT_EQ(otherRunLoopTasksRun, i + 1u);
         auto messages1 = aClient().takeMessages();
         EXPECT_EQ(messageCounts[i], messages1.size());
-        messages.appendVector(WTFMove(messages1));
+        messages.appendVector(WTF::move(messages1));
     }
     EXPECT_EQ(testedCount, messages.size());
     for (uint64_t i = 0u; i < messages.size(); ++i) {
@@ -331,7 +331,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
         EXPECT_EQ(otherRunLoopTasksRun, i + 1u);
         auto messages1 = aClient().takeMessages();
         EXPECT_EQ(messageCounts[i], messages1.size());
-        messages.appendVector(WTFMove(messages1));
+        messages.appendVector(WTF::move(messages1));
     }
     EXPECT_EQ(testedCount - 4, messages.size());
     for (uint64_t i = 0u, j = 0u; i < messages.size(); ++i, ++j) {
@@ -360,9 +360,9 @@ TEST_P(ConnectionTestABBA, ReceiveAlreadyInvalidatedClientNoAssert)
         auto handle = decoder.decode<IPC::Connection::Handle>();
         if (!handle)
             return false;
-        Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(*handle) });
+        Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(*handle) });
         clientConnection->open(connections[i].mockClientClient);
-        connections[i].clientConnection = WTFMove(clientConnection);
+        connections[i].clientConnection = WTF::move(clientConnection);
         // The connection starts as not closed in order for the system to deliver didClose().
         EXPECT_FALSE(connections[i].mockClientClient->gotDidClose()) << i;
         done.add(i);
@@ -371,10 +371,10 @@ TEST_P(ConnectionTestABBA, ReceiveAlreadyInvalidatedClientNoAssert)
     for (uint64_t i = 1; i < iterations; ++i) {
         auto identifiers = IPC::Connection::createConnectionIdentifierPair();
         ASSERT_NE(identifiers, std::nullopt);
-        Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
+        Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTF::move(identifiers->server));
         Ref mockServerClient = MockConnectionClient::create();
         serverConnection->open(mockServerClient);
-        a()->send(MockTestMessageWithConnection { WTFMove(identifiers->client) }, i);
+        a()->send(MockTestMessageWithConnection { WTF::move(identifiers->client) }, i);
         serverConnection->invalidate();
     }
     while (done.size() < iterations - 1)
@@ -555,7 +555,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
         auto listenerID = decoder.decode<uint64_t>();
         auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
         encoder.get() << decoder.destinationID();
-        a()->sendSyncReply(WTFMove(encoder));
+        a()->sendSyncReply(WTF::move(encoder));
         return true;
     });
     HashSet<uint64_t> replies;
@@ -594,7 +594,7 @@ TEST_P(ConnectionRunLoopTest, SendSyncMaintainOrderingWithAsyncMessagesOrder)
         // Sync message handler only to respond with "message was handled".
         bClient().setSyncMessageHandler([&](IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) -> bool {
             bClient().addMessage(decoder);
-            connection.sendSyncReply(WTFMove(encoder));
+            connection.sendSyncReply(WTF::move(encoder));
             return true;
         });
         ASSERT_TRUE(openB());
@@ -634,7 +634,7 @@ TEST_P(ConnectionRunLoopTest, SendSyncMaintainOrderingWithAsyncMessagesOrderMult
         // Sync message handler only to respond with "message was handled".
         bClient().setSyncMessageHandler([&](IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) -> bool {
             bClient().addMessage(decoder);
-            connection.sendSyncReply(WTFMove(encoder));
+            connection.sendSyncReply(WTF::move(encoder));
             sleep(0.1_s);
             return true;
         });
@@ -704,7 +704,7 @@ TEST_P(ConnectionRunLoopTest, SendSyncMaintainOrderingWithAsyncMessagesWaitForOr
         // Sync message handler only to respond with "message was handled".
         bClient().setSyncMessageHandler([&](IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) -> bool {
             bClient().addMessage(decoder);
-            connection.sendSyncReply(WTFMove(encoder));
+            connection.sendSyncReply(WTF::move(encoder));
             sleep(0.1_s);
             return true;
         });
@@ -776,7 +776,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsyncOnTarget)
             auto listenerID = decoder.decode<uint64_t>();
             auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
             encoder.get() << decoder.destinationID();
-            a()->sendSyncReply(WTFMove(encoder));
+            a()->sendSyncReply(WTF::move(encoder));
             return true;
         });
 
@@ -810,7 +810,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
         auto listenerID = decoder.decode<uint64_t>();
         auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
         encoder.get() << decoder.destinationID();
-        a()->sendSyncReply(WTFMove(encoder));
+        a()->sendSyncReply(WTF::move(encoder));
         return true;
     });
     HashSet<uint64_t> replies;
@@ -855,7 +855,7 @@ TEST_P(ConnectionRunLoopTest, SendWithConvertedPromisedReply)
         auto listenerID = decoder.decode<uint64_t>();
         auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
         encoder.get() << decoder.destinationID();
-        a()->sendSyncReply(WTFMove(encoder));
+        a()->sendSyncReply(WTF::move(encoder));
         return true;
     });
     std::atomic<bool> isFinished = false;
@@ -889,7 +889,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatche
             auto listenerID = decoder.decode<uint64_t>();
             auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
             encoder.get() << decoder.destinationID();
-            a()->sendSyncReply(WTFMove(encoder));
+            a()->sendSyncReply(WTF::move(encoder));
             return true;
         });
 
@@ -937,7 +937,7 @@ TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidateOnDispatcher)
                 auto listenerID = decoder.decode<uint64_t>();
                 auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
                 encoder.get() << decoder.destinationID();
-                b()->sendSyncReply(WTFMove(encoder));
+                b()->sendSyncReply(WTF::move(encoder));
                 messages.add(decoder.destinationID());
                 return true;
             });
@@ -1027,7 +1027,7 @@ TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidate)
             auto listenerID = decoder.decode<uint64_t>();
             auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
             encoder.get() << decoder.destinationID();
-            b()->sendSyncReply(WTFMove(encoder));
+            b()->sendSyncReply(WTF::move(encoder));
             messages.add(decoder.destinationID());
             return true;
         });
@@ -1069,7 +1069,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOrder)
         auto listenerID = decoder.decode<uint64_t>();
         auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
         encoder.get() << replyID++;
-        a()->sendSyncReply(WTFMove(encoder));
+        a()->sendSyncReply(WTF::move(encoder));
         return true;
     });
     Vector<uint64_t> replies;
@@ -1117,7 +1117,7 @@ TEST_P(ConnectionRunLoopTest, DISABLED_RunLoopSendAsyncOnAnotherRunLoopDispatche
         auto listenerID = decoder.decode<uint64_t>();
         auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
         encoder.get() << decoder.destinationID();
-        a()->sendSyncReply(WTFMove(encoder));
+        a()->sendSyncReply(WTF::move(encoder));
         return true;
     });
     HashSet<uint64_t> replies;
@@ -1245,7 +1245,7 @@ TEST_P(ConnectionRunLoopTest, SendLocalSyncMessageWithDataReply)
             for (size_t i = 0; i < dataSize; ++i)
                 data[i] = static_cast<uint8_t>(i);
             encoder.get() << data;
-            b()->sendSyncReply(WTFMove(encoder));
+            b()->sendSyncReply(WTF::move(encoder));
             return true;
         });
         ASSERT_TRUE(openB());
@@ -1281,7 +1281,7 @@ TEST_P(ConnectionRunLoopTest, SyncMessageNotHandledIsCancelled)
             if (decoder.destinationID() == 77)
                 return true; // Message destination was unknown, unhandled message.
             if (decoder.destinationID() == 99) {
-                b()->sendSyncReply(WTFMove(encoder));
+                b()->sendSyncReply(WTF::move(encoder));
                 return true;
             }
             EXPECT_TRUE(false);
@@ -1329,7 +1329,7 @@ TEST_P(ConnectionRunLoopTest, SyncMessageDecodeFailureIsCancelled)
                 return true; // Message was handled, but decode failed.
             }
             if (decoder.destinationID() == 99) {
-                b()->sendSyncReply(WTFMove(encoder));
+                b()->sendSyncReply(WTF::move(encoder));
                 return true;
             }
             EXPECT_TRUE(false);

--- a/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
@@ -37,14 +37,14 @@ struct MockTestMessageWithSignal {
     static constexpr bool replyCanDispatchOutOfOrder = false;
     static constexpr IPC::MessageName name()  { return IPC::MessageName::IPCTester_EmptyMessage; }
     MockTestMessageWithSignal(IPC::Signal&& signal)
-        : m_signal(WTFMove(signal))
+        : m_signal(WTF::move(signal))
     {
     }
 
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(m_signal);
+        encoder << WTF::move(m_signal);
     }
 private:
     IPC::Signal&& m_signal;
@@ -99,7 +99,7 @@ TEST_P(EventTestABBA, SerializeAndSignal)
 
     auto pair = IPC::createEventSignalPair();
     ASSERT_TRUE(pair);
-    a()->send(MockTestMessageWithSignal { WTFMove(pair->signal) }, 77);
+    a()->send(MockTestMessageWithSignal { WTF::move(pair->signal) }, 77);
 
     pair->event.wait();
 }
@@ -124,7 +124,7 @@ TEST_P(EventTestABBA, InterruptOnDestruct)
 
     auto pair = IPC::createEventSignalPair();
     ASSERT_TRUE(pair);
-    a()->send(MockTestMessageWithSignal { WTFMove(pair->signal) }, 77);
+    a()->send(MockTestMessageWithSignal { WTF::move(pair->signal) }, 77);
 
     pair->event.wait();
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -138,7 +138,7 @@ std::optional<CFHolderForTesting> CFHolderForTesting::decode(IPC::Decoder& decod
         return std::nullopt;
 
     return { {
-        WTFMove(*value)
+        WTF::move(*value)
     } };
 }
 
@@ -486,7 +486,7 @@ std::optional<ObjCHolderForTesting> ObjCHolderForTesting::decode(IPC::Decoder& d
         return std::nullopt;
 
     return { {
-        WTFMove(*value)
+        WTF::move(*value)
     } };
 }
 
@@ -919,7 +919,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 static void runTestNS(ObjCHolderForTesting&& holderArg)
 {
     __block bool done = false;
-    __block ObjCHolderForTesting holder = WTFMove(holderArg);
+    __block ObjCHolderForTesting holder = WTF::move(holderArg);
     auto sender = SerializationTestSender { };
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(ObjCPingBackMessage(holder), ^(ObjCHolderForTesting&& result) {
         EXPECT_TRUE(holder == result);

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
@@ -53,8 +53,8 @@ void ConnectionTestBase::setupBase()
         FAIL();
         return;
     }
-    m_connections[0].connection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
-    m_connections[1].connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(identifiers->client) });
+    m_connections[0].connection = IPC::Connection::createServerConnection(WTF::move(identifiers->server));
+    m_connections[1].connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTF::move(identifiers->client) });
 }
 
 void ConnectionTestBase::teardownBase()

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -194,19 +194,19 @@ public:
     // Handler returns false if the message should be just recorded.
     void setAsyncMessageHandler(Function<bool(IPC::Connection&, IPC::Decoder&)>&& handler)
     {
-        m_asyncMessageHandler = WTFMove(handler);
+        m_asyncMessageHandler = WTF::move(handler);
     }
 
     // Handler contract as IPC::MessageReceiver::didReceiveSyncMessage: false on invalid message, may adopt encoder,
     // decoder used only during the call, if encoder not adopted it will be submitted.
     void setSyncMessageHandler(Function<bool(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)>&& handler)
     {
-        m_syncMessageHandler = WTFMove(handler);
+        m_syncMessageHandler = WTF::move(handler);
     }
 
     void setInvalidMessageHandler(Function<bool(IPC::Connection&, IPC::MessageName, const Vector<uint32_t>&)>&& handler)
     {
-        m_invalidMessageHandler = WTFMove(handler);
+        m_invalidMessageHandler = WTF::move(handler);
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -66,13 +66,13 @@ struct MockStreamTestMessageNotStreamEncodable {
     static constexpr bool isStreamEncodable = false;
     static constexpr IPC::MessageName name()  { return IPC::MessageName::IPCStreamTester_EmptyMessage; }
     explicit MockStreamTestMessageNotStreamEncodable(IPC::Semaphore&& s)
-        : semaphore(WTFMove(s))
+        : semaphore(WTF::move(s))
     {
     }
     template<typename Encoder>
     void encode(Encoder& encoder)
     {
-        encoder << WTFMove(semaphore);
+        encoder << WTF::move(semaphore);
     }
 
     IPC::Semaphore semaphore;
@@ -180,18 +180,18 @@ public:
     // Handler returns false if the message should be just recorded.
     void setAsyncMessageHandler(Function<bool(IPC::StreamServerConnection&, IPC::Decoder&)>&& handler)
     {
-        m_asyncMessageHandler = WTFMove(handler);
+        m_asyncMessageHandler = WTF::move(handler);
     }
 
     // Handler returns false if the message should be just recorded.
     void setSyncMessageHandler(Function<bool(IPC::StreamServerConnection&, IPC::Decoder&)>&& handler)
     {
-        m_syncMessageHandler = WTFMove(handler);
+        m_syncMessageHandler = WTF::move(handler);
     }
     // Handler returns false if the message should be just recorded.
     void setInvalidMessageHandler(Function<bool(IPC::StreamServerConnection&, IPC::MessageName, const Vector<uint32_t>&)>&& handler)
     {
-        m_invalidMessageHandler = WTFMove(handler);
+        m_invalidMessageHandler = WTF::move(handler);
     }
 
 private:
@@ -274,8 +274,8 @@ TEST_F(StreamConnectionTest, OpenConnections)
 {
     auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
     ASSERT_TRUE(!!connectionPair);
-    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
+    auto [clientConnection, serverConnectionHandle] = WTF::move(*connectionPair);
+    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnectionHandle), { }).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     Ref mockClientReceiver = MockStreamClientConnectionClient::create();
     clientConnection->open(mockClientReceiver);
@@ -293,8 +293,8 @@ TEST_F(StreamConnectionTest, InvalidateUnopened)
 {
     auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
     ASSERT_TRUE(!!connectionPair);
-    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
+    auto [clientConnection, serverConnectionHandle] = WTF::move(*connectionPair);
+    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnectionHandle), { }).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     serverQueue().dispatch([this, serverConnection] {
         assertIsCurrent(serverQueue());
@@ -320,9 +320,9 @@ public:
         setupBase();
         auto connectionPair = IPC::StreamClientConnection::create(bufferSizeLog2(), defaultTimeout);
         ASSERT(!!connectionPair);
-        auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
-        m_clientConnection = WTFMove(clientConnection);
+        auto [clientConnection, serverConnectionHandle] = WTF::move(*connectionPair);
+        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnectionHandle), { }).releaseNonNull();
+        m_clientConnection = WTF::move(clientConnection);
         m_clientConnection->setSemaphores(copyViaEncoder(serverQueue().wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());
         m_clientConnection->open(m_mockClientReceiver);
         m_mockServerReceiver = MockStreamServerConnectionClient::create();
@@ -338,9 +338,9 @@ public:
             connection.sendAsyncReply<MockStreamTestMessageWithAsyncReply1>(*asyncReplyID, *contents);
             return true;
         });
-        serverQueue().dispatch([this, serverConnection = WTFMove(serverConnection)] () mutable {
+        serverQueue().dispatch([this, serverConnection = WTF::move(serverConnection)] () mutable {
             assertIsCurrent(serverQueue());
-            m_serverConnection = WTFMove(serverConnection);
+            m_serverConnection = WTF::move(serverConnection);
             m_serverConnection->open(*m_mockServerReceiver, serverQueue());
             m_serverConnection->startReceivingMessages(*m_mockServerReceiver, IPC::receiverName(MockStreamTestMessage1::name()), defaultDestinationID().toUInt64());
         });
@@ -647,9 +647,9 @@ public:
         setupBase();
         auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
         ASSERT(connectionPair.has_value());
-        auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
-        m_clientConnection = WTFMove(clientConnection);
+        auto [clientConnection, serverConnectionHandle] = WTF::move(*connectionPair);
+        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnectionHandle), { }).releaseNonNull();
+        m_clientConnection = WTF::move(clientConnection);
         m_clientConnection->setSemaphores(copyViaEncoder(serverQueue().wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());
         m_clientConnection->open(m_mockClientReceiver);
         m_mockServerReceiver = MockStreamServerConnectionClient::create();
@@ -676,9 +676,9 @@ public:
                 return true;
             });
         }
-        serverQueue().dispatch([this, serverConnection = WTFMove(serverConnection)] () mutable {
+        serverQueue().dispatch([this, serverConnection = WTF::move(serverConnection)] () mutable {
             assertIsCurrent(serverQueue());
-            m_serverConnection = WTFMove(serverConnection);
+            m_serverConnection = WTF::move(serverConnection);
             m_serverConnection->open(*m_mockServerReceiver, serverQueue());
             m_serverConnection->startReceivingMessages(*m_mockServerReceiver, IPC::receiverName(MockStreamTestMessage1::name()), defaultDestinationID().toUInt64());
         });

--- a/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
@@ -107,9 +107,9 @@ TEST_F(ThreadSafeObjectHeapTest, CompleteReadAfterRemoveWithPendingRead)
     auto read1 = newReadReference();
     auto remove = newWriteReference();
 
-    heap.remove(WTFMove(remove)); // Non-blocking remove.
+    heap.remove(WTF::move(remove)); // Non-blocking remove.
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(345, heap.read(WTFMove(read1), 0_s)->value());
+    EXPECT_EQ(345, heap.read(WTF::move(read1), 0_s)->value());
     EXPECT_EQ(0u, heap.sizeForTesting());
     EXPECT_EQ(0u, TestedObject::instances());
 }
@@ -121,8 +121,8 @@ TEST_F(ThreadSafeObjectHeapTest, ReadWriteWorks)
     auto read1 = newReadReference();
     auto write1 = newWriteReference();
 
-    EXPECT_EQ(1, heap.read(WTFMove(read1), 0_s)->value());
-    EXPECT_EQ(1, heap.take(WTFMove(write1), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read1), 0_s)->value());
+    EXPECT_EQ(1, heap.take(WTF::move(write1), 0_s)->value());
     EXPECT_EQ(0u, TestedObject::instances());
 }
 
@@ -134,7 +134,7 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveWorks)
     auto write1 = newWriteReference();
 
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
     EXPECT_EQ(0u, heap.sizeForTesting());
     EXPECT_EQ(0u, TestedObject::instances());
 }
@@ -147,11 +147,11 @@ TEST_F(ThreadSafeObjectHeapTest, WriteBeforeRetireEarlierReadTimesOut)
     auto write1 = newWriteReference();
 
     // Test that take times out.
-    EXPECT_EQ(nullptr, heap.take(WTFMove(write1), 0_s));
+    EXPECT_EQ(nullptr, heap.take(WTF::move(write1), 0_s));
 
     // Ensure that write works after read.
-    EXPECT_EQ(1, heap.read(WTFMove(read1), 0_s)->value());
-    EXPECT_EQ(1, heap.take(WTFMove(write1), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read1), 0_s)->value());
+    EXPECT_EQ(1, heap.take(WTF::move(write1), 0_s)->value());
     EXPECT_EQ(0u, TestedObject::instances());
     EXPECT_EQ(0u, heap.sizeForTesting());
 }
@@ -164,8 +164,8 @@ TEST_F(ThreadSafeObjectHeapTest, ReadBeforeRetireEarlierWriteTimesOut)
     auto read1 = newReadReference();
     auto newReference = write1.retiredReference();
 
-    EXPECT_EQ(nullptr, heap.read(WTFMove(read1), 0_s));
-    EXPECT_EQ(1, heap.take(WTFMove(write1), 0_s)->value());
+    EXPECT_EQ(nullptr, heap.read(WTF::move(read1), 0_s));
+    EXPECT_EQ(1, heap.take(WTF::move(write1), 0_s)->value());
     EXPECT_TRUE(heap.add(newReference, TestedObject::create(2)));
     EXPECT_EQ(2, heap.get(read1, 0_s)->value());
 }
@@ -176,7 +176,7 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveBeforeAdd)
     auto add1 = newAddReference();
     auto write1 = newWriteReference();
 
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
     EXPECT_EQ(1u, heap.sizeForTesting());
     EXPECT_TRUE(heap.add(add1, TestedObject::create(1)));
     EXPECT_EQ(0u, TestedObject::instances());
@@ -192,15 +192,15 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveBeforeAddAndReads)
     auto read3 = newReadReference();
     auto write1 = newWriteReference();
 
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
     EXPECT_EQ(1u, heap.sizeForTesting());
     EXPECT_TRUE(heap.add(add1, TestedObject::create(1)));
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read1), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read1), 0_s)->value());
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read2), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read2), 0_s)->value());
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read3), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read3), 0_s)->value());
     EXPECT_EQ(0u, TestedObject::instances());
     EXPECT_EQ(0u, heap.sizeForTesting());
 }
@@ -216,13 +216,13 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveBeforeReads)
 
     EXPECT_TRUE(heap.add(add1, TestedObject::create(1)));
     EXPECT_EQ(1u, heap.sizeForTesting());
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read1), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read1), 0_s)->value());
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read2), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read2), 0_s)->value());
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(1, heap.read(WTFMove(read3), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read3), 0_s)->value());
     EXPECT_EQ(0u, TestedObject::instances());
     EXPECT_EQ(0u, heap.sizeForTesting());
 }
@@ -239,9 +239,9 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveBeforeWritesAndReads)
     auto read3 = newReadReference();
     auto write3 = newWriteReference();
 
-    EXPECT_TRUE(heap.remove(WTFMove(write3)));
-    EXPECT_TRUE(heap.remove(WTFMove(write2)));
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
+    EXPECT_TRUE(heap.remove(WTF::move(write3)));
+    EXPECT_TRUE(heap.remove(WTF::move(write2)));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
     EXPECT_EQ(3u, heap.sizeForTesting());
 
     EXPECT_EQ(0u, TestedObject::instances());
@@ -250,9 +250,9 @@ TEST_F(ThreadSafeObjectHeapTest, RemoveBeforeWritesAndReads)
     EXPECT_TRUE(heap.add(add3, TestedObject::create(3)));
     EXPECT_EQ(2u, TestedObject::instances());
     EXPECT_EQ(2u, heap.sizeForTesting());
-    EXPECT_EQ(2, heap.read(WTFMove(read2), 0_s)->value());
+    EXPECT_EQ(2, heap.read(WTF::move(read2), 0_s)->value());
     EXPECT_EQ(1u, TestedObject::instances());
-    EXPECT_EQ(3, heap.read(WTFMove(read3), 0_s)->value());
+    EXPECT_EQ(3, heap.read(WTF::move(read3), 0_s)->value());
     EXPECT_EQ(0u, TestedObject::instances());
 }
 
@@ -263,9 +263,9 @@ TEST_F(ThreadSafeObjectHeapTest, InvalidRemoveTwice)
     TestedObjectWriteReference write2 { write1.reference(), 0 };
     TestedObjectWriteReference write3 { write1.reference(), 0 };
 
-    EXPECT_TRUE(heap.remove(WTFMove(write1)));
-    EXPECT_FALSE(heap.remove(WTFMove(write2)));
-    EXPECT_FALSE(heap.take(WTFMove(write3), 0_s));
+    EXPECT_TRUE(heap.remove(WTF::move(write1)));
+    EXPECT_FALSE(heap.remove(WTF::move(write2)));
+    EXPECT_FALSE(heap.take(WTF::move(write3), 0_s));
 }
 
 TEST_F(ThreadSafeObjectHeapTest, InvalidRemoveTooFewReads)
@@ -274,14 +274,14 @@ TEST_F(ThreadSafeObjectHeapTest, InvalidRemoveTooFewReads)
     auto add1 = newAddReference();
     auto read1 = newReadReference();
     EXPECT_TRUE(heap.add(add1, TestedObject::create(1)));
-    EXPECT_EQ(1, heap.read(WTFMove(read1), 0_s)->value());
+    EXPECT_EQ(1, heap.read(WTF::move(read1), 0_s)->value());
 
     // Already read once, but trying to remove with 0 pending reads.
     TestedObjectWriteReference write1 { add1, 0 };
     TestedObjectWriteReference write2 { add1, 0 };
 
-    EXPECT_FALSE(heap.remove(WTFMove(write1)));
-    EXPECT_FALSE(heap.take(WTFMove(write2), 0_s));
+    EXPECT_FALSE(heap.remove(WTF::move(write1)));
+    EXPECT_FALSE(heap.take(WTF::move(write2), 0_s));
 }
 
 TEST_F(ThreadSafeObjectHeapTest, InvalidAddTwice)

--- a/Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/TransferStringObjCTests.mm
@@ -53,7 +53,7 @@ TEST(TransferStringTests, CreateFromNSString)
             SCOPED_TRACE(::testing::Message() << "releaseToCopy: " << releaseToCopy << " subcase: \"" << wtfString << "\"" << " ptr: " << static_cast<void*>(subcase.get()));
             auto ts = IPC::TransferString::create(subcase.get());
             EXPECT_TRUE(ts.has_value());
-            auto string = releaseToCopy ? WTFMove(*ts).releaseToCopy() : WTFMove(*ts).release();
+            auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
             ASSERT_TRUE(string.has_value());
             EXPECT_EQ(*string, wtfString);
         }

--- a/Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/TransferStringTests.cpp
@@ -52,13 +52,13 @@ TEST(TransferStringTests, CreateFromString)
             {
                 auto ts = IPC::TransferString::create(subcase);
                 EXPECT_TRUE(ts.has_value());
-                auto string = releaseToCopy ? WTFMove(*ts).releaseToCopy() : WTFMove(*ts).release();
+                auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
                 EXPECT_EQ(string, subcase);
             }
             {
                 auto ts = IPC::TransferString::create(StringView { subcase });
                 EXPECT_TRUE(ts.has_value());
-                auto string = releaseToCopy ? WTFMove(*ts).releaseToCopy() : WTFMove(*ts).release();
+                auto string = releaseToCopy ? WTF::move(*ts).releaseToCopy() : WTF::move(*ts).release();
                 EXPECT_EQ(string, subcase);
             }
         }

--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -39,7 +39,7 @@ static Expected<std::pair<WGSL::ShaderModule, WGSL::AST::Expression::Ref>, WGSL:
     auto expression = parser.parsePrimaryExpression();
     if (!expression)
         return makeUnexpected(expression.error());
-    return { std::make_pair(WTFMove(shaderModule), *expression) };
+    return { std::make_pair(WTF::move(shaderModule), *expression) };
 }
 
 template<class NumberType>

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -51,7 +51,7 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
     });
     if (auto* maybeError = std::get_if<WGSL::Error>(&generationResult))
         return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
-    return { WTFMove(std::get<String>(generationResult)) };
+    return { WTF::move(std::get<String>(generationResult)) };
 }
 
 TEST(WGSLMetalGenerationTests, RedFrag)

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -81,7 +81,7 @@ inline Expected<WGSL::ShaderModule, WGSL::FailedCheck> parse(const String& wgsl)
     auto maybeError = WGSL::parse(shaderModule);
     if (maybeError.has_value())
         return makeUnexpected(*maybeError);
-    return { WTFMove(shaderModule) };
+    return { WTF::move(shaderModule) };
 }
 
 struct StructAttributeTest {

--- a/Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/BlockPtr.mm
@@ -42,21 +42,21 @@ TEST(BlockPtr, FromBlock)
 TEST(BlockPtr, FromLambda)
 {
     MoveOnly moveOnly { 10 };
-    auto block = BlockPtr<unsigned ()>::fromCallable([moveOnly = WTFMove(moveOnly)] {
+    auto block = BlockPtr<unsigned ()>::fromCallable([moveOnly = WTF::move(moveOnly)] {
         return moveOnly.value();
     });
 
     EXPECT_EQ(10u, block());
 
     moveOnly = 20;
-    block = makeBlockPtr([moveOnly = WTFMove(moveOnly)] {
+    block = makeBlockPtr([moveOnly = WTF::move(moveOnly)] {
         return moveOnly.value();
     });
 
     EXPECT_EQ(20u, block());
 
     moveOnly = 30;
-    block = makeBlockPtr([moveOnly = WTFMove(moveOnly)]() mutable {
+    block = makeBlockPtr([moveOnly = WTF::move(moveOnly)]() mutable {
         return moveOnly.value();
     });
 

--- a/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
@@ -110,7 +110,7 @@ TEST(WTF_BoxPtr, Basic)
     {
         BoxPtrLogger* a = BoxPtrLogger::create("a");
         BoxPtr<BoxPtrLogger> p1 = adoptInBoxPtr(a);
-        BoxPtr<BoxPtrLogger> p2 = WTFMove(p1);
+        BoxPtr<BoxPtrLogger> p2 = WTF::move(p1);
         EXPECT_EQ(false, static_cast<bool>(p1));
         EXPECT_EQ(a, p2->get());
     }
@@ -119,7 +119,7 @@ TEST(WTF_BoxPtr, Basic)
     {
         BoxPtrLogger* a = BoxPtrLogger::create("a");
         BoxPtr<BoxPtrLogger> p1 = adoptInBoxPtr(a);
-        BoxPtr<BoxPtrLogger> p2(WTFMove(p1));
+        BoxPtr<BoxPtrLogger> p2(WTF::move(p1));
         EXPECT_EQ(false, static_cast<bool>(p1));
         EXPECT_EQ(a, p2->get());
     }
@@ -168,7 +168,7 @@ TEST(WTF_BoxPtr, Assignment)
         EXPECT_EQ(a, p1->get());
         EXPECT_EQ(b, p2->get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(b, p1->get());
         EXPECT_EQ(false, static_cast<bool>(p2));
         log() << "| ";
@@ -193,7 +193,7 @@ TEST(WTF_BoxPtr, Assignment)
         BoxPtr<BoxPtrLogger> ptr = adoptInBoxPtr(a);
         EXPECT_EQ(a, ptr->get());
         IGNORE_WARNINGS_BEGIN("self-move")
-        ptr = WTFMove(ptr);
+        ptr = WTF::move(ptr);
         IGNORE_WARNINGS_END
         EXPECT_EQ(a, ptr->get());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -129,7 +129,7 @@ TEST(WTF_CheckedPtr, Basic)
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr3.get(), checkedObject.get());
 
-        ptr1 = WTFMove(ptr3);
+        ptr1 = WTF::move(ptr3);
         EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr2.get(), checkedObject.get());
@@ -183,7 +183,7 @@ TEST(WTF_CheckedPtr, CheckedRef)
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
-            CheckedPtr ptr { WTFMove(ref) };
+            CheckedPtr ptr { WTF::move(ref) };
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
             EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
@@ -199,7 +199,7 @@ TEST(WTF_CheckedPtr, CheckedRef)
             EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
-            CheckedPtr<CheckedObject> ptr { WTFMove(ref) };
+            CheckedPtr<CheckedObject> ptr { WTF::move(ref) };
             EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
             EXPECT_EQ(checkedObject->checkedPtrCount(), 1u);
@@ -271,7 +271,7 @@ TEST(WTF_CheckedPtr, DerivedClass)
         EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr3.get(), checkedObject.get());
 
-        CheckedPtr<CheckedObject> ptr4 = WTFMove(ptr3);
+        CheckedPtr<CheckedObject> ptr4 = WTF::move(ptr3);
         EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
         EXPECT_EQ(ptr2.get(), checkedObject.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
@@ -125,7 +125,7 @@ TEST(WTF_CheckedRef, Basic)
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
-        ref1 = WTFMove(ref3);
+        ref1 = WTF::move(ref3);
         EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(anotherObject->checkedPtrCount(), 0u);
         EXPECT_EQ(ref1.ptr(), checkedObject.get());
@@ -203,7 +203,7 @@ TEST(WTF_CheckedRef, DerivedClass)
         EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
-        CheckedRef<CheckedObject> ref4 = WTFMove(ref1);
+        CheckedRef<CheckedObject> ref4 = WTF::move(ref1);
         EXPECT_EQ(checkedObject->checkedPtrCount(), 2u);
         EXPECT_EQ(anotherObject->checkedPtrCount(), 1u);
         EXPECT_EQ(ref2.ptr(), checkedObject.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
@@ -103,14 +103,14 @@ TEST(WTF_CompactPtr, Basic)
 
     {
         CompactPtr<AlignedRefLogger> p1 = &a;
-        CompactPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
 
     {
         CompactPtr<AlignedRefLogger> p1 = &a;
-        CompactPtr<AlignedRefLogger> p2(WTFMove(p1));
+        CompactPtr<AlignedRefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -124,7 +124,7 @@ TEST(WTF_CompactPtr, Basic)
 
     {
         CompactPtr<DerivedAlignedRefLogger> p1 = &a;
-        CompactPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -193,7 +193,7 @@ TEST(WTF_CompactPtr, Assignment)
         CompactPtr<AlignedRefLogger> p2 = &b;
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
     }
@@ -213,7 +213,7 @@ TEST(WTF_CompactPtr, Assignment)
         CompactPtr<DerivedAlignedRefLogger> p2 = &c;
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
@@ -76,7 +76,7 @@ TEST(WTF_CompactRefPtr, Basic)
 
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactRefPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -84,7 +84,7 @@ TEST(WTF_CompactRefPtr, Basic)
 
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2(WTFMove(p1));
+        CompactRefPtr<AlignedRefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -100,7 +100,7 @@ TEST(WTF_CompactRefPtr, Basic)
 
     {
         CompactRefPtr<DerivedAlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactRefPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -134,7 +134,7 @@ TEST(WTF_CompactRefPtr, AssignPassRefToCompactRefPtr)
     DerivedAlignedRefLogger a("a");
     {
         Ref<AlignedRefLogger> passRef(a);
-        CompactRefPtr<AlignedRefLogger> ptr = WTFMove(passRef);
+        CompactRefPtr<AlignedRefLogger> ptr = WTF::move(passRef);
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -215,7 +215,7 @@ TEST(WTF_CompactRefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -261,7 +261,7 @@ TEST(WTF_CompactRefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -291,7 +291,7 @@ TEST(WTF_CompactRefPtr, Assignment)
         CompactRefPtr<AlignedRefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
         IGNORE_WARNINGS_BEGIN("self-move")
-        ptr = WTFMove(ptr);
+        ptr = WTF::move(ptr);
         IGNORE_WARNINGS_END
         EXPECT_EQ(&a, ptr.get());
     }
@@ -350,7 +350,7 @@ TEST(WTF_CompactRefPtr, Release)
 
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactRefPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -358,7 +358,7 @@ TEST(WTF_CompactRefPtr, Release)
 
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2(WTFMove(p1));
+        CompactRefPtr<AlignedRefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -366,7 +366,7 @@ TEST(WTF_CompactRefPtr, Release)
 
     {
         CompactRefPtr<DerivedAlignedRefLogger> p1 = &a;
-        CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        CompactRefPtr<AlignedRefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -378,7 +378,7 @@ TEST(WTF_CompactRefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -391,7 +391,7 @@ TEST(WTF_CompactRefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -440,7 +440,7 @@ TEST(WTF_CompactRefPtr, Const)
 {
     // This test passes if it compiles without an error.
     auto a = ConstRefCounted::create();
-    Ref<const ConstRefCounted> b = WTFMove(a);
+    Ref<const ConstRefCounted> b = WTF::move(a);
     CompactRefPtr<const ConstRefCounted> c = b.ptr();
     Ref<const ConstRefCounted> d = returnConstRefCountedRef();
     CompactRefPtr<const ConstRefCounted> e = &returnConstRefCountedRef();
@@ -535,7 +535,7 @@ TEST(WTF_CompactRefPtr, AssignBeforeDeref)
         log() << "| ";
         a.slotToCheck = &p1;
         b.slotToCheck = &p1;
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtrTuple.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtrTuple.cpp
@@ -193,7 +193,7 @@ TEST(WTF_CompactRefPtrTuple, Move)
     // Move constructor
     {
         CompactRefPtrTuple<RefLogger, uint16_t> ptr(&a, 0xffff);
-        CompactRefPtrTuple<RefLogger, uint16_t> ptr2(WTFMove(ptr));
+        CompactRefPtrTuple<RefLogger, uint16_t> ptr2(WTF::move(ptr));
 
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, ptr.pointer());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr.type(), 0x00);
@@ -206,7 +206,7 @@ TEST(WTF_CompactRefPtrTuple, Move)
 
     {
         CompactRefPtrTuple<RefLogger, uint16_t> ptr(&a, 0xffff);
-        CompactRefPtrTuple<RefLogger, uint16_t> ptr2 = WTFMove(ptr);
+        CompactRefPtrTuple<RefLogger, uint16_t> ptr2 = WTF::move(ptr);
 
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, ptr.pointer());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr.type(), 0x00);
@@ -222,7 +222,7 @@ TEST(WTF_CompactRefPtrTuple, Move)
         CompactRefPtrTuple<RefLogger, uint16_t> ptr(&a, 0xffff);
         CompactRefPtrTuple<RefLogger, uint16_t> ptr2;
 
-        ptr2 = WTFMove(ptr);
+        ptr2 = WTF::move(ptr);
 
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, ptr.pointer());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr.type(), 0x00);

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactUniquePtrTuple.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactUniquePtrTuple.cpp
@@ -121,14 +121,14 @@ TEST(WTF_CompactUniquePtrTuple, Basic)
     EXPECT_EQ(movedA.get(), oldPointer);
     EXPECT_EQ(0xf2f2U, a.type());
 
-    a.setPointer(WTFMove(movedA));
+    a.setPointer(WTF::move(movedA));
     EXPECT_EQ(4U, A::s_constructorCallCount);
     EXPECT_EQ(3U, A::s_destructorCallCount);
     EXPECT_EQ(oldPointer, a.pointer());
     EXPECT_EQ(movedA.get(), nullptr);
     EXPECT_EQ(0xf2f2U, a.type());
 
-    CompactUniquePtrTuple<A, uint16_t> b = WTFMove(a);
+    CompactUniquePtrTuple<A, uint16_t> b = WTF::move(a);
     EXPECT_EQ(4U, A::s_constructorCallCount);
     EXPECT_EQ(3U, A::s_destructorCallCount);
     EXPECT_EQ(nullptr, a.pointer());
@@ -138,7 +138,7 @@ TEST(WTF_CompactUniquePtrTuple, Basic)
 
     CompactUniquePtrTuple<A, uint16_t>* bPtr = &b;
 
-    b = WTFMove(*bPtr);
+    b = WTF::move(*bPtr);
     EXPECT_EQ(4U, A::s_constructorCallCount);
     EXPECT_EQ(3U, A::s_destructorCallCount);
     EXPECT_EQ(nullptr, a.pointer());

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
@@ -135,7 +135,7 @@ TEST(WTF_CompactVariant, SmartPointers)
         RefLogger testRefLogger("testRefLogger");
         Ref<RefLogger> ref(testRefLogger);
 
-        CompactVariant<Ref<RefLogger>, std::unique_ptr<double>> variant { WTF::InPlaceType<Ref<RefLogger>>, WTFMove(ref) };
+        CompactVariant<Ref<RefLogger>, std::unique_ptr<double>> variant { WTF::InPlaceType<Ref<RefLogger>>, WTF::move(ref) };
 
         EXPECT_TRUE(WTF::holdsAlternative<Ref<RefLogger>>(variant));
         EXPECT_FALSE(WTF::holdsAlternative<std::unique_ptr<double>>(variant));
@@ -265,7 +265,7 @@ TEST(WTF_CompactVariant, TooBigStruct)
     );
 
     variant = TooBigStruct { 5.0 };
-    CompactVariant<int*, float*, TooBigStruct> movedToVariant = WTFMove(variant);
+    CompactVariant<int*, float*, TooBigStruct> movedToVariant = WTF::move(variant);
 
     EXPECT_TRUE(variant.valueless_by_move());
 
@@ -344,7 +344,7 @@ TEST(WTF_CompactVariant, ValuelessByMove)
     CompactVariant<int*, float*> variant = &testInt;
     EXPECT_FALSE(variant.valueless_by_move());
 
-    CompactVariant<int*, float*> other = WTFMove(variant);
+    CompactVariant<int*, float*> other = WTF::move(variant);
     EXPECT_FALSE(other.valueless_by_move());
     EXPECT_TRUE(variant.valueless_by_move());
 
@@ -354,7 +354,7 @@ TEST(WTF_CompactVariant, ValuelessByMove)
     EXPECT_TRUE(copy.valueless_by_move());
 
     // Test re-moving the "valueless_by_move" variant.
-    CompactVariant<int*, float*> moved = WTFMove(variant);
+    CompactVariant<int*, float*> moved = WTF::move(variant);
     EXPECT_TRUE(variant.valueless_by_move());
     EXPECT_TRUE(moved.valueless_by_move());
 }
@@ -404,7 +404,7 @@ TEST(WTF_CompactVariant, ArgumentMoveConstruct)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        CompactVariant<float, LifecycleLogger> variant { WTFMove(lifecycleLogger) };
+        CompactVariant<float, LifecycleLogger> variant { WTF::move(lifecycleLogger) };
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -426,7 +426,7 @@ TEST(WTF_CompactVariant, ArgumentMoveAssignment)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        CompactVariant<float, LifecycleLogger> variant = WTFMove(lifecycleLogger);
+        CompactVariant<float, LifecycleLogger> variant = WTF::move(lifecycleLogger);
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -473,7 +473,7 @@ TEST(WTF_CompactVariant, MoveConstruct)
     {
         CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
-        CompactVariant<float, LifecycleLogger> other { WTFMove(variant) };
+        CompactVariant<float, LifecycleLogger> other { WTF::move(variant) };
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -485,7 +485,7 @@ TEST(WTF_CompactVariant, MoveAssignment)
     {
         CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
-        CompactVariant<float, LifecycleLogger> other = WTFMove(variant);
+        CompactVariant<float, LifecycleLogger> other = WTF::move(variant);
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -535,7 +535,7 @@ TEST(WTF_CompactVariant, ArgumentMoveReassignment)
         CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         LifecycleLogger lifecycleLogger { "compact" };
-        variant = WTFMove(lifecycleLogger);
+        variant = WTF::move(lifecycleLogger);
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
@@ -112,7 +112,7 @@ TEST_F(CompletionHandlerTest, CalledHandlerCanBeDestroyedOffThread)
 
     bool didDestroy = false;
     Thread::create("CalledHandlerCanBeDestroyedOffThread"_s, [&] {
-        auto ch = WTFMove(ch3);
+        auto ch = WTF::move(ch3);
         didDestroy = true;
     })->waitForCompletion();
     EXPECT_TRUE(didDestroy);

--- a/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
@@ -46,7 +46,7 @@ TEST(WTF_CrossThreadCopier, CopyLVString)
 TEST(WTF_CrossThreadCopier, MoveRVString)
 {
     String original { "1234"_s };
-    auto copy = crossThreadCopy(WTFMove(original));
+    auto copy = crossThreadCopy(WTF::move(original));
     EXPECT_TRUE(copy.impl()->hasOneRef());
     EXPECT_NULL(original.impl());
 }
@@ -55,7 +55,7 @@ TEST(WTF_CrossThreadCopier, CopyRVStringHavingTwoRef)
 {
     String original { "1234"_s };
     String original2 { original };
-    auto copy = crossThreadCopy(WTFMove(original));
+    auto copy = crossThreadCopy(WTF::move(original));
     EXPECT_EQ(original.impl()->refCount(), 2u);
     EXPECT_FALSE(original.impl() == copy.impl());
     EXPECT_TRUE(copy.impl()->hasOneRef());
@@ -73,7 +73,7 @@ TEST(WTF_CrossThreadCopier, CopyLVOptionalString)
 TEST(WTF_CrossThreadCopier, MoveRVOptionalString)
 {
     std::optional<String> original { "1234"_s };
-    auto copy = crossThreadCopy(WTFMove(original));
+    auto copy = crossThreadCopy(WTF::move(original));
     EXPECT_TRUE(copy->impl()->hasOneRef());
     EXPECT_NULL(original->impl());
 }
@@ -101,7 +101,7 @@ TEST(WTF_CrossThreadCopier, Pair)
     std::pair pair2 { "foo"_str, "bar"_str };
     firstStringImpl = pair2.first.impl();
     secondStringImpl = pair2.second.impl();
-    copy = crossThreadCopy(WTFMove(pair2));
+    copy = crossThreadCopy(WTF::move(pair2));
     EXPECT_EQ(copy, pair1);
     EXPECT_EQ(copy.first.impl(), firstStringImpl);
     EXPECT_EQ(copy.second.impl(), secondStringImpl);
@@ -126,13 +126,13 @@ TEST(WTF_CrossThreadCopier, Variant)
 
     variant = "foo"_str;
     impl = std::get<String>(variant).impl();
-    copy = crossThreadCopy(WTFMove(variant));
+    copy = crossThreadCopy(WTF::move(variant));
     ASSERT_EQ(std::get<String>(copy), "foo"_str);
     EXPECT_EQ(std::get<String>(copy).impl(), impl);
 
     variant = URL { "bar"_str };
     impl = std::get<URL>(variant).string().impl();
-    copy = crossThreadCopy(WTFMove(variant));
+    copy = crossThreadCopy(WTF::move(variant));
     ASSERT_EQ(std::get<URL>(copy), URL { "bar"_str });
     EXPECT_EQ(std::get<URL>(copy).string().impl(), impl);
 }
@@ -156,7 +156,7 @@ TEST(WTF_CrossThreadCopier, UncheckedKeyHashMap)
         EXPECT_NE(value.impl(), impls.get(value.utf8()));
     }
 
-    auto copy2 = crossThreadCopy(WTFMove(map));
+    auto copy2 = crossThreadCopy(WTF::move(map));
     EXPECT_EQ(copy2, copy);
     EXPECT_TRUE(map.isEmpty());
     for (auto& [key, value] : copy2) {
@@ -184,7 +184,7 @@ TEST(WTF_CrossThreadCopier, HashMap)
         EXPECT_NE(value.impl(), impls.get(value.utf8()));
     }
 
-    auto copy2 = crossThreadCopy(WTFMove(map));
+    auto copy2 = crossThreadCopy(WTF::move(map));
     EXPECT_EQ(copy2, copy);
     EXPECT_TRUE(map.isEmpty());
     for (auto& [key, value] : copy2) {
@@ -208,7 +208,7 @@ TEST(WTF_CrossThreadCopier, HashSet)
     for (auto& item : copy)
         EXPECT_NE(item.impl(), impls.get(item.utf8()));
 
-    auto copy2 = crossThreadCopy(WTFMove(set));
+    auto copy2 = crossThreadCopy(WTF::move(set));
     EXPECT_EQ(copy2, copy);
     EXPECT_TRUE(set.isEmpty());
     for (auto& item : copy2)
@@ -225,7 +225,7 @@ TEST(WTF_CrossThreadCopier, Optional)
     EXPECT_EQ(copy, optional);
     EXPECT_NE(copy->impl(), impl);
 
-    auto copy2 = crossThreadCopy(WTFMove(optional));
+    auto copy2 = crossThreadCopy(WTF::move(optional));
     EXPECT_EQ(copy2, copy);
     EXPECT_EQ(copy2->impl(), impl);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
@@ -153,7 +153,7 @@ TEST(WTF_Deque, MoveConstructor)
 
     EXPECT_EQ(10u, deque.size());
 
-    Deque<MoveOnly, 4> deque2 = WTFMove(deque);
+    Deque<MoveOnly, 4> deque2 = WTF::move(deque);
 
     EXPECT_EQ(10u, deque2.size());
 
@@ -177,7 +177,7 @@ TEST(WTF_Deque, MoveAssignmentOperator)
     for (unsigned i = 0; i < 10; ++i)
         deque2.append(MoveOnly(i * 2));
 
-    deque1 = WTFMove(deque2);
+    deque1 = WTF::move(deque2);
 
     EXPECT_EQ(10u, deque2.size());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/EmbeddedFixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EmbeddedFixedVector.cpp
@@ -112,7 +112,7 @@ TEST(WTF_EmbeddedFixedVector, MoveVector)
 {
     auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
     EXPECT_EQ(4U, vec1.size());
-    auto vec2 = EmbeddedFixedVector<MoveOnly>::createFromVector(WTFMove(vec1));
+    auto vec2 = EmbeddedFixedVector<MoveOnly>::createFromVector(WTF::move(vec1));
     EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(4U, vec2->size());
     for (unsigned index = 0; index < vec2->size(); ++index)

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
@@ -110,7 +110,7 @@ TEST(WTF_EnumeratedArray, Construction)
     EnumeratedArray<Foo, int, Foo::Three> array2(array1);
     EXPECT_EQ(array2.front(), 3);
     EXPECT_EQ(array2.back(), 17);
-    EnumeratedArray<Foo, int, Foo::Three> array3(WTFMove(array1));
+    EnumeratedArray<Foo, int, Foo::Three> array3(WTF::move(array1));
     EXPECT_EQ(array3.front(), 3);
     EXPECT_EQ(array3.back(), 17);
     EnumeratedArray<Foo, int, Foo::Three> array4;
@@ -118,7 +118,7 @@ TEST(WTF_EnumeratedArray, Construction)
     EXPECT_EQ(array4.front(), 3);
     EXPECT_EQ(array4.back(), 17);
     EnumeratedArray<Foo, int, Foo::Three> array5;
-    array5 = WTFMove(array2);
+    array5 = WTF::move(array2);
     EXPECT_EQ(array5.front(), 3);
     EXPECT_EQ(array5.back(), 17);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
@@ -440,7 +440,7 @@ TEST(WTF_Expected, unique_ptr)
 
     {
         auto s = makeUnexpected(makeUnique<snowflake>());
-        Unexpected<std::unique_ptr<snowflake>> c(WTFMove(s));
+        Unexpected<std::unique_ptr<snowflake>> c(WTF::move(s));
         EXPECT_EQ(snowflakes, 1);
         EXPECT_EQ(melted, 0);
     }
@@ -451,7 +451,7 @@ TEST(WTF_Expected, unique_ptr)
     auto plow = [] (std::unique_ptr<snowflake>&& s)
     {
         {
-            std::unique_ptr<snowflake> moved = WTFMove(s);
+            std::unique_ptr<snowflake> moved = WTF::move(s);
             EXPECT_EQ(snowflakes, 1);
             EXPECT_EQ(melted, 0);
         }
@@ -461,7 +461,7 @@ TEST(WTF_Expected, unique_ptr)
 
     {
         Expected<std::unique_ptr<snowflake>, int> s(makeUnique<snowflake>());
-        plow(WTFMove(s).value());
+        plow(WTF::move(s).value());
     }
     EXPECT_EQ(snowflakes, 1);
     EXPECT_EQ(melted, 1);
@@ -469,7 +469,7 @@ TEST(WTF_Expected, unique_ptr)
 
     {
         Expected<int, std::unique_ptr<snowflake>> s(makeUnexpected(makeUnique<snowflake>()));
-        plow(WTFMove(s).error());
+        plow(WTF::move(s).error());
     }
     EXPECT_EQ(snowflakes, 1);
     EXPECT_EQ(melted, 1);
@@ -477,7 +477,7 @@ TEST(WTF_Expected, unique_ptr)
 
     {
         Expected<void, std::unique_ptr<snowflake>> s(makeUnexpected(makeUnique<snowflake>()));
-        plow(WTFMove(s).error());
+        plow(WTF::move(s).error());
     }
     EXPECT_EQ(snowflakes, 1);
     EXPECT_EQ(melted, 1);
@@ -526,7 +526,7 @@ TEST(WTF_Expected, Ref)
 class NeedsStdAddress {
 public:
     NeedsStdAddress(NeedsStdAddress&& other)
-        : m_ptr(WTFMove(other.m_ptr)) { }
+        : m_ptr(WTF::move(other.m_ptr)) { }
     NeedsStdAddress(int& other)
         : m_ptr(&other) { }
     int* operator&() { ASSERT_NOT_REACHED(); return nullptr; }
@@ -537,8 +537,8 @@ private:
 TEST(WTF_Expected, Address)
 {
     NeedsStdAddress a(*new int(3));
-    Expected<NeedsStdAddress, float> b(WTFMove(a));
-    Expected<NeedsStdAddress, float> c(WTFMove(b));
+    Expected<NeedsStdAddress, float> b(WTF::move(a));
+    Expected<NeedsStdAddress, float> c(WTF::move(b));
     (void)c;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -57,7 +57,7 @@ public:
         // create temp file.
         auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
         m_tempFilePath = result.first;
-        auto handle = WTFMove(result.second);
+        auto handle = WTF::move(result.second);
         handle.write(byteCast<uint8_t>(FileSystemTestData.span()));
         handle = { };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -178,7 +178,7 @@ TEST(WTF_FixedVector, Move)
     vec1[1] = 1;
     vec1[2] = 2;
 
-    FixedVector<unsigned> vec2(WTFMove(vec1));
+    FixedVector<unsigned> vec2(WTF::move(vec1));
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(3U, vec2.size());
     for (unsigned i = 0; i < vec2.size(); ++i)
@@ -193,7 +193,7 @@ TEST(WTF_FixedVector, MoveAssign)
     vec1[2] = 2;
 
     FixedVector<unsigned> vec2;
-    vec2 = WTFMove(vec1);
+    vec2 = WTF::move(vec1);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(3U, vec2.size());
     for (unsigned i = 0; i < vec2.size(); ++i)
@@ -204,7 +204,7 @@ TEST(WTF_FixedVector, MoveVector)
 {
     auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
     EXPECT_EQ(4U, vec1.size());
-    FixedVector<MoveOnly> vec2(WTFMove(vec1));
+    FixedVector<MoveOnly> vec2(WTF::move(vec1));
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(4U, vec2.size());
     for (unsigned index = 0; index < vec2.size(); ++index)
@@ -217,7 +217,7 @@ TEST(WTF_FixedVector, MoveAssignVector)
     {
         auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
         EXPECT_EQ(4U, vec1.size());
-        vec2 = WTFMove(vec1);
+        vec2 = WTF::move(vec1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(0U, vec1.size());
     }
     EXPECT_EQ(4U, vec2.size());
@@ -359,7 +359,7 @@ TEST(WTF_FixedVector, DestructorAfterMove)
                 vector[i] = DestructorObserver(&flags[i]);
             for (unsigned i = 0; i < flags.size(); ++i)
                 EXPECT_FALSE(flags[i]);
-            outerVector = WTFMove(vector);
+            outerVector = WTF::move(vector);
         }
         for (unsigned i = 0; i < flags.size(); ++i)
             EXPECT_FALSE(flags[i]);
@@ -373,14 +373,14 @@ TEST(WTF_FixedVector, MoveKeepsData)
     {
         FixedVector<unsigned> vec1(3);
         auto* data1 = vec1.span().data();
-        FixedVector<unsigned> vec2(WTFMove(vec1));
+        FixedVector<unsigned> vec2(WTF::move(vec1));
         EXPECT_EQ(data1, vec2.span().data());
     }
     {
         FixedVector<unsigned> vec1(3);
         auto* data1 = vec1.span().data();
         FixedVector<unsigned> vec2;
-        vec2 = WTFMove(vec1);
+        vec2 = WTF::move(vec1);
         EXPECT_EQ(data1, vec2.span().data());
     }
 }
@@ -391,7 +391,7 @@ TEST(WTF_FixedVector, MoveKeepsDataNested)
         Vector<FixedVector<unsigned>> vec1;
         vec1.append(FixedVector<unsigned>(3));
         auto* data1 = vec1[0].span().data();
-        FixedVector<FixedVector<unsigned>> vec2(WTFMove(vec1));
+        FixedVector<FixedVector<unsigned>> vec2(WTF::move(vec1));
         EXPECT_EQ(1U, vec2.size());
         EXPECT_EQ(data1, vec2[0].span().data());
     }
@@ -400,7 +400,7 @@ TEST(WTF_FixedVector, MoveKeepsDataNested)
         vec1.append(FixedVector<unsigned>(3));
         auto* data1 = vec1[0].span().data();
         FixedVector<FixedVector<unsigned>> vec2;
-        vec2 = WTFMove(vec1);
+        vec2 = WTF::move(vec1);
         EXPECT_EQ(1U, vec2.size());
         EXPECT_EQ(data1, vec2[0].span().data());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/Function.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Function.cpp
@@ -156,18 +156,18 @@ TEST(WTF_Function, Basics)
     EXPECT_TRUE(static_cast<bool>(a));
     EXPECT_EQ(2U, a());
 
-    Function<unsigned()> b = WTFMove(a);
+    Function<unsigned()> b = WTF::move(a);
     EXPECT_TRUE(static_cast<bool>(b));
     EXPECT_EQ(2U, b());
     EXPECT_FALSE(static_cast<bool>(a));
 
     a = MoveOnly { 3 };
-    Function<unsigned()> c = WTFMove(a);
+    Function<unsigned()> c = WTF::move(a);
     EXPECT_TRUE(static_cast<bool>(c));
     EXPECT_EQ(3U, c());
     EXPECT_FALSE(static_cast<bool>(a));
 
-    b = WTFMove(c);
+    b = WTF::move(c);
     EXPECT_TRUE(static_cast<bool>(b));
     EXPECT_EQ(3U, b());
     EXPECT_FALSE(static_cast<bool>(c));

--- a/Tools/TestWebKitAPI/Tests/WTF/HashCountedSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashCountedSet.cpp
@@ -150,7 +150,7 @@ TEST(WTF_HashCountedSet, MoveOnlyKeys)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyKeys.add(WTFMove(moveOnly));
+        moveOnlyKeys.add(WTF::move(moveOnly));
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -177,7 +177,7 @@ TEST(WTF_HashCountedSet, MoveOnlyKeysInitialCount)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyKeys.add(WTFMove(moveOnly), i + 1);
+        moveOnlyKeys.add(WTF::move(moveOnly), i + 1);
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -243,7 +243,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey)
     HashCountedSet<std::unique_ptr<ConstructorDestructorCounter>> hashCountedSet;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -261,7 +261,7 @@ TEST(WTF_HashCountedSet, UniquePtrKeyInitialCount)
     HashCountedSet<std::unique_ptr<ConstructorDestructorCounter>> hashCountedSet;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    hashCountedSet.add(WTFMove(uniquePtr), 12);
+    hashCountedSet.add(WTF::move(uniquePtr), 12);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -280,7 +280,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey_CustomDeleter)
     HashCountedSet<std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>>> hashCountedSet;
 
     std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>> uniquePtr(new ConstructorDestructorCounter(), DeleterCounter<ConstructorDestructorCounter>());
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -301,7 +301,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     auto it = hashCountedSet.find(ptr);
     ASSERT_TRUE(it != hashCountedSet.end());
@@ -315,7 +315,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(true, hashCountedSet.contains(ptr));
 }
@@ -326,7 +326,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey_GetUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     int value = hashCountedSet.count(ptr);
     EXPECT_EQ(1, value);
@@ -340,7 +340,7 @@ TEST(WTF_HashCountedSet, UniquePtrKey_RemoveUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    hashCountedSet.add(WTFMove(uniquePtr));
+    hashCountedSet.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -378,7 +378,7 @@ TEST(WTF_HashCountedSet, RefPtrKey_AddUsingRelease)
         HashCountedSet<RefPtr<RefLogger>> hashCountedSet;
 
         RefPtr<RefLogger> ptr(&a);
-        hashCountedSet.add(WTFMove(ptr));
+        hashCountedSet.add(WTF::move(ptr));
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -392,7 +392,7 @@ TEST(WTF_HashCountedSet, RefPtrKey_AddUsingMove)
         HashCountedSet<RefPtr<RefLogger>> hashCountedSet;
 
         RefPtr<RefLogger> ptr(&a);
-        hashCountedSet.add(WTFMove(ptr));
+        hashCountedSet.add(WTF::move(ptr));
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -458,7 +458,7 @@ TEST(WTF_HashCountedSet, RefPtrKey_AddUsingReleaseKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = hashCountedSet.add(WTFMove(ptr2));
+            auto addResult = hashCountedSet.add(WTF::move(ptr2));
             EXPECT_FALSE(addResult.isNewEntry);
         }
 
@@ -484,7 +484,7 @@ TEST(WTF_HashCountedSet, RefPtrKey_AddUsingMoveKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = hashCountedSet.add(WTFMove(ptr2));
+            auto addResult = hashCountedSet.add(WTF::move(ptr2));
             EXPECT_FALSE(addResult.isNewEntry);
         }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -126,7 +126,7 @@ TEST(WTF_HashMap, MoveOnlyValues)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyValues.set(i + 1, WTFMove(moveOnly));
+        moveOnlyValues.set(i + 1, WTF::move(moveOnly));
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -149,7 +149,7 @@ TEST(WTF_HashMap, MoveOnlyKeys)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyKeys.set(WTFMove(moveOnly), i + 1);
+        moveOnlyKeys.set(WTF::move(moveOnly), i + 1);
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -213,7 +213,7 @@ TEST(WTF_HashMap, UniquePtrKey)
     HashMap<std::unique_ptr<ConstructorDestructorCounter>, int> map;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -232,7 +232,7 @@ TEST(WTF_HashMap, UniquePtrKey_CustomDeleter)
     HashMap<std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>>, int> map;
 
     std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>> uniquePtr(new ConstructorDestructorCounter(), DeleterCounter<ConstructorDestructorCounter>());
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -253,7 +253,7 @@ TEST(WTF_HashMap, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     auto it = map.find(ptr);
     ASSERT_TRUE(it != map.end());
@@ -267,7 +267,7 @@ TEST(WTF_HashMap, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(true, map.contains(ptr));
 }
@@ -278,7 +278,7 @@ TEST(WTF_HashMap, UniquePtrKey_GetUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     int value = map.get(ptr);
     EXPECT_EQ(2, value);
@@ -292,7 +292,7 @@ TEST(WTF_HashMap, UniquePtrKey_RemoveUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -312,7 +312,7 @@ TEST(WTF_HashMap, UniquePtrKey_TakeUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -328,7 +328,7 @@ TEST(WTF_HashMap, UniqueRefValue)
 {
     HashMap<int, UniqueRef<int>> map;
     UniqueRef<int> five = makeUniqueRefWithoutFastMallocCheck<int>(5);
-    map.add(5, WTFMove(five));
+    map.add(5, WTF::move(five));
     EXPECT_TRUE(map.contains(5));
     int* shouldBeFive = map.get(5);
     EXPECT_EQ(*shouldBeFive, 5);
@@ -365,7 +365,7 @@ TEST(WTF_HashMap, RefPtrKey_AddUsingRelease)
         HashMap<RefPtr<RefLogger>, int> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.add(WTFMove(ptr), 0);
+        map.add(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -379,7 +379,7 @@ TEST(WTF_HashMap, RefPtrKey_AddUsingMove)
         HashMap<RefPtr<RefLogger>, int> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.add(WTFMove(ptr), 0);
+        map.add(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -440,7 +440,7 @@ TEST(WTF_HashMap, RefPtrKey_AddUsingReleaseKeyAlreadyPresent)
 
     {
         RefPtr<RefLogger> ptr2(&a);
-        auto addResult = map.add(WTFMove(ptr2), 0);
+        auto addResult = map.add(WTF::move(ptr2), 0);
         EXPECT_FALSE(addResult.isNewEntry);
     }
 
@@ -466,7 +466,7 @@ TEST(WTF_HashMap, RefPtrKey_AddUsingMoveKeyAlreadyPresent)
 
     {
         RefPtr<RefLogger> ptr2(&a);
-        auto addResult = map.add(WTFMove(ptr2), 0);
+        auto addResult = map.add(WTF::move(ptr2), 0);
         EXPECT_FALSE(addResult.isNewEntry);
     }
 
@@ -499,7 +499,7 @@ TEST(WTF_HashMap, RefPtrKey_SetUsingRelease)
         HashMap<RefPtr<RefLogger>, int> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.set(WTFMove(ptr), 0);
+        map.set(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -514,7 +514,7 @@ TEST(WTF_HashMap, RefPtrKey_SetUsingMove)
         HashMap<RefPtr<RefLogger>, int> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.set(WTFMove(ptr), 0);
+        map.set(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -573,7 +573,7 @@ TEST(WTF_HashMap, RefPtrKey_SetUsingReleaseKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = map.set(WTFMove(ptr2), 1);
+            auto addResult = map.set(WTF::move(ptr2), 1);
             EXPECT_FALSE(addResult.isNewEntry);
             EXPECT_EQ(1, map.get(ptr.get()));
         }
@@ -598,7 +598,7 @@ TEST(WTF_HashMap, RefPtrKey_SetUsingMoveKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = map.set(WTFMove(ptr2), 1);
+            auto addResult = map.set(WTF::move(ptr2), 1);
             EXPECT_FALSE(addResult.isNewEntry);
             EXPECT_EQ(1, map.get(ptr.get()));
         }
@@ -677,7 +677,7 @@ class ObjectWithRefLogger {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ObjectWithRefLogger);
 public:
     ObjectWithRefLogger(Ref<RefLogger>&& logger)
-        : m_logger(WTFMove(logger))
+        : m_logger(WTF::move(logger))
     {
     }
 
@@ -689,7 +689,7 @@ static void testMovingUsingEnsure(Ref<RefLogger>&& logger)
 {
     HashMap<unsigned, std::unique_ptr<ObjectWithRefLogger>> map;
     
-    map.ensure(1, [&] { return makeUnique<ObjectWithRefLogger>(WTFMove(logger)); });
+    map.ensure(1, [&] { return makeUnique<ObjectWithRefLogger>(WTF::move(logger)); });
 }
 
 static void testMovingUsingAdd(Ref<RefLogger>&& logger)
@@ -697,7 +697,7 @@ static void testMovingUsingAdd(Ref<RefLogger>&& logger)
     HashMap<unsigned, std::unique_ptr<ObjectWithRefLogger>> map;
 
     auto& slot = map.add(1, nullptr).iterator->value;
-    slot = makeUnique<ObjectWithRefLogger>(WTFMove(logger));
+    slot = makeUnique<ObjectWithRefLogger>(WTF::move(logger));
 }
 
 TEST(WTF_HashMap, Ensure_LambdasCapturingByReference)
@@ -705,7 +705,7 @@ TEST(WTF_HashMap, Ensure_LambdasCapturingByReference)
     {
         DerivedRefLogger a("a");
         Ref<RefLogger> ref(a);
-        testMovingUsingEnsure(WTFMove(ref));
+        testMovingUsingEnsure(WTF::move(ref));
 
         EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
     }
@@ -713,7 +713,7 @@ TEST(WTF_HashMap, Ensure_LambdasCapturingByReference)
     {
         DerivedRefLogger a("a");
         Ref<RefLogger> ref(a);
-        testMovingUsingAdd(WTFMove(ref));
+        testMovingUsingAdd(WTF::move(ref));
 
         EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
     }
@@ -812,7 +812,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -823,7 +823,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.set(WTFMove(ref), 1);
+        map.set(WTF::move(ref), 1);
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -834,10 +834,10 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> refA(a);
-        map.add(WTFMove(refA), 1);
+        map.add(WTF::move(refA), 1);
 
         Ref<RefLogger> refA2(a);
-        map.set(WTFMove(refA2), 1);
+        map.set(WTF::move(refA2), 1);
     }
 
     ASSERT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());
@@ -848,7 +848,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.ensure(WTFMove(ref), []() { 
+        map.ensure(WTF::move(ref), []() { 
             return 1; 
         });
     }
@@ -861,7 +861,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
         
         auto it = map.find(&a);
         ASSERT_TRUE(it != map.end());
@@ -878,7 +878,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
 
         map.remove(&a);
     }
@@ -891,7 +891,7 @@ TEST(WTF_HashMap, Ref_Key)
         HashMap<Ref<RefLogger>, int> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
 
         int i = map.take(&a);
         ASSERT_EQ(i, 1);
@@ -905,7 +905,7 @@ TEST(WTF_HashMap, Ref_Key)
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
             auto* pointer = ref.ptr();
-            map.add(WTFMove(ref), i + 1);
+            map.add(WTF::move(ref), i + 1);
             ASSERT_TRUE(map.contains(pointer));
         }
     }
@@ -921,7 +921,7 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -932,7 +932,7 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> ref(a);
-        map.set(1, WTFMove(ref));
+        map.set(1, WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -944,10 +944,10 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> refA(a);
-        map.add(1, WTFMove(refA));
+        map.add(1, WTF::move(refA));
 
         Ref<RefLogger> refB(b);
-        map.set(1, WTFMove(refB));
+        map.set(1, WTF::move(refB));
     }
 
     ASSERT_STREQ("ref(a) ref(b) deref(a) deref(b) ", takeLogStr().c_str());
@@ -958,7 +958,7 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
         
         auto aGet = map.get(1);
         ASSERT_EQ(aGet, &a);
@@ -979,7 +979,7 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
         
         auto aOut = map.take(1);
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -1001,7 +1001,7 @@ TEST(WTF_HashMap, Ref_Value)
         HashMap<int, Ref<RefLogger>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
         map.remove(1);
     }
 
@@ -1025,7 +1025,7 @@ TEST(WTF_HashMap, Ref_Value)
         for (int i = 0; i < 64; ++i) {
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
-            map.add(i + 1, WTFMove(ref));
+            map.add(i + 1, WTF::move(ref));
             ASSERT_TRUE(map.contains(i + 1));
         }
     }
@@ -1073,7 +1073,7 @@ TEST(WTF_HashMap, RefMappedToNonZeroEmptyValue)
     for (int32_t i = 0; i < 160; ++i) {
         Ref<Key> key = Key::create();
         map.add(Ref<Key>(key.get()), Value { i });
-        vectorMap.append({ WTFMove(key), i });
+        vectorMap.append({ WTF::move(key), i });
     }
 
     for (auto& pair : vectorMap)
@@ -1204,7 +1204,7 @@ class TestObjectWithCustomDestructor {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(TestObjectWithCustomDestructor);
 public:
     TestObjectWithCustomDestructor(Function<void()>&& runInDestructor)
-        : m_runInDestructor(WTFMove(runInDestructor))
+        : m_runInDestructor(WTF::move(runInDestructor))
     { }
 
     ~TestObjectWithCustomDestructor()
@@ -1397,7 +1397,7 @@ TEST(WTF_HashMap, fromRangeConstructorMoveOnlyValues)
     stdVec.append({ 1, MoveOnly { 42 } });
     stdVec.append({ 2, MoveOnly { 99 } });
 
-    HashMap<int, MoveOnly> wtfMap(fromRange, WTFMove(stdVec));
+    HashMap<int, MoveOnly> wtfMap(fromRange, WTF::move(stdVec));
 
     EXPECT_EQ(2U, wtfMap.size());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -108,7 +108,7 @@ TEST(WTF_HashSet, MoveOnly)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        hashSet.add(WTFMove(moveOnly));
+        hashSet.add(WTF::move(moveOnly));
     }
 
     for (size_t i = 0; i < 100; ++i)
@@ -149,7 +149,7 @@ TEST(WTF_HashSet, UniquePtrKey)
     HashSet<std::unique_ptr<ConstructorDestructorCounter>> set;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -166,7 +166,7 @@ TEST(WTF_HashSet, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     auto it = set.find(ptr);
     ASSERT_TRUE(it != set.end());
@@ -180,7 +180,7 @@ TEST(WTF_HashSet, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(true, set.contains(ptr));
 }
@@ -196,7 +196,7 @@ TEST(WTF_HashSet, UniquePtrKey_RemoveUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -216,7 +216,7 @@ TEST(WTF_HashSet, UniquePtrKey_TakeUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -362,7 +362,7 @@ TEST(WTF_HashSet, UniquePtrNotZeroedBeforeDestructor)
     const DestructorObserver* observerAddress = observer.get();
 
     HashSet<std::unique_ptr<DestructorObserver>> set;
-    auto addResult = set.add(WTFMove(observer));
+    auto addResult = set.add(WTF::move(observer));
 
     EXPECT_TRUE(addResult.isNewEntry);
     EXPECT_TRUE(observedBucket == nullptr);
@@ -383,7 +383,7 @@ TEST(WTF_HashSet, Ref)
         HashSet<Ref<RefLogger>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -405,7 +405,7 @@ TEST(WTF_HashSet, Ref)
         HashSet<Ref<RefLogger>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
         set.remove(&a);
     }
 
@@ -417,7 +417,7 @@ TEST(WTF_HashSet, Ref)
         HashSet<Ref<RefLogger>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
 
         auto aOut = set.take(&a);
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -432,7 +432,7 @@ TEST(WTF_HashSet, Ref)
         HashSet<Ref<RefLogger>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
 
         auto aOut = set.takeAny();
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -453,7 +453,7 @@ TEST(WTF_HashSet, Ref)
         HashSet<Ref<RefLogger>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
         
         ASSERT_TRUE(set.contains(&a));
     }
@@ -466,7 +466,7 @@ TEST(WTF_HashSet, Ref)
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
             auto* pointer = ref.ptr();
-            set.add(WTFMove(ref));
+            set.add(WTF::move(ref));
             ASSERT_TRUE(set.contains(pointer));
         }
     }
@@ -477,7 +477,7 @@ TEST(WTF_HashSet, Ref)
 
         HashSet<Ref<RefLogger>> set;
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
         HashSet<Ref<RefLogger>> set2(set);
     }
     ASSERT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -437,7 +437,7 @@ TEST(JSONValue, ToJSONString)
         subArray->pushString("string"_s);
         subArray->pushObject(JSON::Object::create());
         EXPECT_EQ(subArray->toJSONString(), "[\"string\",{}]"_s);
-        array->pushArray(WTFMove(subArray));
+        array->pushArray(WTF::move(subArray));
         EXPECT_EQ(array->toJSONString(), "[null,true,false,1,1.5,\"webkit\",[\"string\",{}]]"_s);
     }
 
@@ -457,7 +457,7 @@ TEST(JSONValue, ToJSONString)
         Ref<JSON::Object> subObject = JSON::Object::create();
         subObject->setString("foo"_s, "bar"_s);
         subObject->setInteger("baz"_s, 25);
-        object->setObject("object"_s, WTFMove(subObject));
+        object->setObject("object"_s, WTF::move(subObject));
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true,\"double\":1.5,\"string\":\"webkit\",\"array\":[],\"object\":{\"foo\":\"bar\",\"baz\":25}}"_s);
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/LifecycleLogger.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/LifecycleLogger.cpp
@@ -90,10 +90,10 @@ TEST(LifecycleLogger, Basic)
     { LifecycleLogger l("c"); LifecycleLogger l2; l2 = l; }
     ASSERT_STREQ("construct(c) construct(<default>) copy-assign(c) destruct(c) destruct(c) ", takeLogStr().c_str());
 
-    { LifecycleLogger l("d"); LifecycleLogger l2(WTFMove(l)); }
+    { LifecycleLogger l("d"); LifecycleLogger l2(WTF::move(l)); }
     ASSERT_STREQ("construct(d) move-construct(d) destruct(d) destruct(<default>) ", takeLogStr().c_str());
 
-    { LifecycleLogger l("e"); LifecycleLogger l2; l2 = WTFMove(l); }
+    { LifecycleLogger l("e"); LifecycleLogger l2; l2 = WTF::move(l); }
     ASSERT_STREQ("construct(e) construct(<default>) move-assign(e) destruct(e) destruct(<default>) ", takeLogStr().c_str());
 
     { LifecycleLogger l("f"); l.setName("x"); }

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -344,7 +344,7 @@ TEST(WTF_ListHashSet, MoveConstructor)
     ASSERT_EQ(3, *iterator);
     ++iterator;
 
-    ListHashSet<int> list2(WTFMove(list));
+    ListHashSet<int> list2(WTF::move(list));
     ASSERT_EQ(3U, list2.size());
     auto iterator2 = list2.begin();
     ASSERT_EQ(1, *iterator2);
@@ -386,7 +386,7 @@ TEST(WTF_ListHashSet, MoveAssignment)
 
     ListHashSet<int> list2;
     list2.add(10);
-    list2 = (WTFMove(list));
+    list2 = (WTF::move(list));
     ASSERT_EQ(3U, list2.size());
     auto iterator2 = list2.begin();
     ASSERT_EQ(1, *iterator2);
@@ -442,7 +442,7 @@ TEST(WTF_ListHashSet, UniquePtrKey)
     ListHashSet<std::unique_ptr<ConstructorDestructorCounter>> list;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    list.add(WTFMove(uniquePtr));
+    list.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -459,7 +459,7 @@ TEST(WTF_ListHashSet, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     auto ptr = uniquePtr.get();
-    list.add(WTFMove(uniquePtr));
+    list.add(WTF::move(uniquePtr));
 
     auto it = list.find(ptr);
     ASSERT_TRUE(it != list.end());
@@ -473,7 +473,7 @@ TEST(WTF_ListHashSet, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     auto ptr = uniquePtr.get();
-    list.add(WTFMove(uniquePtr));
+    list.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(true, list.contains(ptr));
 }
@@ -487,8 +487,8 @@ TEST(WTF_ListHashSet, UniquePtrKey_InsertBeforeUsingRawPointer)
     auto uniquePtrWith4 = makeUniqueWithoutFastMallocCheck<int>(4);
     auto ptrWith4 = uniquePtrWith4.get();
 
-    list.add(WTFMove(uniquePtrWith2));
-    list.add(WTFMove(uniquePtrWith4));
+    list.add(WTF::move(uniquePtrWith2));
+    list.add(WTF::move(uniquePtrWith4));
 
     // { 2, 4 }
     ASSERT_EQ(ptrWith2, list.first().get());
@@ -499,7 +499,7 @@ TEST(WTF_ListHashSet, UniquePtrKey_InsertBeforeUsingRawPointer)
     auto uniquePtrWith3 = makeUniqueWithoutFastMallocCheck<int>(3);
     auto ptrWith3 = uniquePtrWith3.get();
 
-    list.insertBefore(ptrWith4, WTFMove(uniquePtrWith3));
+    list.insertBefore(ptrWith4, WTF::move(uniquePtrWith3));
     
     // { 2, 3, 4 }
     auto firstWith2 = list.takeFirst();
@@ -525,7 +525,7 @@ TEST(WTF_ListHashSet, UniquePtrKey_RemoveUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     auto* ptr = uniquePtr.get();
-    list.add(WTFMove(uniquePtr));
+    list.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -573,7 +573,7 @@ public:
     ~FakeElementAnimationRareData() = default;
 
     Collection& collection() { return m_collection; }
-    void setCollection(Collection&& collection) { m_collection = WTFMove(collection); }
+    void setCollection(Collection&& collection) { m_collection = WTF::move(collection); }
 
 private:
     Collection m_collection;
@@ -586,12 +586,12 @@ TEST(WTF_ListHashSet, ClearsItemUponAssignment)
     EXPECT_EQ(0u, ListHashSetReferencedItem::instances().size());
 
     Collection firstCollection({ ListHashSetReferencedItem::create() });
-    data->setCollection(WTFMove(firstCollection));
+    data->setCollection(WTF::move(firstCollection));
 
     EXPECT_EQ(1u, ListHashSetReferencedItem::instances().size());
 
     Collection secondCollection;
-    data->setCollection(WTFMove(secondCollection));
+    data->setCollection(WTF::move(secondCollection));
 
     EXPECT_EQ(0u, ListHashSetReferencedItem::instances().size());
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Markable.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Markable.cpp
@@ -143,20 +143,20 @@ TEST(WTF_Markable, FromOptional)
     {
         std::optional<int> from;
         EXPECT_FALSE(static_cast<bool>(from));
-        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTFMove(from) };
+        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTF::move(from) };
         EXPECT_FALSE(static_cast<bool>(optional));
     }
     {
         std::optional<int> from { 42 };
         EXPECT_TRUE(static_cast<bool>(from));
-        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTFMove(from) };
+        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTF::move(from) };
         // We convert this to nullopt.
         EXPECT_FALSE(static_cast<bool>(optional));
     }
     {
         std::optional<int> from { 43 };
         EXPECT_TRUE(static_cast<bool>(from));
-        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTFMove(from) };
+        Markable<int, IntegralMarkableTraits<int, 42>> optional { WTF::move(from) };
         EXPECT_TRUE(static_cast<bool>(optional));
         EXPECT_EQ(optional.value(), 43);
     }
@@ -187,20 +187,20 @@ TEST(WTF_Markable, ToOptional)
     {
         Markable<int, IntegralMarkableTraits<int, 42>> optional;
         EXPECT_FALSE(static_cast<bool>(optional));
-        std::optional<int> to { WTFMove(optional) };
+        std::optional<int> to { WTF::move(optional) };
         EXPECT_FALSE(static_cast<bool>(to));
     }
     {
         Markable<int, IntegralMarkableTraits<int, 42>> optional { 42 };
         EXPECT_FALSE(static_cast<bool>(optional));
         // We convert this to nullopt.
-        std::optional<int> to { WTFMove(optional) };
+        std::optional<int> to { WTF::move(optional) };
         EXPECT_FALSE(static_cast<bool>(to));
     }
     {
         Markable<int, IntegralMarkableTraits<int, 42>> optional { 43 };
         EXPECT_TRUE(static_cast<bool>(optional));
-        std::optional<int> to { WTFMove(optional) };
+        std::optional<int> to { WTF::move(optional) };
         EXPECT_TRUE(static_cast<bool>(to));
         EXPECT_EQ(to.value(), 43);
     }
@@ -250,10 +250,10 @@ TEST(WTF_Markable, MoveOptional)
         std::optional<OnlyMovable> from { std::in_place, 20 };
         EXPECT_TRUE(static_cast<bool>(from));
         EXPECT_EQ(from.value().value(), 20);
-        Markable<OnlyMovable, OnlyMovable> compact = WTFMove(from);
+        Markable<OnlyMovable, OnlyMovable> compact = WTF::move(from);
         EXPECT_TRUE(static_cast<bool>(compact));
         EXPECT_EQ(compact.value().value(), 20);
-        std::optional<OnlyMovable> to = WTFMove(compact);
+        std::optional<OnlyMovable> to = WTF::move(compact);
         EXPECT_TRUE(static_cast<bool>(to));
         EXPECT_EQ(to.value().value(), 20);
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -360,7 +360,7 @@ TEST(WTF, MediaTimeInExpected)
     using Test = Expected<MediaTime, int>;
     Test test1;
     Test test2;
-    test1 = WTFMove(test2);
+    test1 = WTF::move(test2);
     UNUSED_VARIABLE(test1);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/MoveOnlyLifecycleLogger.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MoveOnlyLifecycleLogger.cpp
@@ -71,10 +71,10 @@ TEST(MoveOnlyLifecycleLogger, Basic)
     { MoveOnlyLifecycleLogger l("a"); }
     ASSERT_STREQ("construct(a) destruct(a) ", takeLogStr().c_str());
 
-    { MoveOnlyLifecycleLogger l("d"); MoveOnlyLifecycleLogger l2(WTFMove(l)); }
+    { MoveOnlyLifecycleLogger l("d"); MoveOnlyLifecycleLogger l2(WTF::move(l)); }
     ASSERT_STREQ("construct(d) move-construct(d) destruct(d) destruct(<default>) ", takeLogStr().c_str());
 
-    { MoveOnlyLifecycleLogger l("e"); MoveOnlyLifecycleLogger l2; l2 = WTFMove(l); }
+    { MoveOnlyLifecycleLogger l("e"); MoveOnlyLifecycleLogger l2; l2 = WTF::move(l); }
     ASSERT_STREQ("construct(e) construct(<default>) move-assign(e) destruct(e) destruct(<default>) ", takeLogStr().c_str());
 
     { MoveOnlyLifecycleLogger l("f"); l.setName("x"); }

--- a/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
@@ -68,14 +68,14 @@ TEST(WTF_NakedPtr, Basic)
 
     {
         NakedPtr<RefLogger> p1 = &a;
-        NakedPtr<RefLogger> p2 = WTFMove(p1);
+        NakedPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
 
     {
         NakedPtr<RefLogger> p1 = &a;
-        NakedPtr<RefLogger> p2(WTFMove(p1));
+        NakedPtr<RefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
@@ -89,7 +89,7 @@ TEST(WTF_NakedPtr, Basic)
 
     {
         NakedPtr<DerivedRefLogger> p1 = &a;
-        NakedPtr<RefLogger> p2 = WTFMove(p1);
+        NakedPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
@@ -137,7 +137,7 @@ TEST(WTF_NakedPtr, Assignment)
         NakedPtr<RefLogger> p2(&b);
         ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&b, p2.get());
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         ASSERT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE ASSERT_EQ(&b, p2.get());
     }
@@ -164,7 +164,7 @@ TEST(WTF_NakedPtr, Assignment)
         NakedPtr<DerivedRefLogger> p2(&c);
         ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&c, p2.get());
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         ASSERT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE ASSERT_EQ(&c, p2.get());
     }
@@ -189,7 +189,7 @@ TEST(WTF_NakedPtr, Assignment)
         NakedPtr<RefLogger> ptr(&a);
         ASSERT_EQ(&a, ptr.get());
         IGNORE_WARNINGS_BEGIN("self-move")
-        ptr = WTFMove(ptr);
+        ptr = WTF::move(ptr);
         IGNORE_WARNINGS_END
         ASSERT_EQ(&a, ptr.get());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -107,7 +107,7 @@ public:
         : m_producer(producer)
         , m_iterations(iterations)
         , m_workQueue(workQueue)
-        , m_result(WTFMove(result))
+        , m_result(WTF::move(result))
     {
     }
 
@@ -159,7 +159,7 @@ static auto doFail()
 
 static auto doFailAndReject(Logger::LogSiteIdentifier location = Logger::LogSiteIdentifier(__builtin_FUNCTION(), 0))
 {
-    return [location = WTFMove(location)] {
+    return [location = WTF::move(location)] {
         EXPECT_TRUE(false);
         return TestPromise::createAndReject(0.0, location);
     };
@@ -635,7 +635,7 @@ static Ref<GenericPromise> myMethodReturningThenCommandWithPromise()
     // You would normally do some work here.
     return GenericPromise::createAndResolve()->whenSettled(RunLoop::mainSingleton(),
         [](GenericPromise::Result result) {
-            return GenericPromise::createAndSettle(WTFMove(result));
+            return GenericPromise::createAndSettle(WTF::move(result));
         });
 }
 
@@ -680,7 +680,7 @@ TEST(NativePromise, InvokeAsyncWithExpected)
             return Expected<int, long> { 1 };
         };
 
-        invokeAsync(runLoop, WTFMove(asyncMethodWithExpected))->whenSettled(runLoop, [&](auto&& result) {
+        invokeAsync(runLoop, WTF::move(asyncMethodWithExpected))->whenSettled(runLoop, [&](auto&& result) {
             EXPECT_TRUE(!!result);
             EXPECT_EQ(result.value(), 1L);
             done = true;
@@ -709,7 +709,7 @@ static Ref<GenericPromise> myMethodReturningProducer()
     return GenericPromise::createAndResolve()->whenSettled(RunLoop::mainSingleton(),
         [](GenericPromise::Result result) {
             GenericPromise::Producer producer;
-            producer.settle(WTFMove(result));
+            producer.settle(WTF::move(result));
             return producer;
         });
 }
@@ -1103,7 +1103,7 @@ TEST(NativePromise, WTFString)
             EXPECT_TRUE(val.has_value());
             EXPECT_TRUE(val.value().isSafeToSendToAnotherThread());
             EXPECT_EQ(String("hello"_s), val.value());
-            return MyPromise::createAndSettle(WTFMove(val));
+            return MyPromise::createAndSettle(WTF::move(val));
         })->whenSettled(queue2,
             [](MyPromise::Result val) {
                 EXPECT_TRUE(val.has_value());
@@ -1246,7 +1246,7 @@ TEST(NativePromise, ExpectedWithString)
         });
 
     Expected<String, String> error = Unexpected<String>("error"_s);
-    MyPromise::createAndResolve(WTFMove(error))->whenSettled(queue,
+    MyPromise::createAndResolve(WTF::move(error))->whenSettled(queue,
         [queue](MyPromise::Result&& val) {
             EXPECT_TRUE(val.has_value());
             EXPECT_FALSE(val.value().has_value());
@@ -1382,8 +1382,8 @@ TEST(NativePromise, ChainTo)
             doFail());
 
         // As promise1 is already resolved, it will automatically resolve/reject producer1 and producer2 with its resolved/reject value.
-        promise->chainTo(WTFMove(producer1));
-        promise->chainTo(WTFMove(producer2));
+        promise->chainTo(WTF::move(producer1));
+        promise->chainTo(WTF::move(producer2));
     });
 
     runInCurrentRunLoop([&, producer1 = VectorPromise::Producer(), producer2 = VectorPromise::Producer()](auto& runLoop) mutable {
@@ -1392,8 +1392,8 @@ TEST(NativePromise, ChainTo)
             doFail());
 
         // When producer1 is resolved, it will automatically settle producer2 with the resolved/reject value.
-        producer1->chainTo(WTFMove(producer2));
-        VectorPromise::createAndResolve(resultVector)->chainTo(WTFMove(producer1));
+        producer1->chainTo(WTF::move(producer2));
+        VectorPromise::createAndResolve(resultVector)->chainTo(WTF::move(producer1));
     });
 
     runInCurrentRunLoop([&, producer1 = VectorPromise::Producer()](auto& runLoop) mutable {
@@ -1403,7 +1403,7 @@ TEST(NativePromise, ChainTo)
             doFail());
 
         // As promise1 is already resolved, it will automatically resolve/reject producer1 with its resolved/reject value.
-        promise->chainTo(WTFMove(producer1));
+        promise->chainTo(WTF::move(producer1));
     });
 }
 
@@ -1420,8 +1420,8 @@ TEST(NativePromise, ChainToNonMovable)
             doFail());
 
         // As promise1 is already resolved, it will automatically resolve/reject producer1 and producer2 with its resolved/reject value.
-        promise->chainTo(WTFMove(producer1));
-        promise->chainTo(WTFMove(producer2));
+        promise->chainTo(WTF::move(producer1));
+        promise->chainTo(WTF::move(producer2));
     });
 
     runInCurrentRunLoop([&, producer1 = VectorPromise::Producer(), producer2 = VectorPromise::Producer()](auto& runLoop) mutable {
@@ -1430,8 +1430,8 @@ TEST(NativePromise, ChainToNonMovable)
             doFail());
 
         // When producer1 is resolved, it will automatically settle producer2 with the resolved/reject value.
-        producer1->chainTo(WTFMove(producer2));
-        VectorPromise::createAndResolve(makeUnique<Vector<int>>(5, 42))->chainTo(WTFMove(producer1));
+        producer1->chainTo(WTF::move(producer2));
+        VectorPromise::createAndResolve(makeUnique<Vector<int>>(5, 42))->chainTo(WTF::move(producer1));
     });
 
     runInCurrentRunLoop([&, producer1 = VectorPromise::Producer()](auto& runLoop) mutable {
@@ -1441,7 +1441,7 @@ TEST(NativePromise, ChainToNonMovable)
             doFail());
 
         // As promise1 is already resolved, it will automatically resolve/reject producer1 with its resolved/reject value.
-        promise->chainTo(WTFMove(producer1));
+        promise->chainTo(WTF::move(producer1));
     });
 }
 
@@ -1552,7 +1552,7 @@ TEST(NativePromise, MismatchChainTo)
         producer1->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!!result);
         });
-        nonExclusivePromise->chainTo(WTFMove(producer1));
+        nonExclusivePromise->chainTo(WTF::move(producer1));
 
         // Chaining promise, not yet resolved
         MyNonExclusivePromise::Producer producer2;
@@ -1562,7 +1562,7 @@ TEST(NativePromise, MismatchChainTo)
         promise3->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!!result);
         });
-        producer2->chainTo(WTFMove(producer3));
+        producer2->chainTo(WTF::move(producer3));
         EXPECT_FALSE(promise2->isSettled());
         EXPECT_FALSE(promise3->isSettled());
         producer2->resolve();
@@ -1576,7 +1576,7 @@ TEST(NativePromise, MismatchChainTo)
         auto intPromise1 = IntPromise::createAndResolve(1);
         LongPromise::Producer longPromiseProducer1;
         auto longPromise1 = longPromiseProducer1.promise();
-        intPromise1->chainTo(WTFMove(longPromiseProducer1));
+        intPromise1->chainTo(WTF::move(longPromiseProducer1));
         longPromise1->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(1));
@@ -1587,7 +1587,7 @@ TEST(NativePromise, MismatchChainTo)
         auto intPromise2 = IntPromiseNonExcl::createAndResolve(1);
         LongPromise::Producer longPromiseProducer2;
         auto longPromise2 = longPromiseProducer2.promise();
-        intPromise2->chainTo(WTFMove(longPromiseProducer2));
+        intPromise2->chainTo(WTF::move(longPromiseProducer2));
         longPromise2->whenSettled(runLoop, [](auto&& result) {
             using NonRefQualifiedType = typename std::remove_reference<decltype(result)>::type;
             static_assert(!std::is_const<NonRefQualifiedType>::value, "result is const qualified.");
@@ -1612,7 +1612,7 @@ TEST(NativePromise, MismatchChainTo)
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(1));
             return IntPromise::createAndResolve(2);
-        })->chainTo(WTFMove(longPromiseProducer3));
+        })->chainTo(WTF::move(longPromiseProducer3));
 
         auto intPromise4 = IntPromise::createAndResolve(1);
         LongPromise::Producer longPromiseProducer4;
@@ -1621,7 +1621,7 @@ TEST(NativePromise, MismatchChainTo)
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(1));
             return IntPromise::createAndReject(2);
-        })->chainTo(WTFMove(longPromiseProducer4));
+        })->chainTo(WTF::move(longPromiseProducer4));
         longPromise4->whenSettled(runLoop, [&](auto&& result) mutable {
             EXPECT_TRUE(!result);
             EXPECT_EQ(result.error(), long(2));
@@ -1639,7 +1639,7 @@ TEST(NativePromise, MismatchChainToVoidPromise)
         auto intPromise1 = IntPromise::createAndResolve(1);
         LongPromise::Producer longPromiseProducer1;
         auto longPromise1 = longPromiseProducer1.promise();
-        intPromise1->chainTo(WTFMove(longPromiseProducer1));
+        intPromise1->chainTo(WTF::move(longPromiseProducer1));
         longPromise1->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(1));
@@ -1650,7 +1650,7 @@ TEST(NativePromise, MismatchChainToVoidPromise)
         genericPromiseProducer1->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!!result);
         });
-        intPromise2->chainTo(WTFMove(genericPromiseProducer1));
+        intPromise2->chainTo(WTF::move(genericPromiseProducer1));
 
         auto intPromise3 = IntPromise::createAndReject(1);
         GenericPromise::Producer genericPromiseProducer2;
@@ -1658,7 +1658,7 @@ TEST(NativePromise, MismatchChainToVoidPromise)
             EXPECT_TRUE(!result);
             done = true;
         });
-        intPromise3->chainTo(WTFMove(genericPromiseProducer2));
+        intPromise3->chainTo(WTF::move(genericPromiseProducer2));
     });
 }
 
@@ -1683,7 +1683,7 @@ TEST(NativePromise, DisconnectNotOwnedInstance)
     GenericPromise::Producer producer;
     auto request = NativePromiseRequest::create();
     WeakPtr weakRequest { request.get() };
-    producer->whenSettled(RunLoop::mainSingleton(), [request = WTFMove(request)] (auto&& result) mutable {
+    producer->whenSettled(RunLoop::mainSingleton(), [request = WTF::move(request)] (auto&& result) mutable {
         request->complete();
         EXPECT_TRUE(false);
     })->track(*weakRequest);
@@ -1851,7 +1851,7 @@ private:
         PhotoPromise::Producer producer;
         Ref<PhotoPromise> promise = producer;
 
-        AVCaptureMethod::captureImage(makeMoveableFunction([producer = WTFMove(producer)] (std::vector<uint8_t>&& image, std::string&& mimeType) {
+        AVCaptureMethod::captureImage(makeMoveableFunction([producer = WTF::move(producer)] (std::vector<uint8_t>&& image, std::string&& mimeType) {
             // Note that you can resolve a NativePromise on any threads. Unlike with a CompletionHandler it is not the responsibility of the producer to resolve the promise
             // on a particular thread.
             // The consumer specifies the thread on which it wants to be called back.

--- a/Tools/TestWebKitAPI/Tests/WTF/NeverDestroyed.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NeverDestroyed.cpp
@@ -53,14 +53,14 @@ TEST(WTF_NeverDestroyed, Construct)
 
     {
         static NeverDestroyed<LifecycleLogger> x;
-        static NeverDestroyed<LifecycleLogger> y { WTFMove(x) };
+        static NeverDestroyed<LifecycleLogger> y { WTF::move(x) };
         UNUSED_PARAM(y);
     }
     ASSERT_STREQ("construct(<default>) move-construct(<default>) ", takeLogStr().c_str());
 
     {
         static NeverDestroyed<const LifecycleLogger> x;
-        static NeverDestroyed<const LifecycleLogger> y { WTFMove(x) };
+        static NeverDestroyed<const LifecycleLogger> y { WTF::move(x) };
         UNUSED_PARAM(y);
     }
     ASSERT_STREQ("construct(<default>) move-construct(<default>) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRef.cpp
@@ -99,7 +99,7 @@ TEST(WTF_PackedRef, Assignment)
 
 static PackedRef<RefLogger> passWithRef(PackedRef<RefLogger>&& reference)
 {
-    return WTFMove(reference);
+    return WTF::move(reference);
 }
 
 TEST(WTF_PackedRef, ReturnValue)
@@ -132,7 +132,7 @@ TEST(WTF_PackedRef, ReturnValue)
 
     {
         PackedRefPtr<DerivedRefLogger> ptr(&a);
-        PackedRefPtr<RefLogger> ptr2(WTFMove(ptr));
+        PackedRefPtr<RefLogger> ptr2(WTF::move(ptr));
         EXPECT_EQ(nullptr, ptr.get());
         EXPECT_EQ(&a, ptr2.get());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
@@ -77,7 +77,7 @@ TEST(WTF_PackedRefPtr, Basic)
 
     {
         PackedRefPtr<RefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        PackedRefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -85,7 +85,7 @@ TEST(WTF_PackedRefPtr, Basic)
 
     {
         PackedRefPtr<RefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2(WTFMove(p1));
+        PackedRefPtr<RefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -101,7 +101,7 @@ TEST(WTF_PackedRefPtr, Basic)
 
     {
         PackedRefPtr<DerivedRefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        PackedRefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -121,7 +121,7 @@ TEST(WTF_PackedRefPtr, AssignPassRefToRefPtr)
     DerivedRefLogger a("a");
     {
         PackedRef<RefLogger> passRef(a);
-        PackedRefPtr<RefLogger> ptr = WTFMove(passRef);
+        PackedRefPtr<RefLogger> ptr = WTF::move(passRef);
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -202,7 +202,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -248,7 +248,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -278,7 +278,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         PackedRefPtr<RefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
         IGNORE_WARNINGS_BEGIN("self-move")
-        ptr = WTFMove(ptr);
+        ptr = WTF::move(ptr);
         IGNORE_WARNINGS_END
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(&a, ptr.get());
     }
@@ -337,7 +337,7 @@ TEST(WTF_PackedRefPtr, Release)
 
     {
         PackedRefPtr<RefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        PackedRefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -345,7 +345,7 @@ TEST(WTF_PackedRefPtr, Release)
 
     {
         PackedRefPtr<RefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2(WTFMove(p1));
+        PackedRefPtr<RefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -353,7 +353,7 @@ TEST(WTF_PackedRefPtr, Release)
 
     {
         PackedRefPtr<DerivedRefLogger> p1 = &a;
-        PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        PackedRefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -365,7 +365,7 @@ TEST(WTF_PackedRefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -378,7 +378,7 @@ TEST(WTF_PackedRefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -426,7 +426,7 @@ TEST(WTF_PackedRefPtr, Const)
 {
     // This test passes if it compiles without an error.
     auto a = ConstRefCounted::create();
-    PackedRef<const ConstRefCounted> b = WTFMove(a);
+    PackedRef<const ConstRefCounted> b = WTF::move(a);
     PackedRefPtr<const ConstRefCounted> c = b.ptr();
     PackedRef<const ConstRefCounted> d = returnConstRefCountedRef();
     PackedRefPtr<const ConstRefCounted> e = &returnConstRefCountedRef();
@@ -521,7 +521,7 @@ TEST(WTF_PackedRefPtr, AssignBeforeDeref)
         log() << "| ";
         a.slotToCheck = &p1;
         b.slotToCheck = &p1;
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PriorityQueue.cpp
@@ -38,7 +38,7 @@ template<typename T, bool (*isHigherPriority)(const T&, const T&)>
 static void enqueue(PriorityQueue<T, isHigherPriority>& queue, T element)
 {
     size_t sizeBefore = queue.size();
-    queue.enqueue(WTFMove(element));
+    queue.enqueue(WTF::move(element));
     EXPECT_EQ(sizeBefore + 1, queue.size());
     EXPECT_FALSE(queue.isEmpty());
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
@@ -100,7 +100,7 @@ TEST(WTF_Ref, Assignment)
 
 static Ref<RefLogger> passWithRef(Ref<RefLogger>&& reference)
 {
-    return WTFMove(reference);
+    return WTF::move(reference);
 }
 
 TEST(WTF_Ref, ReturnValue)
@@ -133,7 +133,7 @@ TEST(WTF_Ref, ReturnValue)
 
     {
         RefPtr<DerivedRefLogger> ptr(&a);
-        RefPtr<RefLogger> ptr2(WTFMove(ptr));
+        RefPtr<RefLogger> ptr2(WTF::move(ptr));
         EXPECT_EQ(nullptr, ptr.get());
         EXPECT_EQ(&a, ptr2.get());
     }
@@ -289,7 +289,7 @@ TEST(WTF_Ref, StaticReferenceCastFromRValueReference)
     {
         DerivedRefCheckingRefLogger a("a");
         Ref<DerivedRefCheckingRefLogger> ref(a);
-        auto ref2 = upcast<RefCheckingRefLogger>(WTFMove(ref));
+        auto ref2 = upcast<RefCheckingRefLogger>(WTF::move(ref));
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/RefCountedFixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefCountedFixedVector.cpp
@@ -112,7 +112,7 @@ TEST(WTF_RefCountedFixedVector, MoveVector)
 {
     auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
     EXPECT_EQ(4U, vec1.size());
-    auto vec2 = RefCountedFixedVector<MoveOnly>::createFromVector(WTFMove(vec1));
+    auto vec2 = RefCountedFixedVector<MoveOnly>::createFromVector(WTF::move(vec1));
     EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(4U, vec2->size());
     for (unsigned index = 0; index < vec2->size(); ++index)

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -76,7 +76,7 @@ TEST(WTF_RefPtr, Basic)
 
     {
         RefPtr<RefLogger> p1 = &a;
-        RefPtr<RefLogger> p2 = WTFMove(p1);
+        RefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -84,7 +84,7 @@ TEST(WTF_RefPtr, Basic)
 
     {
         RefPtr<RefLogger> p1 = &a;
-        RefPtr<RefLogger> p2(WTFMove(p1));
+        RefPtr<RefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -100,7 +100,7 @@ TEST(WTF_RefPtr, Basic)
 
     {
         RefPtr<DerivedRefLogger> p1 = &a;
-        RefPtr<RefLogger> p2 = WTFMove(p1);
+        RefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -120,7 +120,7 @@ TEST(WTF_RefPtr, AssignPassRefToRefPtr)
     DerivedRefLogger a("a");
     {
         Ref<RefLogger> passRef(a);
-        RefPtr<RefLogger> ptr = WTFMove(passRef);
+        RefPtr<RefLogger> ptr = WTF::move(passRef);
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -201,7 +201,7 @@ TEST(WTF_RefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -247,7 +247,7 @@ TEST(WTF_RefPtr, Assignment)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -277,7 +277,7 @@ TEST(WTF_RefPtr, Assignment)
         RefPtr<RefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
         IGNORE_WARNINGS_BEGIN("self-move")
-        ptr = WTFMove(ptr);
+        ptr = WTF::move(ptr);
         IGNORE_WARNINGS_END
         EXPECT_EQ(&a, ptr.get());
     }
@@ -343,7 +343,7 @@ TEST(WTF_RefPtr, Release)
 
     {
         RefPtr<RefLogger> p1 = &a;
-        RefPtr<RefLogger> p2 = WTFMove(p1);
+        RefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -351,7 +351,7 @@ TEST(WTF_RefPtr, Release)
 
     {
         RefPtr<RefLogger> p1 = &a;
-        RefPtr<RefLogger> p2(WTFMove(p1));
+        RefPtr<RefLogger> p2(WTF::move(p1));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -359,7 +359,7 @@ TEST(WTF_RefPtr, Release)
 
     {
         RefPtr<DerivedRefLogger> p1 = &a;
-        RefPtr<RefLogger> p2 = WTFMove(p1);
+        RefPtr<RefLogger> p2 = WTF::move(p1);
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -371,7 +371,7 @@ TEST(WTF_RefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&b, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&b, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -384,7 +384,7 @@ TEST(WTF_RefPtr, Release)
         EXPECT_EQ(&a, p1.get());
         EXPECT_EQ(&c, p2.get());
         log() << "| ";
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         EXPECT_EQ(&c, p1.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
@@ -431,7 +431,7 @@ TEST(WTF_RefPtr, Const)
 {
     // This test passes if it compiles without an error.
     auto a = ConstRefCounted::create();
-    Ref<const ConstRefCounted> b = WTFMove(a);
+    Ref<const ConstRefCounted> b = WTF::move(a);
     RefPtr<const ConstRefCounted> c = b.ptr();
     Ref<const ConstRefCounted> d = returnConstRefCountedRef();
     RefPtr<const ConstRefCounted> e = &returnConstRefCountedRef();
@@ -526,7 +526,7 @@ TEST(WTF_RefPtr, AssignBeforeDeref)
         log() << "| ";
         a.slotToCheck = &p1;
         b.slotToCheck = &p1;
-        p1 = WTFMove(p2);
+        p1 = WTF::move(p2);
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -111,7 +111,7 @@ TEST(WTF_RobinHoodHashMap, MoveOnlyValues)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyValues.set(i + 1, WTFMove(moveOnly));
+        moveOnlyValues.set(i + 1, WTF::move(moveOnly));
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -134,7 +134,7 @@ TEST(WTF_RobinHoodHashMap, MoveOnlyKeys)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        moveOnlyKeys.set(WTFMove(moveOnly), i + 1);
+        moveOnlyKeys.set(WTF::move(moveOnly), i + 1);
     }
 
     for (size_t i = 0; i < 100; ++i) {
@@ -198,7 +198,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey)
     MemoryCompactLookupOnlyRobinHoodHashMap<std::unique_ptr<ConstructorDestructorCounter>, int, RobinHoodHash<std::unique_ptr<ConstructorDestructorCounter>>> map;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -217,7 +217,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_CustomDeleter)
     MemoryCompactLookupOnlyRobinHoodHashMap<std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>>, int, RobinHoodHash<std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>>>> map;
 
     std::unique_ptr<ConstructorDestructorCounter, DeleterCounter<ConstructorDestructorCounter>> uniquePtr(new ConstructorDestructorCounter(), DeleterCounter<ConstructorDestructorCounter>());
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -238,7 +238,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     auto it = map.find(ptr);
     ASSERT_TRUE(it != map.end());
@@ -252,7 +252,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(true, map.contains(ptr));
 }
@@ -263,7 +263,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_GetUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     int value = map.get(ptr);
     EXPECT_EQ(2, value);
@@ -277,7 +277,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_RemoveUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -297,7 +297,7 @@ TEST(WTF_RobinHoodHashMap, UniquePtrKey_TakeUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    map.add(WTFMove(uniquePtr), 2);
+    map.add(WTF::move(uniquePtr), 2);
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -313,7 +313,7 @@ TEST(WTF_RobinHoodHashMap, UniqueRefValue)
 {
     MemoryCompactLookupOnlyRobinHoodHashMap<int, UniqueRef<int>, RobinHoodHash<int>> map;
     UniqueRef<int> five = makeUniqueRefWithoutFastMallocCheck<int>(5);
-    map.add(5, WTFMove(five));
+    map.add(5, WTF::move(five));
     EXPECT_TRUE(map.contains(5));
     int* shouldBeFive = map.get(5);
     EXPECT_EQ(*shouldBeFive, 5);
@@ -350,7 +350,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_AddUsingRelease)
         MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<RefLogger>, int, RobinHoodHash<RefPtr<RefLogger>>> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.add(WTFMove(ptr), 0);
+        map.add(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -364,7 +364,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_AddUsingMove)
         MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<RefLogger>, int, RobinHoodHash<RefPtr<RefLogger>>> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.add(WTFMove(ptr), 0);
+        map.add(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -425,7 +425,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_AddUsingReleaseKeyAlreadyPresent)
 
     {
         RefPtr<RefLogger> ptr2(&a);
-        auto addResult = map.add(WTFMove(ptr2), 0);
+        auto addResult = map.add(WTF::move(ptr2), 0);
         EXPECT_FALSE(addResult.isNewEntry);
     }
 
@@ -451,7 +451,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_AddUsingMoveKeyAlreadyPresent)
 
     {
         RefPtr<RefLogger> ptr2(&a);
-        auto addResult = map.add(WTFMove(ptr2), 0);
+        auto addResult = map.add(WTF::move(ptr2), 0);
         EXPECT_FALSE(addResult.isNewEntry);
     }
 
@@ -484,7 +484,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_SetUsingRelease)
         MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<RefLogger>, int, RobinHoodHash<RefPtr<RefLogger>>> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.set(WTFMove(ptr), 0);
+        map.set(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -499,7 +499,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_SetUsingMove)
         MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<RefLogger>, int, RobinHoodHash<RefPtr<RefLogger>>> map;
 
         RefPtr<RefLogger> ptr(&a);
-        map.set(WTFMove(ptr), 0);
+        map.set(WTF::move(ptr), 0);
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -558,7 +558,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_SetUsingReleaseKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = map.set(WTFMove(ptr2), 1);
+            auto addResult = map.set(WTF::move(ptr2), 1);
             EXPECT_FALSE(addResult.isNewEntry);
             EXPECT_EQ(1, map.get(ptr.get()));
         }
@@ -583,7 +583,7 @@ TEST(WTF_RobinHoodHashMap, RefPtrKey_SetUsingMoveKeyAlreadyPresent)
 
         {
             RefPtr<RefLogger> ptr2(&a);
-            auto addResult = map.set(WTFMove(ptr2), 1);
+            auto addResult = map.set(WTF::move(ptr2), 1);
             EXPECT_FALSE(addResult.isNewEntry);
             EXPECT_EQ(1, map.get(ptr.get()));
         }
@@ -662,7 +662,7 @@ class ObjectWithRefLogger {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ObjectWithRefLogger);
 public:
     ObjectWithRefLogger(Ref<RefLogger>&& logger)
-        : m_logger(WTFMove(logger))
+        : m_logger(WTF::move(logger))
     {
     }
 
@@ -674,7 +674,7 @@ static void testMovingUsingEnsure(Ref<RefLogger>&& logger)
 {
     MemoryCompactLookupOnlyRobinHoodHashMap<unsigned, std::unique_ptr<ObjectWithRefLogger>, RobinHoodHash<unsigned>> map;
 
-    map.ensure(1, [&] { return makeUnique<ObjectWithRefLogger>(WTFMove(logger)); });
+    map.ensure(1, [&] { return makeUnique<ObjectWithRefLogger>(WTF::move(logger)); });
 }
 
 static void testMovingUsingAdd(Ref<RefLogger>&& logger)
@@ -682,7 +682,7 @@ static void testMovingUsingAdd(Ref<RefLogger>&& logger)
     MemoryCompactLookupOnlyRobinHoodHashMap<unsigned, std::unique_ptr<ObjectWithRefLogger>, RobinHoodHash<unsigned>> map;
 
     auto& slot = map.add(1, nullptr).iterator->value;
-    slot = makeUnique<ObjectWithRefLogger>(WTFMove(logger));
+    slot = makeUnique<ObjectWithRefLogger>(WTF::move(logger));
 }
 
 TEST(WTF_RobinHoodHashMap, Ensure_LambdasCapturingByReference)
@@ -690,7 +690,7 @@ TEST(WTF_RobinHoodHashMap, Ensure_LambdasCapturingByReference)
     {
         DerivedRefLogger a("a");
         Ref<RefLogger> ref(a);
-        testMovingUsingEnsure(WTFMove(ref));
+        testMovingUsingEnsure(WTF::move(ref));
 
         EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
     }
@@ -698,7 +698,7 @@ TEST(WTF_RobinHoodHashMap, Ensure_LambdasCapturingByReference)
     {
         DerivedRefLogger a("a");
         Ref<RefLogger> ref(a);
-        testMovingUsingAdd(WTFMove(ref));
+        testMovingUsingAdd(WTF::move(ref));
 
         EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
     }
@@ -797,7 +797,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -808,7 +808,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.set(WTFMove(ref), 1);
+        map.set(WTF::move(ref), 1);
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -819,10 +819,10 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> refA(a);
-        map.add(WTFMove(refA), 1);
+        map.add(WTF::move(refA), 1);
 
         Ref<RefLogger> refA2(a);
-        map.set(WTFMove(refA2), 1);
+        map.set(WTF::move(refA2), 1);
     }
 
     ASSERT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());
@@ -833,7 +833,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.ensure(WTFMove(ref), []() {
+        map.ensure(WTF::move(ref), []() {
             return 1;
         });
     }
@@ -846,7 +846,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
 
         auto it = map.find(&a);
         ASSERT_TRUE(it != map.end());
@@ -863,7 +863,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
 
         map.remove(&a);
     }
@@ -876,7 +876,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
         MemoryCompactLookupOnlyRobinHoodHashMap<Ref<RefLogger>, int, RobinHoodHash<Ref<RefLogger>>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(WTFMove(ref), 1);
+        map.add(WTF::move(ref), 1);
 
         int i = map.take(&a);
         ASSERT_EQ(i, 1);
@@ -890,7 +890,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Key)
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
             auto* pointer = ref.ptr();
-            map.add(WTFMove(ref), i + 1);
+            map.add(WTF::move(ref), i + 1);
             ASSERT_TRUE(map.contains(pointer));
         }
     }
@@ -906,7 +906,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -917,7 +917,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> ref(a);
-        map.set(1, WTFMove(ref));
+        map.set(1, WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -929,10 +929,10 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> refA(a);
-        map.add(1, WTFMove(refA));
+        map.add(1, WTF::move(refA));
 
         Ref<RefLogger> refB(b);
-        map.set(1, WTFMove(refB));
+        map.set(1, WTF::move(refB));
     }
 
     ASSERT_STREQ("ref(a) ref(b) deref(a) deref(b) ", takeLogStr().c_str());
@@ -943,7 +943,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
 
         auto aGet = map.get(1);
         ASSERT_EQ(aGet, &a);
@@ -964,7 +964,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
 
         auto aOut = map.take(1);
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -986,7 +986,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
         Ref<RefLogger> ref(a);
-        map.add(1, WTFMove(ref));
+        map.add(1, WTF::move(ref));
         map.remove(1);
     }
 
@@ -1010,7 +1010,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
         for (int i = 0; i < 64; ++i) {
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
-            map.add(i + 1, WTFMove(ref));
+            map.add(i + 1, WTF::move(ref));
             ASSERT_TRUE(map.contains(i + 1));
         }
     }
@@ -1058,7 +1058,7 @@ TEST(WTF_RobinHoodHashMap, RefMappedToNonZeroEmptyValue)
     for (int32_t i = 0; i < 160; ++i) {
         Ref<Key> key = Key::create();
         map.add(Ref<Key>(key.get()), Value { i });
-        vectorMap.append({ WTFMove(key), i });
+        vectorMap.append({ WTF::move(key), i });
     }
 
     for (auto& pair : vectorMap)
@@ -1189,7 +1189,7 @@ class TestObjectWithCustomDestructor {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(TestObjectWithCustomDestructor);
 public:
     TestObjectWithCustomDestructor(Function<void()>&& runInDestructor)
-        : m_runInDestructor(WTFMove(runInDestructor))
+        : m_runInDestructor(WTF::move(runInDestructor))
     { }
 
     ~TestObjectWithCustomDestructor()

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
@@ -106,7 +106,7 @@ TEST(WTF_RobinHoodHashSet, MoveOnly)
 
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i + 1);
-        hashSet.add(WTFMove(moveOnly));
+        hashSet.add(WTF::move(moveOnly));
     }
 
     for (size_t i = 0; i < 100; ++i)
@@ -147,7 +147,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrKey)
     MemoryCompactLookupOnlyRobinHoodHashSet<std::unique_ptr<ConstructorDestructorCounter>, RobinHoodHash<std::unique_ptr<ConstructorDestructorCounter>>> set;
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -164,7 +164,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrKey_FindUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     auto it = set.find(ptr);
     ASSERT_TRUE(it != set.end());
@@ -178,7 +178,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrKey_ContainsUsingRawPointer)
 
     auto uniquePtr = makeUniqueWithoutFastMallocCheck<int>(5);
     int* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(true, set.contains(ptr));
 }
@@ -190,7 +190,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrKey_RemoveUsingRawPointer)
     MemoryCompactLookupOnlyRobinHoodHashSet<std::unique_ptr<ConstructorDestructorCounter>, RobinHoodHash<std::unique_ptr<ConstructorDestructorCounter>>> set;
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -210,7 +210,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrKey_TakeUsingRawPointer)
 
     auto uniquePtr = makeUnique<ConstructorDestructorCounter>();
     ConstructorDestructorCounter* ptr = uniquePtr.get();
-    set.add(WTFMove(uniquePtr));
+    set.add(WTF::move(uniquePtr));
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
@@ -357,7 +357,7 @@ TEST(WTF_RobinHoodHashSet, UniquePtrNotZeroedBeforeDestructor)
     const DestructorObserver* observerAddress = observer.get();
 
     MemoryCompactLookupOnlyRobinHoodHashSet<std::unique_ptr<DestructorObserver>, RobinHoodHash<std::unique_ptr<DestructorObserver>>> set;
-    auto addResult = set.add(WTFMove(observer));
+    auto addResult = set.add(WTF::move(observer));
 
     EXPECT_TRUE(addResult.isNewEntry);
     EXPECT_TRUE(observedBucket == nullptr);
@@ -381,7 +381,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
     }
 
     ASSERT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -403,7 +403,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
         set.remove(&a);
     }
 
@@ -415,7 +415,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
 
         auto aOut = set.take(&a);
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -430,7 +430,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
 
         auto aOut = set.takeAny();
         ASSERT_TRUE(static_cast<bool>(aOut));
@@ -451,7 +451,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
 
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
 
         ASSERT_TRUE(set.contains(&a));
     }
@@ -464,7 +464,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
             // FIXME: All of these RefLogger objects leak. No big deal for a test I guess.
             Ref<RefLogger> ref = adoptRef(*new RefLogger("a"));
             auto* pointer = ref.ptr();
-            set.add(WTFMove(ref));
+            set.add(WTF::move(ref));
             ASSERT_TRUE(set.contains(pointer));
         }
     }
@@ -475,7 +475,7 @@ TEST(WTF_RobinHoodHashSet, Ref)
 
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set;
         Ref<RefLogger> ref(a);
-        set.add(WTFMove(ref));
+        set.add(WTF::move(ref));
         MemoryCompactLookupOnlyRobinHoodHashSet<Ref<RefLogger>, RobinHoodHash<Ref<RefLogger>>> set2(set);
     }
     ASSERT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
@@ -58,7 +58,7 @@ static void testThreadGroup(Mode mode)
             });
             if (mode == Mode::Add)
                 EXPECT_TRUE(threadGroup->add(thread.get()) == ThreadGroupAddResult::NewlyAdded);
-            threads.append(WTFMove(thread));
+            threads.append(WTF::move(thread));
         }
 
         condition.wait(lock, [&] {
@@ -174,7 +174,7 @@ TEST(WTF, ThreadGroupRemove)
             });
         });
         threadGroup->add(thread.get());
-        threads.append(WTFMove(thread));
+        threads.append(WTF::move(thread));
     }
 
     EXPECT_EQ(NumberOfThreads, countThreadGroups(threads));

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -542,7 +542,7 @@ TEST_F(WTF_URL, URLRemoveQueryParameters)
     HashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
 
     auto checkRemovedParameters = [](int lineNumber, const Vector<String>& removedParameters, std::initializer_list<String>&& expected) {
-        Vector<String> expectedParameters { WTFMove(expected) };
+        Vector<String> expectedParameters { WTF::move(expected) };
         bool areEqual = removedParameters == expectedParameters;
         EXPECT_TRUE(areEqual);
         if (areEqual)
@@ -648,7 +648,7 @@ TEST_F(WTF_URL, IsolatedCopy)
     // Tests optimization for URL::isolatedCopy() on a r-value reference.
     URL url2 { "https://www.webkit.org"_str };
     originalStringImpl = url2.string().impl();
-    URL url2Copy = WTFMove(url2).isolatedCopy();
+    URL url2Copy = WTF::move(url2).isolatedCopy();
     EXPECT_EQ(url2Copy, URL { "https://www.webkit.org"_str });
     EXPECT_EQ(url2Copy.string().impl(), originalStringImpl); // Should have adopted the StringImpl of url2.
 }
@@ -657,12 +657,12 @@ TEST_F(WTF_URL, MoveInvalidatesURL)
 {
     URL url1 { "http://www.apple.com"_str };
     EXPECT_TRUE(url1.isValid());
-    URL url2 { WTFMove(url1) };
+    URL url2 { WTF::move(url1) };
     EXPECT_TRUE(url2.isValid());
     SUPPRESS_USE_AFTER_MOVE EXPECT_FALSE(url1.isValid());
 
     URL url3 { "http://www.webkit.org"_str };
-    url3 = WTFMove(url2);
+    url3 = WTF::move(url2);
     EXPECT_TRUE(url3.isValid());
     SUPPRESS_USE_AFTER_MOVE EXPECT_FALSE(url2.isValid());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/UniqueRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UniqueRef.cpp
@@ -51,7 +51,7 @@ class C {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(C);
 public:
     C(UniqueRef<A>&& a)
-        : a(WTFMove(a))
+        : a(WTF::move(a))
     { }
     UniqueRef<A> a;
 };
@@ -69,7 +69,7 @@ TEST(WTF, UniqueRef)
     const B& d = b.get();
     B* e = &b;
     const B* f = &b;
-    UniqueRef<A> j = WTFMove(a);
+    UniqueRef<A> j = WTF::move(a);
     
     Vector<UniqueRef<B>> v;
     v.append(makeUniqueRef<B>(4, 5, 6));

--- a/Tools/TestWebKitAPI/Tests/WTF/UniqueRefVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UniqueRefVector.cpp
@@ -133,7 +133,7 @@ TEST(WTF_UniqueRefVector, UncheckedAppend)
     intRefVector.reserveInitialCapacity(100);
     for (int i = 0; i < 100; ++i) {
         auto moveOnly = MAKE(i);
-        intRefVector.append(WTFMove(moveOnly));
+        intRefVector.append(WTF::move(moveOnly));
         EXPECT_EQ(moveOnly.moveToUniquePtr(), nullptr);
     }
 
@@ -147,7 +147,7 @@ TEST(WTF_UniqueRefVector, Insert)
 
     for (int i = 0; i < 100; ++i) {
         auto moveOnly = MAKE(i);
-        intRefVector.insert(0, WTFMove(moveOnly));
+        intRefVector.insert(0, WTF::move(moveOnly));
         EXPECT_EQ(moveOnly.moveToUniquePtr(), nullptr);
     }
 
@@ -157,7 +157,7 @@ TEST(WTF_UniqueRefVector, Insert)
 
     for (int i = 0; i < 200; i += 2) {
         auto moveOnly = MAKE(1000 + i);
-        intRefVector.insert(i, WTFMove(moveOnly));
+        intRefVector.insert(i, WTF::move(moveOnly));
         EXPECT_EQ(moveOnly.moveToUniquePtr(), nullptr);
     }
 
@@ -176,7 +176,7 @@ TEST(WTF_UniqueRefVector, TakeLast)
 
     for (int i = 0; i < 100; ++i) {
         auto moveOnly = MAKE(i);
-        intRefVector.append(WTFMove(moveOnly));
+        intRefVector.append(WTF::move(moveOnly));
         EXPECT_EQ(moveOnly.moveToUniquePtr(), nullptr);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/VariantList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/VariantList.cpp
@@ -125,7 +125,7 @@ TEST(WTF_VariantList, EmptyMove)
     WTF::VariantList<Variant<int, MoveOnly, float>> variantList;
     EXPECT_TRUE(variantList.isEmpty());
 
-    auto moved = WTFMove(variantList);
+    auto moved = WTF::move(variantList);
     EXPECT_TRUE(moved.isEmpty());
 }
 
@@ -146,7 +146,7 @@ TEST(WTF_VariantList, MoveWithItems)
     variantList.append(MoveOnly(1u));
     variantList.append(2.0f);
 
-    auto moved = WTFMove(variantList);
+    auto moved = WTF::move(variantList);
 
     unsigned iterations = 0;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -279,7 +279,7 @@ TEST(WTF, StringReplaceWithLiteral)
 TEST(WTF, StringIsolatedCopy)
 {
     String original = "1234"_s;
-    auto copy = WTFMove(original).isolatedCopy();
+    auto copy = WTF::move(original).isolatedCopy();
     EXPECT_FALSE(original.impl() == copy.impl());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -250,7 +250,7 @@ TEST(WTF_WeakPtr, Operators)
     weakPtr3 = weakPtr;
     EXPECT_EQ(weakPtr3.get(), &f);
 
-    WeakPtr<Foo> weakPtr4 = WTFMove(weakPtr);
+    WeakPtr<Foo> weakPtr4 = WTF::move(weakPtr);
     EXPECT_EQ(weakPtr4.get(), &f);
     SUPPRESS_USE_AFTER_MOVE EXPECT_FALSE(weakPtr);
 }
@@ -355,7 +355,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssign)
     Derived derived;
     {
         WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
-        WeakPtr<Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
+        WeakPtr<Base> baseWeakPtr { WTF::move(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
     }
@@ -370,7 +370,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssign)
     {
         WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
         WeakPtr<Base> baseWeakPtr;
-        baseWeakPtr = WTFMove(derivedWeakPtr);
+        baseWeakPtr = WTF::move(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
     }
@@ -389,7 +389,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
     const Derived derived;
     {
         auto derivedWeakPtr = makeWeakPtr(derived);
-        WeakPtr<const Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
+        WeakPtr<const Base> baseWeakPtr { WTF::move(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
     }
@@ -404,7 +404,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
     {
         auto derivedWeakPtr = makeWeakPtr(derived);
         WeakPtr<const Base> baseWeakPtr;
-        baseWeakPtr = WTFMove(derivedWeakPtr);
+        baseWeakPtr = WTF::move(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
     }
@@ -738,7 +738,7 @@ TEST(WTF_WeakPtr, WeakHashSetExpansion)
         for (unsigned i = 0; i < initialCapacity / maxLoadCap; ++i) {
             auto object = makeUnique<Base>();
             weakHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             otherObjects.append(makeUnique<Base>());
             weakHashSet.checkConsistency();
         }
@@ -775,7 +775,7 @@ TEST(WTF_WeakPtr, WeakHashSetExpansion)
         for (unsigned i = 0; i < objectCount; ++i) {
             auto object = makeUnique<Base>();
             weakHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             weakHashSet.checkConsistency();
         }
         unsigned originalCapacity = weakHashSet.capacity();
@@ -830,7 +830,7 @@ TEST(WTF_WeakPtr, WeakHashSetisEmptyIgnoringNullReferences)
         do {
             auto object = makeUnique<Base>();
             weakHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
         } while (weakHashSet.begin().get() == firstObject.get());
 
         EXPECT_EQ(s_baseWeakReferences, objects.size() + 1);
@@ -922,7 +922,7 @@ TEST(WTF_WeakPtr, WeakHashSetComputeSize)
         do {
             auto object = makeUnique<Base>();
             weakHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
         } while (weakHashSet.begin().get() == nonFirstObject.get());
 
         unsigned objectsCount = objects.size();
@@ -1311,7 +1311,7 @@ TEST(WTF_WeakPtr, WeakHashMapRemoveIterator)
     for (unsigned i = 0; i < 13; ++i) {
         auto object = makeUnique<Base>();
         weakHashMap.add(*object, 0);
-        objects.append(WTFMove(object));
+        objects.append(WTF::move(object));
     }
     while (!objects.isEmpty()) {
         auto it = weakHashMap.find(*objects.last());
@@ -1345,7 +1345,7 @@ TEST(WTF_WeakPtr, WeakHashMapExpansion)
         for (unsigned i = 0; i < initialCapacity / maxLoadCap; ++i) {
             auto object = makeUnique<Base>();
             weakHashMap.add(*object, i);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             otherObjects.append(makeUnique<Base>());
             weakHashMap.checkConsistency();
         }
@@ -1389,7 +1389,7 @@ TEST(WTF_WeakPtr, WeakHashMapExpansion)
         for (unsigned i = 0; i < objectCount; ++i) {
             auto object = makeUnique<Base>();
             weakHashMap.set(*object, ValueObject::create(100 + i));
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             weakHashMap.checkConsistency();
         }
         unsigned originalCapacity = weakHashMap.capacity();
@@ -1481,7 +1481,7 @@ TEST(WTF_WeakPtr, WeakHashMapIsEmptyIgnoringNullReferences)
         do {
             auto object = makeUnique<Base>();
             weakHashMap.set(*object, ValueObject::create(value++));
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
         } while (&weakHashMap.begin()->key == firstObject.get());
 
         EXPECT_EQ(ValueObject::s_count, objects.size() + 1);
@@ -1560,7 +1560,7 @@ TEST(WTF_WeakPtr, WeakHashMapRemoveNullReferences)
         for (unsigned i = 0; i < 50; ++i) {
             auto key = makeUnique<Derived>();
             weakHashMap.add(*key, ValueObject::create(i + 100));
-            objects.append(WTFMove(key));
+            objects.append(WTF::move(key));
         }
         EXPECT_EQ(ValueObject::s_count, 50U);
         EXPECT_EQ(s_baseWeakReferences, 50U);
@@ -1981,7 +1981,7 @@ TEST(WTF_WeakPtr, WeakHashMap_iterator_destruction)
     for (unsigned i = 0; i < objectCount; ++i) {
         auto object = makeUnique<Base>();
         weakHashMap.add(*object, i);
-        objects.append(WTFMove(object));
+        objects.append(WTF::move(object));
     }
 
     auto a = objects.takeLast();
@@ -2105,7 +2105,7 @@ TEST(WTF_WeakPtr, WeakListHashSetBasic)
         for (unsigned i = 0; i < 50; ++i) {
             auto object = makeUnique<Base>();
             weakListHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
         }
 
         unsigned i = 0;
@@ -2184,7 +2184,7 @@ TEST(WTF_WeakPtr, WeakListHashSetRemoveIterator)
     for (unsigned i = 0; i < 13; ++i) {
         auto object = makeUnique<Base>();
         weakListHashSet.add(*object);
-        objects.append(WTFMove(object));
+        objects.append(WTF::move(object));
     }
     for (unsigned i = 0; i < 13; ++i) {
         auto it = weakListHashSet.find(*objects[0]);
@@ -2223,7 +2223,7 @@ TEST(WTF_WeakPtr, WeakListHashSetExpansion)
         for (unsigned i = 0; i < initialCapacity / maxLoadCap; ++i) {
             auto object = makeUnique<Base>();
             weakListHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             otherObjects.append(makeUnique<Base>());
             weakListHashSet.checkConsistency();
         }
@@ -2260,7 +2260,7 @@ TEST(WTF_WeakPtr, WeakListHashSetExpansion)
         for (unsigned i = 0; i < objectCount; ++i) {
             auto object = makeUnique<Base>();
             weakListHashSet.add(*object);
-            objects.append(WTFMove(object));
+            objects.append(WTF::move(object));
             weakListHashSet.checkConsistency();
         }
         unsigned originalCapacity = weakListHashSet.capacity();
@@ -2372,7 +2372,7 @@ TEST(WTF_WeakPtr, WeakListHashSetRemoveNullReferences)
         for (unsigned i = 0; i < 50; ++i) {
             auto key = makeUnique<Derived>();
             weakListHashSet.add(*key);
-            objects.append(WTFMove(key));
+            objects.append(WTF::move(key));
         }
         EXPECT_EQ(s_baseWeakReferences, 50U);
         EXPECT_FALSE(weakListHashSet.hasNullReferences());
@@ -2860,7 +2860,7 @@ TEST(WTF_ThreadSafeWeakPtr, UseAfterMoveResistance)
 {
     auto counter = adoptRef(*new ThreadSafeInstanceCounter());
     auto weakPtr = ThreadSafeWeakPtr { counter.get() };
-    auto movedTo = WTFMove(weakPtr);
+    auto movedTo = WTF::move(weakPtr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(weakPtr.get());
     EXPECT_NOT_NULL(movedTo.get());
     ThreadSafeWeakPtr<ThreadSafeInstanceCounter> emptyConstructor;
@@ -3065,7 +3065,7 @@ TEST(WTF_ThreadSafeWeakPtr, AmortizedCleanupNotQuadratic)
     for (int i = 0; i < 1000000; ++i) {
         auto obj = adoptRef(*new Struct);
         set.add(obj.get());
-        strongSet.add(WTFMove(obj));
+        strongSet.add(WTF::move(obj));
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -58,7 +58,7 @@ TEST(RetainPtr, ConstructionFromMutableCFType)
     RetainPtr<CFMutableStringRef> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<CFStringRef> ptr2(WTFMove(temp));
+    RetainPtr<CFStringRef> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((CFStringRef)nullptr, temp.get());
@@ -78,7 +78,7 @@ TEST(RetainPtr, ConstructionFromSameCFType)
     RetainPtr<CFStringRef> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<CFStringRef> ptr2(WTFMove(temp));
+    RetainPtr<CFStringRef> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((CFStringRef)nullptr, temp.get());
@@ -100,7 +100,7 @@ TEST(RetainPtr, MoveAssignmentFromMutableCFType)
     RetainPtr<CFMutableStringRef> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((CFStringRef)nullptr, temp.get());
@@ -122,7 +122,7 @@ TEST(RetainPtr, MoveAssignmentFromSameCFType)
     RetainPtr<CFStringRef> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((CFStringRef)nullptr, temp.get());
@@ -162,7 +162,7 @@ TEST(RetainPtr, OptionalRetainPtrCF)
 
     // Test move from std::optional<RetainPtr<CFNumberRef>>.
     EXPECT_EQ(2, CFGetRetainCount(object2.get()));
-    optionalObject1 = WTFMove(optionalObject2);
+    optionalObject1 = WTF::move(optionalObject2);
     EXPECT_EQ(2, CFGetRetainCount(object2.get()));
     EXPECT_TRUE(optionalObject1.value());
     EXPECT_TRUE(optionalObject1.value().get());

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -72,7 +72,7 @@ TEST(TypeCastsCocoa, bridge_cast)
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
 
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
-        objectCF = bridge_cast(WTFMove(objectNS));
+        objectCF = bridge_cast(WTF::move(objectNS));
         objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, objectNS.get());
         EXPECT_EQ(objectNSPtr, objectCFPtr);
@@ -80,7 +80,7 @@ TEST(TypeCastsCocoa, bridge_cast)
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
-        objectNS = bridge_cast(WTFMove(objectCF));
+        objectNS = bridge_cast(WTF::move(objectCF));
         objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(objectCFPtr, objectNSPtr);
@@ -94,7 +94,7 @@ TEST(TypeCastsCocoa, bridge_cast)
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
-        objectNS = bridge_cast(WTFMove(objectCF));
+        objectNS = bridge_cast(WTF::move(objectCF));
         objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(objectCFPtr, objectNSPtr);
@@ -102,7 +102,7 @@ TEST(TypeCastsCocoa, bridge_cast)
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
 
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
-        objectCF = bridge_cast(WTFMove(objectNS));
+        objectCF = bridge_cast(WTF::move(objectNS));
         objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, objectNS.get());
         EXPECT_EQ(objectNSPtr, objectCFPtr);
@@ -114,7 +114,7 @@ TEST(TypeCastsCocoa, bridge_id_cast)
 {
     @autoreleasepool {
         RetainPtr<CFTypeRef> objectCF;
-        auto objectID = bridge_id_cast(WTFMove(objectCF));
+        auto objectID = bridge_id_cast(WTF::move(objectCF));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(nil, objectID.get());
     }
@@ -124,7 +124,7 @@ TEST(TypeCastsCocoa, bridge_id_cast)
         auto objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 
-        auto objectID = bridge_id_cast(WTFMove(objectCF));
+        auto objectID = bridge_id_cast(WTF::move(objectCF));
         uintptr_t objectIDPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectIDPtr = reinterpret_cast<uintptr_t>(objectID.get());
@@ -240,7 +240,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
 {
     @autoreleasepool {
         RetainPtr<NSObject> object;
-        auto objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
+        auto objectCast = dynamic_objc_cast<NSString>(WTF::move(object));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
         EXPECT_EQ(nil, objectCast.get());
     }
@@ -256,7 +256,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSString> objectCast;
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
+            objectCast = dynamic_objc_cast<NSString>(WTF::move(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -272,7 +272,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSObject> objectCast2;
         uintptr_t objectCastPtr2;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast2 = dynamic_objc_cast<NSObject>(WTFMove(object));
+            objectCast2 = dynamic_objc_cast<NSObject>(WTF::move(object));
             objectCastPtr2 = reinterpret_cast<uintptr_t>(objectCast2.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -288,7 +288,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSArray> objectCastBad;
         uintptr_t objectPtr2;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCastBad = dynamic_objc_cast<NSArray>(WTFMove(object));
+            objectCastBad = dynamic_objc_cast<NSArray>(WTF::move(object));
             objectPtr2 = reinterpret_cast<uintptr_t>(object.get());
         }
         EXPECT_EQ(objectPtr, objectPtr2);
@@ -304,7 +304,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
-        RetainPtr<NSObject> objectCast = WTFMove(object);
+        RetainPtr<NSObject> objectCast = WTF::move(object);
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
@@ -326,7 +326,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSObject> objectCast;
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast = dynamic_objc_cast<NSObject>(WTFMove(object));
+            objectCast = dynamic_objc_cast<NSObject>(WTF::move(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -341,7 +341,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
 
         RetainPtr<MyObjectSubtype> objectCastBad;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCastBad = dynamic_objc_cast<MyObjectSubtype>(WTFMove(object));
+            objectCastBad = dynamic_objc_cast<MyObjectSubtype>(WTF::move(object));
         }
         EXPECT_EQ(nil, objectCastBad.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/MachSendRight.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/MachSendRight.cpp
@@ -93,7 +93,7 @@ TEST(MachSendRight, Move)
 
     {
         MachSendRight right = MachSendRight::adopt(port);
-        MachSendRight move = WTFMove(right);
+        MachSendRight move = WTF::move(right);
 
         EXPECT_EQ(getSendRefs(port), 1u);
     }
@@ -129,7 +129,7 @@ TEST(MachSendRight, OverwriteMove)
         MachSendRight firstRight = MachSendRight::adopt(first);
         MachSendRight secondRight = MachSendRight::adopt(second);
 
-        secondRight = WTFMove(firstRight);
+        secondRight = WTF::move(firstRight);
 
         EXPECT_EQ(getSendRefs(first), 1u);
         EXPECT_EQ(getSendRefs(second), 0u);

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
@@ -45,7 +45,7 @@ static void runTestWhileRunLoopIsActive(Function<void()>&& testFunction, bool& d
     ASSERT(!done);
 
     // Schedule test to run immediately after RunLoop starts (0ms delay)
-    RunLoop::currentSingleton().dispatchAfter(0_ms, [testFunction = WTFMove(testFunction)] {
+    RunLoop::currentSingleton().dispatchAfter(0_ms, [testFunction = WTF::move(testFunction)] {
         testFunction();
     });
 

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GMallocString.cpp
@@ -59,7 +59,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
 
     cString = g_strdup(literal);
     auto gUniquePtr = GUniquePtr<char>(cString);
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniquePtr));
     EXPECT_TRUE(string.isNull());
     EXPECT_TRUE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -70,7 +70,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
     cString = g_strdup(literal);
     GUniqueOutPtr<char> gUniqueOutPtr;
     gUniqueOutPtr.outPtr() = cString;
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniqueOutPtr));
     EXPECT_TRUE(string.isNull());
     EXPECT_TRUE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -89,7 +89,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
 
     cString = g_strdup(literal);
     gUniquePtr = GUniquePtr<char>(cString);
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniquePtr));
     EXPECT_FALSE(string.isNull());
     EXPECT_TRUE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -99,7 +99,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
 
     cString = g_strdup(literal);
     gUniqueOutPtr.outPtr() = cString;
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniqueOutPtr));
     EXPECT_FALSE(string.isNull());
     EXPECT_TRUE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -118,7 +118,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
 
     cString = g_strdup(literal);
     gUniquePtr = GUniquePtr<char>(cString);
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniquePtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniquePtr));
     EXPECT_FALSE(string.isNull());
     EXPECT_FALSE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -128,7 +128,7 @@ TEST(WTF_GMallocString, NullAndEmpty)
 
     cString = g_strdup(literal);
     gUniqueOutPtr.outPtr() = cString;
-    string = GMallocString::unsafeAdoptFromUTF8(WTFMove(gUniqueOutPtr));
+    string = GMallocString::unsafeAdoptFromUTF8(WTF::move(gUniqueOutPtr));
     EXPECT_FALSE(string.isNull());
     EXPECT_FALSE(string.isEmpty());
     EXPECT_EQ(string.utf8(), cString);
@@ -141,28 +141,28 @@ TEST(WTF_GMallocString, Move)
 {
     GMallocString emptyString1;
     EXPECT_TRUE(emptyString1.isNull());
-    GMallocString emptyString2(WTFMove(emptyString1));
+    GMallocString emptyString2(WTF::move(emptyString1));
     EXPECT_TRUE(emptyString1.isNull());
     EXPECT_TRUE(emptyString2.isNull());
-    emptyString1 = WTFMove(emptyString2);
+    emptyString1 = WTF::move(emptyString2);
     EXPECT_TRUE(emptyString1.isNull());
     EXPECT_TRUE(emptyString2.isNull());
 
     GMallocString nullString1(nullptr);
     EXPECT_TRUE(nullString1.isNull());
-    GMallocString nullString2(WTFMove(nullString1));
+    GMallocString nullString2(WTF::move(nullString1));
     EXPECT_TRUE(nullString1.isNull());
     EXPECT_TRUE(nullString2.isNull());
-    nullString1 = WTFMove(nullString2);
+    nullString1 = WTF::move(nullString2);
     EXPECT_TRUE(nullString1.isNull());
     EXPECT_TRUE(nullString2.isNull());
 
     auto nonEmptyString1 = GMallocString::unsafeAdoptFromUTF8(g_strdup("test"));
     EXPECT_FALSE(nonEmptyString1.isNull());
-    GMallocString nonEmptyString2(WTFMove(nonEmptyString1));
+    GMallocString nonEmptyString2(WTF::move(nonEmptyString1));
     EXPECT_TRUE(nonEmptyString1.isNull());
     EXPECT_FALSE(nonEmptyString2.isNull());
-    nonEmptyString1 = WTFMove(nonEmptyString2);
+    nonEmptyString1 = WTF::move(nonEmptyString2);
     EXPECT_FALSE(nonEmptyString1.isNull());
     EXPECT_TRUE(nonEmptyString2.isNull());
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GRefPtr.cpp
@@ -117,7 +117,7 @@ TEST(WTF_GRefPtr, Basic)
         obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
         GWeakPtr weak(reinterpret_cast<gpointer*>(&obj));
         GRefPtr<GObject> o1 = obj;
-        GRefPtr<GObject> o2(WTFMove(o1));
+        GRefPtr<GObject> o2(WTF::move(o1));
         EXPECT_NULL(o1.get());
         EXPECT_EQ(obj, o2.get());
         EXPECT_EQ(obj->ref_count, 2);
@@ -130,7 +130,7 @@ TEST(WTF_GRefPtr, Basic)
         obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
         GWeakPtr weak(reinterpret_cast<gpointer*>(&obj));
         GRefPtr<GObject> o1 = obj;
-        GRefPtr<GObject> o2 = WTFMove(o1);
+        GRefPtr<GObject> o2 = WTF::move(o1);
         EXPECT_NULL(o1.get());
         EXPECT_EQ(obj, o2.get());
         EXPECT_EQ(obj->ref_count, 2);

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
@@ -120,7 +120,7 @@ TEST(WTF_GWeakPtr, Move)
         GWeakPtr<GObject> weak(obj);
         EXPECT_EQ(obj, weak.get());
         EXPECT_TRUE(weak);
-        GWeakPtr<GObject> weak2(WTFMove(weak));
+        GWeakPtr<GObject> weak2(WTF::move(weak));
         EXPECT_NULL(weak.get());
         EXPECT_FALSE(weak);
         EXPECT_EQ(obj, weak2.get());
@@ -137,7 +137,7 @@ TEST(WTF_GWeakPtr, Move)
         GWeakPtr<GObject> weak(obj);
         EXPECT_EQ(obj, weak.get());
         EXPECT_TRUE(weak);
-        GWeakPtr<GObject> weak2 = WTFMove(weak);
+        GWeakPtr<GObject> weak2 = WTF::move(weak);
         EXPECT_NULL(weak.get());
         EXPECT_FALSE(weak);
         EXPECT_EQ(obj, weak2.get());
@@ -208,7 +208,7 @@ TEST(WTF_GThreadSafeWeakPtr, Move)
         obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
         GThreadSafeWeakPtr<GObject> weak(obj);
         EXPECT_EQ(obj, weak.get());
-        GThreadSafeWeakPtr<GObject> weak2 = WTFMove(weak);
+        GThreadSafeWeakPtr<GObject> weak2 = WTF::move(weak);
         EXPECT_NULL(weak.get());
         EXPECT_EQ(obj, weak2.get());
         g_clear_object(&obj);

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -95,7 +95,7 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromMutableNSType)
     RetainPtr<NSMutableString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<NSString> ptr2(WTFMove(temp));
+    RetainPtr<NSString> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -115,7 +115,7 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSameNSType)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<NSString> ptr2(WTFMove(temp));
+    RetainPtr<NSString> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -135,7 +135,7 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSType)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<NSString> ptr2(WTFMove(temp));
+    RetainPtr<NSString> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -155,7 +155,7 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSTypeReversed)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<NSString> ptr2(WTFMove(temp));
+    RetainPtr<NSString> ptr2(WTF::move(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -177,7 +177,7 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromMutableNSType)
     RetainPtr<NSMutableString> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -199,7 +199,7 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSameNSType)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -221,7 +221,7 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -243,7 +243,7 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSTypeReversed)
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
-    ptr = WTFMove(temp);
+    ptr = WTF::move(temp);
 
     EXPECT_EQ(string, ptr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -307,7 +307,7 @@ TEST(RETAIN_PTR_TEST_NAME, OptionalRetainPtrNS)
     // Test move from std::optional<RetainPtr<NSObject>>.
     EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectPtr2));
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
-        optionalObject1 = WTFMove(optionalObject2);
+        optionalObject1 = WTF::move(optionalObject2);
     }
     EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectPtr2));
     EXPECT_TRUE(optionalObject1.value());

--- a/Tools/TestWebKitAPI/Tests/WebCore/ASN1Utilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ASN1Utilities.cpp
@@ -98,7 +98,7 @@ struct Sequence : Object {
         return makeUniqueRef<Sequence>(Vector<UniqueRef<Object>>::from(std::forward<Types>(types)...));
     }
     Sequence(Vector<UniqueRef<Object>>&& elements)
-        : elements(WTFMove(elements)) { }
+        : elements(WTF::move(elements)) { }
 private:
     const Vector<UniqueRef<Object>> elements;
     size_t encodedLengthBytes() const final
@@ -136,7 +136,7 @@ private:
 struct IndexWrapper : Object {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(IndexWrapper);
     IndexWrapper(uint8_t index, UniqueRef<Object>&& wrapped)
-        : index(index), wrapped(WTFMove(wrapped)) { }
+        : index(index), wrapped(WTF::move(wrapped)) { }
 private:
     const uint8_t index;
     UniqueRef<Object> wrapped;
@@ -186,7 +186,7 @@ private:
 struct BitString : Object {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(BitString);
     BitString(Vector<uint8_t>&& bytes)
-        : bytes(WTFMove(bytes)) { }
+        : bytes(WTF::move(bytes)) { }
 private:
     const Vector<uint8_t> bytes;
     size_t encodedLengthBytes() const final
@@ -226,7 +226,7 @@ Vector<uint8_t> wrapPublicKeyWithRSAPSSOID(Vector<uint8_t>&& publicKey)
                 makeUniqueRef<ASN1::IndexWrapper>(2, makeUniqueRef<ASN1::Integer>(48))
             )
         ),
-        makeUniqueRef<ASN1::BitString>(WTFMove(publicKey))
+        makeUniqueRef<ASN1::BitString>(WTF::move(publicKey))
     );
 #else
     auto sequence = ASN1::Sequence::create(
@@ -234,7 +234,7 @@ Vector<uint8_t> wrapPublicKeyWithRSAPSSOID(Vector<uint8_t>&& publicKey)
             makeUniqueRef<ASN1::ObjectIdentifier>(ASN1::ObjectIdentifier::Type::RsaEncryption),
             makeUniqueRef<ASN1::Null>()
         ),
-        makeUniqueRef<ASN1::BitString>(WTFMove(publicKey))
+        makeUniqueRef<ASN1::BitString>(WTF::move(publicKey))
     );
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/AbortableTaskQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/AbortableTaskQueue.cpp
@@ -55,8 +55,8 @@ TEST(AbortableTaskQueue, AsyncTasks)
             testFinished = true;
         });
     };
-    RunLoop::currentSingleton().dispatch([backgroundThreadFunction = WTFMove(backgroundThreadFunction)]() mutable {
-        WTF::Thread::create("atq-background"_s, WTFMove(backgroundThreadFunction))->detach();
+    RunLoop::currentSingleton().dispatch([backgroundThreadFunction = WTF::move(backgroundThreadFunction)]() mutable {
+        WTF::Thread::create("atq-background"_s, WTF::move(backgroundThreadFunction))->detach();
     });
 
     Util::run(&testFinished);
@@ -123,8 +123,8 @@ TEST(AbortableTaskQueue, SyncTasks)
             testFinished = true;
         });
     };
-    RunLoop::currentSingleton().dispatch([backgroundThreadFunction = WTFMove(backgroundThreadFunction)]() mutable {
-        WTF::Thread::create("atq-background"_s, WTFMove(backgroundThreadFunction))->detach();
+    RunLoop::currentSingleton().dispatch([backgroundThreadFunction = WTF::move(backgroundThreadFunction)]() mutable {
+        WTF::Thread::create("atq-background"_s, WTF::move(backgroundThreadFunction))->detach();
     });
 
     Util::run(&testFinished);
@@ -218,10 +218,10 @@ TEST(AbortableTaskQueue, Abort)
             testFinished = true;
         });
     };
-    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTFMove(backgroundThreadFunction)]() mutable {
+    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTF::move(backgroundThreadFunction)]() mutable {
         EXPECT_TRUE(isMainThread());
         DeterministicScheduler<TestThread>::ThreadContext mainThreadContext(scheduler, TestThread::Main);
-        WTF::Thread::create("atq-background"_s, WTFMove(backgroundThreadFunction))->detach();
+        WTF::Thread::create("atq-background"_s, WTF::move(backgroundThreadFunction))->detach();
 
         mainThreadContext.waitMyTurn();
 
@@ -258,9 +258,9 @@ TEST(AbortableTaskQueue, AbortBeforeSyncTaskRun)
             testFinished = true;
         });
     };
-    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTFMove(backgroundThreadFunction)]() mutable {
+    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTF::move(backgroundThreadFunction)]() mutable {
         EXPECT_TRUE(isMainThread());
-        WTF::Thread::create("atq-background"_s, WTFMove(backgroundThreadFunction))->detach();
+        WTF::Thread::create("atq-background"_s, WTF::move(backgroundThreadFunction))->detach();
 
         // Give the background thread a bit of time to get blocked waiting for a response.
         WTF::sleep(100_ms);
@@ -305,9 +305,9 @@ TEST(AbortableTaskQueue, AbortedBySyncTaskHandler)
             testFinished = true;
         });
     };
-    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTFMove(backgroundThreadFunction)]() mutable {
+    RunLoop::currentSingleton().dispatch([&, backgroundThreadFunction = WTF::move(backgroundThreadFunction)]() mutable {
         EXPECT_TRUE(isMainThread());
-        WTF::Thread::create("atq-background"_s, WTFMove(backgroundThreadFunction))->detach();
+        WTF::Thread::create("atq-background"_s, WTF::move(backgroundThreadFunction))->detach();
     });
 
     Util::run(&testFinished);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApduTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApduTest.cpp
@@ -113,11 +113,11 @@ TEST(ApduTest, TestDeserializeResponse)
     Vector<uint8_t> testVector;
     // Invalid length.
     Vector<uint8_t> message({ 0xAA });
-    EXPECT_FALSE(ApduResponse::createFromMessage(WTFMove(message)));
+    EXPECT_FALSE(ApduResponse::createFromMessage(WTF::move(message)));
     // Valid length and status.
     status = ApduResponse::Status::SW_CONDITIONS_NOT_SATISFIED;
     message = { static_cast<uint8_t>(static_cast<uint16_t>(status) >> 8), static_cast<uint8_t>(status) };
-    auto response = ApduResponse::createFromMessage(WTFMove(message));
+    auto response = ApduResponse::createFromMessage(WTF::move(message));
     ASSERT_TRUE(response);
     EXPECT_EQ(ApduResponse::Status::SW_CONDITIONS_NOT_SATISFIED, response->status());
     EXPECT_EQ(response->data(), Vector<uint8_t>());
@@ -126,7 +126,7 @@ TEST(ApduTest, TestDeserializeResponse)
     message = { static_cast<uint8_t>(static_cast<uint16_t>(status) >> 8), static_cast<uint8_t>(status)};
     testVector = { 0x01, 0x02, 0xEF, 0xFF };
     message.insertVector(0, testVector);
-    response = ApduResponse::createFromMessage(WTFMove(message));
+    response = ApduResponse::createFromMessage(WTF::move(message));
     ASSERT_TRUE(response);
     EXPECT_EQ(ApduResponse::Status::SW_NO_ERROR, response->status());
     EXPECT_EQ(response->data(), testVector);
@@ -154,7 +154,7 @@ TEST(ApduTest, TestSerializeCommand)
     EXPECT_EQ(expected, deserializedCmd->getEncodedCommand());
     // Data exists, response expected.
     Vector<uint8_t> data({ 0x1, 0x2, 0x3, 0x4 });
-    cmd.setData(WTFMove(data));
+    cmd.setData(WTF::move(data));
     expected = { 0xA, 0xB, 0xC, 0xD, 0x0,  0x0, 0x4, 0x1, 0x2, 0x3, 0x4, 0xCA, 0xFE };
     EXPECT_EQ(expected, cmd.getEncodedCommand());
     deserializedCmd = ApduCommand::createFromMessage(expected);
@@ -183,7 +183,7 @@ TEST(ApduTest, TestSerializeEdgeCases)
     EXPECT_EQ(expected, deserializedCmd->getEncodedCommand());
     // Maximum data size.
     Vector<uint8_t> oversized(ApduCommand::kApduMaxDataLength);
-    cmd.setData(WTFMove(oversized));
+    cmd.setData(WTF::move(oversized));
     deserializedCmd = ApduCommand::createFromMessage(cmd.getEncodedCommand());
     ASSERT_TRUE(deserializedCmd);
     EXPECT_EQ(cmd.getEncodedCommand(), deserializedCmd->getEncodedCommand());

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORReaderTest.cpp
@@ -240,7 +240,7 @@ TEST(CBORReaderTest, TestReadArray)
 
     std::optional<CBORValue> cbor = CBORReader::read(kArrayTestCaseCBOR);
     ASSERT_TRUE(cbor.has_value());
-    const CBORValue cborArray = WTFMove(cbor.value());
+    const CBORValue cborArray = WTF::move(cbor.value());
     ASSERT_TRUE(cborArray.type() == CBORValue::Type::Array);
     ASSERT_EQ(cborArray.getArray().size(), 25u);
 
@@ -270,7 +270,7 @@ TEST(CBORReaderTest, TestReadMapWithMapValue)
 
     std::optional<CBORValue> cbor = CBORReader::read(kMapTestCaseCBOR);
     ASSERT_TRUE(cbor.has_value());
-    const CBORValue cborVal = WTFMove(cbor.value());
+    const CBORValue cborVal = WTF::move(cbor.value());
     ASSERT_TRUE(cborVal.type() == CBORValue::Type::Map);
     ASSERT_EQ(cborVal.getMap().size(), 4u);
 
@@ -314,7 +314,7 @@ TEST(CBORReaderTest, TestReadMapWithIntegerKeys)
 
     std::optional<CBORValue> cbor = CBORReader::read(kMapWithIntegerKeyCBOR);
     ASSERT_TRUE(cbor.has_value());
-    const CBORValue cborVal = WTFMove(cbor.value());
+    const CBORValue cborVal = WTF::move(cbor.value());
     ASSERT_TRUE(cborVal.type() == CBORValue::Type::Map);
     ASSERT_EQ(cborVal.getMap().size(), 4u);
 
@@ -354,7 +354,7 @@ TEST(CBORReaderTest, TestReadMapWithArray)
 
     std::optional<CBORValue> cbor = CBORReader::read(kMapArrayTestCaseCBOR);
     ASSERT_TRUE(cbor.has_value());
-    const CBORValue cborVal = WTFMove(cbor.value());
+    const CBORValue cborVal = WTF::move(cbor.value());
     ASSERT_TRUE(cborVal.type() == CBORValue::Type::Map);
     ASSERT_EQ(cborVal.getMap().size(), 2u);
 
@@ -393,7 +393,7 @@ TEST(CBORReaderTest, TestReadNestedMap)
 
     std::optional<CBORValue> cbor = CBORReader::read(kNestedMapTestCase);
     ASSERT_TRUE(cbor.has_value());
-    const CBORValue cborVal = WTFMove(cbor.value());
+    const CBORValue cborVal = WTF::move(cbor.value());
     ASSERT_TRUE(cborVal.type() == CBORValue::Type::Map);
     ASSERT_EQ(cborVal.getMap().size(), 2u);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORValueTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORValueTest.cpp
@@ -71,7 +71,7 @@ TEST(CBORValueTest, ConstructStringFromWTFStringConstRef)
 TEST(CBORValueTest, ConstructStringFromWTFStringRefRef)
 {
     String str = "foobar"_s;
-    CBORValue value(WTFMove(str));
+    CBORValue value(WTF::move(str));
     ASSERT_TRUE(CBORValue::Type::String == value.type());
     EXPECT_TRUE("foobar"_s == value.getString());
 }
@@ -97,7 +97,7 @@ TEST(CBORValueTest, ConstructArray)
 
     array.last() = CBORValue("bar");
     {
-        CBORValue value(WTFMove(array));
+        CBORValue value(WTF::move(array));
         ASSERT_TRUE(CBORValue::Type::Array == value.type());
         ASSERT_EQ(1u, value.getArray().size());
         ASSERT_TRUE(CBORValue::Type::String == value.getArray()[0].type());
@@ -120,7 +120,7 @@ TEST(CBORValueTest, ConstructMap)
 
     map[CBORValue("foo")] = CBORValue("baz");
     {
-        CBORValue value(WTFMove(map));
+        CBORValue value(WTF::move(map));
         ASSERT_TRUE(CBORValue::Type::Map == value.type());
         ASSERT_EQ(value.getMap().count(keyFoo), 1u);
         ASSERT_TRUE(CBORValue::Type::String == value.getMap().find(keyFoo)->second.type());
@@ -219,7 +219,7 @@ TEST(CBORValueTest, CopyArray)
 {
     CBORValue::ArrayValue array;
     array.append(123);
-    CBORValue value(WTFMove(array));
+    CBORValue value(WTF::move(array));
 
     CBORValue copiedValue(value.clone());
     ASSERT_EQ(1u, copiedValue.getArray().size());
@@ -236,7 +236,7 @@ TEST(CBORValueTest, CopyMap)
     CBORValue::MapValue map;
     CBORValue keyA("a");
     map[CBORValue("a")] = CBORValue(123);
-    CBORValue value(WTFMove(map));
+    CBORValue value(WTF::move(map));
 
     CBORValue copiedValue(value.clone());
     EXPECT_EQ(1u, copiedValue.getMap().size());
@@ -271,7 +271,7 @@ TEST(CBORValueTest, CopySimpleValue)
 TEST(CBORValueTest, MoveUnsigned)
 {
     CBORValue value(74);
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::Unsigned == moved_value.type());
     EXPECT_EQ(74u, moved_value.getInteger());
 
@@ -285,7 +285,7 @@ TEST(CBORValueTest, MoveUnsigned)
 TEST(CBORValueTest, MoveNegativeInteger)
 {
     CBORValue value(-74);
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::Negative == moved_value.type());
     EXPECT_EQ(-74, moved_value.getInteger());
 
@@ -299,7 +299,7 @@ TEST(CBORValueTest, MoveNegativeInteger)
 TEST(CBORValueTest, MoveString)
 {
     CBORValue value("foobar");
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::String == moved_value.type());
     EXPECT_TRUE("foobar"_s == moved_value.getString());
 
@@ -314,7 +314,7 @@ TEST(CBORValueTest, MoveBytestring)
 {
     const CBORValue::BinaryValue bytes({ 0xF, 0x0, 0x0, 0xB, 0xA, 0x2 });
     CBORValue value(bytes);
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::ByteString == moved_value.type());
     EXPECT_TRUE(bytes == moved_value.getByteString());
 
@@ -331,8 +331,8 @@ TEST(CBORValueTest, MoveConstructMap)
     const CBORValue keyA("a");
     map[CBORValue("a")] = CBORValue(123);
 
-    CBORValue value(WTFMove(map));
-    CBORValue moved_value(WTFMove(value));
+    CBORValue value(WTF::move(map));
+    CBORValue moved_value(WTF::move(value));
     ASSERT_TRUE(CBORValue::Type::Map == moved_value.type());
     ASSERT_EQ(moved_value.getMap().count(keyA), 1u);
     ASSERT_TRUE(moved_value.getMap().find(keyA)->second.isUnsigned());
@@ -346,7 +346,7 @@ TEST(CBORValueTest, MoveAssignMap)
     map[CBORValue("a")] = CBORValue(123);
 
     CBORValue blank;
-    blank = CBORValue(WTFMove(map));
+    blank = CBORValue(WTF::move(map));
     ASSERT_TRUE(blank.isMap());
     ASSERT_EQ(blank.getMap().count(keyA), 1u);
     ASSERT_TRUE(blank.getMap().find(keyA)->second.isUnsigned());
@@ -358,12 +358,12 @@ TEST(CBORValueTest, MoveArray)
     CBORValue::ArrayValue array;
     array.append(123);
     CBORValue value(array);
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::Array == moved_value.type());
     EXPECT_EQ(123u, moved_value.getArray().last().getInteger());
 
     CBORValue blank;
-    blank = CBORValue(WTFMove(array));
+    blank = CBORValue(WTF::move(array));
     EXPECT_TRUE(CBORValue::Type::Array == blank.type());
     EXPECT_EQ(123u, blank.getArray().last().getInteger());
 }
@@ -371,7 +371,7 @@ TEST(CBORValueTest, MoveArray)
 TEST(CBORValueTest, MoveSimpleValue)
 {
     CBORValue value(CBORValue::SimpleValue::Undefined);
-    CBORValue moved_value(WTFMove(value));
+    CBORValue moved_value(WTF::move(value));
     EXPECT_TRUE(CBORValue::Type::SimpleValue == moved_value.type());
     EXPECT_TRUE(CBORValue::SimpleValue::Undefined == moved_value.getSimpleValue());
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp
@@ -187,7 +187,7 @@ TEST(Color, Validity)
     EXPECT_EQ(validColorComponents.blue, 3);
     EXPECT_EQ(validColorComponents.alpha, 4);
 
-    Color yetAnotherValidColor(WTFMove(validColor));
+    Color yetAnotherValidColor(WTF::move(validColor));
     EXPECT_TRUE(yetAnotherValidColor.isValid());
     auto yetAnotherValidColorComponents = yetAnotherValidColor.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
     EXPECT_EQ(yetAnotherValidColorComponents.red, 1);
@@ -195,7 +195,7 @@ TEST(Color, Validity)
     EXPECT_EQ(yetAnotherValidColorComponents.blue, 3);
     EXPECT_EQ(yetAnotherValidColorComponents.alpha, 4);
 
-    otherValidColor = WTFMove(yetAnotherValidColor);
+    otherValidColor = WTF::move(yetAnotherValidColor);
     EXPECT_TRUE(otherValidColor.isValid());
     auto otherValidColorComponents = otherValidColor.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
     EXPECT_EQ(otherValidColorComponents.red, 1);
@@ -317,7 +317,7 @@ TEST(Color, Hash)
 TEST(Color, MoveConstructor)
 {
     Color c1 { DisplayP3<float> { 1.0, 0.5, 0.25, 1.0 } };
-    Color c2(WTFMove(c1));
+    Color c2(WTF::move(c1));
 
     // We should have moved the out of line color pointer into c2,
     // and set c1 to invalid so that it doesn't cause deletion.
@@ -339,7 +339,7 @@ namespace {
 template<typename T>
 void selfMove(T& a, T&& b)
 {
-    a = WTFMove(b);
+    a = WTF::move(b);
 }
 }
 
@@ -347,7 +347,7 @@ TEST(Color, MoveAssignment)
 {
     Color c1 { DisplayP3<float> { 1.0, 0.5, 0.25, 1.0 } };
     Color c2;
-    c2 = WTFMove(c1);
+    c2 = WTF::move(c1);
 
     EXPECT_TRUE(c2.isValid());
 
@@ -371,16 +371,16 @@ TEST(Color, MoveAssignment)
     // invalid condition.
     Color c3 { DisplayP3<float> { 1.0, 0.5, 0.25, 1.0 } };
     EXPECT_EQ(c2, c3);
-    c2 = WTFMove(c3);
+    c2 = WTF::move(c3);
     EXPECT_FALSE(c3.isValid()); // Moved-from source marked invalid.
     EXPECT_TRUE(c2.isValid());
     EXPECT_EQ(serializationForCSS(c2), "color(display-p3 1 0.5 0.25)"_s);
 
     // Moving into itself works.
-    selfMove(c2, WTFMove(c2));
+    selfMove(c2, WTF::move(c2));
     EXPECT_TRUE(c2.isValid());
     EXPECT_EQ(serializationForCSS(c2), "color(display-p3 1 0.5 0.25)"_s);
-    selfMove(c1, WTFMove(c1));
+    selfMove(c1, WTF::move(c1));
     EXPECT_FALSE(c1.isValid());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -49,7 +49,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont()->spaceWidth();
 
@@ -63,8 +63,8 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 5, 6, false);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run1));
-    runs.append(WTFMove(run2));
+    runs.append(WTF::move(run1));
+    runs.append(WTF::move(run2));
     ComplexTextController controller(font, textRun, runs);
 
     float totalWidth = 0;
@@ -95,7 +95,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     Vector<FloatSize> advances = { FloatSize(), FloatSize(21.640625, 0.0), FloatSize(42.3046875, 0.0), FloatSize(55.8984375, 0.0), FloatSize(22.34375, 0.0) };
@@ -107,7 +107,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
     TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run));
+    runs.append(WTF::move(run));
     ComplexTextController controller(font, textRun, runs);
 
     float totalWidth = 0;
@@ -138,7 +138,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
     FontCascadeDescription description;
     description.setOneFamily("LucidaGrande"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
     auto spaceWidth = font.primaryFont()->spaceWidth();
 
@@ -152,8 +152,8 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 1, 3, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run1));
-    runs.append(WTFMove(run2));
+    runs.append(WTF::move(run1));
+    runs.append(WTF::move(run2));
     ComplexTextController controller(font, textRun, runs);
 
     EXPECT_NEAR(controller.totalAdvance().width(), spaceWidth + 76.347656 + initialAdvance.width(), 0.0001);
@@ -180,7 +180,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
     FontCascadeDescription description;
     description.setOneFamily("LucidaGrande"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     Vector<FloatSize> advances = { FloatSize(76.347656, 0.000000), FloatSize(0.000000, 0.000000) };
@@ -192,7 +192,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
     TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 2, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run));
+    runs.append(WTF::move(run));
     ComplexTextController controller(font, textRun, runs);
 
     EXPECT_NEAR(controller.totalAdvance().width(), 76.347656 + initialAdvance.width(), 0.0001);
@@ -216,7 +216,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(48);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     FloatSize initialAdvance = FloatSize(4.33996383363472, 12.368896925859);
@@ -227,9 +227,9 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 1, 2, false);
     auto run3 = ComplexTextController::ComplexTextRun::create({ FloatSize(43.8119349005425, 0) }, { }, { 276 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run1));
-    runs.append(WTFMove(run2));
-    runs.append(WTFMove(run3));
+    runs.append(WTF::move(run1));
+    runs.append(WTF::move(run2));
+    runs.append(WTF::move(run3));
     ComplexTextController controller(font, textRun, runs);
 
     float totalWidth = 14.0397830018083 + 12.0 + 43.8119349005425;
@@ -261,14 +261,14 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(48);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     std::array<char16_t, 1> characters { 'a' };
     TextRun textRun(StringView(characters), 0, 100, ExpansionBehavior::forceLeftOnly());
     auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run));
+    runs.append(WTF::move(run));
     ComplexTextController controller(font, textRun, runs);
 
     float totalWidth = 100 + 24;
@@ -290,7 +290,7 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(48);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     std::array<char16_t, 4> characters { 'a', 'b', 'c', 'd' };
@@ -298,8 +298,8 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), std::span { characters }, 0, 0, 2, true);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), std::span { characters }, 0, 2, 4, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run1));
-    runs.append(WTFMove(run2));
+    runs.append(WTF::move(run1));
+    runs.append(WTF::move(run2));
     ComplexTextController controller(font, textRun, runs);
 
     EXPECT_NEAR(controller.totalAdvance().width(), 0, 0.0001);
@@ -333,7 +333,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     Vector<FloatSize> advances = { FloatSize(1, 0), FloatSize(2, 0), FloatSize(4, 0), FloatSize(8, 0), FloatSize(16, 0) };
@@ -345,7 +345,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
     TextRun textRun(StringView(characters), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
-    runs.append(WTFMove(run));
+    runs.append(WTF::move(run));
     ComplexTextController controller(font, textRun, runs);
 
     EXPECT_NEAR(controller.totalAdvance().width(), 1 + 20 + 7 + 4 + 20 + 7 + 16, 0.0001);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -143,12 +143,12 @@ public:
         CompiledContentExtensionData extensionData;
         InMemoryContentExtensionCompilationClient client(extensionData);
         auto parsedRules = ContentExtensions::parseRuleList(filter, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes);
-        auto compilerError = ContentExtensions::compileRuleList(client, WTFMove(filter), WTFMove(parsedRules.value()));
+        auto compilerError = ContentExtensions::compileRuleList(client, WTF::move(filter), WTF::move(parsedRules.value()));
 
         // Compiling should always succeed here. We have other tests for compile failures.
         EXPECT_FALSE(compilerError);
 
-        return adoptRef(*new InMemoryCompiledContentExtension(WTFMove(extensionData)));
+        return adoptRef(*new InMemoryCompiledContentExtension(WTF::move(extensionData)));
     }
 
     const CompiledContentExtensionData& data() { return m_data; };
@@ -160,7 +160,7 @@ private:
     std::span<const uint8_t> frameURLFiltersBytecode() const final { return m_data.frameURLFilters.span(); }
 
     InMemoryCompiledContentExtension(CompiledContentExtensionData&& data)
-        : m_data(WTFMove(data))
+        : m_data(WTF::move(data))
     { }
 
     CompiledContentExtensionData m_data;
@@ -171,12 +171,12 @@ static std::pair<Vector<WebCore::ContentExtensions::Action>, Vector<String>> all
     Vector<ContentExtensions::Action> actions;
     Vector<String> identifiersApplyingStylesheets;
     for (auto&& actionsFromContentRuleList : backend.actionsForResourceLoad(info)) {
-        for (auto&& action : WTFMove(actionsFromContentRuleList.actions))
-            actions.append(WTFMove(action));
+        for (auto&& action : WTF::move(actionsFromContentRuleList.actions))
+            actions.append(WTF::move(action));
         if (!actionsFromContentRuleList.sawIgnorePreviousRules)
             identifiersApplyingStylesheets.append(actionsFromContentRuleList.contentRuleListIdentifier);
     }
-    return { WTFMove(actions), WTFMove(identifiersApplyingStylesheets) };
+    return { WTF::move(actions), WTF::move(identifiersApplyingStylesheets) };
 }
 
 #define testRequest(...) testRequestImpl(__LINE__, __VA_ARGS__)
@@ -216,9 +216,9 @@ static ResourceLoadInfo requestInTopAndFrameURLs(ASCIILiteral url, ASCIILiteral 
 ContentExtensions::ContentExtensionsBackend makeBackend(String&& json)
 {
     WebCore::initializeCommonAtomStrings();
-    auto extension = InMemoryCompiledContentExtension::create(WTFMove(json));
+    auto extension = InMemoryCompiledContentExtension::create(WTF::move(json));
     ContentExtensions::ContentExtensionsBackend backend;
-    backend.addContentExtension("testFilter"_s, WTFMove(extension), { });
+    backend.addContentExtension("testFilter"_s, WTF::move(extension), { });
     return backend;
 }
 
@@ -226,7 +226,7 @@ static Vector<ContentExtensions::NFA> createNFAs(ContentExtensions::CombinedURLF
 {
     Vector<ContentExtensions::NFA> nfas;
     combinedURLFilters.processNFAs(std::numeric_limits<size_t>::max(), [&](ContentExtensions::NFA&& nfa) {
-        nfas.append(WTFMove(nfa));
+        nfas.append(WTF::move(nfa));
         return true;
     });
     return nfas;
@@ -575,7 +575,7 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithIdenticalActionAreMerged)
     EXPECT_EQ(1ul, nfas.size());
     EXPECT_EQ(12ul, nfas.first().nodes.size());
 
-    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTFMove(nfas.first()));
+    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTF::move(nfas.first()));
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
@@ -601,7 +601,7 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithDistinguishableActionAreNotMerged
     EXPECT_EQ(1ul, nfas.size());
     EXPECT_EQ(17ul, nfas.first().nodes.size());
 
-    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTFMove(nfas.first()));
+    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTF::move(nfas.first()));
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
@@ -866,8 +866,8 @@ TEST_F(ContentExtensionTest, MultipleExtensions)
     auto extension1 = InMemoryCompiledContentExtension::create("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block_load\"}}]"_s);
     auto extension2 = InMemoryCompiledContentExtension::create("[{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"block_cookies\"}}]"_s);
     ContentExtensions::ContentExtensionsBackend backend;
-    backend.addContentExtension("testFilter1"_s, WTFMove(extension1), { });
-    backend.addContentExtension("testFilter2"_s, WTFMove(extension2), { });
+    backend.addContentExtension("testFilter1"_s, WTF::move(extension1), { });
+    backend.addContentExtension("testFilter2"_s, WTF::move(extension2), { });
     
     testRequest(backend, mainDocumentRequest("http://webkit.org"_s), { }, 2);
     testRequest(backend, mainDocumentRequest("http://webkit.org/block_load.html"_s), { variantIndex<ContentExtensions::BlockLoadAction> }, 2);
@@ -880,8 +880,8 @@ TEST_F(ContentExtensionTest, MultipleExtensions)
     auto ignoreExtension2 = InMemoryCompiledContentExtension::create("[{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"block_cookies\"}},"
         "{\"action\":{\"type\":\"ignore-previous-rules\"},\"trigger\":{\"url-filter\":\"ignore2\"}}]"_s);
     ContentExtensions::ContentExtensionsBackend backendWithIgnore;
-    backendWithIgnore.addContentExtension("testFilter1"_s, WTFMove(ignoreExtension1), { });
-    backendWithIgnore.addContentExtension("testFilter2"_s, WTFMove(ignoreExtension2), { });
+    backendWithIgnore.addContentExtension("testFilter1"_s, WTF::move(ignoreExtension1), { });
+    backendWithIgnore.addContentExtension("testFilter2"_s, WTF::move(ignoreExtension2), { });
 
     testRequest(backendWithIgnore, mainDocumentRequest("http://webkit.org"_s), { }, 2);
     testRequest(backendWithIgnore, mainDocumentRequest("http://webkit.org/block_load/ignore1.html"_s), { }, 1);
@@ -1121,7 +1121,7 @@ TEST_F(ContentExtensionTest, UselessTermsMatchingEverythingAreEliminated)
     EXPECT_EQ(1ul, nfas.size());
     EXPECT_EQ(7ul, nfas.first().nodes.size());
 
-    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTFMove(nfas.first()));
+    ContentExtensions::DFA dfa = *ContentExtensions::NFAToDFA::convert(WTF::move(nfas.first()));
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
@@ -1283,14 +1283,14 @@ TEST_F(ContentExtensionTest, LargeJumps)
     
     Vector<ContentExtensions::NFA> nfas;
     combinedURLFilters.processNFAs(std::numeric_limits<size_t>::max(), [&](ContentExtensions::NFA&& nfa) {
-        nfas.append(WTFMove(nfa));
+        nfas.append(WTF::move(nfa));
         return true;
     });
     EXPECT_EQ(nfas.size(), 1ull);
     
     Vector<ContentExtensions::DFA> dfas;
-    for (auto&& nfa : WTFMove(nfas))
-        dfas.append(*ContentExtensions::NFAToDFA::convert(WTFMove(nfa)));
+    for (auto&& nfa : WTF::move(nfas))
+        dfas.append(*ContentExtensions::NFAToDFA::convert(WTF::move(nfa)));
     EXPECT_EQ(dfas.size(), 1ull);
     
     Vector<ContentExtensions::DFABytecode> combinedBytecode;
@@ -1403,7 +1403,7 @@ void checkCompilerError(String&& json, std::error_code expectedError)
     auto parsedRules = ContentExtensions::parseRuleList(json, WebCore::ContentExtensions::CSSSelectorsAllowed::Yes);
     std::error_code compilerError;
     if (parsedRules.has_value())
-        compilerError = ContentExtensions::compileRuleList(client, WTFMove(json), WTFMove(parsedRules.value()));
+        compilerError = ContentExtensions::compileRuleList(client, WTF::move(json), WTF::move(parsedRules.value()));
     else
         compilerError = parsedRules.error();
     EXPECT_EQ(compilerError.value(), expectedError.value());
@@ -1530,8 +1530,8 @@ TEST_F(ContentExtensionTest, InvalidJSON)
         rules.append("{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"a\"}},"_s);
     String rules150000 = makeString(rules.toString(), "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"a\"}}]"_s);
     String rules150001 = makeString(rules.toString(), "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"a\"}},{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"a\"}}]"_s);
-    checkCompilerError(WTFMove(rules150000), { });
-    checkCompilerError(WTFMove(rules150001), ContentExtensionError::JSONTooManyRules);
+    checkCompilerError(WTF::move(rules150000), { });
+    checkCompilerError(WTF::move(rules150001), ContentExtensionError::JSONTooManyRules);
 
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"request-method\":\"foo\"}}]"_s, ContentExtensionError::JSONInvalidRequestMethod);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"request-method\":null}}]"_s, ContentExtensionError::JSONInvalidRequestMethod);
@@ -1741,14 +1741,14 @@ TEST_F(ContentExtensionTest, SplittingLargeNFAs)
         
         Vector<ContentExtensions::NFA> nfas;
         combinedURLFilters.processNFAs(i, [&](ContentExtensions::NFA&& nfa) {
-            nfas.append(WTFMove(nfa));
+            nfas.append(WTF::move(nfa));
             return true;
         });
         EXPECT_EQ(nfas.size(), expectedNFACounts[i]);
         
         Vector<ContentExtensions::DFA> dfas;
-        for (auto& nfa : WTFMove(nfas))
-            dfas.append(*ContentExtensions::NFAToDFA::convert(WTFMove(nfa)));
+        for (auto& nfa : WTF::move(nfas))
+            dfas.append(*ContentExtensions::NFAToDFA::convert(WTF::move(nfa)));
         
         Vector<ContentExtensions::DFABytecode> combinedBytecode;
         for (const auto& dfa : dfas) {
@@ -3179,8 +3179,8 @@ TEST_F(ContentExtensionTest, UnlessFrameURL)
 TEST_F(ContentExtensionTest, RegexSubstitution)
 {
     auto transformURL = [] (String&& regexSubstitution, String&& regexFilter, String&& originalURL, const char* expectedTransformedURL) {
-        WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction action { WTFMove(regexSubstitution), WTFMove(regexFilter) };
-        URL url(WTFMove(originalURL));
+        WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction action { WTF::move(regexSubstitution), WTF::move(regexFilter) };
+        URL url(WTF::move(originalURL));
         action.applyToURL(url);
         EXPECT_STREQ(url.string().utf8().data(), expectedTransformedURL);
     };

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -140,7 +140,7 @@ TEST(CtapPinTest, TestSetPinRequest)
     crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
-    auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageDecrypt);
+    auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTF::move(sharedKeyHash), true, CryptoKeyUsageDecrypt);
     EXPECT_TRUE(aesKey);
 
     const auto& it6 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kNewPinEnc)));
@@ -328,7 +328,7 @@ TEST(CtapPinTest, TestTokenRequest)
     crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
-    auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageDecrypt);
+    auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTF::move(sharedKeyHash), true, CryptoKeyUsageDecrypt);
     EXPECT_TRUE(aesKey);
 
     const auto& it6 = responseMap.find(CBORValue(static_cast<uint8_t>(RequestKey::kPinHashEnc)));

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -632,8 +632,8 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithHmacSecret)
     AuthenticationExtensionsClientInputs::PRFValues prfValues;
     prfValues.first = WebCore::toBufferSource(salt1Data);
     prfValues.second = WebCore::toBufferSource(salt2Data);
-    prfInputs.eval = WTFMove(prfValues);
-    extensions.prf = WTFMove(prfInputs);
+    prfInputs.eval = WTF::move(prfValues);
+    extensions.prf = WTF::move(prfInputs);
 
     options.extensions = extensions;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -645,7 +645,7 @@ TEST(CTAPResponseTest, TestSerializeGetInfoResponse)
     options.setIsPlatformDevice(true);
     options.setClientPinAvailability(AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedButPinNotSet);
     options.setUserVerificationAvailability(AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured);
-    response.setOptions(WTFMove(options));
+    response.setOptions(WTF::move(options));
     response.setMaxMsgSize(1200);
     response.setPinProtocols({ PINUVAuthProtocol::kPinProtocol1 });
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/DFACombiner.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DFACombiner.cpp
@@ -48,7 +48,7 @@ Vector<DFA> combine(Vector<DFA> dfas, unsigned minimumSize)
 {
     DFACombiner combiner;
     for (DFA& dfa : dfas)
-        combiner.addDFA(WTFMove(dfa));
+        combiner.addDFA(WTF::move(dfa));
 
     Vector<DFA> output;
     combiner.combineDFAs(minimumSize, [&output](DFA&& dfa) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/DFAHelpers.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DFAHelpers.h
@@ -50,7 +50,7 @@ static Vector<ContentExtensions::NFA> createNFAs(ContentExtensions::CombinedURLF
 {
     Vector<ContentExtensions::NFA> nfas;
     combinedURLFilters.processNFAs(std::numeric_limits<size_t>::max(), [&](ContentExtensions::NFA&& nfa) {
-        nfas.append(WTFMove(nfa));
+        nfas.append(WTF::move(nfa));
         return true;
     });
     return nfas;
@@ -65,7 +65,7 @@ static ContentExtensions::DFA buildDFAFromPatterns(const Vector<ASCIILiteral>& p
         parser.addPattern(pattern, false, 0);
     Vector<ContentExtensions::NFA> nfas = createNFAs(combinedURLFilters);
     EXPECT_EQ(1ul, nfas.size());
-    return *ContentExtensions::NFAToDFA::convert(WTFMove(nfas.first()));
+    return *ContentExtensions::NFAToDFA::convert(WTF::move(nfas.first()));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/DNS.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DNS.cpp
@@ -55,7 +55,7 @@ TEST(DNSTest, cancelResolveDNS)
     };
 
     done = false;
-    resolveDNS(hostname, identifier, WTFMove(completionHandler));
+    resolveDNS(hostname, identifier, WTF::move(completionHandler));
     stopResolveDNS(identifier);
     Util::run(&done);
 }
@@ -77,7 +77,7 @@ TEST(DNSTest, cannotResolveDNS)
     };
 
     done = false;
-    resolveDNS(hostname, identifier, WTFMove(completionHandler));
+    resolveDNS(hostname, identifier, WTF::move(completionHandler));
     Util::run(&done);
 }
 
@@ -97,7 +97,7 @@ TEST(DNSTest, resolveDNS)
     };
 
     done = false;
-    resolveDNS(hostname, identifier, WTFMove(completionHandler));
+    resolveDNS(hostname, identifier, WTF::move(completionHandler));
     Util::run(&done);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/FidoHidMessageTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FidoHidMessageTest.cpp
@@ -50,7 +50,7 @@ TEST(FidoHidMessageTest, TestPacketSize)
     auto initPacket = makeUnique<FidoHidInitPacket>(channelId, FidoHidDeviceCommand::kInit, Vector<uint8_t>(data), data.size());
     EXPECT_EQ(64u, initPacket->getSerializedData().size());
 
-    auto continuationPacket = makeUnique<FidoHidContinuationPacket>(channelId, 0, WTFMove(data));
+    auto continuationPacket = makeUnique<FidoHidContinuationPacket>(channelId, 0, WTF::move(data));
     EXPECT_EQ(64u, continuationPacket->getSerializedData().size());
 }
 
@@ -120,7 +120,7 @@ TEST(FidoHidMessageTest, TestPacketConstructors)
     Vector<uint8_t> data {10, 11};
     FidoHidDeviceCommand cmd = FidoHidDeviceCommand::kWink;
     size_t length = data.size();
-    auto origPacket = makeUnique<FidoHidInitPacket>(channelId, cmd, WTFMove(data), length);
+    auto origPacket = makeUnique<FidoHidInitPacket>(channelId, cmd, WTF::move(data), length);
 
     size_t payloadLength = static_cast<size_t>(origPacket->payloadLength());
     Vector<uint8_t> origData = origPacket->getSerializedData();

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -57,7 +57,7 @@ public:
         // create temp file
         auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
         m_tempFilePath = result.first;
-        auto handle = WTFMove(result.second);
+        auto handle = WTF::move(result.second);
         ASSERT_TRUE(!!handle);
 
         auto rc = handle.write(byteCast<uint8_t>(FileMonitorTestData.utf8().span()));

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatSegmentTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatSegmentTest.cpp
@@ -37,87 +37,87 @@ TEST(FloatSegment, DilateWithDifference)
     // Empty a.
     {
         Vector<FloatSegment> intersections { { 77.f, 88.f } };
-        auto result = differenceWithDilation({ 0, 0 }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 0 }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { };
         EXPECT_EQ(result, expected);
     }
     // Empty bs.
     {
         Vector<FloatSegment> intersections { };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     // First element removed due to dilation filtering.
     {
         Vector<FloatSegment> intersections { { 1.0f, 2.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 2.5f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     // Last element removed due to dilation filtering.
     {
         Vector<FloatSegment> intersections { { 66.f, 169.7f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 65.5f } };
         EXPECT_EQ(result, expected);
     }
     // All removed.
     {
         Vector<FloatSegment> intersections { { 0.5f, 80.f }, { 80.5f, 169.5f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { };
         EXPECT_EQ(result, expected);
     }
     // All removed.
     {
         Vector<FloatSegment> intersections { { 0.0f, 80.f }, { 80.f, 180.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.f);
         Vector<FloatSegment> expected { };
         EXPECT_EQ(result, expected);
     }
     // Normal operation.
     {
         Vector<FloatSegment> intersections { { 1.1f, 2.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 0.6f }, { 2.5f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     {
         Vector<FloatSegment> intersections { { 0.f, 1.f }, { 5.f, 77.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 1.5f, 4.5f }, { 77.5f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     {
         Vector<FloatSegment> intersections { { 0.f, 1.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 1.5f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     {
         Vector<FloatSegment> intersections { { 2.f, 6.f }, { 8.f, 77.f }, { 3.f, 4.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 1.5f }, { 6.5f, 7.5f }, { 77.5f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     {
         Vector<FloatSegment> intersections { { 2.f, 6.f }, { 8.f, 77.f }, { 3.f, 4.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.f);
         Vector<FloatSegment> expected { { 0.f, 2.f }, { 6.f, 8.f }, { 77.f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     // Out of range, after end.
     {
         Vector<FloatSegment> intersections { { 180.f, 188.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 170.f } };
         EXPECT_EQ(result, expected);
     }
     // Out of range, before begin.
     {
         Vector<FloatSegment> intersections { { -188.f, -180.f } };
-        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        auto result = differenceWithDilation({ 0, 170.f }, WTF::move(intersections), 0.5f);
         Vector<FloatSegment> expected { { 0.f, 170.f } };
         EXPECT_EQ(result, expected);
     }

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -255,7 +255,7 @@ TEST_P(AnyScaleTest, SinkIntoNativeImageWorks)
     ASSERT_NE(verifyBuffer, nullptr);
     drawTestPattern(*buffer, 0);
 
-    auto image = ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
+    auto image = ImageBuffer::sinkIntoNativeImage(WTF::move(buffer));
     ASSERT_NE(image, nullptr);
 
     EXPECT_EQ(image->size(), expandedIntSize(testSize.scaled(deviceScaleFactor())));

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
@@ -95,7 +95,7 @@ TEST(MediaReorderQueue, MediaSample)
     while (!queue.isEmpty()) {
         RefPtr nextSample = queue.takeFirst();
         ASSERT_LE(currentSample->presentationTime(), nextSample->presentationTime());
-        currentSample = WTFMove(nextSample);
+        currentSample = WTF::move(nextSample);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
@@ -320,7 +320,7 @@ TEST(PrivateClickMeasurement, InvalidBlindedSecret)
 
     auto ephemeralNonce = PCM::EphemeralNonce { "ABCDEFabcdef0123456789"_s };
     EXPECT_TRUE(ephemeralNonce.isValid());
-    pcm.setEphemeralSourceNonce(WTFMove(ephemeralNonce));
+    pcm.setEphemeralSourceNonce(WTF::move(ephemeralNonce));
 
     auto errorMessage = pcm.calculateAndUpdateSourceUnlinkableToken(serverPublicKeyBase64URL);
     EXPECT_FALSE(errorMessage);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -112,7 +112,7 @@ static RefPtr<PushDatabase> createDatabaseSync(const String& path)
     bool done = false;
 
     PushDatabase::create(path, [&done, &result](RefPtr<PushDatabase>&& database) {
-        result = WTFMove(database);
+        result = WTF::move(database);
         done = true;
     });
     Util::run(&done);
@@ -126,7 +126,7 @@ static Vector<uint8_t> getPublicTokenSync(PushDatabase& database)
     Vector<uint8_t> getResult;
 
     database.getPublicToken([&done, &getResult](auto&& result) {
-        getResult = WTFMove(result);
+        getResult = WTF::move(result);
         done = true;
     });
     Util::run(&done);
@@ -140,7 +140,7 @@ static PushDatabase::PublicTokenChanged updatePublicTokenSync(PushDatabase& data
     auto updateResult = PushDatabase::PublicTokenChanged::No;
 
     database.updatePublicToken(token, [&done, &updateResult](auto&& result) {
-        updateResult = WTFMove(result);
+        updateResult = WTF::move(result);
         done = true;
     });
     Util::run(&done);
@@ -154,7 +154,7 @@ static std::optional<PushRecord> getRecordBySubscriptionSetAndScopeSync(PushData
     std::optional<PushRecord> getResult;
 
     database.getRecordBySubscriptionSetAndScope(subscriptionSetIdentifier, scope, [&done, &getResult](std::optional<PushRecord>&& result) {
-        getResult = WTFMove(result);
+        getResult = WTF::move(result);
         done = true;
     });
     Util::run(&done);
@@ -183,7 +183,7 @@ static Vector<PushSubscriptionSetRecord> getPushSubscriptionSetsSync(PushDatabas
     Vector<PushSubscriptionSetRecord> result;
 
     database.getPushSubscriptionSetRecords([&done, &result](auto&& records) {
-        result = WTFMove(records);
+        result = WTF::move(records);
         done = true;
     });
     Util::run(&done);
@@ -197,7 +197,7 @@ static PushTopics getTopicsSync(PushDatabase& database)
     PushTopics topics;
 
     database.getTopics([&done, &topics](auto&& result) {
-        topics = WTFMove(result);
+        topics = WTF::move(result);
         done = true;
     });
     Util::run(&done);
@@ -348,7 +348,7 @@ public:
         std::optional<PushRecord> insertResult;
 
         db->insertRecord(record, [&done, &insertResult](std::optional<PushRecord>&& result) {
-            insertResult = WTFMove(result);
+            insertResult = WTF::move(result);
             done = true;
         });
         Util::run(&done);
@@ -376,7 +376,7 @@ public:
         std::optional<PushRecord> getResult;
 
         db->getRecordByTopic(topic, [&done, &getResult](std::optional<PushRecord>&& result) {
-            getResult = WTFMove(result);
+            getResult = WTF::move(result);
             done = true;
         });
         Util::run(&done);
@@ -410,7 +410,7 @@ public:
         Vector<RemovedPushRecord> removedRecords;
 
         db->removeRecordsBySubscriptionSet(subscriptionSetIdentifier, [&done, &removedRecords](Vector<RemovedPushRecord>&& result) {
-            removedRecords = WTFMove(result);
+            removedRecords = WTF::move(result);
             done = true;
         });
         Util::run(&done);
@@ -424,7 +424,7 @@ public:
         Vector<RemovedPushRecord> removedRecords;
 
         db->removeRecordsBySubscriptionSetAndSecurityOrigin(subscriptionSetIdentifier, securityOrigin, [&done, &removedRecords](auto&& result) {
-            removedRecords = WTFMove(result);
+            removedRecords = WTF::move(result);
             done = true;
         });
         Util::run(&done);
@@ -438,7 +438,7 @@ public:
         Vector<RemovedPushRecord> removedRecords;
 
         db->removeRecordsByBundleIdentifierAndDataStore(bundleIdentifier, dataStoreIdentifier, [&done, &removedRecords](auto&& result) {
-            removedRecords = WTFMove(result);
+            removedRecords = WTF::move(result);
             done = true;
         });
         Util::run(&done);
@@ -569,19 +569,19 @@ TEST_F(PushDatabaseTest, InsertRecord)
     // Inserting a record with the same (subscriptionSetIdentifier, scope) as record 1 should fail.
     PushRecord record8 = record1;
     record8.topic = "topic8"_s;
-    EXPECT_FALSE(insertRecord(WTFMove(record8)));
+    EXPECT_FALSE(insertRecord(WTF::move(record8)));
     
     // Inserting a record that has a different dataStoreIdentifier should succeed.
     PushRecord record9 = record1;
     record9.subscriptionSetIdentifier.dataStoreIdentifier = WTF::UUID::createVersion4Weak();
     record9.topic = "topic9"_s;
-    EXPECT_TRUE(insertRecord(WTFMove(record9)));
+    EXPECT_TRUE(insertRecord(WTF::move(record9)));
 
     // Inserting a record that has a different pushPartition should succeed.
     PushRecord record10 = record1;
     record10.subscriptionSetIdentifier.pushPartition = "foobar"_s;
     record10.topic = "topic10"_s;
-    EXPECT_TRUE(insertRecord(WTFMove(record10)));
+    EXPECT_TRUE(insertRecord(WTF::move(record10)));
 
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
 
@@ -626,7 +626,7 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSet)
 
     // Inserting a new record should produce a new identifier.
     PushRecord record8 = record3;
-    auto insertResult = insertRecord(WTFMove(record8));
+    auto insertResult = insertRecord(WTF::move(record8));
     EXPECT_TRUE(insertResult);
     EXPECT_EQ(insertResult->identifier, ObjectIdentifier<PushSubscriptionIdentifierType>(8));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 8 }));
@@ -663,7 +663,7 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSetAndSecurityOrigin)
 
     // Inserting a new record should produce a new identifier.
     PushRecord record8 = record3;
-    auto insertResult = insertRecord(WTFMove(record8));
+    auto insertResult = insertRecord(WTF::move(record8));
     EXPECT_TRUE(insertResult);
     EXPECT_EQ(insertResult->identifier, ObjectIdentifier<PushSubscriptionIdentifierType>(8));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 5, 8 }));
@@ -688,7 +688,7 @@ TEST_F(PushDatabaseTest, RemoveRecordsByBundleIdentifierAndDataStore)
 
     // Inserting a new record should produce a new identifier.
     PushRecord record8 = record5;
-    auto insertResult = insertRecord(WTFMove(record8));
+    auto insertResult = insertRecord(WTF::move(record8));
     EXPECT_TRUE(insertResult);
     EXPECT_EQ(insertResult->identifier, ObjectIdentifier<PushSubscriptionIdentifierType>(8));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 3, 4, 8 }));

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushMessageCrypto.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushMessageCrypto.cpp
@@ -53,8 +53,8 @@ static ClientKeys makeAES128GCMClientKeys(void)
     auto secret = mustBase64URLDecode("BTBZMqHH6r4Tts7J_aSIgg"_s);
 
     return ClientKeys {
-        P256DHKeyPair { WTFMove(publicKey), WTFMove(privateKey) },
-        WTFMove(secret)
+        P256DHKeyPair { WTF::move(publicKey), WTF::move(privateKey) },
+        WTF::move(secret)
     };
 }
 
@@ -108,8 +108,8 @@ static ClientKeys makeAESGCMClientKeys(void)
     auto secret = mustBase64URLDecode("R29vIGdvbyBnJyBqb29iIQ"_s);
 
     return ClientKeys {
-        P256DHKeyPair { WTFMove(publicKey), WTFMove(privateKey) },
-        WTFMove(secret)
+        P256DHKeyPair { WTF::move(publicKey), WTF::move(privateKey) },
+        WTF::move(secret)
     };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
@@ -203,7 +203,7 @@ TEST(RTCRtpSFrameTransformer, EncryptDecrypt)
     auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
-    auto encrypted = WTFMove(encryptedResult.value());
+    auto encrypted = WTF::move(encryptedResult.value());
     auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 
@@ -223,7 +223,7 @@ TEST(RTCRtpSFrameTransformer, EncryptDecryptKeyID0)
     auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
-    auto encrypted = WTFMove(encryptedResult.value());
+    auto encrypted = WTF::move(encryptedResult.value());
     auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 
@@ -245,7 +245,7 @@ TEST(RTCRtpSFrameTransformer, EncryptDecryptAudio)
     auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
-    auto encrypted = WTFMove(encryptedResult.value());
+    auto encrypted = WTF::move(encryptedResult.value());
     auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/RenderStyleChange.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RenderStyleChange.cpp
@@ -38,10 +38,10 @@ TEST(RenderStyleChangeTest, None)
 {
     RenderStyle style1 = RenderStyle::create();
     FontCascadeDescription fontDescription1;
-    style1.setFontDescription(WTFMove(fontDescription1));
+    style1.setFontDescription(WTF::move(fontDescription1));
     RenderStyle style2 = RenderStyle::create();
     FontCascadeDescription fontDescription2;
-    style1.setFontDescription(WTFMove(fontDescription2));
+    style1.setFontDescription(WTF::move(fontDescription2));
     auto changes = determineChanges(style1, style2);
     EXPECT_EQ(changes, OptionSet<Change> { });
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/STUNMessageParsingTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/STUNMessageParsingTest.cpp
@@ -38,7 +38,7 @@ using namespace WebCore;
 TEST(STUNMessageParsing, MessageLength)
 {
     auto buffer = Vector<uint8_t>::from(0, 1, 3, 0, 2, 4);
-    buffer = WebRTC::extractMessages(WTFMove(buffer), WebRTC::MessageType::Data, [](std::span<const uint8_t> data) {
+    buffer = WebRTC::extractMessages(WTF::move(buffer), WebRTC::MessageType::Data, [](std::span<const uint8_t> data) {
         EXPECT_EQ(data.size(), 1u);
         EXPECT_EQ(data[0], 3u);
     });

--- a/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
@@ -47,7 +47,7 @@ static void deserializeJSValue(std::array<uint8_t, T> bytes)
     JSC::initialize();
     WebCore::Process::identifier();
     Vector<uint8_t> vector { std::span<uint8_t>(bytes) };
-    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTFMove(vector));
+    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTF::move(vector));
     WebCore::callOnIDBSerializationThreadAndWait([&](auto& globalObject) {
         auto jsValue = WebCore::deserializeIDBValueToJSValue(globalObject, value);
         UNUSED_PARAM(jsValue);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -135,9 +135,9 @@ TEST_F(FragmentedSharedBufferTest, tryCreateArrayBufferLargeSegments)
     Vector<uint8_t> vector1(0x4000, 'b');
     Vector<uint8_t> vector2(0x4000, 'c');
 
-    SharedBufferBuilder builder(std::in_place, WTFMove(vector0));
-    builder.append(WTFMove(vector1));
-    builder.append(WTFMove(vector2));
+    SharedBufferBuilder builder(std::in_place, WTF::move(vector0));
+    builder.append(WTF::move(vector1));
+    builder.append(WTF::move(vector2));
     RefPtr<ArrayBuffer> arrayBuffer = builder.buffer()->tryCreateArrayBuffer();
     ASSERT_EQ(0x4000U + 0x4000U + 0x4000U, arrayBuffer->byteLength());
     int position = 0;
@@ -265,9 +265,9 @@ TEST_F(FragmentedSharedBufferTest, getSomeData)
     Vector<uint8_t> s3 = { 'i', 'j', 'k', 'l' };
 
     SharedBufferBuilder builder;
-    builder.append(WTFMove(s1));
-    builder.append(WTFMove(s2));
-    builder.append(WTFMove(s3));
+    builder.append(WTF::move(s1));
+    builder.append(WTF::move(s2));
+    builder.append(WTF::move(s3));
     auto buffer = builder.takeBuffer();
     
     auto abcd = buffer->getSomeData(0);
@@ -300,9 +300,9 @@ TEST_F(FragmentedSharedBufferTest, getContiguousData)
     Vector<uint8_t> s3 = { 'i', 'j', 'k', 'l' };
 
     SharedBufferBuilder builder;
-    builder.append(WTFMove(s1));
-    builder.append(WTFMove(s2));
-    builder.append(WTFMove(s3));
+    builder.append(WTF::move(s1));
+    builder.append(WTF::move(s2));
+    builder.append(WTF::move(s3));
     auto buffer = builder.takeBuffer();
 
     auto abcd = buffer->getContiguousData(0, 4);
@@ -333,13 +333,13 @@ TEST_F(FragmentedSharedBufferTest, isEqualTo)
     auto makeBuffer = [] (Vector<Vector<uint8_t>>&& contents) {
         SharedBufferBuilder builder;
         for (auto& content : contents)
-            builder.append(WTFMove(content));
+            builder.append(WTF::move(content));
         return builder.takeBuffer();
     };
     auto buffer1 = makeBuffer({ { 'a', 'b', 'c', 'd' } });
     EXPECT_EQ(buffer1.get(), buffer1.get());
 
-    SharedBufferBuilder builder(WTFMove(buffer1));
+    SharedBufferBuilder builder(WTF::move(buffer1));
     builder.append(Vector<uint8_t>({ 'a', 'b', 'c', 'd' }));
     EXPECT_EQ(*builder.buffer(), makeBuffer({ { 'a', 'b', 'c', 'd', 'a', 'b', 'c', 'd' } }).get());
 
@@ -353,7 +353,7 @@ TEST_F(FragmentedSharedBufferTest, toHexString)
 {
     Vector<uint8_t> t1 = {0x11, 0x5, 0x12};
     SharedBufferBuilder builder;
-    builder.append(WTFMove(t1));
+    builder.append(WTF::move(t1));
     auto buffer = builder.takeBuffer();
     String result = buffer->toHexString();
     EXPECT_EQ(result, "110512"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
@@ -109,7 +109,7 @@ public:
     }
     VMAllocSpan(VMAllocSpan&& other)
     {
-        *this = WTFMove(other);
+        *this = WTF::move(other);
     }
     VMAllocSpan& operator=(VMAllocSpan&& other)
     {
@@ -155,13 +155,13 @@ std::span<uint8_t> SharedMemoryFromMemoryTest::allocate()
     if (memorySource() == MemorySource::Malloc) {
         if (auto source = std::unique_ptr<uint8_t[]> { new (std::nothrow) uint8_t[size] }) {
             data = { source.get(), size };
-            m_source = WTFMove(source);
+            m_source = WTF::move(source);
         }
     }
     if (memorySource() == MemorySource::SharedMemory) {
         if (auto shm = SharedMemory::allocate(size)) {
             data = shm->mutableSpan();
-            m_source = WTFMove(shm);
+            m_source = WTF::move(shm);
         }
     }
 #if PLATFORM(COCOA)
@@ -214,7 +214,7 @@ TEST_P(SharedMemoryFromMemoryTest, CreateHandleFromMemory)
     ASSERT_FALSE(handle.has_value());
 #endif
     ASSERT_TRUE(handle.has_value());
-    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    auto shm2 = SharedMemory::map(WTF::move(*handle), protection());
     ASSERT_NOT_NULL(shm2);
     auto data2 = shm2->mutableSpan();
     expectTestPattern(data2, 1);
@@ -256,7 +256,7 @@ TEST_P(SharedMemoryFromMemoryTest, CreateHandleVMCopyFromMemory)
     ASSERT_FALSE(handle.has_value());
 #endif
     ASSERT_TRUE(handle.has_value());
-    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    auto shm2 = SharedMemory::map(WTF::move(*handle), protection());
     ASSERT_NOT_NULL(shm2);
     auto data2 = shm2->mutableSpan();
     expectTestPattern(data2, 1);
@@ -287,7 +287,7 @@ TEST_P(SharedMemoryFromMemoryTest, CreateHandleCopyFromMemory)
 
     auto handle = SharedMemory::Handle::createCopy(data, protection());
     ASSERT_TRUE(handle.has_value());
-    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    auto shm2 = SharedMemory::map(WTF::move(*handle), protection());
     ASSERT_NOT_NULL(shm2);
     auto data2 = shm2->mutableSpan();
     expectTestPattern(data2, 1);

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -63,10 +63,10 @@ PublicKeyCredentialCreationOptions constructMakeCredentialRequest()
     AuthenticationExtensionsClientInputs extensions;
 
     PublicKeyCredentialCreationOptions options;
-    options.rp = WTFMove(rp);
-    options.user = WTFMove(user);
-    options.pubKeyCredParams.append(WTFMove(params));
-    options.extensions = WTFMove(extensions);
+    options.rp = WTF::move(rp);
+    options.user = WTF::move(user);
+    options.pubKeyCredParams.append(WTF::move(params));
+    options.extensions = WTF::move(extensions);
 
     return options;
 }
@@ -97,7 +97,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fCheckOnlySign)
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle).variant();
     Vector<PublicKeyCredentialDescriptor> excludeList;
     excludeList.append(credentialDescriptor);
-    makeCredentialParam.excludeCredentials = WTFMove(excludeList);
+    makeCredentialParam.excludeCredentials = WTF::move(excludeList);
     EXPECT_TRUE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
 
     const auto u2fCheckOnlySign = convertToU2fCheckOnlySignCommand(std::array { TestData::kClientDataHash }, makeCredentialParam, credentialDescriptor);
@@ -113,7 +113,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fCheckOnlySignW
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle).variant();
     Vector<PublicKeyCredentialDescriptor> excludeList;
     excludeList.append(credentialDescriptor);
-    makeCredentialParam.excludeCredentials = WTFMove(excludeList);
+    makeCredentialParam.excludeCredentials = WTF::move(excludeList);
     EXPECT_TRUE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
 
     const auto u2fCheckOnlySign = convertToU2fCheckOnlySignCommand(std::span { TestData::kClientDataHash }, makeCredentialParam, credentialDescriptor);
@@ -137,9 +137,9 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterCredentialAlgorithmRequirement)
     params.alg = -257;
 
     PublicKeyCredentialCreationOptions makeCredentialParam;
-    makeCredentialParam.rp = WTFMove(rp);
-    makeCredentialParam.user = WTFMove(user);
-    makeCredentialParam.pubKeyCredParams.append(WTFMove(params));
+    makeCredentialParam.rp = WTF::move(rp);
+    makeCredentialParam.user = WTF::move(user);
+    makeCredentialParam.pubKeyCredParams.append(WTF::move(params));
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
 }
@@ -149,7 +149,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterUserVerificationRequirement)
     auto makeCredentialParam = constructMakeCredentialRequest();
     AuthenticatorSelectionCriteria selection;
     selection.userVerification = UserVerificationRequirement::Required;
-    makeCredentialParam.authenticatorSelection = WTFMove(selection);
+    makeCredentialParam.authenticatorSelection = WTF::move(selection);
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
 }
@@ -159,7 +159,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterResidentKeyRequirement)
     auto makeCredentialParam = constructMakeCredentialRequest();
     AuthenticatorSelectionCriteria selection;
     selection.requireResidentKey = true;
-    makeCredentialParam.authenticatorSelection = WTFMove(selection);
+    makeCredentialParam.authenticatorSelection = WTF::move(selection);
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
 }
@@ -171,8 +171,8 @@ TEST(U2fCommandConstructorTest, TestConvertCtapGetAssertionToU2fSignRequest)
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
-    allowedList.append(WTFMove(credentialDescriptor));
-    getAssertionReq.allowCredentials = WTFMove(allowedList);
+    allowedList.append(WTF::move(credentialDescriptor));
+    getAssertionReq.allowCredentials = WTF::move(allowedList);
     EXPECT_TRUE(isConvertibleToU2fSignCommand(getAssertionReq));
 
     const auto u2fSignCommand = convertToU2fSignCommand(std::span { TestData::kClientDataHash }, getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle));
@@ -187,14 +187,14 @@ TEST(U2fCommandConstructorTest, TestConvertCtapGetAssertionWithAppIDToU2fSignReq
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
-    allowedList.append(WTFMove(credentialDescriptor));
-    getAssertionReq.allowCredentials = WTFMove(allowedList);
+    allowedList.append(WTF::move(credentialDescriptor));
+    getAssertionReq.allowCredentials = WTF::move(allowedList);
     EXPECT_TRUE(isConvertibleToU2fSignCommand(getAssertionReq));
 
     // AppID
     WebCore::AuthenticationExtensionsClientInputs extensions;
     extensions.appid = "https://www.example.com/appid"_s;
-    getAssertionReq.extensions = WTFMove(extensions);
+    getAssertionReq.extensions = WTF::move(extensions);
 
     const auto u2fSignCommand = convertToU2fSignCommand(std::span { TestData::kClientDataHash }, getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle), true);
     ASSERT_TRUE(u2fSignCommand);
@@ -214,8 +214,8 @@ TEST(U2fCommandConstructorTest, TestU2fSignUserVerificationRequirement)
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
-    allowedList.append(WTFMove(credentialDescriptor));
-    getAssertionReq.allowCredentials = WTFMove(allowedList);
+    allowedList.append(WTF::move(credentialDescriptor));
+    getAssertionReq.allowCredentials = WTF::move(allowedList);
     getAssertionReq.userVerification = UserVerificationRequirement::Required;
 
     EXPECT_FALSE(isConvertibleToU2fSignCommand(getAssertionReq));
@@ -228,8 +228,8 @@ TEST(U2fCommandConstructorTest, TestCreateSignWithIncorrectKeyHandle)
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
     credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
-    allowedList.append(WTFMove(credentialDescriptor));
-    getAssertionReq.allowCredentials = WTFMove(allowedList);
+    allowedList.append(WTF::move(credentialDescriptor));
+    getAssertionReq.allowCredentials = WTF::move(allowedList);
     ASSERT_TRUE(isConvertibleToU2fSignCommand(getAssertionReq));
 
     Vector<uint8_t> keyHandle(kMaxKeyHandleLength, 0xff);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -89,7 +89,7 @@ TEST(BifurcatedGraphicsContextTests, Text)
     FontCascadeDescription description;
     description.setOneFamily("Times"_s);
     description.setComputedSize(80);
-    FontCascade font(WTFMove(description));
+    FontCascade font(WTF::move(description));
     font.update();
 
     String string = "Hello!"_s;

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
@@ -90,7 +90,7 @@ TEST(IOSurfacePoolTest, IOSurfacePoolNames)
     auto s1 = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::nameForRenderingPurpose(initialPurpose));
     EXPECT_EQ(WebCore::IOSurface::Name::ImageBufferShareableMapped, s1->name());
 
-    pool->addSurface(WTFMove(s1));
+    pool->addSurface(WTF::move(s1));
 
     auto s2 = WebCore::IOSurface::create(pool, { 5, 5 }, WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::nameForRenderingPurpose(purpose));
     EXPECT_EQ(WebCore::IOSurface::Name::Canvas, s2->name());

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm
@@ -50,7 +50,7 @@ TEST(PrivateClickMeasurement, ValidBlindedSecret)
         WallTime::now(),
         WebCore::PCM::AttributionEphemeral::No
     );
-    pcm.setEphemeralSourceNonce(WTFMove(ephemeralNonce));
+    pcm.setEphemeralSourceNonce(WTF::move(ephemeralNonce));
 
     // Generate the server key pair.
     size_t modulusNBits = 4096;
@@ -73,7 +73,7 @@ TEST(PrivateClickMeasurement, ValidBlindedSecret)
     Vector<uint8_t> rawKeyBytes(exportSize);
     ccder_encode_rsa_pub(rsaPublicKey, rawKeyBytes.begin(), rawKeyBytes.end());
 
-    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(WTFMove(rawKeyBytes));
+    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(WTF::move(rawKeyBytes));
 
     // Continue the test.
     auto errorMessage = pcm.calculateAndUpdateSourceUnlinkableToken(base64URLEncodeToString(wrappedKeyBytes));

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -61,7 +61,7 @@ class TestedGraphicsContextGLCocoa : public GraphicsContextGLCocoa {
 public:
     static RefPtr<TestedGraphicsContextGLCocoa> create(GraphicsContextGLAttributes&& attributes)
     {
-        auto context = adoptRef(*new TestedGraphicsContextGLCocoa(WTFMove(attributes)));
+        auto context = adoptRef(*new TestedGraphicsContextGLCocoa(WTF::move(attributes)));
         if (!context->initialize())
             return nullptr;
         return context;
@@ -69,7 +69,7 @@ public:
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final { return nullptr; }
 private:
     TestedGraphicsContextGLCocoa(GraphicsContextGLAttributes attributes)
-        : GraphicsContextGLCocoa(WTFMove(attributes), { })
+        : GraphicsContextGLCocoa(WTF::move(attributes), { })
     {
     }
 };
@@ -314,7 +314,7 @@ TEST_F(GraphicsContextGLCocoaTest, ClearBufferIncorrectSizes)
     attributes.isWebGL2 = true;
     attributes.depth = true;
     attributes.stencil = true;
-    auto gl = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    auto gl = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
     gl->reshape(1, 1);
 
     float floats5[5] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f };
@@ -401,11 +401,11 @@ TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)
     attributes.isWebGL2 = true;
     attributes.depth = true;
     attributes.stencil = true;
-    RefPtr gl1 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    RefPtr gl1 = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
     gl1->reshape(1, 1);
-    RefPtr gl2 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    RefPtr gl2 = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
     gl2->reshape(1, 1);
-    RefPtr gl3 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    RefPtr gl3 = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
     gl3->reshape(1, 1);
     // Current context is now 3.
     gl1 = nullptr; // Test the case where we destroy with other context being current.
@@ -416,7 +416,7 @@ TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)
 TEST_F(GraphicsContextGLCocoaTest, TwoLinks)
 {
     GraphicsContextGLAttributes attributes;
-    auto gl = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    auto gl = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
     auto vs = gl->createShader(GraphicsContextGL::VERTEX_SHADER);
     gl->shaderSource(vs, "void main() { }"_s);
     gl->compileShader(vs);
@@ -747,7 +747,7 @@ protected:
     void SetUp() override // NOLINT
     {
         GraphicsContextGLAttributes attributes;
-        m_context = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+        m_context = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
         m_expectedColor = Color::gray;
         auto [r, g, b, a] = m_expectedColor.toColorTypeLossy<SRGBA<float>>().resolved();
         m_context->reshape(20, 20);
@@ -809,7 +809,7 @@ protected:
     void SetUp() override // NOLINT
     {
         GraphicsContextGLAttributes attributes;
-        m_context = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+        m_context = TestedGraphicsContextGLCocoa::create(WTF::move(attributes));
         m_context->reshape(INITIAL_WIDTH, INITIAL_HEIGHT);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -66,7 +66,7 @@ public:
     void didReceiveHeaderFromMultipart(Vector<String>&& headers) final
     {
         for (auto header : headers)
-            m_headers.append(WTFMove(header));
+            m_headers.append(WTF::move(header));
     }
 
     void didReceiveDataFromMultipart(std::span<const uint8_t> receivedData) final

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -149,7 +149,7 @@ TEST(Damage, Move)
     EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
-    Damage other = WTFMove(damage);
+    Damage other = WTF::move(damage);
     EXPECT_FALSE(other.isEmpty());
     EXPECT_EQ(other.size(), 2);
     EXPECT_EQ(other.bounds(), IntRect(100, 100, 400, 400));

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -53,7 +53,7 @@ static void initializePlatformDisplayIfNeeded()
         return;
     auto display = PlatformDisplaySurfaceless::create();
     RELEASE_ASSERT(display);
-    PlatformDisplay::setSharedDisplay(WTFMove(display));
+    PlatformDisplay::setSharedDisplay(WTF::move(display));
 }
 
 using TestedGraphicsContextGLTextureMapper = GraphicsContextGLTextureMapperANGLE;
@@ -61,7 +61,7 @@ using TestedGraphicsContextGLTextureMapper = GraphicsContextGLTextureMapperANGLE
 static RefPtr<TestedGraphicsContextGLTextureMapper> createTestedGraphicsContextGL(GraphicsContextGLAttributes attribute)
 {
     initializePlatformDisplayIfNeeded();
-    return TestedGraphicsContextGLTextureMapper::create(WTFMove(attribute));
+    return TestedGraphicsContextGLTextureMapper::create(WTF::move(attribute));
 }
 
 class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
@@ -690,7 +690,7 @@ public:
 
     void dispatch(Function<void()>&& function)
     {
-        m_runLoop->dispatch(WTFMove(function));
+        m_runLoop->dispatch(WTF::move(function));
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -43,7 +43,7 @@ namespace TestWebKitAPI {
 TEST_F(GStreamerTest, harnessBasic)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [](auto&, auto&&) { });
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [](auto&, auto&&) { });
 
     // The identity element has a single source pad. Fetch the corresponding stream.
     ASSERT_FALSE(harness->outputStreams().isEmpty());
@@ -61,7 +61,7 @@ TEST_F(GStreamerTest, harnessBasic)
     EXPECT_EQ(mappedInputBuffer.size(), 64);
     auto caps = adoptGRef(gst_caps_new_empty_simple("foo"));
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+    EXPECT_TRUE(harness->pushSample(WTF::move(sample)));
 
     auto event = stream->pullEvent();
     ASSERT_NOT_NULL(event.get());
@@ -96,7 +96,7 @@ TEST_F(GStreamerTest, harnessBasic)
 TEST_F(GStreamerTest, harnessManualStart)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [](auto&, auto&&) { });
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [](auto&, auto&&) { });
 
     // The identity element has a single source pad. Fetch the corresponding stream.
     ASSERT_FALSE(harness->outputStreams().isEmpty());
@@ -111,7 +111,7 @@ TEST_F(GStreamerTest, harnessManualStart)
 
     // Start the harness and expect initial events.
     auto caps = adoptGRef(gst_caps_new_empty_simple("foo"));
-    harness->start(WTFMove(caps));
+    harness->start(WTF::move(caps));
 
     auto event = stream->pullEvent();
     ASSERT_NOT_NULL(event.get());
@@ -154,7 +154,7 @@ TEST_F(GStreamerTest, harnessBufferProcessing)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
     unsigned counter = 0;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, auto&& outputSample) mutable {
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [&counter](auto&, auto&& outputSample) mutable {
         auto outputBuffer = gst_sample_get_buffer(outputSample.get());
         GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
         ASSERT_TRUE(mappedOutputBuffer);
@@ -178,7 +178,7 @@ TEST_F(GStreamerTest, harnessBufferProcessing)
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, 64, nullptr));
         gst_buffer_memset(buffer.get(), 0, i, 64);
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-        EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+        EXPECT_TRUE(harness->pushSample(WTF::move(sample)));
     }
     harness->processOutputSamples();
     ASSERT_EQ(counter, 3);
@@ -188,7 +188,7 @@ TEST_F(GStreamerTest, harnessFlush)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
     unsigned counter = 0;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, auto&& outputSample) mutable {
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [&counter](auto&, auto&& outputSample) mutable {
         auto outputBuffer = gst_sample_get_buffer(outputSample.get());
         GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
         ASSERT_TRUE(mappedOutputBuffer);
@@ -213,7 +213,7 @@ TEST_F(GStreamerTest, harnessFlush)
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, 64, nullptr));
         gst_buffer_memset(buffer.get(), 0, i, 64);
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-        EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+        EXPECT_TRUE(harness->pushSample(WTF::move(sample)));
     }
     auto firstOutputSample = stream->pullSample();
     auto firstOutputBuffer = gst_sample_get_buffer(firstOutputSample.get());
@@ -244,7 +244,7 @@ TEST_F(GStreamerTest, harnessParseMP4)
         uint64_t totalAudioBuffers { 0 };
         uint64_t totalVideoBuffers { 0 };
     } bufferTracker;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&bufferTracker](auto& stream, auto&&) mutable {
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [&bufferTracker](auto& stream, auto&&) mutable {
         auto gstStream = adoptGRef(gst_pad_get_stream(stream.pad().get()));
         auto streamType = gst_stream_get_stream_type(gstStream.get());
         if (streamType == GST_STREAM_TYPE_AUDIO)
@@ -275,7 +275,7 @@ TEST_F(GStreamerTest, harnessParseMP4)
             handle.read(mappedBuffer.mutableSpan<uint8_t>());
         }
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-        EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+        EXPECT_TRUE(harness->pushSample(WTF::move(sample)));
 
         totalRead += bytesToRead;
     }
@@ -330,7 +330,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
     struct BufferTracker {
         uint64_t totalVideoBuffers { 0 };
     } bufferTracker;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&bufferTracker](auto& stream, auto&&) mutable {
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [&bufferTracker](auto& stream, auto&&) mutable {
         auto gstStream = adoptGRef(gst_pad_get_stream(stream.pad().get()));
         auto streamType = gst_stream_get_stream_type(gstStream.get());
         if (streamType == GST_STREAM_TYPE_VIDEO)
@@ -342,7 +342,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
     });
 
     auto caps = adoptGRef(gst_caps_new_empty_simple("video/quicktime"));
-    harness->start(WTFMove(caps));
+    harness->start(WTF::move(caps));
 
     // Feed the contents of a MP4 file to the harnessed decodebin3, until it is able to figure out
     // the stream topology.
@@ -363,7 +363,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
             GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
             handle.read(mappedBuffer.mutableSpan<uint8_t>());
         }
-        EXPECT_TRUE(harness->pushBuffer(WTFMove(buffer)));
+        EXPECT_TRUE(harness->pushBuffer(WTF::move(buffer)));
         totalRead += bytesToRead;
 
         // Process events, if a stream collection is received, interrupt the buffer feed.
@@ -413,7 +413,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
             GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
             handle.read(mappedBuffer.mutableSpan<uint8_t>());
         }
-        EXPECT_TRUE(harness->pushBuffer(WTFMove(buffer)));
+        EXPECT_TRUE(harness->pushBuffer(WTF::move(buffer)));
 
         totalRead += bytesToRead;
     }
@@ -434,7 +434,7 @@ TEST_F(GStreamerTest, harnessCustomCaps)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
     auto caps = adoptGRef(gst_caps_new_empty_simple("foo/bar"));
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [](auto&, auto&&) { }, std::nullopt, GRefPtr(caps));
+    auto harness = WebCore::GStreamerElementHarness::create(WTF::move(element), [](auto&, auto&&) { }, std::nullopt, GRefPtr(caps));
 
     // The identity element has a single source pad. Fetch the corresponding stream.
     ASSERT_FALSE(harness->outputStreams().isEmpty());
@@ -451,7 +451,7 @@ TEST_F(GStreamerTest, harnessCustomCaps)
     ASSERT_TRUE(mappedInputBuffer);
     EXPECT_EQ(mappedInputBuffer.size(), 64);
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-    EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+    EXPECT_TRUE(harness->pushSample(WTF::move(sample)));
 
     auto event = stream->pullEvent();
     ASSERT_NOT_NULL(event.get());

--- a/Tools/TestWebKitAPI/Tests/WebCore/win/BitmapImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/win/BitmapImage.cpp
@@ -45,7 +45,7 @@ TEST(WebCore, BitmapImageEmptyFrameTest)
     auto bmp = adoptGDIObject(CreateDIBSection(0, &bitmapInfo, DIB_RGB_COLORS, 0, 0, 0));
     auto nativeImage = ImageAdapter::nativeImageOfHBITMAP(bmp.get());
 
-    RefPtr<Image> bitmapImageTest = BitmapImage::create(WTFMove(nativeImage));
+    RefPtr<Image> bitmapImageTest = BitmapImage::create(WTF::move(nativeImage));
     if (!bitmapImageTest)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -108,7 +108,7 @@ namespace TestWebKitAPI {
 static IMP makeQueryParameterRequestHandler(NSArray<NSString *> *parameters, NSArray<NSString *> *domains, NSArray<NSString *> *paths, bool& didHandleRequest)
 {
     return imp_implementationWithBlock([&didHandleRequest, parameters = RetainPtr { parameters }, domains = RetainPtr { domains }, paths = RetainPtr { paths }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
-        RunLoop::mainSingleton().dispatch([&didHandleRequest, parameters = WTFMove(parameters), domains = WTFMove(domains), paths = WTFMove(paths), completion = makeBlockPtr(completion)]() mutable {
+        RunLoop::mainSingleton().dispatch([&didHandleRequest, parameters = WTF::move(parameters), domains = WTF::move(domains), paths = WTF::move(paths), completion = makeBlockPtr(completion)]() mutable {
             auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()
 #if defined(HAS_WEB_PRIVACY_LINK_FILTERING_RULE_PATH)
                 domains:domains.get() paths:paths.get()
@@ -123,7 +123,7 @@ static IMP makeQueryParameterRequestHandler(NSArray<NSString *> *parameters, NSA
 static IMP makeAllowedLinkFilteringDataRequestHandler(NSArray<NSString *> *parameters)
 {
     return imp_implementationWithBlock([parameters = RetainPtr { parameters }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
-        RunLoop::mainSingleton().dispatch([parameters = WTFMove(parameters), completion = makeBlockPtr(completion)]() mutable {
+        RunLoop::mainSingleton().dispatch([parameters = WTF::move(parameters), completion = makeBlockPtr(completion)]() mutable {
             auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()]);
             completion(data.get(), nil);
         });
@@ -555,7 +555,7 @@ TEST(AdvancedPrivacyProtections, DoNotHideReferrerInPopupWindow)
     RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setPopUpPolicy:_WKWebsitePopUpPolicyAllow];
 
-    RetainPtr webView = createWebViewWithAdvancedPrivacyProtections(YES, WTFMove(preferences));
+    RetainPtr webView = createWebViewWithAdvancedPrivacyProtections(YES, WTF::move(preferences));
     [webView setUIDelegate:uiDelegate.get()];
 
     // Load the main page on 127.0.0.1, which opens a cross-origin popup window on localhost.

--- a/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
@@ -269,7 +269,7 @@ public:
     {
         for (auto event : events) {
             auto eventMessage = makeString(event, " event"_s);
-            [webView() performAfterReceivingMessage:eventMessage.createNSString().get() action:[this, eventMessage = WTFMove(eventMessage)] {
+            [webView() performAfterReceivingMessage:eventMessage.createNSString().get() action:[this, eventMessage = WTF::move(eventMessage)] {
                 _eventListenersCalled.add(eventMessage);
             }];
         }
@@ -310,7 +310,7 @@ public:
             auto handlerMessage = makeString(handler, suffix);
             RetainPtr nsHandlerMessage = handlerMessage.createNSString();
             [_messageHandlers addObject:nsHandlerMessage.get()];
-            [webView() performAfterReceivingMessage:nsHandlerMessage.get() action:[this, handlerMessage = WTFMove(handlerMessage)] {
+            [webView() performAfterReceivingMessage:nsHandlerMessage.get() action:[this, handlerMessage = WTF::move(handlerMessage)] {
                 _sessionMessagesPosted.add(handlerMessage);
             }];
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/ResponsivenessTimerCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ResponsivenessTimerCrash.mm
@@ -83,7 +83,7 @@ TEST(WebKit, ResponsivenessTimerCrash)
         for (size_t i = 0; i < 50; ++i) {
             RetainPtr<id> observableState = adoptNS(WKPageCreateObservableState(pageRef));
             [observableState.get() addObserver:observer.get() forKeyPath:@"_webProcessIsResponsive" options:0 context:nullptr];
-            observableStates.add(WTFMove(observableState));
+            observableStates.add(WTF::move(observableState));
         }
 
         [webView synchronouslyLoadHTMLString:@"<script>document.addEventListener('keydown', function(){while(1){}});</script>"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp
@@ -48,7 +48,7 @@ static void didFinishNavigation(WKPageRef, WKNavigationRef, WKTypeRef, const voi
 static void decidePolicyForNavigationAction(WKPageRef page, WKFrameRef frame, WKFrameNavigationType navigationType, WKEventModifiers modifiers, WKEventMouseButton mouseButton, WKFrameRef originatingFrame, WKURLRequestRef request, WKFramePolicyListenerRef listener, WKTypeRef userData, const void* clientInfo)
 {
     WKRetainPtr<WKFramePolicyListenerRef> retainedListener(listener);
-    RunLoop::mainSingleton().dispatch([retainedListener = WTFMove(retainedListener)] {
+    RunLoop::mainSingleton().dispatch([retainedListener = WTF::move(retainedListener)] {
         WKFramePolicyListenerUse(retainedListener.get());
     });
 }
@@ -56,7 +56,7 @@ static void decidePolicyForNavigationAction(WKPageRef page, WKFrameRef frame, WK
 static void decidePolicyForNavigationActionIgnore(WKPageRef page, WKFrameRef frame, WKFrameNavigationType navigationType, WKEventModifiers modifiers, WKEventMouseButton mouseButton, WKFrameRef originatingFrame, WKURLRequestRef request, WKFramePolicyListenerRef listener, WKTypeRef userData, const void* clientInfo)
 {
     WKRetainPtr<WKFramePolicyListenerRef> retainedListener(listener);
-    RunLoop::mainSingleton().dispatch([retainedListener = WTFMove(retainedListener), page = WTFMove(page)] {
+    RunLoop::mainSingleton().dispatch([retainedListener = WTF::move(retainedListener), page = WTF::move(page)] {
         EXPECT_NOT_NULL(adoptWK(WKPageCopyPendingAPIRequestURL(page)));
         WKFramePolicyListenerIgnore(retainedListener.get());
         didDecideNavigationPolicy = true;
@@ -66,7 +66,7 @@ static void decidePolicyForNavigationActionIgnore(WKPageRef page, WKFrameRef fra
 static void decidePolicyForResponse(WKPageRef page, WKFrameRef frame, WKURLResponseRef response, WKURLRequestRef request, bool canShowMIMEType, WKFramePolicyListenerRef listener, WKTypeRef userData, const void* clientInfo)
 {
     WKRetainPtr<WKFramePolicyListenerRef> retainedListener(listener);
-    RunLoop::mainSingleton().dispatch([retainedListener = WTFMove(retainedListener)] {
+    RunLoop::mainSingleton().dispatch([retainedListener = WTF::move(retainedListener)] {
         WKFramePolicyListenerUse(retainedListener.get());
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
@@ -40,7 +40,7 @@
 Function<void(WKScriptMessage*)> _messageHandler;
 }
 - (void)setMessageHandler:(Function<void(WKScriptMessage*)>&&)messageHandler {
-    _messageHandler = WTFMove(messageHandler);
+    _messageHandler = WTF::move(messageHandler);
 }
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/cocoa/WeakObjCPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/cocoa/WeakObjCPtr.mm
@@ -140,7 +140,7 @@ TEST(WebKit2_WeakObjCPtr, MoveConstructor)
 {
     id object = [[NSObject alloc] init];
     WeakObjCPtr<id> weak1(object);
-    WeakObjCPtr<id> weak2(WTFMove(weak1));
+    WeakObjCPtr<id> weak2(WTF::move(weak1));
 
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(weak1.get(), (void*)nil);
     EXPECT_EQ(weak2.get(), object);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
@@ -181,7 +181,7 @@ RetainPtr<SecIdentityRef> testIdentity2()
     auto privateKeyBytes = base64Decode(pemEncodedPrivateKey);
     auto certificateBytes = base64Decode(pemEncodedCertificate);
 
-    return createTestIdentity(WTFMove(*privateKeyBytes), WTFMove(*certificateBytes));
+    return createTestIdentity(WTF::move(*privateKeyBytes), WTF::move(*certificateBytes));
 }
 
 static RetainPtr<NSURLCredential> credentialWithIdentity()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
@@ -174,7 +174,7 @@ TEST(WKHTTPCookieStore, CookiePolicyAllowIsOnlyFromMainDocumentDomain)
                     "Connection: close\r\n"
                     "\r\n"_s;
             }
-            connection.send(WTFMove(reply));
+            connection.send(WTF::move(reply));
         });
     });
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -201,7 +201,7 @@ static std::pair<RetainPtr<NSAttributedString>, RetainPtr<NSError>> copyAndLoadA
     }];
     TestWebKitAPI::Util::run(&done);
 
-    return { WTFMove(resultString), WTFMove(resultError) };
+    return { WTF::move(resultString), WTF::move(resultError) };
 }
 
 TEST(CopyHTML, SanitizationPreservesRelativeURLInAttributedString)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
@@ -72,7 +72,7 @@ Function<bool()> _decisionHandler;
 - (instancetype)initWithHandler:(Function<bool()>&&)decisionHandler
 {
     self = [super init];
-    _decisionHandler = WTFMove(decisionHandler);
+    _decisionHandler = WTF::move(decisionHandler);
     return self;
 }
 
@@ -383,7 +383,7 @@ TEST(DeviceOrientation, PermissionSecureContextCheck)
 Function<void(WKSecurityOrigin*, WKFrameInfo*)> _validationHandler;
 }
 - (void)setValidationHandler:(Function<void(WKSecurityOrigin*, WKFrameInfo*)>&&)validationHandler {
-    _validationHandler = WTFMove(validationHandler);
+    _validationHandler = WTF::move(validationHandler);
 }
 
 - (void)webView:(WKWebView *)webView requestDeviceOrientationAndMotionPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -1690,7 +1690,7 @@ TEST(DocumentEditingContext, RequestAnnotationsForTextChecking)
             String { dynamic_objc_cast<NSString>(context.selectedText) },
             String { dynamic_objc_cast<NSString>(context.contextAfter) }
         );
-        return std::pair { WTFMove(combinedContext), WTFMove(annotatedText) };
+        return std::pair { WTF::move(combinedContext), WTF::move(annotatedText) };
     };
     {
         [webView _setEditable:YES];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -866,7 +866,7 @@ void respondSlowly(const Connection& connection, double kbps)
     const double writesPerSecond = 100;
     Vector<uint8_t> writeBuffer(static_cast<size_t>(1024 * kbps / writesPerSecond));
     auto before = MonotonicTime::now();
-    connection.send(WTFMove(writeBuffer), [=] {
+    connection.send(WTF::move(writeBuffer), [=] {
         double writeDuration = (MonotonicTime::now() - before).seconds();
         double desiredSleep = 1.0 / writesPerSecond;
         if (writeDuration < desiredSleep)
@@ -1214,10 +1214,10 @@ enum class TerminateAfterFirstReply : bool { No, Yes };
 
 static TestWebKitAPI::HTTPServer downloadTestServer(IncludeETag includeETag = IncludeETag::Yes, Function<void(TestWebKitAPI::Connection)>&& terminator = nullptr)
 {
-    return { [includeETag, terminator = WTFMove(terminator), connectionCount = 0](TestWebKitAPI::Connection connection) mutable {
+    return { [includeETag, terminator = WTF::move(terminator), connectionCount = 0](TestWebKitAPI::Connection connection) mutable {
         switch (++connectionCount) {
         case 1:
-            connection.receiveHTTPRequest([includeETag, connection, terminator = WTFMove(terminator)] (Vector<char>&&) mutable {
+            connection.receiveHTTPRequest([includeETag, connection, terminator = WTF::move(terminator)] (Vector<char>&&) mutable {
                 auto response = makeString(
                     "HTTP/1.1 200 OK\r\n"_s,
                     includeETag == IncludeETag::Yes ? "ETag: test\r\n"_s : ""_s,
@@ -1225,7 +1225,7 @@ static TestWebKitAPI::HTTPServer downloadTestServer(IncludeETag includeETag = In
                     "Content-Disposition: attachment; filename=\"example.txt\"\r\n"
                     "\r\n"_s, longString<5000>('a')
                 );
-                connection.send(WTFMove(response), [connection, terminator = WTFMove(terminator)] () mutable {
+                connection.send(WTF::move(response), [connection, terminator = WTF::move(terminator)] () mutable {
                     if (terminator)
                         terminator(connection);
                 });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
@@ -220,7 +220,7 @@ static DragStartData runDragStartDataTestCase(DragAndDropSimulator *simulator, N
     [allData removeObjectForKey:@"text/html"];
     [allData removeObjectForKey:@"Files"];
     if ([allData count])
-        result.customData = WTFMove(allData);
+        result.customData = WTF::move(allData);
     return result;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -300,10 +300,10 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<Util::PlatformWindow>> setU
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration.get() addToWindow:NO]);
     RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:frame]);
     [window addSubview:webView.get()];
-    return { WTFMove(webView), WTFMove(window) };
+    return { WTF::move(webView), WTF::move(window) };
 #else
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
-    return { WTFMove(webView), { [webView window] } };
+    return { WTF::move(webView), { [webView window] } };
 #endif
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -249,7 +249,7 @@ static void triggerAttributionWithSubresourceRedirect(Connection& connection, co
     connection.receiveHTTPRequest([connection, location] (Vector<char>&& request1) {
         EXPECT_TRUE(contains(request1.span(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n"_span));
         auto redirect = makeString("HTTP/1.1 302 Found\r\nLocation: "_s, location, "\r\nContent-Length: 0\r\n\r\n"_s);
-        connection.send(WTFMove(redirect), [connection, location] {
+        connection.send(WTF::move(redirect), [connection, location] {
             connection.receiveHTTPRequest([connection, location] (Vector<char>&& request2) {
                 auto expectedHttpGetString = makeString("GET "_s, location, " HTTP/1.1\r\n"_s).utf8();
                 EXPECT_TRUE(contains(request2.span(), expectedHttpGetString.span()));
@@ -322,7 +322,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                     "Content-Type: application/json\r\n"
                     "Content-Length: "_s, 24 + keyData.length(), "\r\n\r\n"
                     "{\"token_public_key\": \""_s, keyData, "\"}"_s);
-                connection.send(WTFMove(response), [signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] {
+                connection.send(WTF::move(response), [signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] {
                     connection.receiveHTTPRequest([signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] (Vector<char>&& request2) {
                         EXPECT_TRUE(contains(request2.span(), "POST / HTTP/1.1\r\n"_span));
 
@@ -345,7 +345,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                             "Content-Type: application/json\r\n"
                             "Content-Length: "_s, 24 + unlinkableToken.length(), "\r\n\r\n"
                             "{\"unlinkable_token\": \""_s, unlinkableToken, "\"}"_s);
-                        connection.send(WTFMove(response), [signingParty, connection, &keyData, &done, unlinkableToken, token, &secKey] {
+                        connection.send(WTF::move(response), [signingParty, connection, &keyData, &done, unlinkableToken, token, &secKey] {
                             connection.receiveHTTPRequest([signingParty, connection, &keyData, &done, unlinkableToken, token, &secKey] (Vector<char>&& request3) {
                                 EXPECT_TRUE(contains(request3.span(), "GET / HTTP/1.1\r\n"_span));
 
@@ -354,7 +354,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                                     "Content-Type: application/json\r\n"
                                     "Content-Length: "_s, 24 + keyData.length(), "\r\n\r\n"
                                     "{\"token_public_key\": \""_s, keyData, "\"}"_s);
-                                connection.send(WTFMove(response), [signingParty, connection, &done, unlinkableToken, token, &secKey] {
+                                connection.send(WTF::move(response), [signingParty, connection, &done, unlinkableToken, token, &secKey] {
                                     connection.receiveHTTPRequest([signingParty, connection, &done, unlinkableToken, token, &secKey] (Vector<char>&& request4) {
                                         EXPECT_TRUE(contains(request4.span(), "POST / HTTP/1.1\r\n"_span));
                                         EXPECT_TRUE(contains(request4.span(), "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3,"_span));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm
@@ -247,8 +247,8 @@ TEST(FontAttributes, FontAttributesAfterChangingSelection)
         }
         EXPECT_EQ(underline, fontPanel.hasUnderline);
         EXPECT_EQ(strikeThrough, fontPanel.hasStrikeThrough);
-        checkColor([fontPanel.foregroundColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace], { WTFMove(expectedColor) });
-        checkFont(fontManager.selectedFont, WTFMove(expectedFont));
+        checkColor([fontPanel.foregroundColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace], { WTF::move(expectedColor) });
+        checkFont(fontManager.selectedFont, WTF::move(expectedFont));
         EXPECT_EQ(expectMultipleFonts, fontManager.multiple);
 #else
         UNUSED_PARAM(expectedFont);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/HSTS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/HSTS.mm
@@ -56,7 +56,7 @@ std::pair<RetainPtr<WKWebView>, RetainPtr<TestNavigationDelegate>> hstsWebViewAn
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
-    return { WTFMove(webView), WTFMove(delegate) };
+    return { WTF::move(webView), WTF::move(delegate) };
 }
 
 static HTTPServer hstsServer()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JITEnabled.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JITEnabled.mm
@@ -51,6 +51,6 @@ TEST(WebKit, JITEnabled)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setProcessPool:adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]).get()];
     auto webViewNoJIT = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    checkJITEnabled(WTFMove(webViewNoJIT), NO);
+    checkJITEnabled(WTF::move(webViewNoJIT), NO);
     checkJITEnabled(adoptNS([WKWebView new]), YES);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -292,7 +292,7 @@ RetainPtr<NSData> tiffRepresentation(CocoaImage *image)
     if (!cgImage)
         return nullptr;
 
-    RefPtr nativeImage = WebCore::NativeImage::create(WTFMove(cgImage));
+    RefPtr nativeImage = WebCore::NativeImage::create(WTF::move(cgImage));
     if (!nativeImage)
         return nullptr;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Loading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Loading.mm
@@ -38,7 +38,7 @@
 Function<void(WKScriptMessage*)> _messageHandler;
 }
 - (void)setMessageHandler:(Function<void(WKScriptMessage*)>&&)messageHandler {
-    _messageHandler = WTFMove(messageHandler);
+    _messageHandler = WTF::move(messageHandler);
 }
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
@@ -187,7 +187,7 @@ public:
             auto eventMessage = makeString(event, " event"_s);
             RetainPtr nsEventMessage = eventMessage.createNSString();
             [_messageHandlers addObject:nsEventMessage.get()];
-            [webView() performAfterReceivingMessage:nsEventMessage.get() action:[this, eventMessage = WTFMove(eventMessage)] {
+            [webView() performAfterReceivingMessage:nsEventMessage.get() action:[this, eventMessage = WTF::move(eventMessage)] {
                 _eventListenersCalled.add(eventMessage);
             }];
         }
@@ -221,7 +221,7 @@ public:
             auto handlerMessage = makeString(handler, " handler"_s);
             RetainPtr nsHandleMessage = handlerMessage.createNSString();
             [_messageHandlers addObject:nsHandleMessage.get()];
-            [webView() performAfterReceivingMessage:nsHandleMessage.get() action:[this, handlerMessage = WTFMove(handlerMessage)] {
+            [webView() performAfterReceivingMessage:nsHandleMessage.get() action:[this, handlerMessage = WTF::move(handlerMessage)] {
                 _mediaSessionHandlersCalled.add(handlerMessage);
             }];
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -4253,7 +4253,7 @@ PrivateTokenTestSetupState setupWebViewForPrivateTokenTests(bool& didDecideServi
     };
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    return { webView, WTFMove(server), storeConfiguration, dataStore, websiteDataStoreDelegate, navigationDelegate };
+    return { webView, WTF::move(server), storeConfiguration, dataStore, websiteDataStoreDelegate, navigationDelegate };
 }
 
 #if HAVE(ALLOW_PRIVATE_ACCESS_TOKENS_FOR_THIRD_PARTY)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
@@ -526,7 +526,7 @@ TEST(_WKDataTask, Basic)
                 continue;
             }
             if (path == "/second_request"_s) {
-                secondRequest = WTFMove(request);
+                secondRequest = WTF::move(request);
                 co_await connection.awaitableSend(HTTPResponse(secondResponse).serialize());
                 continue;
             }
@@ -656,7 +656,7 @@ TEST(_WKDataTask, Challenge)
 void sendLoop(TestWebKitAPI::Connection connection, bool& sentWithError)
 {
     Vector<uint8_t> bytes(1000, 0);
-    connection.sendAndReportError(WTFMove(bytes), [&, connection] (bool sawError) {
+    connection.sendAndReportError(WTF::move(bytes), [&, connection] (bool sawError) {
         if (sawError)
             sentWithError = true;
         else

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NotificationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NotificationAPI.mm
@@ -63,7 +63,7 @@ Function<bool()> _decisionHandler;
 - (instancetype)initWithHandler:(Function<bool()>&&)decisionHandler
 {
     self = [super init];
-    _decisionHandler = WTFMove(decisionHandler);
+    _decisionHandler = WTF::move(decisionHandler);
     return self;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
@@ -196,7 +196,7 @@ private:
     using NotificationCallback = Function<bool(CFDictionaryRef)>;
     void performAfterReceivingNotification(CFNotificationName name, NotificationCallback&& callback)
     {
-        _callbacks.add(name, WTFMove(callback));
+        _callbacks.add(name, WTF::move(callback));
     }
 
     RetainPtr<WKWebViewConfiguration> _configuration;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm
@@ -55,7 +55,7 @@
     auto webView = adoptNS([[ParserYieldTokenTestWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration]);
     [[webView _remoteObjectRegistry] registerExportedObject:webView.get() interface:[_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ParserYieldTokenTestRunner)]];
     webView->_bundle = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:[_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ParserYieldTokenTestBundle)]];
-    webView->_schemeHandler = WTFMove(schemeHandler);
+    webView->_schemeHandler = WTF::move(schemeHandler);
     return webView;
 }
 
@@ -168,7 +168,7 @@ TEST(ParserYieldTokenTests, AsyncScriptRunsWhenFetched)
     [webView schemeHandler].startURLSchemeTaskHandler = [] (WKWebView *, id <WKURLSchemeTask> task) {
         auto script = retainPtr(@"window.eventMessages.push('Running async script.');");
         auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/javascript" expectedContentLength:[script length] textEncodingName:nil]);
-        dispatch_async(mainDispatchQueueSingleton(), [task = retainPtr(task), response = WTFMove(response), script = WTFMove(script)] {
+        dispatch_async(mainDispatchQueueSingleton(), [task = retainPtr(task), response = WTF::move(response), script = WTF::move(script)] {
             [task didReceiveResponse:response.get()];
             [task didReceiveData:[script dataUsingEncoding:NSUTF8StringEncoding]];
             [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Preconnect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Preconnect.mm
@@ -153,7 +153,7 @@ static void pingPong(Ref<H2::Connection>&& connection, size_t* headersCount)
             ASSERT_NOT_REACHED();
             break;
         }
-        pingPong(WTFMove(connection), headersCount);
+        pingPong(WTF::move(connection), headersCount);
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -354,7 +354,7 @@ static RetainPtr<WKWebView> createdWebView;
     auto doAsynchronouslyIfNecessary = [self, strongSelf = retainPtr(self), task = retainPtr(task)](Function<void(id <WKURLSchemeTask>)>&& f, double delay) {
         if (!_shouldRespondAsynchronously)
             return f(task.get());
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), mainDispatchQueueSingleton(), makeBlockPtr([self, strongSelf, task, f = WTFMove(f)] {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), mainDispatchQueueSingleton(), makeBlockPtr([self, strongSelf, task, f = WTF::move(f)] {
             if (_runningTasks.contains(task.get()))
                 f(task.get());
         }).get());
@@ -786,9 +786,9 @@ TEST(ProcessSwap, PSONRedirectionToExternal)
 
     HashMap<String, String> redirectHeaders;
     redirectHeaders.add("location"_s, "other://test"_s);
-    TestWebKitAPI::HTTPResponse redirectResponse(301, WTFMove(redirectHeaders));
+    TestWebKitAPI::HTTPResponse redirectResponse(301, WTF::move(redirectHeaders));
 
-    server.addResponse("/popup.html"_s, WTFMove(redirectResponse));
+    server.addResponse("/popup.html"_s, WTF::move(redirectResponse));
     auto popupURL = makeString("https://localhost:"_s, server.port(), "/popup.html"_s);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -7871,7 +7871,7 @@ TEST(ProcessSwap, COOPAndCOEPOn304Response)
     HTTPResponse response({ { { "Content-Type"_s, "text/html"_s }, { "Cross-Origin-Opener-Policy"_s, "same-origin"_s }, { "cross-origin-embedder-policy"_s, "require-corp"_s }, { "Etag"_s, "123456789"_s } }, "foo"_s });
     response.setShouldRespondWith304ToConditionalRequests({ { "Cross-Origin-Opener-Policy"_s, "same-origin"_s }, { "cross-origin-embedder-policy"_s, "require-corp"_s } });
     HTTPServer server({
-        { "/index.html"_s, WTFMove(response) },
+        { "/index.html"_s, WTF::move(response) },
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -8279,24 +8279,24 @@ static void runCOOPProcessSwapTest(ASCIILiteral sourceCOOP, ASCIILiteral sourceC
         destinationHeaders.add("Cross-Origin-Opener-Policy"_s, destinationCOOP);
     if (destinationCOEP)
         destinationHeaders.add("Cross-Origin-Embedder-Policy"_s, destinationCOEP);
-    HTTPResponse destinationResponse(WTFMove(destinationHeaders), "popup"_s);
+    HTTPResponse destinationResponse(WTF::move(destinationHeaders), "popup"_s);
 
     HTTPServer server(std::initializer_list<std::pair<String, HTTPResponse>> { }, HTTPServer::Protocol::Https);
 
     auto popupURL = isSameOrigin == IsSameOrigin::Yes ? "popup.html"_str : makeString("https://localhost:"_s, server.port(), "/popup.html"_s);
     auto popupSource = makeString("<script>onload = () => { w = open('"_s, popupURL, "', 'foo'); };</script>"_s);
-    server.addResponse("/main.html"_s, HTTPResponse { WTFMove(sourceHeaders), WTFMove(popupSource) });
+    server.addResponse("/main.html"_s, HTTPResponse { WTF::move(sourceHeaders), WTF::move(popupSource) });
 
     if (doServerSideRedirect == DoServerSideRedirect::Yes) {
         HashMap<String, String> redirectHeaders;
         String redirectionURL = isSameOrigin == IsSameOrigin::Yes ? makeString("https://127.0.0.1:"_s, server.port(), "/popup-after-redirection.html"_s) : makeString("https://localhost:"_s, server.port(), "/popup-after-redirection.html"_s);
-        redirectHeaders.add("location"_s, WTFMove(redirectionURL));
-        HTTPResponse redirectResponse(301, WTFMove(redirectHeaders));
+        redirectHeaders.add("location"_s, WTF::move(redirectionURL));
+        HTTPResponse redirectResponse(301, WTF::move(redirectHeaders));
 
-        server.addResponse("/popup.html"_s, WTFMove(redirectResponse));
-        server.addResponse("/popup-after-redirection.html"_s, WTFMove(destinationResponse));
+        server.addResponse("/popup.html"_s, WTF::move(redirectResponse));
+        server.addResponse("/popup-after-redirection.html"_s, WTF::move(destinationResponse));
     } else
-        server.addResponse("/popup.html"_s, WTFMove(destinationResponse));
+        server.addResponse("/popup.html"_s, WTF::move(destinationResponse));
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -129,7 +129,7 @@ TEST(WebKit, SOCKS5)
                         'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
                         httpPortFirstByte, httpPortSecondByte
                     };
-                    connection.send(WTFMove(response), [=] {
+                    connection.send(WTF::move(response), [=] {
                         connection.receiveHTTPRequest([=] (Vector<char>&&) {
                             connection.send(
                                 "HTTP/1.1 200 OK\r\n"
@@ -284,7 +284,7 @@ TEST(WebKit, SOCKS5API)
                         'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
                         httpPortFirstByte, httpPortSecondByte
                     };
-                    connection.send(WTFMove(response), [=] {
+                    connection.send(WTF::move(response), [=] {
                         connection.receiveHTTPRequest([=] (Vector<char>&&) {
                             connection.send(
                                 "HTTP/1.1 200 OK\r\n"
@@ -493,7 +493,7 @@ TEST(WebKit, RelaxThirdPartyCookieBlocking)
                 default:
                     ASSERT_NOT_REACHED();
                 }
-                connection.send(WTFMove(reply));
+                connection.send(WTF::move(reply));
             });
         });
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -497,8 +497,8 @@ void waitUntilTwoServersConnected(const unsigned& serversConnected, CompletionHa
         completionHandler();
         return;
     }
-    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([&serversConnected, completionHandler = WTFMove(completionHandler)] () mutable {
-        waitUntilTwoServersConnected(serversConnected, WTFMove(completionHandler));
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([&serversConnected, completionHandler = WTF::move(completionHandler)] () mutable {
+        waitUntilTwoServersConnected(serversConnected, WTF::move(completionHandler));
     }).get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -864,9 +864,9 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)
     auto simpleURL = server.request("/simple.html"_s).URL;
     redirectHeaders.add("location"_s, simpleURL.absoluteString);
 
-    TestWebKitAPI::HTTPResponse redirectResponse(302, WTFMove(redirectHeaders));
+    TestWebKitAPI::HTTPResponse redirectResponse(302, WTF::move(redirectHeaders));
 
-    server.addResponse("/redirection.html"_s, WTFMove(redirectResponse));
+    server.addResponse("/redirection.html"_s, WTF::move(redirectResponse));
 
     navigationCompleted = false;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -97,7 +97,7 @@ static bool didCloseCalled;
     if (!result)
         return nil;
 
-    result->_provider = WTFMove(provider);
+    result->_provider = WTF::move(provider);
     result->_isPhishing = phishing;
     result->_isMalware = malware;
     result->_isUnwantedSoftware = unwantedSoftware;
@@ -160,7 +160,7 @@ static bool didCloseCalled;
     if (!result)
         return nil;
     
-    result->_results = WTFMove(results);
+    result->_results = WTF::move(results);
     
     return result.autorelease();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -61,7 +61,7 @@
 
     _observable = observable;
     _keyPath = keyPath;
-    _callback = WTFMove(callback);
+    _callback = WTF::move(callback);
 
     [_observable addObserver:self forKeyPath:_keyPath.get() options:0 context:nil];
 
@@ -106,7 +106,7 @@ static void waitForSampledPageTopColorToChange(TestWKWebView *webView, Function<
 
 static void waitForSampledPageTopColorToChangeForHTML(TestWKWebView *webView, String&& html)
 {
-    waitForSampledPageTopColorToChange(webView, [webView, html = WTFMove(html)] () mutable {
+    waitForSampledPageTopColorToChange(webView, [webView, html = WTF::move(html)] () mutable {
         [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:html.createNSString().get()];
     });
 }
@@ -117,10 +117,10 @@ static String createHTMLGradientWithColorStops(String&& direction, Vector<String
 
     StringBuilder gradientBuilder;
     gradientBuilder.append("<body style=\"background-image: linear-gradient(to "_s);
-    gradientBuilder.append(WTFMove(direction));
-    for (auto&& colorStop : WTFMove(colorStops)) {
+    gradientBuilder.append(WTF::move(direction));
+    for (auto&& colorStop : WTF::move(colorStops)) {
         gradientBuilder.append(", "_s);
-        gradientBuilder.append(WTFMove(colorStop));
+        gradientBuilder.append(WTF::move(colorStop));
     }
     gradientBuilder.append(")\">Test"_s);
     return gradientBuilder.toString();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
@@ -111,8 +111,8 @@ namespace TestWebKitAPI {
 
 static IMP makeFingerprintingScriptsRequestHandler(NSArray<NSString *> *hostNames, Vector<WPScriptAccessCategories>&& allowedCategories)
 {
-    return imp_implementationWithBlock([hostNames = RetainPtr { hostNames }, allowedCategories = WTFMove(allowedCategories)](WPResources *, WPResourceRequestOptions *, void(^completion)(NSArray<WPFingerprintingScript *> *, NSError *)) mutable {
-        RunLoop::mainSingleton().dispatch([hostNames = WTFMove(hostNames), allowedCategories = WTFMove(allowedCategories), completion = makeBlockPtr(completion)] mutable {
+    return imp_implementationWithBlock([hostNames = RetainPtr { hostNames }, allowedCategories = WTF::move(allowedCategories)](WPResources *, WPResourceRequestOptions *, void(^completion)(NSArray<WPFingerprintingScript *> *, NSError *)) mutable {
+        RunLoop::mainSingleton().dispatch([hostNames = WTF::move(hostNames), allowedCategories = WTF::move(allowedCategories), completion = makeBlockPtr(completion)] mutable {
             RetainPtr scripts = [NSMutableArray arrayWithCapacity:[hostNames count]];
             size_t index = 0;
             for (NSString *host in hostNames.get()) {
@@ -138,7 +138,7 @@ public:
         m_swizzler = makeUnique<InstanceMethodSwizzler>(
             PAL::getWPResourcesClassSingleton(),
             @selector(requestFingerprintingScripts:completionHandler:),
-            makeFingerprintingScriptsRequestHandler(hosts, WTFMove(allowedCategories))
+            makeFingerprintingScriptsRequestHandler(hosts, WTF::move(allowedCategories))
         );
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -4400,7 +4400,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     HashMap<String, String> sourceHeaders;
     sourceHeaders.add("Cache-Control"_s, "no-cache"_s);
     sourceHeaders.add("Content-Type"_s, "application/javascript"_s);
-    server.setResponse("/sw.js"_s, TestWebKitAPI::HTTPResponse { WTFMove(sourceHeaders), serviceWorkerStorageTimingScriptBytesV2 });
+    server.setResponse("/sw.js"_s, TestWebKitAPI::HTTPResponse { WTF::move(sourceHeaders), serviceWorkerStorageTimingScriptBytesV2 });
 
     done = false;
     expectedMessage = "Message from worker: V1"_s;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -269,7 +269,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
         enableSiteIsolation(configuration.get());
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:rect configuration:configuration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
-    return { WTFMove(webView), WTFMove(navigationDelegate) };
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
 }
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> viewAndDelegate(RetainPtr<WKWebViewConfiguration> configuration, CGRect rect = CGRectZero)
@@ -316,7 +316,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
     enableFeature(configuration.get(), @"SiteIsolationSharedProcessEnabled");
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
-    return { WTFMove(webView), WTFMove(navigationDelegate) };
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
 }
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewAndDelegate(const HTTPServer& server, CGRect rect = CGRectZero)
@@ -433,7 +433,7 @@ static void checkFrameTreesInProcesses(NSSet<_WKFrameTreeNode *> *actualTrees, c
 
 void checkFrameTreesInProcesses(WKWebView *webView, Vector<ExpectedFrameTree>&& expectedFrameTrees)
 {
-    checkFrameTreesInProcesses(frameTrees(webView).get(), WTFMove(expectedFrameTrees));
+    checkFrameTreesInProcesses(frameTrees(webView).get(), WTF::move(expectedFrameTrees));
 }
 
 static unsigned countWebPages(const RetainPtr<WKWebView>& webView)
@@ -784,7 +784,7 @@ static std::pair<WebViewAndDelegates, WebViewAndDelegates> openerAndOpenedViews(
         Util::spinRunLoop();
     if (waitForOpenedNavigation)
         [opened.navigationDelegate waitForDidFinishNavigation];
-    return { WTFMove(opener), WTFMove(opened) };
+    return { WTF::move(opener), WTF::move(opened) };
 }
 
 TEST(SiteIsolation, NavigationAfterWindowOpen)
@@ -1865,7 +1865,7 @@ TEST(SiteIsolation, ProvisionalLoadFailure)
     [webView evaluateJavaScript:@"iframe.onload = alert('done');iframe.src = 'https://webkit.org/webkit'" completionHandler:nil];
 
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
-    checkFrameTreesInProcesses(webView.get(), WTFMove(expectedFrameTreesAfterAddingApple));
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedFrameTreesAfterAddingApple));
 }
 
 TEST(SiteIsolation, MultipleReloads)
@@ -3204,7 +3204,7 @@ TEST(SiteIsolation, CancelProvisionalLoad)
     auto checkStateAfterSequentialFrameLoads = [webView = RetainPtr { webView }, navigationDelegate = RetainPtr { navigationDelegate }] (NSString *first, NSString *second, Vector<ExpectedFrameTree>&& expectedTrees) {
         [webView evaluateJavaScript:[NSString stringWithFormat:@"i = document.getElementById('testiframe'); i.addEventListener('load', () => { alert('iframe loaded') }); i.src = '%@'; setTimeout(()=>{ i.src = '%@' }, Math.random() * 100)", first, second] completionHandler:nil];
         EXPECT_WK_STREQ([webView _test_waitForAlert], "iframe loaded");
-        checkFrameTreesInProcesses(webView.get(), WTFMove(expectedTrees));
+        checkFrameTreesInProcesses(webView.get(), WTF::move(expectedTrees));
     };
 
     checkStateAfterSequentialFrameLoads(@"https://webkit.org/never_respond", @"https://example.com/respond_quickly", {
@@ -4091,10 +4091,10 @@ static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server, bool enab
     RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     return {
-        WTFMove(webView),
-        WTFMove(messageHandler),
-        WTFMove(navigationDelegate),
-        WTFMove(uiDelegate)
+        WTF::move(webView),
+        WTF::move(messageHandler),
+        WTF::move(navigationDelegate),
+        WTF::move(uiDelegate)
     };
 };
 
@@ -6748,10 +6748,10 @@ TEST(SiteIsolation, AdvanceFocusAcrossFrames)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto webViewAndDelegates = makeWebViewAndDelegates(server);
-    auto webView = WTFMove(webViewAndDelegates.webView);
-    auto messageHandler = WTFMove(webViewAndDelegates.messageHandler);
-    auto navigationDelegate = WTFMove(webViewAndDelegates.navigationDelegate);
-    auto uiDelegate = WTFMove(webViewAndDelegates.uiDelegate);
+    auto webView = WTF::move(webViewAndDelegates.webView);
+    auto messageHandler = WTF::move(webViewAndDelegates.messageHandler);
+    auto navigationDelegate = WTF::move(webViewAndDelegates.navigationDelegate);
+    auto uiDelegate = WTF::move(webViewAndDelegates.uiDelegate);
 
     __block RetainPtr<NSString> mostRecentMessage;
     __block bool messageReceived = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoPresentationMode.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoPresentationMode.mm
@@ -153,7 +153,7 @@ TEST(VideoPresentationMode, Fullscreen)
         [viewStack removeLastObject];
 
         if ([view isKindOfClass:NSClassFromString(@"WebAVPlayerLayerView")]) {
-            playerLayerView = WTFMove(view);
+            playerLayerView = WTF::move(view);
             break;
         }
 
@@ -213,7 +213,7 @@ TEST(VideoPresentationMode, Inline)
         [viewStack removeLastObject];
 
         if ([view isKindOfClass:NSClassFromString(@"WebAVPlayerLayerView")]) {
-            playerLayerView = WTFMove(view);
+            playerLayerView = WTF::move(view);
             break;
         }
 
@@ -256,7 +256,7 @@ TEST(VideoPresentationMode, Standby)
             [viewControllerStack removeLastObject];
 
             if ([viewController isKindOfClass:AVPlayerViewController.class]) {
-                playerViewController = WTFMove(viewController);
+                playerViewController = WTF::move(viewController);
                 EXPECT_TRUE(window.isHidden);
                 break;
             }
@@ -312,7 +312,7 @@ TEST(VideoPresentationMode, PictureInPicture)
             [viewControllerStack removeLastObject];
 
             if ([viewController isKindOfClass:AVPlayerViewController.class]) {
-                playerViewController = WTFMove(viewController);
+                playerViewController = WTF::move(viewController);
                 break;
             }
 
@@ -334,7 +334,7 @@ TEST(VideoPresentationMode, PictureInPicture)
         [viewStack removeLastObject];
 
         if ([view isKindOfClass:NSClassFromString(@"WebAVPlayerLayerView")]) {
-            playerLayerView = WTFMove(view);
+            playerLayerView = WTF::move(view);
             break;
         }
 
@@ -376,7 +376,7 @@ TEST(VideoPresentationMode, CaptionPreview)
             RetainPtr view = (UIView *)[viewStack lastObject];
             [viewStack removeLastObject];
             if ([view isKindOfClass:NSClassFromString(@"WebAVPlayerLayerView")]) {
-                playerLayerView = WTFMove(view);
+                playerLayerView = WTF::move(view);
                 break;
             }
             [viewStack addObjectsFromArray:[view subviews]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -154,7 +154,7 @@ TEST(WebKit, WindowOpenWithoutUIDelegate)
 }
 
 - (void)setValidationHandler:(Function<void(WKFrameInfo*)>&&)validationHandler {
-    _validationHandler = WTFMove(validationHandler);
+    _validationHandler = WTF::move(validationHandler);
 }
 
 - (void)_webView:(WKWebView *)webView requestGeolocationPermissionForFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(BOOL allowed))decisionHandler
@@ -255,7 +255,7 @@ TEST(WebKit, GeolocationPermission)
     Function<void(WKSecurityOrigin*, WKFrameInfo*)> _validationHandler;
 }
 - (void)setValidationHandler:(Function<void(WKSecurityOrigin*, WKFrameInfo*)>&&)validationHandler {
-    _validationHandler = WTFMove(validationHandler);
+    _validationHandler = WTF::move(validationHandler);
 }
 
 - (void)_webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -419,7 +419,7 @@ enum class Command {
     if (!self)
         return nil;
     
-    self->commands = WTFMove(commandVector);
+    self->commands = WTF::move(commandVector);
     self->expectedException = expected;
     
     return self;
@@ -471,7 +471,7 @@ static void checkCallSequence(Vector<Command>&& commands, ShouldRaiseException s
 {
     done = false;
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[TaskSchemeHandler alloc] initWithCommands:WTFMove(commands) expectedException:shouldRaiseException == ShouldRaiseException::Yes]);
+    auto handler = adoptNS([[TaskSchemeHandler alloc] initWithCommands:WTF::move(commands) expectedException:shouldRaiseException == ShouldRaiseException::Yes]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"testing:///initial"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -460,7 +460,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
                     "Connection: close\r\n"
                     "\r\n"_s, body
                 );
-                co_await connection.awaitableSend(WTFMove(reply));
+                co_await connection.awaitableSend(WTF::move(reply));
                 continue;
             }
             if (path == "/frame.html"_s) {
@@ -470,7 +470,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
                     "\r\n"_s, longString<500000>(' ')
                 );
 
-                co_await connection.awaitableSend(WTFMove(response));
+                co_await connection.awaitableSend(WTF::move(response));
                 connection.terminate();
                 continue;
             }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -155,7 +155,7 @@ TEST(WebKit, ConfigurationHTTPSUpgrade)
     Vector<char> requestBytes;
     HTTPServer server([&] (Connection connection) {
         connection.receiveHTTPRequest([&, connection](Vector<char>&& bytes) mutable {
-            requestBytes = WTFMove(bytes);
+            requestBytes = WTF::move(bytes);
             done = true;
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -303,7 +303,7 @@ template<> struct TestArgumentCoder<URL> {
         auto string = decoder.template decode<String>();
         if (!string)
             return std::nullopt;
-        return { URL(WTFMove(*string)) };
+        return { URL(WTF::move(*string)) };
     }
 };
 
@@ -462,7 +462,7 @@ void WebPushXPCConnectionMessageSender::sendWithoutUsingIPCConnection(M&& messag
     TestEncoder encoder;
     encoder.encodeHeader<M>();
     message.encode(encoder);
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
     xpc_connection_send_message(m_connection.get(), dictionary.get());
 }
 
@@ -472,12 +472,12 @@ void WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnect
     TestEncoder encoder;
     encoder.encodeHeader<M>();
     message.encode(encoder);
-    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
-    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
+    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) == XPC_TYPE_ERROR) {
             // We only expect an error if we were purposefully testing the wrong protocol version.
             RELEASE_ASSERT(m_shouldIncrementProtocolVersionForTesting);
-            return IPC::cancelReplyWithoutUsingConnection<M>(WTFMove(completionHandler));
+            return IPC::cancelReplyWithoutUsingConnection<M>(WTF::move(completionHandler));
         }
 
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY)
@@ -488,7 +488,7 @@ void WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnect
         auto data = xpcDictionaryGetData(reply, WebKit::WebPushD::protocolEncodedMessageKey);
         TestDecoder decoder(data);
         decoder.ignoreHeader<M>();
-        IPC::callReplyWithoutUsingConnection<M>(decoder, WTFMove(completionHandler));
+        IPC::callReplyWithoutUsingConnection<M>(decoder, WTF::move(completionHandler));
     }).get());
 }
 
@@ -507,7 +507,7 @@ static WebKit::WebPushD::WebPushDaemonConnectionConfiguration defaultWebPushDaem
     memcpySpan(auditToken.mutableSpan(), asByteSpan(token));
 
     IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
-    return { .hostAppAuditTokenData = WTFMove(auditToken) };
+    return { .hostAppAuditTokenData = WTF::move(auditToken) };
     IGNORE_CLANG_WARNINGS_END
 }
 
@@ -1381,19 +1381,19 @@ public:
         m_notificationProvider = makeUnique<TestWebKitAPI::TestNotificationProvider>(Vector<WKNotificationManagerRef> { [processPool _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
 
         auto webView = makeUniqueRef<WebPushDTestWebView>(emptyString(), std::nullopt, processPool.get(), *m_notificationProvider, m_html, m_installDataStoreDelegate, m_builtInNotificationsEnabled);
-        m_webViews.append(WTFMove(webView));
+        m_webViews.append(WTF::move(webView));
 
         auto webViewWithIdentifier1 = makeUniqueRef<WebPushDTestWebView>(emptyString(), WTF::UUID::parse("0bf5053b-164c-4b7d-8179-832e6bf158df"_s), processPool.get(), *m_notificationProvider, m_html, m_installDataStoreDelegate, m_builtInNotificationsEnabled);
-        m_webViews.append(WTFMove(webViewWithIdentifier1));
+        m_webViews.append(WTF::move(webViewWithIdentifier1));
 
         auto webViewWithIdentifier2 = makeUniqueRef<WebPushDTestWebView>(emptyString(), WTF::UUID::parse("940e7729-738e-439f-a366-1a8719e23b2d"_s), processPool.get(), *m_notificationProvider, m_html, m_installDataStoreDelegate, m_builtInNotificationsEnabled);
-        m_webViews.append(WTFMove(webViewWithIdentifier2));
+        m_webViews.append(WTF::move(webViewWithIdentifier2));
 
         auto webViewWithPartition = makeUniqueRef<WebPushDTestWebView>("testPartition"_s, std::nullopt, processPool.get(), *m_notificationProvider, m_html, m_installDataStoreDelegate, m_builtInNotificationsEnabled);
-        m_webViews.append(WTFMove(webViewWithPartition));
+        m_webViews.append(WTF::move(webViewWithPartition));
 
         auto webViewWithPartitionAndIdentifier = makeUniqueRef<WebPushDTestWebView>("testPartition"_s, WTF::UUID::parse("940e7729-738e-439f-a366-1a8719e23b2d"_s), processPool.get(), *m_notificationProvider, m_html, m_installDataStoreDelegate, m_builtInNotificationsEnabled);
-        m_webViews.append(WTFMove(webViewWithPartitionAndIdentifier));
+        m_webViews.append(WTF::move(webViewWithPartitionAndIdentifier));
     }
 
     ~WebPushDTest()
@@ -1417,7 +1417,7 @@ public:
         });
         TestWebKitAPI::Util::run(&done);
 
-        return std::make_pair(WTFMove(enabledTopics), WTFMove(ignoredTopics));
+        return std::make_pair(WTF::move(enabledTopics), WTF::move(ignoredTopics));
     }
 
     size_t subscribedTopicsCount() { return getPushTopics().first.size(); }
@@ -1869,7 +1869,7 @@ TEST_F(WebPushDBuiltInTest, ShowAndGetNotifications)
     auto configuration = defaultWebPushDaemonConfiguration();
     configuration.pushPartitionString = dataStore.get()._webPushPartition;
     configuration.dataStoreIdentifier = WTF::UUID::fromNSUUID(dataStore.get()._identifier);
-    auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service", WTFMove(configuration));
+    auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service", WTF::move(configuration));
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
 
     WebKit::WebPushD::PushMessageForTesting message;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm
@@ -70,7 +70,7 @@ TEST(WebSocket, LongMessageNoDeflate)
                 for (size_t i = 0; i < twoMegabytes; i++)
                     bytesToSend.append('x');
 
-                connection.send(WTFMove(bytesToSend));
+                connection.send(WTF::move(bytesToSend));
             }, expectedReceiveSize);
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -89,7 +89,7 @@ TEST(WebTransport, ClientBidirectional)
         request.append('d');
         request.append('e');
         request.append('f');
-        co_await connection.awaitableSend(WTFMove(request));
+        co_await connection.awaitableSend(WTF::move(request));
     });
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
@@ -152,7 +152,7 @@ TEST(WebTransport, Datagram)
     WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
         auto request = co_await datagramConnection.awaitableReceiveBytes();
-        co_await datagramConnection.awaitableSend(WTFMove(request));
+        co_await datagramConnection.awaitableSend(WTF::move(request));
     });
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
@@ -208,7 +208,7 @@ TEST(WebTransport, Unidirectional)
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverUnidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Unidirectional);
-        co_await serverUnidirectionalStream.awaitableSend(WTFMove(request));
+        co_await serverUnidirectionalStream.awaitableSend(WTF::move(request));
     });
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
@@ -255,7 +255,7 @@ TEST(WebTransport, ServerBidirectional)
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
-        co_await serverBidirectionalStream.awaitableSend(WTFMove(request));
+        co_await serverBidirectionalStream.awaitableSend(WTF::move(request));
     });
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
@@ -480,7 +480,7 @@ TEST(WebTransport, Worker)
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
-        co_await serverBidirectionalStream.awaitableSend(WTFMove(request));
+        co_await serverBidirectionalStream.awaitableSend(WTF::move(request));
     });
 
     auto mainHTML = "<script>"
@@ -527,7 +527,7 @@ TEST(WebTransport, WorkerAfterNetworkProcessCrash)
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
-        co_await serverBidirectionalStream.awaitableSend(WTFMove(request));
+        co_await serverBidirectionalStream.awaitableSend(WTF::move(request));
     });
 
     auto mainHTML = "<script>"
@@ -585,13 +585,13 @@ TEST(WebTransport, CreateStreamsBeforeReady)
     WebTransportServer datagramServer([](ConnectionGroup group) -> ConnectionTask {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
         auto request = co_await datagramConnection.awaitableReceiveBytes();
-        co_await datagramConnection.awaitableSend(WTFMove(request));
+        co_await datagramConnection.awaitableSend(WTF::move(request));
     });
 
     WebTransportServer streamServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
-        co_await connection.awaitableSend(WTFMove(request));
+        co_await connection.awaitableSend(WTF::move(request));
     });
 
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
@@ -699,7 +699,7 @@ TEST(WebTransport, ServerCertificateHashes)
             auto connection = co_await group.receiveIncomingConnection();
             auto request = co_await connection.awaitableReceiveBytes();
             auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
-            co_await serverBidirectionalStream.awaitableSend(WTFMove(request));
+            co_await serverBidirectionalStream.awaitableSend(WTF::move(request));
         }, adoptNS(sec_identity_create(identity.get())).get());
 
         std::array<uint8_t, CC_SHA256_DIGEST_LENGTH> sha2 { };
@@ -793,7 +793,7 @@ TEST(WebTransport, BackForwardCache)
     WebTransportServer echoServer([&](ConnectionGroup group) -> ConnectionTask {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
         auto request = co_await datagramConnection.awaitableReceiveBytes();
-        co_await datagramConnection.awaitableSend(WTFMove(request));
+        co_await datagramConnection.awaitableSend(WTF::move(request));
         co_await group.awaitableFailure();
         serverConnectionTerminatedByClient = true;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -748,7 +748,7 @@ static void respondToRangeRequests(const TestWebKitAPI::Connection& connection, 
         NSData *responseBody = [data subdataWithRange:NSMakeRange(rangeBegin, rangeEnd - rangeBegin)];
         auto response = makeVector(responseHeader);
         response.append(span(responseBody));
-        connection.send(WTFMove(response), [=] {
+        connection.send(WTF::move(response), [=] {
             respondToRangeRequests(connection, data);
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -682,7 +682,7 @@ struct ParsedRange {
     if (!self)
         return nil;
     
-    videoData = WTFMove(data);
+    videoData = WTF::move(data);
     
     return self;
 }
@@ -722,7 +722,7 @@ TEST(WebpagePreferences, WebsitePoliciesDuringRedirect)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto videoData = adoptNS([[NSData alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]]);
-    [configuration setURLSchemeHandler:adoptNS([[TestSchemeHandler alloc] initWithVideoData:WTFMove(videoData)]).get() forURLScheme:@"test"];
+    [configuration setURLSchemeHandler:adoptNS([[TestSchemeHandler alloc] initWithVideoData:WTF::move(videoData)]).get() forURLScheme:@"test"];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
     auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
@@ -1109,7 +1109,7 @@ static unsigned loadCount;
 
 - (void)setTaskHandler:(Function<void(id <WKURLSchemeTask>)>&&)handler
 {
-    _taskHandler = WTFMove(handler);
+    _taskHandler = WTF::move(handler);
 }
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)task

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -2810,7 +2810,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
 
     _observable = observable;
     _keyPath = keyPath;
-    _callback = WTFMove(callback);
+    _callback = WTF::move(callback);
 
     [_observable addObserver:self forKeyPath:_keyPath.get() options:0 context:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -221,7 +221,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    return { WTFMove(webView), WTFMove(navigationDelegate) };
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
 }
 
 static void testFractionalCoordinatesInIFrame(TestWKWebView *webView, double mouseX, double mouseY, NSString *expectedX, NSString *expectedY, NSString *jsTransform = nil, bool isCrossOrigin = false)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
@@ -361,7 +361,7 @@ public:
 
     void connect(Function<void (const char*)>&& completionHandler)
     {
-        m_completionHandler = WTFMove(completionHandler);
+        m_completionHandler = WTF::move(completionHandler);
         GRefPtr<GSocketClient> client = adoptGRef(g_socket_client_new());
         auto* uri = soup_server_message_get_uri(m_message.get());
         const char* host = g_uri_get_host(uri);
@@ -394,7 +394,7 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
         g_assert_cmpuint(port, ==, gProxyServerPort);
         auto tunnel = makeUnique<Tunnel>(server, message);
         auto* tunnelPtr = tunnel.get();
-        tunnelPtr->connect([tunnel = WTFMove(tunnel)](const char* errorMessage) {
+        tunnelPtr->connect([tunnel = WTF::move(tunnel)](const char* errorMessage) {
             if (errorMessage) {
                 soup_server_message_set_status(tunnel->m_message.get(), SOUP_STATUS_BAD_GATEWAY, nullptr);
                 soup_server_message_set_response(tunnel->m_message.get(), "text/plain", SOUP_MEMORY_COPY, errorMessage, strlen(errorMessage));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
@@ -37,7 +37,7 @@ public:
         GRefPtr<GSocketClient> socketClient = adoptGRef(g_socket_client_new());
         g_socket_client_connect_to_host_async(socketClient.get(), "127.0.0.1:2229", 0, nullptr, [](GObject* client, GAsyncResult* result, gpointer userData) {
             GRefPtr<GSocketConnection> connection = adoptGRef(g_socket_client_connect_to_host_finish(G_SOCKET_CLIENT(client), result, nullptr));
-            static_cast<AutomationTest*>(userData)->setConnection(SocketConnection::create(WTFMove(connection), s_messageHandlers, userData));
+            static_cast<AutomationTest*>(userData)->setConnection(SocketConnection::create(WTF::move(connection), s_messageHandlers, userData));
         }, this);
         g_main_loop_run(m_mainLoop.get());
     }
@@ -58,7 +58,7 @@ public:
 
     void setConnection(Ref<SocketConnection>&& connection)
     {
-        m_connection = WTFMove(connection);
+        m_connection = WTF::move(connection);
         g_main_loop_quit(m_mainLoop.get());
     }
 
@@ -67,7 +67,7 @@ public:
         bool newConnection = !m_connectionID;
         bool wasPaired = m_target.isPaired;
         m_connectionID = connectionID;
-        m_target = WTFMove(target);
+        m_target = WTF::move(target);
         if (newConnection || (!wasPaired && m_target.isPaired))
             g_main_loop_quit(m_mainLoop.get());
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
@@ -235,7 +235,7 @@ public:
             g_main_loop_quit(data->mainLoop);
         }, &data);
         g_main_loop_run(m_mainLoop);
-        return WTFMove(data.dataList);
+        return WTF::move(data.dataList);
     }
 
     char** getDomains()

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
@@ -358,13 +358,13 @@ public:
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "isComposing"));
             g_assert_true(jsc_value_is_boolean(value.get()));
             event.isComposing = jsc_value_to_boolean(value.get());
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         } else if (!g_strcmp0(strValue.get(), "keyPress")) {
             InputMethodTest::Event event(InputMethodTest::Event::Type::KeyPress);
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "keyCode"));
             g_assert_true(jsc_value_is_number(value.get()));
             event.keyCode = jsc_value_to_int32(value.get());
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         } else if (!g_strcmp0(strValue.get(), "keyUp")) {
             InputMethodTest::Event event(InputMethodTest::Event::Type::KeyUp);
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "keyCode"));
@@ -377,28 +377,28 @@ public:
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "isComposing"));
             g_assert_true(jsc_value_is_boolean(value.get()));
             event.isComposing = jsc_value_to_boolean(value.get());
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         } else if (!g_strcmp0(strValue.get(), "compositionstart")) {
             InputMethodTest::Event event(InputMethodTest::Event::Type::CompositionStart);
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "data"));
             g_assert_true(jsc_value_is_string(value.get()));
             strValue.reset(jsc_value_to_string(value.get()));
             event.data = strValue.get();
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         } else if (!g_strcmp0(strValue.get(), "compositionupdate")) {
             InputMethodTest::Event event(InputMethodTest::Event::Type::CompositionUpdate);
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "data"));
             g_assert_true(jsc_value_is_string(value.get()));
             strValue.reset(jsc_value_to_string(value.get()));
             event.data = strValue.get();
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         } else if (!g_strcmp0(strValue.get(), "compositionend")) {
             InputMethodTest::Event event(InputMethodTest::Event::Type::CompositionEnd);
             value = adoptGRef(jsc_value_object_get_property(jsEvent, "data"));
             g_assert_true(jsc_value_is_string(value.get()));
             strValue.reset(jsc_value_to_string(value.get()));
             event.data = strValue.get();
-            m_events.append(WTFMove(event));
+            m_events.append(WTF::move(event));
         }
 
         if (m_events.size() == m_eventsExpected)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -469,7 +469,7 @@ void testWebKitFeatures(Test* test, gconstpointer)
 
             auto identifier = String::fromUTF8(webkit_feature_get_identifier(feature));
             g_assert_false(featureIdentifiers.contains(identifier));
-            featureIdentifiers.add(WTFMove(identifier));
+            featureIdentifiers.add(WTF::move(identifier));
         }
 
         g_assert_cmpuint(featureIdentifiers.size(), ==, allFeaturesCount);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
@@ -185,7 +185,7 @@ static void testDisplayStringParsingWithLocalization(Test*, gconstpointer)
         { "_locales/en_US/messages.json"_s, createGBytes(regionalMessages) }
     };
 
-    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkitWebExtensionCreate(WTFMove(resources), &error.outPtr()));
+    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkitWebExtensionCreate(WTF::move(resources), &error.outPtr()));
 
     g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Default String");
     g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Regional String");
@@ -209,7 +209,7 @@ static void testDisplayStringParsingWithLocalization(Test*, gconstpointer)
         { "_locales/en_US/messages.json"_s, createGBytes(regionalMessages) }
     };
 
-    extension = adoptGRef(webkitWebExtensionCreate(WTFMove(resources), &error.outPtr()));
+    extension = adoptGRef(webkitWebExtensionCreate(WTF::move(resources), &error.outPtr()));
 
     g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Default String");
     g_assert_no_error(error.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
@@ -577,7 +577,7 @@ public:
 
     const Vector<GRefPtr<WebKitUserMessage>>& waitUntilViewMessagesReceived(Vector<CString>&& messageNames)
     {
-        m_expectedViewMessageNames = WTFMove(messageNames);
+        m_expectedViewMessageNames = WTF::move(messageNames);
         m_receivedViewMessages = { };
         g_main_loop_run(m_mainLoop);
         m_expectedViewMessageNames = { };
@@ -591,7 +591,7 @@ public:
 
     const Vector<GRefPtr<WebKitUserMessage>>& waitUntilContextMessagesReceived(Vector<CString>&& messageNames)
     {
-        m_expectedContextMessageNames = WTFMove(messageNames);
+        m_expectedContextMessageNames = WTF::move(messageNames);
         m_receivedContextMessages = { };
         g_main_loop_run(m_mainLoop);
         m_expectedContextMessageNames = { };

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp
@@ -36,7 +36,7 @@ static TestsMap& testsMap()
 
 void WebProcessTest::add(const String& testName, std::function<std::unique_ptr<WebProcessTest> ()> closure)
 {
-    testsMap().add(testName, WTFMove(closure));
+    testsMap().add(testName, WTF::move(closure));
 }
 
 std::unique_ptr<WebProcessTest> WebProcessTest::create(const String& testName)

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
@@ -294,7 +294,7 @@ static void testPrintOperationCloseAfterPrint(CloseAfterPrintTest* test, gconstp
         g_test_skip("no suitable printer found");
         return;
     }
-    test->m_printer = WTFMove(printer);
+    test->m_printer = WTF::move(printer);
     test->loadHtml("<html><body onLoad=\"w = window.open();w.print();w.close();\"></body></html>", 0);
     test->waitUntilPrintFinishedAndViewClosed();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
@@ -131,7 +131,7 @@ public:
     void startEventMonitor(std::optional<AtspiAccessible*> source, Vector<CString>&& events)
     {
         m_eventMonitor.source = source;
-        m_eventMonitor.eventTypes = WTFMove(events);
+        m_eventMonitor.eventTypes = WTF::move(events);
         m_eventMonitor.listener = adoptGRef(atspi_event_listener_new([](AtspiEvent* event, gpointer userData) {
             auto* test = static_cast<AccessibilityTest*>(userData);
             if (test->shouldProcessEvent(event))
@@ -149,7 +149,7 @@ public:
         while (m_eventMonitor.events.size() < expectedEvents && MonotonicTime::now() - startTime < timeout.value_or(Seconds::infinity()))
             g_main_context_iteration(nullptr, timeout ? FALSE : TRUE);
 
-        auto events = WTFMove(m_eventMonitor.events);
+        auto events = WTF::move(m_eventMonitor.events);
         for (const auto& event : m_eventMonitor.eventTypes)
             atspi_event_listener_deregister(m_eventMonitor.listener.get(), event.data(), nullptr);
         m_eventMonitor = { nullptr, { }, { }, nullptr };

--- a/Tools/TestWebKitAPI/Tests/ios/EnterKeyHintTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/EnterKeyHintTests.mm
@@ -76,7 +76,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> createW
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
     [webView _setInputDelegate:inputDelegate.get()];
-    return { WTFMove(webView), WTFMove(inputDelegate) };
+    return { WTF::move(webView), WTF::move(inputDelegate) };
 }
 
 TEST(EnterKeyHintTests, EnterKeyHintInContentEditableElement)

--- a/Tools/TestWebKitAPI/Tests/ios/UIWKInteractionViewProtocol.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIWKInteractionViewProtocol.mm
@@ -234,7 +234,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> setUpEd
 
     [webView synchronouslyLoadTestPageNamed:@"editable-responsive-body"];
     TestWebKitAPI::Util::run(&didStartInputSession);
-    return { WTFMove(webView), WTFMove(inputDelegate) };
+    return { WTF::move(webView), WTF::move(inputDelegate) };
 }
 
 TEST(UIWKInteractionViewProtocol, TextInteractionCanBeginInExistingSelection)

--- a/Tools/TestWebKitAPI/Tests/ios/Viewport.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/Viewport.mm
@@ -81,8 +81,8 @@ TEST(Viewport, RespectInitialScaleExceptOnWikipediaDomain)
         RetainPtr response = makeViewportMetaTag(viewportWidth, expectedViewportScale);
         [webView loadSimulatedRequest:request responseHTMLString:response.get()];
         [navigationDelegate waitForDidFinishNavigation];
-        [webView _doAfterNextPresentationUpdate:makeBlockPtr([&done, &webView, expectedViewportScale, scaleExpectation = WTFMove(scaleExpectation)]() mutable {
-            [webView evaluateJavaScript:@"visualViewport.scale" completionHandler:makeBlockPtr([&done, expectedViewportScale, scaleExpectation = WTFMove(scaleExpectation)] (NSNumber *value, NSError *error) mutable {
+        [webView _doAfterNextPresentationUpdate:makeBlockPtr([&done, &webView, expectedViewportScale, scaleExpectation = WTF::move(scaleExpectation)]() mutable {
+            [webView evaluateJavaScript:@"visualViewport.scale" completionHandler:makeBlockPtr([&done, expectedViewportScale, scaleExpectation = WTF::move(scaleExpectation)] (NSNumber *value, NSError *error) mutable {
                 auto actualViewportScale = value.floatValue;
                 scaleExpectation(actualViewportScale, expectedViewportScale);
                 done = true;

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -62,7 +62,7 @@
     [notificationCenter addObserver:self selector:@selector(handleNotification:) name:NSPopoverDidShowNotification object:nil];
     [notificationCenter addObserver:self selector:@selector(handleNotification:) name:NSPopoverWillCloseNotification object:nil];
     [notificationCenter addObserver:self selector:@selector(handleNotification:) name:NSPopoverDidCloseNotification object:nil];
-    _callback = WTFMove(callback);
+    _callback = WTF::move(callback);
     return self;
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm
@@ -123,9 +123,9 @@ static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server)
     [webView setUIDelegate:uiDelegate.get()];
 
     return {
-        WTFMove(webView),
-        WTFMove(navigationDelegate),
-        WTFMove(uiDelegate)
+        WTF::move(webView),
+        WTF::move(navigationDelegate),
+        WTF::move(uiDelegate)
     };
 };
 
@@ -138,9 +138,9 @@ TEST(FocusWebView, AdvanceFocusRelinquishToChrome)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto webViewAndDelegates = makeWebViewAndDelegates(server);
-    RetainPtr webView = WTFMove(webViewAndDelegates.webView);
-    RetainPtr navigationDelegate = WTFMove(webViewAndDelegates.navigationDelegate);
-    RetainPtr uiDelegate = WTFMove(webViewAndDelegates.uiDelegate);
+    RetainPtr webView = WTF::move(webViewAndDelegates.webView);
+    RetainPtr navigationDelegate = WTF::move(webViewAndDelegates.navigationDelegate);
+    RetainPtr uiDelegate = WTF::move(webViewAndDelegates.uiDelegate);
 
     NSRect newWindowFrame = NSMakeRect(0, 0, 400, 500);
     NSRect textFieldFrame = NSMakeRect(0, 400, 400, 100);

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewScheduleInRunLoop.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewScheduleInRunLoop.mm
@@ -59,7 +59,7 @@ TEST(WebKitLegacy, ScheduleInRunLoop)
         [webView unscheduleFromRunLoop:[NSRunLoop currentRunLoop] forMode:(NSString *)kCFRunLoopCommonModes];
         [webView scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:@"TestRunLoopMode"];
         [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
-        webViews.append(WTFMove(webView));
+        webViews.append(WTF::move(webView));
     }
 
     while (loadsFinished < webViewCount)

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -37,9 +37,9 @@
 namespace TestWebKitAPI {
 
 struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
-    static Ref<Data> create(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler) { return adoptRef(*new Data(WTFMove(connectionGroupHandler))); }
+    static Ref<Data> create(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler) { return adoptRef(*new Data(WTF::move(connectionGroupHandler))); }
     Data(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler)
-        : connectionGroupHandler(WTFMove(connectionGroupHandler)) { }
+        : connectionGroupHandler(WTF::move(connectionGroupHandler)) { }
 
     Function<ConnectionTask(ConnectionGroup)> connectionGroupHandler;
     RetainPtr<nw_listener_t> listener;
@@ -48,7 +48,7 @@ struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
 };
 
 WebTransportServer::WebTransportServer(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler, sec_identity_t identity)
-    : m_data(Data::create(WTFMove(connectionGroupHandler)))
+    : m_data(Data::create(WTF::move(connectionGroupHandler)))
 {
     auto configureWebTransport = [](nw_protocol_options_t options) {
         nw_webtransport_options_set_is_datagram(options, true);
@@ -109,7 +109,7 @@ WebTransportServer::WebTransportServer(Function<ConnectionTask(ConnectionGroup)>
     nw_listener_start(listener.get());
     Util::run(&ready);
 
-    m_data->listener = WTFMove(listener);
+    m_data->listener = WTF::move(listener);
 }
 
 WebTransportServer::~WebTransportServer() = default;

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -92,15 +92,15 @@ struct HTTPResponse {
     };
 
     HTTPResponse(Vector<uint8_t>&& body)
-        : body(WTFMove(body)) { }
+        : body(WTF::move(body)) { }
     HTTPResponse(const String& body)
         : body(bodyFromString(body)) { }
     HTTPResponse(HashMap<String, String>&& headerFields, const String& body)
-        : headerFields(WTFMove(headerFields))
+        : headerFields(WTF::move(headerFields))
         , body(bodyFromString(body)) { }
     HTTPResponse(unsigned statusCode, HashMap<String, String>&& headerFields = { }, const String& body = { })
         : statusCode(statusCode)
-        , headerFields(WTFMove(headerFields))
+        , headerFields(WTF::move(headerFields))
         , body(bodyFromString(body)) { }
     HTTPResponse(Behavior behavior)
         : behavior(behavior) { }
@@ -116,7 +116,7 @@ struct HTTPResponse {
     void setShouldRespondWith304ToConditionalRequests(HashMap<String, String>&& headerFields = { })
     {
         shouldRespondWith304ToConditionalRequests = true;
-        headerFieldsFor304 = WTFMove(headerFields);
+        headerFieldsFor304 = WTF::move(headerFields);
     }
 
     enum class IncludeContentLength : bool { No, Yes };
@@ -155,7 +155,7 @@ public:
         : m_type(type)
         , m_flags(flags)
         , m_streamID(streamID)
-        , m_payload(WTFMove(payload)) { }
+        , m_payload(WTF::move(payload)) { }
 
     Type type() const { return m_type; }
     uint8_t flags() const { return m_flags; }

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEViewMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEViewMock.cpp
@@ -77,7 +77,7 @@ static gboolean wpeViewMockRenderBuffer(WPEView* view, WPEBuffer* buffer, const 
         auto* view = WPE_VIEW(userData);
         if (priv->committedBuffer)
             wpe_view_buffer_released(view, priv->committedBuffer.get());
-        priv->committedBuffer = WTFMove(priv->pendingBuffer);
+        priv->committedBuffer = WTF::move(priv->pendingBuffer);
         wpe_view_buffer_rendered(view, priv->committedBuffer.get());
 
         return G_SOURCE_REMOVE;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
@@ -134,7 +134,7 @@ void AccessibilityController::executeOnAXThread(Function<void()>&& function)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (m_accessibilityIsolatedTreeMode) {
-        AXThread::dispatch([function = WTFMove(function)] {
+        AXThread::dispatch([function = WTF::move(function)] {
             function();
         });
     } else
@@ -149,7 +149,7 @@ void AccessibilityController::executeOnMainThread(Function<void()>&& function)
         return;
     }
 
-    AXThread::dispatchBarrier([function = WTFMove(function)] {
+    AXThread::dispatchBarrier([function = WTF::move(function)] {
         function();
     });
 }
@@ -200,7 +200,7 @@ void AXThread::dispatch(Function<void()>&& function)
 
     {
         Locker locker { axThread.m_functionsMutex };
-        axThread.m_functions.append(WTFMove(function));
+        axThread.m_functions.append(WTF::move(function));
     }
 
     axThread.wakeUpRunLoop();
@@ -208,8 +208,8 @@ void AXThread::dispatch(Function<void()>&& function)
 
 void AXThread::dispatchBarrier(Function<void()>&& function)
 {
-    dispatch([function = WTFMove(function)] () mutable {
-        callOnMainThread(WTFMove(function));
+    dispatch([function = WTF::move(function)] () mutable {
+        callOnMainThread(WTF::move(function));
     });
 }
 
@@ -248,7 +248,7 @@ void AXThread::dispatchFunctionsFromAXThread()
 
     {
         Locker locker { m_functionsMutex };
-        functions = WTFMove(m_functions);
+        functions = WTF::move(m_functions);
     }
 
     for (auto& function : functions)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -106,7 +106,7 @@ static WKRetainPtr<WKDictionaryRef> createWKDictionary(std::initializer_list<std
         auto key = toWK(pair.first);
         keys.append(key.get());
         values.append(pair.second.get());
-        strings.append(WTFMove(key));
+        strings.append(WTF::move(key));
     }
     return adoptWK(WKDictionaryCreate(keys.span().data(), values.span().data(), keys.size()));
 }
@@ -1168,8 +1168,8 @@ static WKRetainPtr<WKDictionaryRef> captureDeviceProperties(JSContextRef context
 
             keys.append(propertyName.get());
             values.append(propertyValue.get());
-            strings.append(WTFMove(propertyName));
-            strings.append(WTFMove(propertyValue));
+            strings.append(WTF::move(propertyName));
+            strings.append(WTF::move(propertyValue));
         }
         JSPropertyNameArrayRelease(propertyNameArray);
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -576,9 +576,9 @@ RefPtr<AccessibilityUIElement>  AccessibilityUIElement::elementAtPointWithRemote
 void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef context, int x, int y, JSValueRef jsCallback)
 {
     JSValueProtect(context, jsCallback);
-    s_controller->executeOnAXThreadAndWait([x, y, protectedThis = Ref { *this }, jsCallback = WTFMove(jsCallback), context = JSRetainPtr { JSContextGetGlobalContext(context) }] () mutable {
-        auto callback = [jsCallback = WTFMove(jsCallback), context = WTFMove(context)](NSString *result) mutable {
-            s_controller->executeOnMainThread([result = WTFMove(result), jsCallback = WTFMove(jsCallback), context = WTFMove(context)] () {
+    s_controller->executeOnAXThreadAndWait([x, y, protectedThis = Ref { *this }, jsCallback = WTF::move(jsCallback), context = JSRetainPtr { JSContextGetGlobalContext(context) }] () mutable {
+        auto callback = [jsCallback = WTF::move(jsCallback), context = WTF::move(context)](NSString *result) mutable {
+            s_controller->executeOnMainThread([result = WTF::move(result), jsCallback = WTF::move(jsCallback), context = WTF::move(context)] () {
                 JSValueRef arguments[1];
                 arguments[0] = makeValueRefForValue(context.get(), result);
                 JSObjectCallAsFunction(context.get(), const_cast<JSObjectRef>(jsCallback), 0, 1, arguments, 0);
@@ -586,7 +586,7 @@ void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef con
             });
         };
 
-        [protectedThis->m_element _accessibilityHitTestResolvingRemoteFrame:NSMakePoint(x, y) callback:WTFMove(callback)];
+        [protectedThis->m_element _accessibilityHitTestResolvingRemoteFrame:NSMakePoint(x, y) callback:WTF::move(callback)];
     });
 }
 
@@ -893,12 +893,12 @@ void AccessibilityUIElement::attributeValueAsync(JSContextRef context, JSStringR
         return;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    s_controller->executeOnAXThreadAndWait([attribute = retainPtr([NSString stringWithJSStringRef:attribute]), callback = WTFMove(callback), context = JSRetainPtr { JSContextGetGlobalContext(context) }, this] () mutable {
+    s_controller->executeOnAXThreadAndWait([attribute = retainPtr([NSString stringWithJSStringRef:attribute]), callback = WTF::move(callback), context = JSRetainPtr { JSContextGetGlobalContext(context) }, this] () mutable {
         id value = [m_element accessibilityAttributeValue:attribute.get()];
         if ([value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]])
             value = [value description];
 
-        s_controller->executeOnMainThread([value = retainPtr(value), callback = WTFMove(callback), context = WTFMove(context)] () {
+        s_controller->executeOnMainThread([value = retainPtr(value), callback = WTF::move(callback), context = WTF::move(context)] () {
             JSValueRef arguments[1];
             arguments[0] = makeValueRefForValue(context.get(), value.get());
             JSObjectCallAsFunction(context.get(), const_cast<JSObjectRef>(callback), 0, 1, arguments, 0);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -835,7 +835,7 @@ PlatformWebView* TestController::createOtherPlatformWebView(PlatformWebView* par
     TestController::singleton().updateWindowScaleForTest(view.ptr(), *TestController::singleton().protectedCurrentInvocation());
 
     PlatformWebView* viewToReturn = view.ptr();
-    m_auxiliaryWebViews.append(WTFMove(view));
+    m_auxiliaryWebViews.append(WTF::move(view));
     return viewToReturn;
 }
 
@@ -1889,8 +1889,8 @@ static void adoptAndCallCompletionHandler(void* context)
 struct UIScriptInvocationData {
     UIScriptInvocationData(unsigned callbackID, WebKit::WKRetainPtr<WKStringRef>&& scriptString, WeakPtr<TestInvocation>&& testInvocation)
         : callbackID(callbackID)
-        , scriptString(WTFMove(scriptString))
-        , testInvocation(WTFMove(testInvocation)) { }
+        , scriptString(WTF::move(scriptString))
+        , testInvocation(WTF::move(testInvocation)) { }
 
     unsigned callbackID;
     WebKit::WKRetainPtr<WKStringRef> scriptString;
@@ -2247,7 +2247,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
     }
 
     if (WKStringIsEqualToUTF8CString(command, "RemoveAllCookies"))
-        return removeAllCookies(WTFMove(completionHandler));
+        return removeAllCookies(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "AddChromeInputField")) {
         mainWebView()->addChromeInputField();
@@ -2291,7 +2291,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         return WKPageDisplayAndTrackRepaintsForTesting(TestController::singleton().mainWebView()->page(), completionHandler.leak(), adoptAndCallCompletionHandler);
 
     if (WKStringIsEqualToUTF8CString(command, "SetResourceMonitorList"))
-        return setResourceMonitorList(stringValue(argument), WTFMove(completionHandler));
+        return setResourceMonitorList(stringValue(argument), WTF::move(completionHandler));
 
 
     if (WKStringIsEqualToUTF8CString(command, "SetPageScaleFactor")) {
@@ -2299,7 +2299,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto scaleFactor = doubleValue(argumentDictionary, "scaleFactor");
         auto x = doubleValue(argumentDictionary, "x");
         auto y = doubleValue(argumentDictionary, "y");
-        return setPageScaleFactor(static_cast<float>(scaleFactor), static_cast<int>(x), static_cast<int>(y), WTFMove(completionHandler));
+        return setPageScaleFactor(static_cast<float>(scaleFactor), static_cast<int>(x), static_cast<int>(y), WTF::move(completionHandler));
     }
 
     if (WKStringIsEqualToUTF8CString(command, "SetObscuredContentInsets")) {
@@ -2312,7 +2312,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
     }
 
     if (WKStringIsEqualToUTF8CString(command, "UpdatePresentation"))
-        return updatePresentation(WTFMove(completionHandler));
+        return updatePresentation(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "FlushConsoleLogs"))
         return completionHandler(nullptr);
@@ -2324,33 +2324,33 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         return completionHandler(takeViewPortSnapshot().get());
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsShouldBlockThirdPartyCookies"))
-        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::All, WTFMove(completionHandler));
+        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::All, WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsShouldDowngradeReferrer"))
-        return setStatisticsShouldDowngradeReferrer(booleanValue(argument), WTFMove(completionHandler));
+        return setStatisticsShouldDowngradeReferrer(booleanValue(argument), WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsFirstPartyWebsiteDataRemovalMode"))
-        return setStatisticsFirstPartyWebsiteDataRemovalMode(booleanValue(argument), WTFMove(completionHandler));
+        return setStatisticsFirstPartyWebsiteDataRemovalMode(booleanValue(argument), WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsSetToSameSiteStrictCookies"))
-        return setStatisticsToSameSiteStrictCookies(stringValue(argument), WTFMove(completionHandler));
+        return setStatisticsToSameSiteStrictCookies(stringValue(argument), WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsSetFirstPartyHostCNAMEDomain")) {
         auto argumentDictionary = dictionaryValue(argument);
         auto firstPartyURLString = stringValue(argumentDictionary, "FirstPartyURL");
         auto cnameURLString = stringValue(argumentDictionary, "CNAME");
-        setStatisticsFirstPartyHostCNAMEDomain(firstPartyURLString, cnameURLString, WTFMove(completionHandler));
+        setStatisticsFirstPartyHostCNAMEDomain(firstPartyURLString, cnameURLString, WTF::move(completionHandler));
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsSetThirdPartyCNAMEDomain"))
-        return setStatisticsThirdPartyCNAMEDomain(stringValue(argument), WTFMove(completionHandler));
+        return setStatisticsThirdPartyCNAMEDomain(stringValue(argument), WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "LoadedSubresourceDomains"))
-        return loadedSubresourceDomains(WTFMove(completionHandler));
+        return loadedSubresourceDomains(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "RemoveAllSessionCredentials"))
-        return TestController::singleton().removeAllSessionCredentials(WTFMove(completionHandler));
+        return TestController::singleton().removeAllSessionCredentials(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "SetStorageAccessPermission")) {
         auto argumentDictionary = dictionaryValue(argument);
@@ -2367,7 +2367,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
 
     if (WKStringIsEqualToUTF8CString(command, "GetAllStorageAccessEntries"))
-        return getAllStorageAccessEntries(WTFMove(completionHandler));
+        return getAllStorageAccessEntries(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsResetToConsistentState")) {
         protectedCurrentInvocation()->dumpResourceLoadStatisticsIfNecessary();
@@ -2379,37 +2379,37 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto argumentDictionary = dictionaryValue(argument);
         auto hostName = stringValue(argumentDictionary, "HostName");
         auto includeHttpOnlyCookies = booleanValue(argumentDictionary, "IncludeHttpOnlyCookies");
-        return TestController::singleton().statisticsDeleteCookiesForHost(hostName, includeHttpOnlyCookies, WTFMove(completionHandler));
+        return TestController::singleton().statisticsDeleteCookiesForHost(hostName, includeHttpOnlyCookies, WTF::move(completionHandler));
     }
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsClearInMemoryAndPersistentStore"))
-        return statisticsClearInMemoryAndPersistentStore(WTFMove(completionHandler));
+        return statisticsClearInMemoryAndPersistentStore(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsClearThroughWebsiteDataRemoval"))
-        return statisticsClearThroughWebsiteDataRemoval(WTFMove(completionHandler));
+        return statisticsClearThroughWebsiteDataRemoval(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsClearInMemoryAndPersistentStoreModifiedSinceHours"))
-        return statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(uint64Value(argument), WTFMove(completionHandler));
+        return statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(uint64Value(argument), WTF::move(completionHandler));
 
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsUpdateCookieBlocking"))
-        return statisticsUpdateCookieBlocking(WTFMove(completionHandler));
+        return statisticsUpdateCookieBlocking(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "StatisticsProcessStatisticsAndDataRecords"))
-        return TestController::singleton().statisticsProcessStatisticsAndDataRecords(WTFMove(completionHandler));
+        return TestController::singleton().statisticsProcessStatisticsAndDataRecords(WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsHasHadUserInteraction")) {
         auto argumentDictionary = dictionaryValue(argument);
         auto hostName = stringValue(argumentDictionary, "HostName");
         auto value = booleanValue(argumentDictionary, "Value");
-        setStatisticsHasHadUserInteraction(hostName, value, WTFMove(completionHandler));
+        setStatisticsHasHadUserInteraction(hostName, value, WTF::move(completionHandler));
         return;
     }
 
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsPrevalentResourceForDebugMode")) {
         WKStringRef hostName = stringValue(argument);
-        setStatisticsPrevalentResourceForDebugMode(hostName, WTFMove(completionHandler));
+        setStatisticsPrevalentResourceForDebugMode(hostName, WTF::move(completionHandler));
         return;
     }
 
@@ -2417,7 +2417,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto argumentDictionary = dictionaryValue(argument);
         auto hostName = stringValue(argumentDictionary, "HostName");
         auto value = doubleValue(argumentDictionary, "Value");
-        setStatisticsLastSeen(hostName, value, WTFMove(completionHandler));
+        setStatisticsLastSeen(hostName, value, WTF::move(completionHandler));
         return;
     }
 
@@ -2433,7 +2433,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto isPrevalent = booleanValue(argumentDictionary, "IsPrevalent");
         auto isVeryPrevalent = booleanValue(argumentDictionary, "IsVeryPrevalent");
         auto dataRecordsRemoved = uint64Value(argumentDictionary, "DataRecordsRemoved");
-        setStatisticsMergeStatistic(hostName, topFrameDomain1, topFrameDomain2, lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, WTFMove(completionHandler));
+        setStatisticsMergeStatistic(hostName, topFrameDomain1, topFrameDomain2, lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, WTF::move(completionHandler));
         return;
     }
 
@@ -2444,7 +2444,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto hadUserInteraction = booleanValue(argumentDictionary, "HadUserInteraction");
         auto isScheduledForAllButCookieDataRemoval = booleanValue(argumentDictionary, "IsScheduledForAllButCookieDataRemoval");
         auto isPrevalent = booleanValue(argumentDictionary, "IsPrevalent");
-        setStatisticsExpiredStatistic(hostName, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, WTFMove(completionHandler));
+        setStatisticsExpiredStatistic(hostName, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, WTF::move(completionHandler));
         return;
     }
 
@@ -2452,7 +2452,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto argumentDictionary = dictionaryValue(argument);
         auto hostName = stringValue(argumentDictionary, "HostName");
         auto value = booleanValue(argumentDictionary, "Value");
-        setStatisticsPrevalentResource(hostName, value, WTFMove(completionHandler));
+        setStatisticsPrevalentResource(hostName, value, WTF::move(completionHandler));
         return;
     }
 
@@ -2460,12 +2460,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         auto argumentDictionary = dictionaryValue(argument);
         auto hostName = stringValue(argumentDictionary, "HostName");
         auto value = booleanValue(argumentDictionary, "Value");
-        setStatisticsVeryPrevalentResource(hostName, value, WTFMove(completionHandler));
+        setStatisticsVeryPrevalentResource(hostName, value, WTF::move(completionHandler));
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsDebugMode"))
-        return setStatisticsDebugMode(booleanValue(argument), WTFMove(completionHandler));
+        return setStatisticsDebugMode(booleanValue(argument), WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "InstallTooltipCallback")) {
         m_tooltipCallbacks.append(dynamic_wk_cast<WKJSHandleRef>(argument));
@@ -2628,10 +2628,10 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
     }
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsShouldBlockThirdPartyCookiesOnSitesWithoutUserInteraction"))
-        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::AllOnlyOnSitesWithoutUserInteraction, WTFMove(completionHandler));
+        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::AllOnlyOnSitesWithoutUserInteraction, WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "SetStatisticsShouldBlockThirdPartyCookiesExceptPartitioned"))
-        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::AllExceptPartitioned, WTFMove(completionHandler));
+        return setStatisticsShouldBlockThirdPartyCookies(booleanValue(argument), ThirdPartyCookieBlockingPolicy::AllExceptPartitioned, WTF::move(completionHandler));
 
     if (WKStringIsEqualToUTF8CString(command, "FindStringMatches")) {
         auto argumentDictionary = dictionaryValue(argument);
@@ -2644,12 +2644,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "SetManagedDomains")) {
         const auto urlArray = WKURLArrayFromWKStringArray(argument);
-        return setManagedDomains(urlArray.get(), WTFMove(completionHandler));
+        return setManagedDomains(urlArray.get(), WTF::move(completionHandler));
     }
 
     if (WKStringIsEqualToUTF8CString(command, "SetAppBoundDomains")) {
         const auto urlArray = WKURLArrayFromWKStringArray(argument);
-        return setAppBoundDomains(urlArray.get(), WTFMove(completionHandler));
+        return setAppBoundDomains(urlArray.get(), WTF::move(completionHandler));
     }
 
     if (WKStringIsEqualToUTF8CString(command, "SetAuthenticationUsername")) {
@@ -3372,7 +3372,7 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
     }
 
     auto setHTTPCookieAcceptPolicy = [&] (WKHTTPCookieAcceptPolicy policy, CompletionHandler<void(WKTypeRef)>&& completionHandler) {
-        auto context = new CompletionHandler<void(WKTypeRef)>(WTFMove(completionHandler));
+        auto context = new CompletionHandler<void(WKTypeRef)>(WTF::move(completionHandler));
         WKHTTPCookieStoreSetHTTPCookieAcceptPolicy(WKWebsiteDataStoreGetHTTPCookieStore(websiteDataStore()), policy, context, [] (void* context) {
             auto completionHandlerPointer = static_cast<CompletionHandler<void(WKTypeRef)>*>(context);
             (*completionHandlerPointer)(nullptr);
@@ -3384,14 +3384,14 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
         auto policy = WKBooleanGetValue(static_cast<WKBooleanRef>(messageBody))
             ? kWKHTTPCookieAcceptPolicyAlways
             : kWKHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain;
-        return setHTTPCookieAcceptPolicy(policy, WTFMove(completionHandler));
+        return setHTTPCookieAcceptPolicy(policy, WTF::move(completionHandler));
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetOnlyAcceptFirstPartyCookies")) {
         auto policy = WKBooleanGetValue(static_cast<WKBooleanRef>(messageBody))
             ? kWKHTTPCookieAcceptPolicyExclusivelyFromMainDocumentDomain
             : kWKHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain;
-        return setHTTPCookieAcceptPolicy(policy, WTFMove(completionHandler));
+        return setHTTPCookieAcceptPolicy(policy, WTF::move(completionHandler));
     }
 
     completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
@@ -4210,7 +4210,7 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
     }
 
     if (m_shouldDecideNavigationPolicyAfterDelay)
-        RunLoop::mainSingleton().dispatch(WTFMove(decisionFunction));
+        RunLoop::mainSingleton().dispatch(WTF::move(decisionFunction));
     else
         decisionFunction();
 }
@@ -4253,7 +4253,7 @@ void TestController::decidePolicyForNavigationResponse(WKNavigationResponseRef n
     }
 
     if (m_shouldDecideResponsePolicyAfterDelay)
-        RunLoop::mainSingleton().dispatch(WTFMove(decisionFunction));
+        RunLoop::mainSingleton().dispatch(WTF::move(decisionFunction));
     else
         decisionFunction();
 }

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -70,7 +70,7 @@ struct TestCommand;
 class AsyncTask {
 public:
     AsyncTask(WTF::Function<void ()>&& task, WTF::Seconds timeout)
-        : m_task(WTFMove(task))
+        : m_task(WTF::move(task))
         , m_timeout(timeout)
     {
         ASSERT(!currentTask());

--- a/Tools/WebKitTestRunner/WorkQueueManager.cpp
+++ b/Tools/WebKitTestRunner/WorkQueueManager.cpp
@@ -126,7 +126,7 @@ void WorkQueueManager::queueLoad(const String& relativeURL, const String& target
     class LoadItem : public WorkQueueItem {
     public:
         LoadItem(WKRetainPtr<WKURLRef>&& url, const String& target, bool shouldOpenExternalURLs)
-            : m_url(WTFMove(url))
+            : m_url(WTF::move(url))
             , m_target(target)
             , m_shouldOpenExternalURLs(shouldOpenExternalURLs)
         {
@@ -150,7 +150,7 @@ void WorkQueueManager::queueLoad(const String& relativeURL, const String& target
 
     auto baseURL = adoptWK(WKFrameCopyURL(WKPageGetMainFrame(mainPage())));
     auto url = adoptWK(WKURLCreateWithBaseURL(baseURL.get(), relativeURL.utf8().data()));
-    enqueue(new LoadItem(WTFMove(url), target, shouldOpenExternalURLs));
+    enqueue(new LoadItem(WTF::move(url), target, shouldOpenExternalURLs));
 }
 
 void WorkQueueManager::queueLoadHTMLString(const String& content, const String& baseURL, const String& unreachableURL)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -565,7 +565,7 @@ unsigned TestController::imageCountInGeneralPasteboard() const
 void TestController::removeAllSessionCredentials(CompletionHandler<void(WKTypeRef)>&& completionHandler)
 {
     auto types = adoptNS([[NSSet alloc] initWithObjects:_WKWebsiteDataTypeCredentials, nil]);
-    [(__bridge WKWebsiteDataStore *)m_websiteDataStore.get() removeDataOfTypes:types.get() modifiedSince:[NSDate distantPast] completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] () mutable {
+    [(__bridge WKWebsiteDataStore *)m_websiteDataStore.get() removeDataOfTypes:types.get() modifiedSince:[NSDate distantPast] completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)] () mutable {
         completionHandler(nullptr);
     }).get()];
 }
@@ -869,7 +869,7 @@ WKRetainPtr<WKStringRef> TestController::backgroundFetchState(WKStringRef identi
 
 void TestController::updatePresentation(CompletionHandler<void(WKTypeRef)>&& completionHandler)
 {
-    [m_mainWebView->platformView() _doAfterNextPresentationUpdate:makeBlockPtr([completionHandler = WTFMove(completionHandler)] mutable {
+    [m_mainWebView->platformView() _doAfterNextPresentationUpdate:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
         completionHandler(nullptr);
     }).get()];
 }

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -556,7 +556,7 @@ static InterpolationType interpolationFromString(NSString *string)
         kIOHIDEventOptionNone));
     
     if (markerEvent) {
-        dispatch_async(mainDispatchQueueSingleton(), [markerEvent = WTFMove(markerEvent)] {
+        dispatch_async(mainDispatchQueueSingleton(), [markerEvent = WTF::move(markerEvent)] {
             auto contextID = [UIApplication sharedApplication].keyWindow._contextId;
             ASSERT(contextID);
             BKSHIDEventSetDigitizerInfo(markerEvent.get(), contextID, false, false, NULL, 0, 0);

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -424,7 +424,7 @@ void UIScriptControllerIOS::singleTapAtPointWithModifiers(WebCore::FloatPoint lo
     for (auto& modifierFlag : modifierFlags)
         [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
 
-    [[HIDEventGenerator sharedHIDEventGenerator] tap:globalToContentCoordinates(webView(), location.x(), location.y()) completionBlock:[this, protectedThis = Ref { *this }, modifierFlags = WTFMove(modifierFlags), block = WTFMove(block)] () mutable {
+    [[HIDEventGenerator sharedHIDEventGenerator] tap:globalToContentCoordinates(webView(), location.x(), location.y()) completionBlock:[this, protectedThis = Ref { *this }, modifierFlags = WTF::move(modifierFlags), block = WTF::move(block)] () mutable {
         if (!m_context)
             return;
 
@@ -499,7 +499,7 @@ void UIScriptControllerIOS::stylusTapAtPointWithModifiers(long x, long y, float 
         [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] stylusTapAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID, modifierFlags = WTFMove(modifierFlags)] {
+    [[HIDEventGenerator sharedHIDEventGenerator] stylusTapAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID, modifierFlags = WTF::move(modifierFlags)] {
         if (!m_context)
             return;
         for (size_t i = modifierFlags.size(); i; ) {
@@ -999,7 +999,7 @@ JSObjectRef UIScriptControllerIOS::selectionStartGrabberViewRect() const
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (RetainPtr view = [textSelectionDisplayInteraction().handleViews firstObject]; !isHiddenOrHasHiddenAncestor(view.get())) {
         sanityCheckCustomHandlePath(view.get());
-        handleView = WTFMove(view);
+        handleView = WTF::move(view);
     }
 #endif
 
@@ -1015,7 +1015,7 @@ JSObjectRef UIScriptControllerIOS::selectionEndGrabberViewRect() const
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (RetainPtr view = [textSelectionDisplayInteraction().handleViews lastObject]; !isHiddenOrHasHiddenAncestor(view.get())) {
         sanityCheckCustomHandlePath(view.get());
-        handleView = WTFMove(view);
+        handleView = WTF::move(view);
     }
 #endif
 


### PR DESCRIPTION
#### fae11cb3695fc7c4967a410534fda4e36d4fa669
<pre>
Use WTF::move() instead of WTFMove() macro in Tools/
<a href="https://bugs.webkit.org/show_bug.cgi?id=304464">https://bugs.webkit.org/show_bug.cgi?id=304464</a>

Reviewed by Darin Adler.

* Tools/*:

Canonical link: <a href="https://commits.webkit.org/304794@main">https://commits.webkit.org/304794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47f2ec26d292eba56e17a23cc195dd561dad18f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136408 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144120 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/101ff139-2a04-439e-a325-4f4d68ad990f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104306 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9959358a-81b2-453b-9b02-550104cdd64f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139353 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6887 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85142 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/54eb47c5-b1dc-479e-8e99-ede58d89efaa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4190 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112645 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6467 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62434 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8495 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36584 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8213 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->