### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for PaintDefinition

### DIFF
--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -81,10 +81,11 @@ static RefPtr<CSSValue> extractComputedProperty(const AtomString& name, Element&
 ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, const FloatSize& destSize)
 {
     CheckedPtr renderElement = m_element.get();
-    if (!renderElement || !renderElement->element() || !m_paintDefinition)
+    CheckedPtr paintDefinition = m_paintDefinition.get();
+    if (!renderElement || !renderElement->element() || !paintDefinition)
         return ImageDrawResult::DidNothing;
 
-    JSC::JSValue paintConstructor = m_paintDefinition->paintConstructor;
+    JSC::JSValue paintConstructor = paintDefinition->paintConstructor;
 
     if (!paintConstructor)
         return ImageDrawResult::DidNothing;
@@ -92,7 +93,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
     ASSERT(!renderElement->needsLayout());
     ASSERT(!renderElement->element()->document().needsStyleRecalc());
 
-    Ref callback = static_cast<JSCSSPaintCallback&>(m_paintDefinition->paintCallback.get());
+    Ref callback = paintDefinition->paintCallback.get();
     RefPtr scriptExecutionContext = callback->scriptExecutionContext();
     if (!scriptExecutionContext)
         return ImageDrawResult::DidNothing;

--- a/Source/WebCore/rendering/style/StylePaintImage.cpp
+++ b/Source/WebCore/rendering/style/StylePaintImage.cpp
@@ -80,7 +80,7 @@ RefPtr<Image> StylePaintImage::image(const RenderElement* renderer, const FloatS
         return nullptr;
 
     Locker locker { selectedGlobalScope->paintDefinitionLock() };
-    auto* registration = selectedGlobalScope->paintDefinitionMap().get(m_name);
+    CheckedPtr registration = selectedGlobalScope->paintDefinitionMap().get(m_name);
 
     if (!registration)
         return nullptr;

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.h
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.h
@@ -29,16 +29,8 @@
 #include "WorkletGlobalScope.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Lock.h>
-
-namespace WebCore {
-struct PaintDefinition;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PaintDefinition> : std::true_type { };
-}
 
 namespace JSC {
 class JSObject;
@@ -49,8 +41,10 @@ namespace WebCore {
 class JSDOMGlobalObject;
 
 // All paint definitions must be destroyed before the vm is destroyed, because otherwise they will point to freed memory.
-struct PaintDefinition : public CanMakeWeakPtr<PaintDefinition> {
+struct PaintDefinition final : public CanMakeWeakPtr<PaintDefinition>, public CanMakeCheckedPtr<PaintDefinition> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(PaintDefinition);
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(PaintDefinition);
+
     PaintDefinition(const AtomString& name, JSC::JSObject* paintConstructor, Ref<CSSPaintCallback>&&, Vector<AtomString>&& inputProperties, Vector<String>&& inputArguments);
 
     const AtomString name;


### PR DESCRIPTION
#### 2fc2123a2dca085c765805d56bf2f2b0a83ccc54
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for PaintDefinition
<a href="https://bugs.webkit.org/show_bug.cgi?id=304470">https://bugs.webkit.org/show_bug.cgi?id=304470</a>

Reviewed by Darin Adler.

* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::CustomPaintImage::doCustomPaint):
* Source/WebCore/rendering/style/StylePaintImage.cpp:
(WebCore::StylePaintImage::image const):
* Source/WebCore/worklets/PaintWorkletGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/304805@main">https://commits.webkit.org/304805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f5f6ecf494271e28b53e8744f97cc5e1d59007

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144138 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccf846d9-88ca-4ba3-b5b8-2a83a012fb20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24919fee-ae80-4c9c-b684-2f2a7f87013f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85160 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a3953de-0667-4792-8f30-571a0d4778d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4208 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4730 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146885 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112661 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6481 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8513 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36597 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8231 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->