### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for Inspector::InspectorTarget

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorTarget.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.cpp
@@ -31,7 +31,11 @@
 #include "config.h"
 #include "InspectorTarget.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTarget);
 
 void InspectorTarget::pause()
 {

--- a/Source/JavaScriptCore/inspector/InspectorTarget.h
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
@@ -27,17 +27,10 @@
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
-
-namespace Inspector {
-class InspectorTarget;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<Inspector::InspectorTarget> : std::true_type { };
-}
 
 namespace Inspector {
 
@@ -48,7 +41,9 @@ enum class InspectorTargetType : uint8_t {
     ServiceWorker,
 };
 
-class InspectorTarget : public CanMakeWeakPtr<InspectorTarget> {
+class InspectorTarget : public CanMakeWeakPtr<InspectorTarget>, public CanMakeCheckedPtr<InspectorTarget> {
+    WTF_MAKE_TZONE_ALLOCATED(InspectorTarget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorTarget);
 public:
     virtual ~InspectorTarget() = default;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -67,7 +67,7 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::setPauseOnStart(bool pauseOn
 
 Protocol::ErrorStringOr<void> InspectorTargetAgent::resume(const String& targetId)
 {
-    auto* target = m_targets.get(targetId);
+    CheckedPtr target = m_targets.get(targetId);
     if (!target)
         return makeUnexpected("Missing target for given targetId"_s);
 
@@ -81,7 +81,7 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::resume(const String& targetI
 
 Protocol::ErrorStringOr<void> InspectorTargetAgent::sendMessageToTarget(const String& targetId, const String& message)
 {
-    InspectorTarget* target = m_targets.get(targetId);
+    CheckedPtr target = m_targets.get(targetId);
     if (!target)
         return makeUnexpected("Missing target for given targetId"_s);
 
@@ -157,8 +157,7 @@ void InspectorTargetAgent::didCommitProvisionalTarget(const String& oldTargetID,
     if (!m_isConnected)
         return;
 
-    auto* target = m_targets.get(committedTargetID);
-    if (!target)
+    if (!m_targets.contains(committedTargetID))
         return;
 
     m_frontendDispatcher->didCommitProvisionalTarget(oldTargetID, committedTargetID);
@@ -171,7 +170,7 @@ FrontendChannel::ConnectionType InspectorTargetAgent::connectionType() const
 
 void InspectorTargetAgent::connectToTargets()
 {
-    for (InspectorTarget* target : m_targets.values()) {
+    for (CheckedPtr target : m_targets.values()) {
         target->connect(connectionType());
         m_frontendDispatcher->targetCreated(buildTargetInfoObject(*target));
     }
@@ -179,7 +178,7 @@ void InspectorTargetAgent::connectToTargets()
 
 void InspectorTargetAgent::disconnectFromTargets()
 {
-    for (InspectorTarget* target : m_targets.values())
+    for (CheckedPtr target : m_targets.values())
         target->disconnect();
 }
 

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -34,10 +34,13 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <JavaScriptCore/InspectorTarget.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTargetProxy);
 
 InspectorTargetProxy::InspectorTargetProxy(const String& targetId, Inspector::InspectorTargetType type)
     : m_identifier(targetId)

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -26,10 +26,13 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorTarget.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class InspectorTargetProxy : public Inspector::InspectorTarget {
+    WTF_MAKE_TZONE_ALLOCATED(InspectorTargetProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorTargetProxy);
 public:
     virtual ~InspectorTargetProxy() = default;
 

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h
@@ -41,6 +41,7 @@ class WebFrameProxy;
 class WebFrameInspectorTargetProxy final : public InspectorTargetProxy {
     WTF_MAKE_TZONE_ALLOCATED(WebFrameInspectorTargetProxy);
     WTF_MAKE_NONCOPYABLE(WebFrameInspectorTargetProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFrameInspectorTargetProxy);
 public:
     static std::unique_ptr<WebFrameInspectorTargetProxy> create(WebFrameProxy&, const String& targetId);
     static std::unique_ptr<WebFrameInspectorTargetProxy> create(ProvisionalFrameProxy&, const String& targetId);

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -183,7 +183,7 @@ void WebPageInspectorController::destroyInspectorTarget(const String& targetId)
     auto it = m_targets.find(targetId);
     if (it == m_targets.end())
         return;
-    checkedTargetAgent()->targetDestroyed(*it->value);
+    checkedTargetAgent()->targetDestroyed(CheckedRef { *it->value });
     m_targets.remove(it);
 }
 
@@ -197,14 +197,14 @@ bool WebPageInspectorController::shouldPauseLoading(const ProvisionalPageProxy& 
     if (!m_frontendRouter->hasFrontends())
         return false;
 
-    auto* target = m_targets.get(getTargetID(provisionalPage));
+    CheckedPtr target = m_targets.get(getTargetID(provisionalPage));
     ASSERT(target);
     return target->isPaused();
 }
 
 void WebPageInspectorController::setContinueLoadingCallback(const ProvisionalPageProxy& provisionalPage, WTF::Function<void()>&& callback)
 {
-    auto* target = m_targets.get(getTargetID(provisionalPage));
+    CheckedPtr target = m_targets.get(getTargetID(provisionalPage));
     ASSERT(target);
     target->setResumeCallback(WTF::move(callback));
 }

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h
@@ -40,6 +40,7 @@ class WebPageProxy;
 class WebPageInspectorTargetProxy final : public InspectorTargetProxy {
     WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTargetProxy);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTargetProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPageInspectorTargetProxy);
 public:
     static std::unique_ptr<WebPageInspectorTargetProxy> create(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);
     static std::unique_ptr<WebPageInspectorTargetProxy> create(ProvisionalPageProxy&, const String& targetId, Inspector::InspectorTargetType);

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
@@ -40,6 +40,7 @@ class WebFrameInspectorTargetFrontendChannel;
 class WebFrameInspectorTarget final : public Inspector::InspectorTarget {
     WTF_MAKE_TZONE_ALLOCATED(WebFrameInspectorTarget);
     WTF_MAKE_NONCOPYABLE(WebFrameInspectorTarget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFrameInspectorTarget);
 public:
     explicit WebFrameInspectorTarget(WebFrame&);
     ~WebFrameInspectorTarget();

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
@@ -39,6 +39,7 @@ class WebPageInspectorTargetFrontendChannel;
 class WebPageInspectorTarget final : public Inspector::InspectorTarget {
     WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTarget);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTarget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPageInspectorTarget);
 public:
     explicit WebPageInspectorTarget(WebPage&);
     virtual ~WebPageInspectorTarget();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1596,7 +1596,7 @@ void WebFrame::takeSnapshotOfNode(JSHandleIdentifier identifier, CompletionHandl
     completion(bitmap->createHandle(SharedMemory::Protection::ReadOnly));
 }
 
-WebFrameInspectorTarget& WebFrame::ensureInspectorTarget()
+CheckedRef<WebFrameInspectorTarget> WebFrame::ensureInspectorTarget()
 {
     if (!m_inspectorTarget)
         m_inspectorTarget = makeUnique<WebFrameInspectorTarget>(*this);
@@ -1605,17 +1605,17 @@ WebFrameInspectorTarget& WebFrame::ensureInspectorTarget()
 
 void WebFrame::connectInspector(Inspector::FrontendChannel::ConnectionType connectionType)
 {
-    ensureInspectorTarget().connect(connectionType);
+    ensureInspectorTarget()->connect(connectionType);
 }
 
 void WebFrame::disconnectInspector()
 {
-    ensureInspectorTarget().disconnect();
+    ensureInspectorTarget()->disconnect();
 }
 
 void WebFrame::sendMessageToInspectorTarget(const String& message)
 {
-    ensureInspectorTarget().sendMessageToTargetBackend(message);
+    ensureInspectorTarget()->sendMessageToTargetBackend(message);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -292,7 +292,7 @@ private:
 
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
 
-    WebFrameInspectorTarget& ensureInspectorTarget();
+    CheckedRef<WebFrameInspectorTarget> ensureInspectorTarget();
 
     WeakPtr<WebCore::Frame> m_coreFrame;
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4067,7 +4067,7 @@ void WebPage::setControlledByAutomation(bool controlled)
     m_page->setControlledByAutomation(controlled);
 }
 
-WebPageInspectorTarget& WebPage::ensureInspectorTarget()
+CheckedRef<WebPageInspectorTarget> WebPage::ensureInspectorTarget()
 {
     if (!m_inspectorTarget)
         m_inspectorTarget = makeUnique<WebPageInspectorTarget>(*this);
@@ -4076,17 +4076,17 @@ WebPageInspectorTarget& WebPage::ensureInspectorTarget()
 
 void WebPage::connectInspector(Inspector::FrontendChannel::ConnectionType connectionType)
 {
-    ensureInspectorTarget().connect(connectionType);
+    ensureInspectorTarget()->connect(connectionType);
 }
 
 void WebPage::disconnectInspector()
 {
-    ensureInspectorTarget().disconnect();
+    ensureInspectorTarget()->disconnect();
 }
 
 void WebPage::sendMessageToTargetBackend(const String& message)
 {
-    ensureInspectorTarget().sendMessageToTargetBackend(message);
+    ensureInspectorTarget()->sendMessageToTargetBackend(message);
 }
 
 void WebPage::insertNewlineInQuotedContent()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2686,7 +2686,7 @@ private:
 
     void frameNameWasChangedInAnotherProcess(WebCore::FrameIdentifier, const String& frameName);
 
-    WebPageInspectorTarget& ensureInspectorTarget();
+    CheckedRef<WebPageInspectorTarget> ensureInspectorTarget();
 
     struct Internals;
     const UniqueRef<Internals> m_internals;

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
@@ -82,6 +82,7 @@ private:
 class PageTarget final : public Inspector::InspectorTarget {
     WTF_MAKE_TZONE_ALLOCATED(PageTarget);
     WTF_MAKE_NONCOPYABLE(PageTarget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageTarget);
 public:
     static String identifier(const WebCore::Page& page)
     {
@@ -136,6 +137,7 @@ private:
 class FrameTarget final : public Inspector::InspectorTarget {
     WTF_MAKE_TZONE_ALLOCATED(FrameTarget);
     WTF_MAKE_NONCOPYABLE(FrameTarget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameTarget);
 public:
     static String identifier(const WebCore::LocalFrame& frame)
     {
@@ -274,7 +276,7 @@ void LegacyWebPageInspectorController::removeTarget(const String& targetID)
     if (it == m_targets.end())
         return;
 
-    checkedTargetAgent()->targetDestroyed(*it->value);
+    checkedTargetAgent()->targetDestroyed(CheckedRef { *it->value });
     m_targets.remove(it);
 }
 


### PR DESCRIPTION
#### eb87cd58268c560ccdadae84684c2865ee0483c1
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for Inspector::InspectorTarget
<a href="https://bugs.webkit.org/show_bug.cgi?id=304474">https://bugs.webkit.org/show_bug.cgi?id=304474</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/inspector/InspectorTarget.cpp:
* Source/JavaScriptCore/inspector/InspectorTarget.h:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::InspectorTargetAgent::resume):
(Inspector::InspectorTargetAgent::sendMessageToTarget):
(Inspector::InspectorTargetAgent::didCommitProvisionalTarget):
(Inspector::InspectorTargetAgent::connectToTargets):
(Inspector::InspectorTargetAgent::disconnectFromTargets):
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::destroyInspectorTarget):
(WebKit::WebPageInspectorController::shouldPauseLoading const):
(WebKit::WebPageInspectorController::setContinueLoadingCallback):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h:
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::ensureInspectorTarget):
(WebKit::WebFrame::connectInspector):
(WebKit::WebFrame::disconnectInspector):
(WebKit::WebFrame::sendMessageToInspectorTarget):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::ensureInspectorTarget):
(WebKit::WebPage::connectInspector):
(WebKit::WebPage::disconnectInspector):
(WebKit::WebPage::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp:
(LegacyWebPageInspectorController::removeTarget):

Canonical link: <a href="https://commits.webkit.org/304806@main">https://commits.webkit.org/304806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c9ec56bb8a419b475f47919cd3cd446bbc2842

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144146 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f070895-bf35-4e64-a3c0-424b8df5fead) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0c0ad90-2d54-4e18-8504-dbc74aa9ab4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4215 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4738 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128391 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134918 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112670 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6489 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62460 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36608 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167698 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72080 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43746 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->