### PR TITLE
http/tests/media/fairplay/fps-mse-unmuxed-mpts.html is a permanent failure with MediaSourceUseRemoteAudioVideoRenderer on

### DIFF
--- a/Source/WebCore/platform/TrackInfo.h
+++ b/Source/WebCore/platform/TrackInfo.h
@@ -67,7 +67,7 @@ using TrackInfoEncryptionInitData = TrackInfoAtomData;
 
 struct EncryptionDataCollection {
     TrackInfoEncryptionData encryptionData;
-    FourCC encryptionOriginalFormat;
+    std::optional<FourCC> encryptionOriginalFormat;
     Vector<TrackInfoEncryptionInitData> encryptionInitDatas { };
 
     bool operator==(const EncryptionDataCollection&) const = default;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8897,7 +8897,7 @@ using WebCore::TrackInfoEncryptionInitData = WebCore::TrackInfoAtomData;
 header: <WebCore/TrackInfo.h>
 [CustomHeader] struct WebCore::EncryptionDataCollection {
     WebCore::TrackInfoEncryptionData encryptionData;
-    WebCore::FourCC encryptionOriginalFormat;
+    std::optional<WebCore::FourCC> encryptionOriginalFormat;
     Vector<WebCore::TrackInfoEncryptionInitData> encryptionInitDatas;
 };
 #endif


### PR DESCRIPTION
#### a2b90ad9657875f4b51d6ff1de3ed24983544c72
<pre>
http/tests/media/fairplay/fps-mse-unmuxed-mpts.html is a permanent failure with MediaSourceUseRemoteAudioVideoRenderer on
<a href="https://bugs.webkit.org/show_bug.cgi?id=304479">https://bugs.webkit.org/show_bug.cgi?id=304479</a>
<a href="https://rdar.apple.com/166852196">rdar://166852196</a>

Reviewed by Youenn Fablet.

We had two issues in place:
1- When using mpeg-ts encrypted content, the key CommonEncryptionOriginalFormat wasn&apos;t present
   We incorrectly aborted the retrieval of the EncryptionDataCollection early.
   We make this field in the TrackInfo&apos;s EncryptionDataCollection optional
2- When the key TransportStreamEncryptionInitData was set, we incorrectly used CommonEncryptionTrackEncryptionBox
   instead TransportStreamEncryptionInitData EncryptionBoxType value.

Covered by existing test. Unfortunately those tests are not run when using the public SDK (EWS).
* Source/WebCore/platform/TrackInfo.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::getEncryptionDataCollection):
(WebCore::createFormatDescriptionFromTrackInfo):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304740@main">https://commits.webkit.org/304740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3de3361bab274cdaba09e4396c0eef649299d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144136 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ffa797ee-99ae-4a22-8bde-6cd014f6d631) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/911f4d20-ae91-4b97-b66b-dadfa789cdaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85158 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f219865-9209-4fcd-9e41-d1574062b384) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4206 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146883 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8463 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6483 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118547 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8511 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36599 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->