### PR TITLE
Use WTF::move() instead of WTFMove() macro in Source/WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -446,7 +446,7 @@ void InProcessIDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifi
     std::optional<WebCore::IDBResourceIdentifier> transactionIdentifierCopy;
     if (transactionIdentifier)
         transactionIdentifierCopy = transactionIdentifier->isolatedCopy();
-    dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = WTFMove(transactionIdentifierCopy)] {
+    dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = WTF::move(transactionIdentifierCopy)] {
         Locker locker { m_serverLock };
         m_server->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
     });
@@ -486,8 +486,8 @@ void InProcessIDBServer::getAllDatabaseNamesAndVersions(const WebCore::IDBResour
 
 void InProcessIDBServer::didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier& requestIdentifier, Vector<WebCore::IDBDatabaseNameAndVersion>&& databases)
 {
-    dispatchTaskReply([this, protectedThis = Ref { *this }, requestIdentifier, databases = crossThreadCopy(WTFMove(databases))]() mutable {
-        m_connectionToServer->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTFMove(databases));
+    dispatchTaskReply([this, protectedThis = Ref { *this }, requestIdentifier, databases = crossThreadCopy(WTF::move(databases))]() mutable {
+        m_connectionToServer->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTF::move(databases));
     });
 }
 
@@ -502,11 +502,11 @@ void InProcessIDBServer::closeAndDeleteDatabasesModifiedSince(WallTime modificat
 void InProcessIDBServer::dispatchTask(Function<void()>&& function)
 {
     ASSERT(isMainThread());
-    m_queue->dispatch(WTFMove(function));
+    m_queue->dispatch(WTF::move(function));
 }
 
 void InProcessIDBServer::dispatchTaskReply(Function<void()>&& function)
 {
     ASSERT(!isMainThread());
-    callOnMainThread(WTFMove(function));
+    callOnMainThread(WTF::move(function));
 }

--- a/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
@@ -53,7 +53,7 @@ inline StorageAreaImpl::StorageAreaImpl(StorageType storageType, const SecurityO
     : m_storageType(storageType)
     , m_securityOrigin(origin)
     , m_storageMap(quota)
-    , m_storageSyncManager(WTFMove(syncManager))
+    , m_storageSyncManager(WTF::move(syncManager))
     , m_accessCount(0)
     , m_closeDatabaseTimer(*this, &StorageAreaImpl::closeDatabaseTimerFired)
 {
@@ -66,7 +66,7 @@ inline StorageAreaImpl::StorageAreaImpl(StorageType storageType, const SecurityO
 
 Ref<StorageAreaImpl> StorageAreaImpl::create(StorageType storageType, const SecurityOrigin& origin, RefPtr<StorageSyncManager>&& syncManager, unsigned quota)
 {
-    Ref<StorageAreaImpl> area = adoptRef(*new StorageAreaImpl(storageType, origin, WTFMove(syncManager), quota));
+    Ref<StorageAreaImpl> area = adoptRef(*new StorageAreaImpl(storageType, origin, WTF::move(syncManager), quota));
     // FIXME: If there's no backing storage for LocalStorage, the default WebKit behavior should be that of private browsing,
     // not silently ignoring it. https://bugs.webkit.org/show_bug.cgi?id=25894
     if (area->m_storageSyncManager) {
@@ -191,7 +191,7 @@ void StorageAreaImpl::importItems(HashMap<String, String>&& items)
     ASSERT(!m_isShutdown);
     ASSERT(!isMainThread());
 
-    m_storageMap.importItems(WTFMove(items));
+    m_storageMap.importItems(WTF::move(items));
 }
 
 void StorageAreaImpl::close()
@@ -284,9 +284,9 @@ void StorageAreaImpl::dispatchStorageEvent(const String& key, const String& oldV
         return storage.frame() == &sourceFrame;
     };
     if (isLocalStorage(m_storageType))
-        StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, &page->group(), m_securityOrigin, sourceFrame.document()->url().string(), WTFMove(isSourceStorage));
+        StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, &page->group(), m_securityOrigin, sourceFrame.document()->url().string(), WTF::move(isSourceStorage));
     else
-        StorageEventDispatcher::dispatchSessionStorageEvents(key, oldValue, newValue, *page, m_securityOrigin, sourceFrame.document()->url().string(), WTFMove(isSourceStorage));
+        StorageEventDispatcher::dispatchSessionStorageEvents(key, oldValue, newValue, *page, m_securityOrigin, sourceFrame.document()->url().string(), WTF::move(isSourceStorage));
 }
 
 void StorageAreaImpl::sessionChanged(bool isNewSessionPersistent)

--- a/Source/WebKitLegacy/Storage/StorageAreaSync.cpp
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.cpp
@@ -51,8 +51,8 @@ inline StorageAreaSync::StorageAreaSync(RefPtr<StorageSyncManager>&& storageSync
     : m_syncTimer(*this, &StorageAreaSync::syncTimerFired)
     , m_itemsCleared(false)
     , m_finalSyncScheduled(false)
-    , m_storageArea(WTFMove(storageArea))
-    , m_syncManager(WTFMove(storageSyncManager))
+    , m_storageArea(WTF::move(storageArea))
+    , m_syncManager(WTF::move(storageSyncManager))
     , m_databaseIdentifier(databaseIdentifier.isolatedCopy())
     , m_clearItemsWhileSyncing(false)
     , m_syncScheduled(false)
@@ -75,7 +75,7 @@ inline StorageAreaSync::StorageAreaSync(RefPtr<StorageSyncManager>&& storageSync
 
 Ref<StorageAreaSync> StorageAreaSync::create(RefPtr<StorageSyncManager>&& storageSyncManager, Ref<StorageAreaImpl>&& storageArea, const String& databaseIdentifier)
 {
-    return adoptRef(*new StorageAreaSync(WTFMove(storageSyncManager), WTFMove(storageArea), databaseIdentifier));
+    return adoptRef(*new StorageAreaSync(WTF::move(storageSyncManager), WTF::move(storageArea), databaseIdentifier));
 }
 
 StorageAreaSync::~StorageAreaSync()
@@ -347,7 +347,7 @@ void StorageAreaSync::performImport()
         return;
     }
 
-    m_storageArea->importItems(WTFMove(itemMap));
+    m_storageArea->importItems(WTF::move(itemMap));
 
     markImported();
 }

--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
@@ -99,7 +99,7 @@ Ref<StorageNamespace> StorageNamespaceImpl::copy(Page&)
     for (auto& iter : m_storageAreaMap)
         newNamespace->m_storageAreaMap.set(iter.key, iter.value->copy());
 
-    return WTFMove(newNamespace);
+    return WTF::move(newNamespace);
 }
 
 Ref<StorageArea> StorageNamespaceImpl::storageArea(const SecurityOrigin& origin)

--- a/Source/WebKitLegacy/Storage/StorageSyncManager.cpp
+++ b/Source/WebKitLegacy/Storage/StorageSyncManager.cpp
@@ -70,7 +70,7 @@ void StorageSyncManager::dispatch(Function<void ()>&& function)
     ASSERT(m_thread);
 
     if (m_thread)
-        m_thread->dispatch(WTFMove(function));
+        m_thread->dispatch(WTF::move(function));
 }
 
 void StorageSyncManager::close()

--- a/Source/WebKitLegacy/Storage/StorageThread.cpp
+++ b/Source/WebKitLegacy/Storage/StorageThread.cpp
@@ -83,7 +83,7 @@ void StorageThread::dispatch(Function<void ()>&& function)
 {
     ASSERT(isMainThread());
     ASSERT(!m_queue.killed() && m_thread);
-    m_queue.append(makeUnique<Function<void ()>>(WTFMove(function)));
+    m_queue.append(makeUnique<Function<void ()>>(WTF::move(function)));
 }
 
 void StorageThread::terminate()

--- a/Source/WebKitLegacy/Storage/StorageTracker.cpp
+++ b/Source/WebKitLegacy/Storage/StorageTracker.cpp
@@ -300,8 +300,8 @@ void StorageTracker::setOriginDetails(const String& originIdentifier, const Stri
     };
 
     // FIXME: This weird ping-ponging was done to fix a deadlock. We should figure out a cleaner way to avoid it instead.
-    ensureOnMainThread([this, function = WTFMove(function)]() mutable {
-        m_thread->dispatch(WTFMove(function));
+    ensureOnMainThread([this, function = WTF::move(function)]() mutable {
+        m_thread->dispatch(WTF::move(function));
     });
 }
 
@@ -490,7 +490,7 @@ void StorageTracker::deleteOrigin(const SecurityOriginData& origin)
         m_originSet.remove(originId);
     }
 
-    m_thread->dispatch([this, originId = WTFMove(originId).isolatedCopy()] {
+    m_thread->dispatch([this, originId = WTF::move(originId).isolatedCopy()] {
         syncDeleteOrigin(originId);
     });
 }

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -147,7 +147,7 @@ void WebStorageNamespaceProvider::cloneSessionStorageNamespaceForPage(WebCore::P
 
     auto& dstSessionStorageNamespaces = static_cast<WebStorageNamespaceProvider&>(dstPage.storageNamespaceProvider()).m_sessionStorageNamespaces;
     ASSERT(!dstSessionStorageNamespaces.contains(dstPage));
-    dstSessionStorageNamespaces.set(dstPage, WTFMove(dstPageSessionStorageNamespaces));
+    dstSessionStorageNamespaces.set(dstPage, WTF::move(dstPageSessionStorageNamespaces));
 }
 
 }

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
@@ -101,9 +101,9 @@ void LegacyWebPageDebuggable::disconnect(Inspector::FrontendChannel& frontendCha
 
 void LegacyWebPageDebuggable::dispatchMessageFromRemote(String&& message)
 {
-    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTFMove(message).isolatedCopy()] mutable {
+    callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTF::move(message).isolatedCopy()] mutable {
         if (RefPtr controller = m_inspectorController.get())
-            controller->dispatchMessageFromFrontend(WTFMove(message));
+            controller->dispatchMessageFromFrontend(WTF::move(message));
     });
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
@@ -58,7 +58,7 @@ public:
     using MessageHandler = Function<void(const String& targetID, const String& message)>;
 
     FrontendChannel(String&& targetID, Inspector::FrontendChannel::ConnectionType connectionType, MessageHandler& handler)
-        : m_targetID(WTFMove(targetID))
+        : m_targetID(WTF::move(targetID))
         , m_connectionType(connectionType)
         , m_handler(handler)
     {
@@ -90,7 +90,7 @@ public:
 
     PageTarget(WebCore::Page& page, FrontendChannel::MessageHandler&& handler)
         : m_page(page)
-        , m_handler(WTFMove(handler))
+        , m_handler(WTF::move(handler))
     {
     }
 
@@ -144,7 +144,7 @@ public:
 
     FrameTarget(WebCore::LocalFrame& frame, FrontendChannel::MessageHandler&& handler)
         : m_frame(frame)
-        , m_handler(WTFMove(handler))
+        , m_handler(WTF::move(handler))
     {
     }
 
@@ -229,7 +229,7 @@ LegacyWebPageInspectorController::LegacyWebPageInspectorController(WebCore::Page
 {
     UniqueRef targetAgent = makeUniqueRef<Inspector::InspectorTargetAgent>(m_frontendRouter, m_backendDispatcher);
     m_targetAgent = targetAgent.ptr();
-    m_agents.append(WTFMove(targetAgent));
+    m_agents.append(WTF::move(targetAgent));
 
     m_agents.append(makeUniqueRef<EmptyBrowserAgent>(m_backendDispatcher));
 
@@ -265,7 +265,7 @@ void LegacyWebPageInspectorController::willDestroyPage(const WebCore::Page& page
 void LegacyWebPageInspectorController::addTarget(std::unique_ptr<Inspector::InspectorTarget>&& target)
 {
     checkedTargetAgent()->targetCreated(*target);
-    m_targets.set(target->identifier(), WTFMove(target));
+    m_targets.set(target->identifier(), WTF::move(target));
 }
 
 void LegacyWebPageInspectorController::removeTarget(const String& targetID)

--- a/Source/WebKitLegacy/WebCoreSupport/NetworkStorageSessionMap.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/NetworkStorageSessionMap.cpp
@@ -73,7 +73,7 @@ void NetworkStorageSessionMap::switchToNewTestingSession()
             cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, session.get()));
     }
 
-    defaultNetworkStorageSession() = makeUnique<WebCore::NetworkStorageSession>(PAL::SessionID::defaultSessionID(), WTFMove(session), WTFMove(cookieStorage));
+    defaultNetworkStorageSession() = makeUnique<WebCore::NetworkStorageSession>(PAL::SessionID::defaultSessionID(), WTF::move(session), WTF::move(cookieStorage));
 #endif
 }
 
@@ -99,7 +99,7 @@ void NetworkStorageSessionMap::ensureSession(PAL::SessionID sessionID, const Str
             cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
     }
 
-    addResult.iterator->value = makeUnique<WebCore::NetworkStorageSession>(sessionID, WTFMove(storageSession), WTFMove(cookieStorage));
+    addResult.iterator->value = makeUnique<WebCore::NetworkStorageSession>(sessionID, WTF::move(storageSession), WTF::move(cookieStorage));
 #endif
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -48,7 +48,7 @@ public:
     static void start(WebCore::NetworkingContext* networkingContext, const WebCore::ResourceRequest& request, bool shouldUseCredentialStorage, bool shouldFollowRedirects, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&& completionHandler)
     {
         Ref handle = adoptRef(*new PingHandle(request, shouldUseCredentialStorage, shouldFollowRedirects));
-        handle->start(networkingContext, [handle, completionHandler = WTFMove(completionHandler)](const WebCore::ResourceError& error, const WebCore::ResourceResponse& response) mutable {
+        handle->start(networkingContext, [handle, completionHandler = WTF::move(completionHandler)](const WebCore::ResourceError& error, const WebCore::ResourceResponse& response) mutable {
             completionHandler(error, response);
         });
     }
@@ -74,7 +74,7 @@ private:
 
     void start(WebCore::NetworkingContext* networkingContext, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&& completionHandler)
     {
-        m_completionHandler = WTFMove(completionHandler);
+        m_completionHandler = WTF::move(completionHandler);
         bool defersLoading = false;
         bool shouldContentSniff = false;
         m_handle = WebCore::ResourceHandle::create(networkingContext, m_currentRequest, this, defersLoading, shouldContentSniff, WebCore::ContentEncodingSniffingPolicy::Default, nullptr, false);
@@ -86,7 +86,7 @@ private:
 
     void willSendRequestAsync(WebCore::ResourceHandle*, WebCore::ResourceRequest&& request, WebCore::ResourceResponse&&, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler) final
     {
-        m_currentRequest = WTFMove(request);
+        m_currentRequest = WTF::move(request);
         if (m_shouldFollowRedirects) {
             completionHandler(WebCore::ResourceRequest { m_currentRequest });
             return;

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
@@ -53,14 +53,14 @@ void SocketStreamHandle::sendData(std::span<const uint8_t> data, Function<void(b
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false);
-    platformSend(data, WTFMove(completionHandler));
+    platformSend(data, WTF::move(completionHandler));
 }
 
 void SocketStreamHandle::sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&& headerFieldProxy, Function<void(bool, bool)> completionHandler)
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false, false);
-    platformSendHandshake(byteCast<uint8_t>(handshake.span()), WTFMove(headerFieldProxy), WTFMove(completionHandler));
+    platformSendHandshake(byteCast<uint8_t>(handshake.span()), WTF::move(headerFieldProxy), WTF::move(completionHandler));
 }
 
 void SocketStreamHandle::close()

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
@@ -47,7 +47,7 @@ class SocketStreamHandleClient;
 
 class SocketStreamHandleImpl : public SocketStreamHandle {
 public:
-    static Ref<SocketStreamHandleImpl> create(const URL& url, SocketStreamHandleClient& client, PAL::SessionID sessionID, const String& credentialPartition, SourceApplicationAuditToken&& auditData, const StorageSessionProvider* provider, bool shouldAcceptInsecureCertificates) { return adoptRef(*new SocketStreamHandleImpl(url, client, sessionID, credentialPartition, WTFMove(auditData), provider, shouldAcceptInsecureCertificates)); }
+    static Ref<SocketStreamHandleImpl> create(const URL& url, SocketStreamHandleClient& client, PAL::SessionID sessionID, const String& credentialPartition, SourceApplicationAuditToken&& auditData, const StorageSessionProvider* provider, bool shouldAcceptInsecureCertificates) { return adoptRef(*new SocketStreamHandleImpl(url, client, sessionID, credentialPartition, WTF::move(auditData), provider, shouldAcceptInsecureCertificates)); }
 
     virtual ~SocketStreamHandleImpl();
 

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -83,7 +83,7 @@ SocketStreamHandleImpl::SocketStreamHandleImpl(const URL& url, SocketStreamHandl
     , m_sentStoredCredentials(false)
     , m_shouldAcceptInsecureCertificates(acceptInsecureCertificates)
     , m_credentialPartition(credentialPartition)
-    , m_auditData(WTFMove(auditData))
+    , m_auditData(WTF::move(auditData))
     , m_storageSessionProvider(provider)
 {
     LOG(Network, "SocketStreamHandle %p new client %p", this, &m_client);

--- a/Source/WebKitLegacy/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -69,7 +69,7 @@ void WebBroadcastChannelRegistry::unregisterChannel(const WebCore::PartitionedSe
 void WebBroadcastChannelRegistry::postMessage(const WebCore::PartitionedSecurityOrigin& origin, const String& name, WebCore::BroadcastChannelIdentifier source, Ref<WebCore::SerializedScriptValue>&& message, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(isMainThread());
-    auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
+    auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
     auto channelsForOriginIterator = m_channels.find(origin);
     ASSERT(channelsForOriginIterator != m_channels.end());

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
@@ -52,14 +52,14 @@ std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8
     auto masterKey = WebCore::defaultWebCryptoMasterKey();
     if (!masterKey)
         return std::nullopt;
-    if (!WebCore::wrapSerializedCryptoKey(WTFMove(*masterKey), key, wrappedKey))
+    if (!WebCore::wrapSerializedCryptoKey(WTF::move(*masterKey), key, wrappedKey))
         return std::nullopt;
     return wrappedKey;
 }
 
 std::optional<Vector<uint8_t>> WebCryptoClient::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData) const
 {
-    auto key = WebCore::CryptoKey::create(WTFMove(keyData));
+    auto key = WebCore::CryptoKey::create(WTF::move(keyData));
     if (!key)
         return std::nullopt;
 

--- a/Source/WebKitLegacy/ios/Misc/WebGeolocationProviderIOS.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebGeolocationProviderIOS.mm
@@ -347,7 +347,7 @@ static inline void abortSendLastPosition(WebGeolocationProviderIOS* provider)
 
 - (void)positionChanged:(WebCore::GeolocationPositionData&&)position
 {
-    RetainPtr<WebGeolocationPosition> webPosition = adoptNS([[WebGeolocationPosition alloc] initWithGeolocationPosition:WTFMove(position)]);
+    RetainPtr<WebGeolocationPosition> webPosition = adoptNS([[WebGeolocationPosition alloc] initWithGeolocationPosition:WTF::move(position)]);
     WebThreadRun(^{
         [_provider positionChanged:webPosition.get()];
     });

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -154,7 +154,7 @@ void WebChromeClientIOS::runOpenPanel(LocalFrame&, FileChooser& chooser)
     };
 
     if (WebThreadIsCurrent()) {
-        RunLoop::mainSingleton().dispatch([this, listener = WTFMove(listener), configuration = retainPtr(configuration)] {
+        RunLoop::mainSingleton().dispatch([this, listener = WTF::move(listener), configuration = retainPtr(configuration)] {
             [[webView() _UIKitDelegateForwarder] webView:webView() runOpenPanelForFileButtonWithResultListener:listener.get() configuration:configuration.get()];
         });
     } else

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
@@ -181,9 +181,9 @@ WebFixedPositionContentData::~WebFixedPositionContentData() = default;
         auto layerData = makeUnique<ViewportConstrainedLayerData>();
 
         layerData->m_enclosingAcceleratedScrollLayer = stickyContainers.get(layer);
-        layerData->m_viewportConstraints = WTFMove(layerAndConstraints.value);
+        layerData->m_viewportConstraints = WTF::move(layerAndConstraints.value);
 
-        _private->m_viewportConstrainedLayers.set(layer, WTFMove(layerData));
+        _private->m_viewportConstrainedLayers.set(layer, WTF::move(layerData));
     }
 }
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
@@ -116,7 +116,7 @@ void WebInspectorClient::didSetSearchingForNode(bool enabled)
 #pragma mark WebInspectorFrontendClient Implementation
 
 WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, LegacyWebPageInspectorController& webPageInspectorController, WebInspectorWindowController* frontendWindowController, PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings> settings)
-    : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTFMove(settings))
+    : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTF::move(settings))
 {
     // iOS does not have a local inspector, this should not be reached.
     notImplemented();

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -471,7 +471,7 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
     auto* frame = core([_dataSource webFrame]);
     FrameLoadRequest frameLoadRequest { *frame->document(), frame->document()->securityOrigin(), { URL }, { }, InitiatedByMainFrame::Unknown };
     frameLoadRequest.setReferrerPolicy(ReferrerPolicy::NoReferrer);
-    frame->loader().loadFrameRequest(WTFMove(frameLoadRequest), event.ptr(), nullptr);
+    frame->loader().loadFrameRequest(WTF::move(frameLoadRequest), event.ptr(), nullptr);
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
@@ -192,7 +192,7 @@
         variantElement = downcast<WebCore::HTMLOptGroupElement>(coreElement);
     else
         raiseTypeErrorException();
-    raiseOnDOMError(IMPL->add(WTFMove(variantElement), WebCore::HTMLSelectElement::HTMLElementOrInt(core(before))));
+    raiseOnDOMError(IMPL->add(WTF::move(variantElement), WebCore::HTMLSelectElement::HTMLElementOrInt(core(before))));
 }
 
 - (void)remove:(int)index

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -92,13 +92,13 @@ using namespace JSC;
 - (WebArchive *)webArchive
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTFMove(options))]).autorelease();
+    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTF::move(options))]).autorelease();
 }
 
 - (WebArchive *)webArchiveByFilteringSubframes:(WebArchiveSubframeFilter)webArchiveSubframeFilter
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    auto webArchive = adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTFMove(options), [webArchiveSubframeFilter](LocalFrame& subframe) -> bool {
+    auto webArchive = adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTF::move(options), [webArchiveSubframeFilter](LocalFrame& subframe) -> bool {
         return webArchiveSubframeFilter(kit(&subframe));
     })]);
 
@@ -193,7 +193,7 @@ using namespace JSC;
 - (WebArchive *)webArchive
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(makeSimpleRange(*core(self)), WTFMove(options))]).autorelease();
+    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(makeSimpleRange(*core(self)), WTF::move(options))]).autorelease();
 }
 
 - (NSString *)markupString

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -65,7 +65,7 @@ void BackForwardList::addItem(Ref<HistoryItem>&& newItem)
     // Toss the first item if the list is getting too big, as long as we're not using it
     // (or even if we are, if we only want 1 entry).
     if (m_entries.size() == m_capacity && (m_current || m_capacity == 1)) {
-        Ref<HistoryItem> item = WTFMove(m_entries[0]);
+        Ref<HistoryItem> item = WTF::move(m_entries[0]);
         m_entries.removeAt(0);
         m_entryHash.remove(item.ptr());
         BackForwardCache::singleton().remove(item);
@@ -73,7 +73,7 @@ void BackForwardList::addItem(Ref<HistoryItem>&& newItem)
     }
 
     m_entryHash.add(newItem.ptr());
-    m_entries.insert(m_current + 1, WTFMove(newItem));
+    m_entries.insert(m_current + 1, WTF::move(newItem));
     ++m_current;
 }
 

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -290,7 +290,7 @@ WebHistoryItem *kit(HistoryItem* item)
         return nil;
 
     _private = [[WebHistoryItemPrivate alloc] init];
-    _private->_historyItem = WTFMove(item);
+    _private->_historyItem = WTF::move(item);
 
     ASSERT(!historyItemWrappers().get(*core(_private)));
     historyItemWrappers().set(*core(_private), self);

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -57,7 +57,7 @@ static void callOnDelegateThread(Function<void()>&& function)
 {
     if (shouldCallOnNetworkThread())
         function();
-    callOnMainThread(WTFMove(function));
+    callOnMainThread(WTF::move(function));
 }
 
 template<typename Callable>
@@ -123,7 +123,7 @@ using namespace WebCore;
         ASSERT(isMainThread());
         returnValue = [realDelegate download:download willSendRequest:request redirectResponse:redirectResponse];
     };
-    callOnDelegateThreadAndWait(WTFMove(work));
+    callOnDelegateThreadAndWait(WTF::move(work));
     return returnValue.autorelease();
 }
 
@@ -175,7 +175,7 @@ using namespace WebCore;
     auto work = [&] {
         returnValue = [realDelegate download:download shouldDecodeSourceDataOfMIMEType:encodingType];
     };
-    callOnDelegateThreadAndWait(WTFMove(work));
+    callOnDelegateThreadAndWait(WTF::move(work));
     return returnValue;
 }
 

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
@@ -444,7 +444,7 @@ static void cancelOutstandingCheck(const void *item, void *context)
         WebCore::FrameLoadRequest frameLoadRequest { *core(frame), request };
         frameLoadRequest.setFrameName(target);
         frameLoadRequest.setShouldCheckNewWindowPolicy(true);
-        core(frame)->loader().load(WTFMove(frameLoadRequest));
+        core(frame)->loader().load(WTF::move(frameLoadRequest));
     }
 }
 

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
@@ -102,7 +102,7 @@ public:
     static void dispatchToMainThread(WebDatabaseManagerClient& client, const SecurityOriginData& origin)
     {
         auto context = makeUnique<DidModifyOriginData>(client, origin);
-        callOnMainThread([context = WTFMove(context)] {
+        callOnMainThread([context = WTF::move(context)] {
             context->client.dispatchDidModifyOrigin(context->origin);
         });
     }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
@@ -74,7 +74,7 @@ void TextIndicatorWindow::setAnimationProgress(float progress)
 
 void TextIndicatorWindow::clearTextIndicator(WebCore::TextIndicatorDismissalAnimation animation)
 {
-    RefPtr<WebCore::TextIndicator> textIndicator = WTFMove(m_textIndicator);
+    RefPtr<WebCore::TextIndicator> textIndicator = WTF::move(m_textIndicator);
 
     if ([m_textIndicatorLayer isFadingOut])
         return;
@@ -141,7 +141,7 @@ void TextIndicatorWindow::updateTextIndicator(Ref<WebCore::TextIndicator>&& text
 {
     bool wantsBounce = textIndicator->wantsBounce();
     if (m_textIndicator != textIndicator.ptr())
-        m_textIndicator = WTFMove(textIndicator);
+        m_textIndicator = WTF::move(textIndicator);
 
     CGFloat horizontalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultHorizontalMargin;
     CGFloat verticalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultVerticalMargin;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -1076,14 +1076,14 @@ void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaEleme
 {
     SEL selector = @selector(webView:enterFullScreenForElement:listener:);
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
-        auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:&element initialCompletionHandler:WTFMove(willEnterFullscreen) finalCompletionHandler:[didEnterFullscreen = WTFMove(didEnterFullscreen)] (bool result) mutable {
+        auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:&element initialCompletionHandler:WTF::move(willEnterFullscreen) finalCompletionHandler:[didEnterFullscreen = WTF::move(didEnterFullscreen)] (bool result) mutable {
             didEnterFullscreen(result);
         }]);
         CallUIDelegate(m_webView, selector, kit(&element), listener.get());
     }
 #if !PLATFORM(IOS_FAMILY)
     else
-        [m_webView _enterFullScreenForElement:&element willEnterFullscreen:WTFMove(willEnterFullscreen) didEnterFullscreen:[didEnterFullscreen = WTFMove(didEnterFullscreen)] (bool result) mutable {
+        [m_webView _enterFullScreenForElement:&element willEnterFullscreen:WTF::move(willEnterFullscreen) didEnterFullscreen:[didEnterFullscreen = WTF::move(didEnterFullscreen)] (bool result) mutable {
             didEnterFullscreen(result);
         }];
 #endif
@@ -1093,14 +1093,14 @@ void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandl
 {
     SEL selector = @selector(webView:exitFullScreenForElement:listener:);
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
-        auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:element initialCompletionHandler:[completionHandler = WTFMove(completionHandler)] (auto) mutable {
+        auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:element initialCompletionHandler:[completionHandler = WTF::move(completionHandler)] (auto) mutable {
             completionHandler();
         } finalCompletionHandler:nullptr]);
         CallUIDelegate(m_webView, selector, kit(element), listener.get());
     }
 #if !PLATFORM(IOS_FAMILY)
     else
-        [m_webView _exitFullScreenForElement:element completionHandler:WTFMove(completionHandler)];
+        [m_webView _exitFullScreenForElement:element completionHandler:WTF::move(completionHandler)];
 #endif
 }
 
@@ -1184,7 +1184,7 @@ RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeD
 void WebChromeClient::getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&& completionHandler) const
 {
 #if HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
-    WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats(WTFMove(completionHandler));
+    WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats(WTF::move(completionHandler));
 #else
     completionHandler({ });
 #endif

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -226,7 +226,7 @@ RetainPtr<NSImage> WebContextMenuClient::imageForCurrentSharingServicePickerItem
     localFrame->selection().setSelection(oldSelection);
     frameView->setPaintBehavior(oldPaintBehavior);
 
-    auto image = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTFMove(buffer)));
+    auto image = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)));
     if (!image)
         return nil;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -147,7 +147,7 @@ static WebViewInsertAction kit(EditorInsertAction action)
     self = [super init];
     if (!self)
         return nil;
-    m_step = WTFMove(step);
+    m_step = WTF::move(step);
     return self;
 }
 
@@ -161,7 +161,7 @@ static WebViewInsertAction kit(EditorInsertAction action)
 
 + (WebUndoStep *)stepWithUndoStep:(Ref<UndoStep>&&)step
 {
-    return adoptNS([[WebUndoStep alloc] initWithUndoStep:WTFMove(step)]).autorelease();
+    return adoptNS([[WebUndoStep alloc] initWithUndoStep:WTF::move(step)]).autorelease();
 }
 
 - (UndoStep&)step

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -865,7 +865,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForResponse(const WebCore::Resour
         decidePolicyForMIMEType:response.mimeType().createNSString().get()
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         frame:m_webFrame.get()
-        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Use, nil, nil).get()];
+        decisionListener:setUpPolicyListener(WTF::move(function), WebCore::PolicyAction::Use, nil, nil).get()];
 }
 
 
@@ -905,7 +905,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore:
         decidePolicyForNewWindowAction:actionDictionary(action, formState)
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         newFrameName:frameName.createNSString().get()
-        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
+        decisionListener:setUpPolicyListener(WTF::move(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
 }
 
 void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction& action, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse&, WebCore::FormState* formState, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&& function)
@@ -925,7 +925,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore
         decidePolicyForNavigationAction:actionDictionary(action, formState)
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         frame:m_webFrame.get()
-        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
+        decisionListener:setUpPolicyListener(WTF::move(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
 }
 
 void WebFrameLoaderClient::cancelPolicyCheck()
@@ -973,7 +973,7 @@ void WebFrameLoaderClient::dispatchWillSubmitForm(WebCore::FormState& formState,
     }
 
     NSDictionary *values = makeFormFieldValuesDictionary(formState);
-    CallFormDelegate(getWebView(m_webFrame.get()), @selector(frame:sourceFrame:willSubmitForm:withValues:submissionListener:), m_webFrame.get(), kit(formState.sourceDocument().frame()), kit(&formState.form()), values, setUpPolicyListener([completionHandler = WTFMove(completionHandler)] (WebCore::PolicyAction) mutable { completionHandler(); },
+    CallFormDelegate(getWebView(m_webFrame.get()), @selector(frame:sourceFrame:willSubmitForm:withValues:submissionListener:), m_webFrame.get(), kit(formState.sourceDocument().frame()), kit(&formState.form()), values, setUpPolicyListener([completionHandler = WTF::move(completionHandler)] (WebCore::PolicyAction) mutable { completionHandler(); },
         WebCore::PolicyAction::Ignore, nil, nil).get());
 }
 
@@ -1271,12 +1271,12 @@ void WebFrameLoaderClient::prepareForDataSourceReplacement()
 
 Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
 {
-    auto loader = WebDocumentLoaderMac::create(WTFMove(request), WTFMove(substituteData));
+    auto loader = WebDocumentLoaderMac::create(WTF::move(request), WTF::move(substituteData));
 
     auto dataSource = adoptNS([[WebDataSource alloc] _initWithDocumentLoader:loader.copyRef()]);
     loader->setDataSource(dataSource.get(), getWebView(m_webFrame.get()));
 
-    return WTFMove(loader);
+    return WTF::move(loader);
 }
 
 void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, const URL& url)
@@ -1453,10 +1453,10 @@ RetainPtr<WebFramePolicyListener> WebFrameLoaderClient::setUpPolicyListener(WebC
     RetainPtr<WebFramePolicyListener> policyListener;
 #if HAVE(APP_LINKS)
     if (appLinkURL)
-        policyListener = adoptNS([[WebFramePolicyListener alloc] initWithFrame:core(m_webFrame.get()) policyFunction:WTFMove(function) defaultPolicy:defaultPolicy appLinkURL:appLinkURL referrerURL:referrerURL]);
+        policyListener = adoptNS([[WebFramePolicyListener alloc] initWithFrame:core(m_webFrame.get()) policyFunction:WTF::move(function) defaultPolicy:defaultPolicy appLinkURL:appLinkURL referrerURL:referrerURL]);
     else
 #endif
-        policyListener = adoptNS([[WebFramePolicyListener alloc] initWithFrame:core(m_webFrame.get()) policyFunction:WTFMove(function) defaultPolicy:defaultPolicy]);
+        policyListener = adoptNS([[WebFramePolicyListener alloc] initWithFrame:core(m_webFrame.get()) policyFunction:WTF::move(function) defaultPolicy:defaultPolicy]);
 
     m_policyListener = policyListener.get();
 
@@ -1753,7 +1753,7 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
         if (pluginPackage) {
             RetainPtr newMIMEType = [pluginPackage MIMETypeForExtension:extension];
             if ([newMIMEType length] != 0)
-                MIMEType = WTFMove(newMIMEType);
+                MIMEType = WTF::move(newMIMEType);
         }
     }
 
@@ -1947,7 +1947,7 @@ RefPtr<WebCore::LegacyPreviewLoaderClient> WebFrameLoaderClient::createPreviewLo
 #if ENABLE(CONTENT_FILTERING)
 void WebFrameLoaderClient::contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler&& unblockHandler)
 {
-    core(m_webFrame.get())->loader().policyChecker().setContentFilterUnblockHandler(WTFMove(unblockHandler));
+    core(m_webFrame.get())->loader().policyChecker().setContentFilterUnblockHandler(WTF::move(unblockHandler));
 }
 #endif
 
@@ -2061,7 +2061,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
         return nil;
 
     _frame = frame;
-    _policyFunction = WTFMove(policyFunction);
+    _policyFunction = WTF::move(policyFunction);
     _defaultPolicy = defaultPolicy;
 
     return self;
@@ -2070,7 +2070,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
 #if HAVE(APP_LINKS)
 - (id)initWithFrame:(NakedPtr<WebCore::LocalFrame>)frame policyFunction:(WebCore::FramePolicyFunction&&)policyFunction defaultPolicy:(WebCore::PolicyAction)defaultPolicy appLinkURL:(NSURL *)appLinkURL referrerURL:(NSURL *)referrerURL
 {
-    self = [self initWithFrame:frame policyFunction:WTFMove(policyFunction) defaultPolicy:defaultPolicy];
+    self = [self initWithFrame:frame policyFunction:WTF::move(policyFunction) defaultPolicy:defaultPolicy];
     if (!self)
         return nil;
 
@@ -2106,7 +2106,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
 
 - (void)receivedPolicyDecision:(WebCore::PolicyAction)action
 {
-    auto frame = WTFMove(_frame);
+    auto frame = WTF::move(_frame);
     if (!frame)
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -181,7 +181,7 @@ void WebInspectorClient::releaseFrontend()
 }
 
 WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, LegacyWebPageInspectorController& webPageInspectorController, WebInspectorWindowController* frontendWindowController, PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings> settings)
-    : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTFMove(settings))
+    : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTF::move(settings))
     , m_inspectedWebView(inspectedWebView)
     , m_webPageInspectorController(&webPageInspectorController)
     , m_frontendWindowController(frontendWindowController)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
@@ -43,8 +43,8 @@ using namespace WebCore;
         return nil;
 
     _element = element;
-    _initialCompletionHandler = WTFMove(initialCompletionHandler);
-    _finalCompletionHandler = WTFMove(finalCompletionHandler);
+    _initialCompletionHandler = WTF::move(initialCompletionHandler);
+    _finalCompletionHandler = WTF::move(finalCompletionHandler);
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
@@ -65,7 +65,7 @@ bool WebNotificationClient::show(ScriptExecutionContext&, NotificationData&& not
         return false;
 
     auto notificationID = notification.notificationID;
-    RetainPtr<WebNotification> webNotification = adoptNS([[WebNotification alloc] initWithCoreNotification:WTFMove(notification)]);
+    RetainPtr<WebNotification> webNotification = adoptNS([[WebNotification alloc] initWithCoreNotification:WTF::move(notification)]);
     m_notificationMap.set(notificationID, webNotification);
 
     [[m_webView _notificationProvider] showNotification:webNotification.get() fromWebView:m_webView];
@@ -119,7 +119,7 @@ void WebNotificationClient::requestPermission(ScriptExecutionContext& context, W
 void WebNotificationClient::requestPermission(ScriptExecutionContext& context, PermissionHandler&& permissionHandler)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    auto listener = adoptNS([[WebNotificationPolicyListener alloc] initWithPermissionHandler:WTFMove(permissionHandler)]);
+    auto listener = adoptNS([[WebNotificationPolicyListener alloc] initWithPermissionHandler:WTF::move(permissionHandler)]);
     requestPermission(context, listener.get());
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -157,7 +157,7 @@ NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExec
     if (!(self = [super init]))
         return nil;
 
-    _permissionHandler = WTFMove(permissionHandler);
+    _permissionHandler = WTF::move(permissionHandler);
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
@@ -56,14 +56,14 @@ bool WebPaymentCoordinatorClient::canMakePayments()
 
 void WebPaymentCoordinatorClient::canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler)
 {
-    callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable {
+    callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
         completionHandler(false);
     });
 }
 
 void WebPaymentCoordinatorClient::openPaymentSetup(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler)
 {
-    callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable {
+    callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
         completionHandler(false);
     });
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -89,15 +89,15 @@ class WebBlobRegistry final : public BlobRegistry {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebBlobRegistry);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBlobRegistry);
 private:
-    void registerInternalFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerInternalFileBlobURL(url, WTFMove(reference), contentType); }
-    void registerInternalBlobURL(const URL& url, Vector<BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerInternalBlobURL(url, WTFMove(parts), contentType); }
+    void registerInternalFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerInternalFileBlobURL(url, WTF::move(reference), contentType); }
+    void registerInternalBlobURL(const URL& url, Vector<BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerInternalBlobURL(url, WTF::move(parts), contentType); }
     void registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURL(url, srcURL, policyContainer, topOrigin); }
-    void registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerInternalBlobURLOptionallyFileBacked(url, srcURL, WTFMove(reference), contentType, { }); }
+    void registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerInternalBlobURLOptionallyFileBacked(url, srcURL, WTF::move(reference), contentType, { }); }
     void registerInternalBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerInternalBlobURLForSlice(url, srcURL, start, end, contentType); }
     void unregisterBlobURL(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.unregisterBlobURL(url, topOrigin); }
     String blobType(const URL& url) final { return m_blobRegistry.blobType(url); }
     unsigned long long blobSize(const URL& url) final { return m_blobRegistry.blobSize(url); }
-    void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler)); }
+    void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTF::move(completionHandler)); }
     void registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURLHandle(url, topOrigin); }
     void unregisterBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin) final { m_blobRegistry.unregisterBlobURLHandle(url, topOrigin); }
 

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -87,7 +87,7 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
         [self release];
         return nil;
     }
-    coreArchive = WTFMove(_coreArchive);
+    coreArchive = WTF::move(_coreArchive);
     return self;
 }
 
@@ -98,7 +98,7 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
 
 - (void)setCoreArchive:(Ref<LegacyWebArchive>&&)newCoreArchive
 {
-    coreArchive = WTFMove(newCoreArchive);
+    coreArchive = WTF::move(newCoreArchive);
 }
 
 - (void)dealloc
@@ -174,7 +174,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
     for (WebArchive *subframeArchive in subframeArchives)
         coreArchives.append(*[subframeArchive->_private coreArchive]);
 
-    [_private setCoreArchive:LegacyWebArchive::create([mainResource _coreResource].get(), WTFMove(coreResources), WTFMove(coreArchives), std::nullopt)];
+    [_private setCoreArchive:LegacyWebArchive::create([mainResource _coreResource].get(), WTF::move(coreResources), WTF::move(coreArchives), std::nullopt)];
     return self;
 }
 
@@ -344,7 +344,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
     if (!self)
         return nil;
     
-    _private = [[WebArchivePrivate alloc] initWithCoreArchive:WTFMove(coreLegacyWebArchive)];
+    _private = [[WebArchivePrivate alloc] initWithCoreArchive:WTF::move(coreLegacyWebArchive)];
     if (!_private) {
         [self release];
         return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -82,7 +82,7 @@ class WebDataSourcePrivate
 {
 public:
     WebDataSourcePrivate(Ref<WebDocumentLoaderMac>&& loader)
-        : loader(WTFMove(loader))
+        : loader(WTF::move(loader))
         , representationFinishedLoading(NO)
         , includedInWebKitStatistics(NO)
 #if PLATFORM(IOS_FAMILY)
@@ -398,7 +398,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
     if (!self)
         return nil;
 
-    _private = static_cast<void*>(new WebDataSourcePrivate(WTFMove(loader)));
+    _private = static_cast<void*>(new WebDataSourcePrivate(WTF::move(loader)));
         
     LOG(Loading, "creating datasource for %@", toPrivate(_private)->loader->request().url().createNSURL().get());
 
@@ -541,7 +541,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 - (NSArray *)subresources
 {
     return createNSArray(toPrivate(_private)->loader->subresources(), [] (auto&& resource) {
-        return adoptNS([[WebResource alloc] _initWithCoreResource:WTFMove(resource)]);
+        return adoptNS([[WebResource alloc] _initWithCoreResource:WTF::move(resource)]);
     }).autorelease();
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
@@ -34,7 +34,7 @@ using namespace WebCore;
     self = [super init];
     if (!self)
         return nil;
-    m_orientation = WTFMove(coreDeviceOrientation);
+    m_orientation = WTF::move(coreDeviceOrientation);
     return self;
 }
 
@@ -47,7 +47,7 @@ using namespace WebCore;
     self = [super init];
     if (!self)
         return nil;
-    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:WTFMove(coreDeviceOrientation)];
+    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:WTF::move(coreDeviceOrientation)];
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
@@ -42,7 +42,7 @@ class WebDocumentLoaderMac : public WebCore::DocumentLoader {
 public:
     static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data)
     {
-        return adoptRef(*new WebDocumentLoaderMac(WTFMove(request), WTFMove(data)));
+        return adoptRef(*new WebDocumentLoaderMac(WTF::move(request), WTF::move(data)));
     }
 
     void setDataSource(WebDataSource *, WebView*);

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -35,7 +35,7 @@
 using namespace WebCore;
 
 WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData)
-    : DocumentLoader(WTFMove(request), WTFMove(substituteData))
+    : DocumentLoader(WTF::move(request), WTF::move(substituteData))
     , m_dataSource(nil)
     , m_isDataSourceRetained(false)
 {

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -868,7 +868,7 @@ static NSURL *createUniqueWebDataURL();
         return std::nullopt;
 
     auto scopeEnd = makeBoundaryPointAfterNodeContents(paragraphStart->container->treeScope().rootNode());
-    return WebCore::resolveCharacterRange({ WTFMove(*paragraphStart), WTFMove(scopeEnd) }, range);
+    return WebCore::resolveCharacterRange({ WTF::move(*paragraphStart), WTF::move(scopeEnd) }, range);
 }
 
 - (DOMRange *)_convertNSRangeToDOMRange:(NSRange)nsrange
@@ -2476,7 +2476,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!resourceRequest.url().isValid() && !resourceRequest.url().isEmpty())
         resourceRequest.setURL([NSURL URLWithString:[@"file:" stringByAppendingString:[[request URL] absoluteString]]]);
 
-    coreFrame->loader().load(WebCore::FrameLoadRequest(*coreFrame, WTFMove(resourceRequest)));
+    coreFrame->loader().load(WebCore::FrameLoadRequest(*coreFrame, WTF::move(resourceRequest)));
 }
 
 static NSURL *createUniqueWebDataURL()
@@ -2515,9 +2515,9 @@ static NSURL *createUniqueWebDataURL()
     WebCore::ResourceRequest request(absoluteBaseURL.get());
 
     WebCore::ResourceResponse response(responseURL.get(), MIMEType, [data length], encodingName);
-    WebCore::SubstituteData substituteData(WebCore::SharedBuffer::create(data), [unreachableURL absoluteURL], WTFMove(response), WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
+    WebCore::SubstituteData substituteData(WebCore::SharedBuffer::create(data), [unreachableURL absoluteURL], WTF::move(response), WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
 
-    _private->coreFrame->loader().load(WebCore::FrameLoadRequest(*_private->coreFrame, WTFMove(request), WTFMove(substituteData)));
+    _private->coreFrame->loader().load(WebCore::FrameLoadRequest(*_private->coreFrame, WTF::move(request), WTF::move(substituteData)));
 }
 
 - (void)loadData:(NSData *)data MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)encodingName baseURL:(NSURL *)baseURL

--- a/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
@@ -1239,7 +1239,7 @@ enum {
     // together with our becomeFirstResponder and setNextKeyView overrides.
     [super setNextKeyView:scrollView.get()];
 
-    _private->frameScrollView = WTFMove(scrollView);
+    _private->frameScrollView = WTF::move(scrollView);
 
     [self _setDocumentView:documentView.get()];
     [self _install];

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -140,7 +140,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
 
 - (void)setElement:(RefPtr<WebCore::Element>&&)element
 {
-    _element = WTFMove(element);
+    _element = WTF::move(element);
 }
 
 - (BOOL)isFullScreen
@@ -239,7 +239,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _savedScale = [_webView _viewScaleFactor];
     [_webView _scaleWebView:1 atOrigin:NSMakePoint(0, 0)];
-    _didEnterFullscreen = WTFMove(didEnterFullscreen);
+    _didEnterFullscreen = WTF::move(didEnterFullscreen);
     willEnterFullscreen([self _manager]->willEnterFullscreen(*_element, WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard));
     [self _manager]->setAnimatingFullscreen(true);
     [self _document]->updateLayout();
@@ -340,7 +340,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [webWindow setAnimationBehavior:animationBehavior];
 
     [self _startExitFullScreenAnimationWithDuration:defaultAnimationDuration];
-    _exitCompletionHandler = WTFMove(completionHandler);
+    _exitCompletionHandler = WTF::move(completionHandler);
 }
 
 - (void)finishedExitFullScreenAnimation:(bool)completed

--- a/Source/WebKitLegacy/mac/WebView/WebGeolocationPosition.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebGeolocationPosition.mm
@@ -47,7 +47,7 @@ using namespace WebCore;
     self = [super init];
     if (!self)
         return nil;
-    _position = WTFMove(coreGeolocationPosition);
+    _position = WTF::move(coreGeolocationPosition);
     return self;
 }
 
@@ -76,7 +76,7 @@ std::optional<GeolocationPositionData> core(WebGeolocationPosition *position)
     self = [super init];
     if (!self)
         return nil;
-    _internal = [[WebGeolocationPositionInternal alloc] initWithCoreGeolocationPosition:WTFMove(coreGeolocationPosition)];
+    _internal = [[WebGeolocationPositionInternal alloc] initWithCoreGeolocationPosition:WTF::move(coreGeolocationPosition)];
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -5185,7 +5185,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)_applyEditingStyleToSelection:(Ref<WebCore::EditingStyle>&&)editingStyle withUndoAction:(WebCore::EditAction)undoAction
 {
     if (auto* coreFrame = core([self _frame]))
-        coreFrame->editor().applyStyleToSelection(WTFMove(editingStyle), undoAction, WebCore::Editor::ColorFilterMode::InvertColor);
+        coreFrame->editor().applyStyleToSelection(WTF::move(editingStyle), undoAction, WebCore::Editor::ColorFilterMode::InvertColor);
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -577,7 +577,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
     if (!range)
         return nil;
 
-    auto dictionaryRange = WTFMove(*range);
+    auto dictionaryRange = WTF::move(*range);
     auto dictionaryPopupInfo = [WebImmediateActionController _dictionaryPopupInfoForRange:dictionaryRange inFrame:frame indicatorOptions: { } transition: WebCore::TextIndicatorPresentationTransition::FadeIn];
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
     if (!dictionaryPopupInfo.platformData.attributedString.nsAttributedString())

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
@@ -85,7 +85,7 @@ void WebMediaPlaybackTargetPicker::setPlaybackTarget(WebCore::PlaybackTargetClie
     if (!m_page)
         return;
 
-    m_page->setPlaybackTarget(contextId, WTFMove(target));
+    m_page->setPlaybackTarget(contextId, WTF::move(target));
 }
 
 void WebMediaPlaybackTargetPicker::externalOutputDeviceAvailableDidChange(WebCore::PlaybackTargetClientContextIdentifier contextId, bool available)

--- a/Source/WebKitLegacy/mac/WebView/WebNotification.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebNotification.mm
@@ -60,7 +60,7 @@ using namespace WebCore;
     if (!(self = [super init]))
         return nil;
     _private = [[WebNotificationPrivate alloc] init];
-    _private->_internal = WTFMove(coreNotification);
+    _private->_internal = WTF::move(coreNotification);
     return self;
 }
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -971,7 +971,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     auto* frame = core([dataSource webFrame]);
     WebCore::FrameLoadRequest frameLoadRequest { *frame->document(), frame->document()->securityOrigin(), { URL }, { }, WebCore::InitiatedByMainFrame::Unknown };
     frameLoadRequest.setReferrerPolicy(WebCore::ReferrerPolicy::NoReferrer);
-    frame->loader().loadFrameRequest(WTFMove(frameLoadRequest), event.get(), nullptr);
+    frame->loader().loadFrameRequest(WTF::move(frameLoadRequest), event.get(), nullptr);
 }
 
 - (void)PDFViewOpenPDFInNativeApplication:(PDFView *)sender

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -82,7 +82,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     self = [super init];
     if (!self)
         return nil;
-    coreResource = WTFMove(passedResource);
+    coreResource = WTF::move(passedResource);
     return self;
 }
 
@@ -256,7 +256,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     if (!self)
         return nil;
 
-    _private = [[WebResourcePrivate alloc] initWithCoreResource:WTFMove(coreResource)];
+    _private = [[WebResourcePrivate alloc] initWithCoreResource:WTF::move(coreResource)];
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -56,7 +56,7 @@ static WorldMap& allWorlds()
         return nil;
 
     _private = [[WebScriptWorldPrivate alloc] init];
-    _private->world = WTFMove(world);
+    _private->world = WTF::move(world);
 
     ASSERT_ARG(world, !allWorlds().contains(*_private->world));
     allWorlds().add(*_private->world, self);

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1532,7 +1532,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     pageConfiguration.pluginInfoProvider = WebPluginInfoProvider::singleton();
     pageConfiguration.storageNamespaceProvider = _private->group->storageNamespaceProvider();
     pageConfiguration.visitedLinkStore = _private->group->visitedLinkStore();
-    _private->page = WebCore::Page::create(WTFMove(pageConfiguration));
+    _private->page = WebCore::Page::create(WTF::move(pageConfiguration));
     storageProvider->setPage(*_private->page);
 
     _private->page->setGroupName(groupName);
@@ -1786,7 +1786,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     pageConfiguration.visitedLinkStore = _private->group->visitedLinkStore();
     pageConfiguration.pluginInfoProvider = WebPluginInfoProvider::singleton();
 
-    _private->page = WebCore::Page::create(WTFMove(pageConfiguration));
+    _private->page = WebCore::Page::create(WTF::move(pageConfiguration));
     storageProvider->setPage(*_private->page);
 
     [self setSmartInsertDeleteEnabled:YES];
@@ -1912,7 +1912,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     RefPtr<WebCore::TextIndicator> textIndicator = dragImage.textIndicator();
 
     if (textIndicator)
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicator:WTFMove(textIndicator) scale:_private->page->deviceScaleFactor()]);
+        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
     else
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
     _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
@@ -1980,7 +1980,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    return kit(std::get<std::optional<WebCore::DragOperation>>(_private->page->dragController().dragEnteredOrUpdated(*localMainFrame, WTFMove(dragData))));
+    return kit(std::get<std::optional<WebCore::DragOperation>>(_private->page->dragController().dragEnteredOrUpdated(*localMainFrame, WTF::move(dragData))));
 }
 
 - (uint64_t)_updatedDataInteraction:(id <UIDropSession>)session client:(CGPoint)clientPosition global:(CGPoint)globalPosition operation:(uint64_t)operation
@@ -1991,7 +1991,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    return kit(std::get<std::optional<WebCore::DragOperation>>(_private->page->dragController().dragEnteredOrUpdated(*localMainFrame, WTFMove(dragData))));
+    return kit(std::get<std::optional<WebCore::DragOperation>>(_private->page->dragController().dragEnteredOrUpdated(*localMainFrame, WTF::move(dragData))));
 }
 
 - (void)_exitedDataInteraction:(id <UIDropSession>)session client:(CGPoint)clientPosition global:(CGPoint)globalPosition operation:(uint64_t)operation
@@ -2002,7 +2002,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    _private->page->dragController().dragExited(*localMainFrame, WTFMove(dragData));
+    _private->page->dragController().dragExited(*localMainFrame, WTF::move(dragData));
 }
 
 - (void)_performDataInteraction:(id <UIDropSession>)session client:(CGPoint)clientPosition global:(CGPoint)globalPosition operation:(uint64_t)operation
@@ -2014,7 +2014,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 {
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    return _private->page->dragController().performDragOperation(WTFMove(dragData));
+    return _private->page->dragController().performDragOperation(WTF::move(dragData));
 }
 
 - (void)_endedDataInteraction:(CGPoint)clientPosition global:(CGPoint)globalPosition
@@ -2050,7 +2050,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         return;
     if (auto range = frame->selection().selection().toNormalizedRange()) {
         if (RefPtr textIndicator = WebCore::TextIndicator::createWithRange(*range, defaultEditDragTextIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize()))
-            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicatorData alloc] initWithImage:nil textIndicator:WTFMove(textIndicator) scale:page->deviceScaleFactor()]);
+            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicatorData alloc] initWithImage:nil textIndicator:WTF::move(textIndicator) scale:page->deviceScaleFactor()]);
     }
 }
 
@@ -2768,7 +2768,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         Ref newItem = otherBackForward->itemAtIndex(i)->copy();
         if (i == 0)
             newItemToGoTo = newItem.ptr();
-        backForward->client().addItem(WTFMove(newItem));
+        backForward->client().addItem(WTF::move(newItem));
     }
 
     ASSERT(newItemToGoTo);
@@ -4274,7 +4274,7 @@ IGNORE_WARNINGS_END
         return;
 
     auto userScript = makeUnique<WebCore::UserScript>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectionTime == WebInjectAtDocumentStart ? WebCore::UserScriptInjectionTime::DocumentStart : WebCore::UserScriptInjectionTime::DocumentEnd, injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly);
-    viewGroup->userContentController().addUserScript(*core(world), WTFMove(userScript));
+    viewGroup->userContentController().addUserScript(*core(world), WTF::move(userScript));
 }
 
 + (void)_addUserStyleSheetToGroup:(NSString *)groupName world:(WebScriptWorld *)world source:(NSString *)source url:(NSURL *)url includeMatchPatternStrings:(NSArray *)includeMatchPatternStrings excludeMatchPatternStrings:(NSArray *)excludeMatchPatternStrings injectedFrames:(WebUserContentInjectedFrames)injectedFrames
@@ -4289,7 +4289,7 @@ IGNORE_WARNINGS_END
         return;
 
     auto styleSheet = makeUnique<WebCore::UserStyleSheet>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly);
-    viewGroup->userContentController().addUserStyleSheet(*core(world), WTFMove(styleSheet), WebCore::InjectInExistingDocuments);
+    viewGroup->userContentController().addUserStyleSheet(*core(world), WTF::move(styleSheet), WebCore::InjectInExistingDocuments);
 }
 
 + (void)_removeUserScriptFromGroup:(NSString *)groupName world:(WebScriptWorld *)world url:(NSURL *)url
@@ -6312,7 +6312,7 @@ static bool needsWebViewInitThreadWorkaround()
     WebCore::IntPoint global(WebCore::globalPoint([draggingInfo draggingLocation], [self window]));
 
     WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask([draggingInfo draggingSourceOperationMask]), [self _applicationFlagsForDrag:draggingInfo], [self actionMaskForDraggingInfo:draggingInfo]);
-    return kit(std::get<std::optional<WebCore::DragOperation>>(core(self)->dragController().dragEnteredOrUpdated(*localMainFrame, WTFMove(dragData))));
+    return kit(std::get<std::optional<WebCore::DragOperation>>(core(self)->dragController().dragEnteredOrUpdated(*localMainFrame, WTF::move(dragData))));
 }
 
 - (NSDragOperation)draggingUpdated:(id <NSDraggingInfo>)draggingInfo
@@ -6329,7 +6329,7 @@ static bool needsWebViewInitThreadWorkaround()
     WebCore::IntPoint global(WebCore::globalPoint([draggingInfo draggingLocation], [self window]));
 
     WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask([draggingInfo draggingSourceOperationMask]), [self _applicationFlagsForDrag:draggingInfo], [self actionMaskForDraggingInfo:draggingInfo]);
-    return kit(std::get<std::optional<WebCore::DragOperation>>(page->dragController().dragEnteredOrUpdated(*localMainFrame, WTFMove(dragData))));
+    return kit(std::get<std::optional<WebCore::DragOperation>>(page->dragController().dragEnteredOrUpdated(*localMainFrame, WTF::move(dragData))));
 }
 
 - (void)draggingExited:(id <NSDraggingInfo>)draggingInfo
@@ -6345,7 +6345,7 @@ static bool needsWebViewInitThreadWorkaround()
     WebCore::IntPoint client([draggingInfo draggingLocation]);
     WebCore::IntPoint global(WebCore::globalPoint([draggingInfo draggingLocation], [self window]));
     WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask([draggingInfo draggingSourceOperationMask]), [self _applicationFlagsForDrag:draggingInfo]);
-    page->dragController().dragExited(*localMainFrame, WTFMove(dragData));
+    page->dragController().dragExited(*localMainFrame, WTF::move(dragData));
 }
 
 - (BOOL)prepareForDragOperation:(id <NSDraggingInfo>)draggingInfo
@@ -8957,14 +8957,14 @@ FORWARD(toggleUnderline)
 
     [_private->newFullscreenController setElement:element.get()];
     [_private->newFullscreenController setWebView:self];
-    [_private->newFullscreenController enterFullScreen:[[self window] screen] willEnterFullscreen:WTFMove(willEnterFullscreen) didEnterFullscreen:WTFMove(didEnterFullscreen)];
+    [_private->newFullscreenController enterFullScreen:[[self window] screen] willEnterFullscreen:WTF::move(willEnterFullscreen) didEnterFullscreen:WTF::move(didEnterFullscreen)];
 }
 
 - (void)_exitFullScreenForElement:(NakedPtr<WebCore::Element>)element completionHandler:(CompletionHandler<void()>&&)completionHandler
 {
     if (!_private->newFullscreenController)
         return completionHandler();
-    [_private->newFullscreenController exitFullScreen:WTFMove(completionHandler)];
+    [_private->newFullscreenController exitFullScreen:WTF::move(completionHandler)];
 }
 #endif
 


### PR DESCRIPTION
#### ebeda8943f3ca6fea417abba98fffd81dd10789f
<pre>
Use WTF::move() instead of WTFMove() macro in Source/WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=304467">https://bugs.webkit.org/show_bug.cgi?id=304467</a>

Reviewed by Darin Adler.

* Source/WebKitLegacy/*:

Canonical link: <a href="https://commits.webkit.org/304796@main">https://commits.webkit.org/304796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a7b25a352cd1b91ba0930a4f8c16e1782eddd5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144123 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cc33650a-801c-42d9-b52c-f110e65e4608) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104309 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cf58fba-42d8-42f1-9328-8a4b47c0d1b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85145 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/65980ca0-cae9-44ee-b49b-6f793c33b7cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4191 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146870 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6474 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62437 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8498 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36583 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->