### PR TITLE
Resync libvpx up to M143

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/args.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/args.c
@@ -91,24 +91,31 @@ char **argv_dup(int argc, const char **argv) {
 }
 
 void arg_show_usage(FILE *fp, const struct arg_def *const *defs) {
-  char option_text[40] = { 0 };
-
   for (; *defs; defs++) {
     const struct arg_def *def = *defs;
     char *short_val = def->has_val ? " <arg>" : "";
     char *long_val = def->has_val ? "=<arg>" : "";
+    int n = 0;
 
+    // Short options are indented with two spaces. Long options are indented
+    // with 12 spaces.
     if (def->short_name && def->long_name) {
       char *comma = def->has_val ? "," : ",      ";
 
-      snprintf(option_text, 37, "-%s%s%s --%s%6s", def->short_name, short_val,
-               comma, def->long_name, long_val);
+      n = fprintf(fp, "  -%s%s%s --%s%s", def->short_name, short_val, comma,
+                  def->long_name, long_val);
     } else if (def->short_name)
-      snprintf(option_text, 37, "-%s%s", def->short_name, short_val);
+      n = fprintf(fp, "  -%s%s", def->short_name, short_val);
     else if (def->long_name)
-      snprintf(option_text, 37, "          --%s%s", def->long_name, long_val);
+      n = fprintf(fp, "            --%s%s", def->long_name, long_val);
 
-    fprintf(fp, "  %-37s\t%s\n", option_text, def->desc);
+    // Descriptions are indented with 40 spaces. If an option is 40 characters
+    // or longer, its description starts on the next line.
+    if (n < 40)
+      for (int i = 0; i < 40 - n; i++) fputc(' ', fp);
+    else
+      fputs("\n                                        ", fp);
+    fprintf(fp, "%s\n", def->desc);
 
     if (def->enums) {
       const struct arg_enum_list *listptr;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/Android.mk
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/Android.mk
@@ -25,7 +25,7 @@ ifdef NDK_ROOT
 # Android.mk file in the libvpx directory:
 # LOCAL_PATH := $(call my-dir)
 # include $(CLEAR_VARS)
-# include jni/libvpx/build/make/Android.mk
+# include libvpx/build/make/Android.mk
 #
 # By default libvpx will use the 'cpufeatures' module from the NDK. This allows
 # the library to be built with all available optimizations (SSE2->AVX512 for

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/configure.sh
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/configure.sh
@@ -1229,8 +1229,8 @@ EOF
                 ;;
             esac
 
-            if [ "$(show_darwin_sdk_major_version iphoneos)" -gt 8 \
-               && [ "$(show_xcode_version)" -lt 16 ]; then
+            if [ "$(show_darwin_sdk_major_version iphoneos)" -gt 8 ] \
+               && [ "$(show_xcode_version | cut -d. -f1)" -lt 16 ]; then
               check_add_cflags -fembed-bitcode
               check_add_asflags -fembed-bitcode
               check_add_ldflags -fembed-bitcode
@@ -1381,6 +1381,10 @@ EOF
           AS=${AS:-nasm}
           add_ldflags -Zhigh-mem
           ;;
+        darwin*)
+          enabled x86 && darwin_arch="-arch i386" || darwin_arch="-arch x86_64"
+          add_cflags  ${darwin_arch}
+          add_ldflags ${darwin_arch}
       esac
 
       AS="${alt_as:-${AS:-auto}}"
@@ -1503,9 +1507,6 @@ EOF
           ;;
         darwin*)
           add_asflags -f macho${bits}
-          enabled x86 && darwin_arch="-arch i386" || darwin_arch="-arch x86_64"
-          add_cflags  ${darwin_arch}
-          add_ldflags ${darwin_arch}
           # -mdynamic-no-pic is still a bit of voodoo -- it was required at
           # one time, but does not seem to be now, and it breaks some of the
           # code that still relies on inline assembly.

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/iosbuild.sh
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/build/make/iosbuild.sh
@@ -30,13 +30,9 @@ SCRIPT_DIR=$(dirname "$0")
 LIBVPX_SOURCE_DIR=$(cd ${SCRIPT_DIR}/../..; pwd)
 LIPO=$(xcrun -sdk iphoneos${SDK} -find lipo)
 ORIG_PWD="$(pwd)"
-ARM_TARGETS="arm64-darwin-gcc
-             armv7-darwin-gcc
-             armv7s-darwin-gcc"
-SIM_TARGETS="x86-iphonesimulator-gcc
-             x86_64-iphonesimulator-gcc"
-OSX_TARGETS="x86-darwin16-gcc
-             x86_64-darwin16-gcc"
+ARM_TARGETS="arm64-darwin-gcc"
+SIM_TARGETS="x86_64-iphonesimulator-gcc"
+OSX_TARGETS="x86_64-darwin16-gcc"
 TARGETS="${ARM_TARGETS} ${SIM_TARGETS}"
 
 # Configures for the target specified by $1, and invokes make with the dist

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/vp9_spatial_svc_encoder.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/vp9_spatial_svc_encoder.c
@@ -14,6 +14,8 @@
  * that benefit from a scalable bitstream.
  */
 
+#include <assert.h>
+#include <limits.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -25,12 +27,13 @@
 #include "../tools_common.h"
 #include "../video_writer.h"
 
+#include "../vpx_ports/bitops.h"
 #include "../vpx_ports/vpx_timer.h"
 #include "./svc_context.h"
 #include "vpx/vp8cx.h"
+#include "vpx/vpx_decoder.h"
 #include "vpx/vpx_encoder.h"
 #include "../vpxstats.h"
-#include "vp9/encoder/vp9_encoder.h"
 #include "./y4minput.h"
 
 #define OUTPUT_FRAME_STATS 0
@@ -783,8 +786,8 @@ static void svc_output_rc_stats(
   int count = 0;
   double sum_bitrate = 0.0;
   double sum_bitrate2 = 0.0;
-  vp9_zero(sizes);
-  vp9_zero(sizes_parsed);
+  memset(sizes, 0, sizeof(sizes));
+  memset(sizes_parsed, 0, sizeof(sizes_parsed));
   vpx_codec_control(codec, VP9E_GET_SVC_LAYER_ID, layer_id);
   parse_superframe_index(cx_pkt->data.frame.buf, cx_pkt->data.frame.sz,
                          sizes_parsed, &count);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/libs.mk
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/libs.mk
@@ -182,13 +182,17 @@ INSTALL-LIBS-$(CONFIG_ENCODERS) += include/vpx/vpx_tpl.h
 ifeq ($(CONFIG_EXTERNAL_BUILD),yes)
 ifeq ($(CONFIG_MSVS),yes)
 INSTALL-LIBS-yes                  += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/$(CODEC_LIB).lib)
+ifeq ($(CONFIG_STATIC),yes)
 INSTALL-LIBS-$(CONFIG_DEBUG_LIBS) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/$(CODEC_LIB)d.lib)
+endif
 INSTALL-LIBS-$(CONFIG_SHARED) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/vpx.dll)
 INSTALL-LIBS-$(CONFIG_SHARED) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/vpx.exp)
 endif
 else
 INSTALL-LIBS-$(CONFIG_STATIC) += $(LIBSUBDIR)/libvpx.a
+ifeq ($(CONFIG_STATIC),yes)
 INSTALL-LIBS-$(CONFIG_DEBUG_LIBS) += $(LIBSUBDIR)/libvpx_g.a
+endif
 endif
 
 CODEC_SRCS=$(call enabled,CODEC_SRCS)

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/convolve_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/convolve_test.cc
@@ -1804,6 +1804,24 @@ WRAP12TAP(convolve12_vert_ssse3, 12)
 WRAP12TAP(convolve12_ssse3, 12)
 #endif  // HAVE_SSSE3
 
+#if HAVE_NEON
+WRAP12TAP(convolve12_horiz_neon, 8)
+WRAP12TAP(convolve12_vert_neon, 8)
+WRAP12TAP(convolve12_neon, 8)
+WRAP12TAP(convolve12_horiz_neon, 10)
+WRAP12TAP(convolve12_vert_neon, 10)
+WRAP12TAP(convolve12_neon, 10)
+WRAP12TAP(convolve12_horiz_neon, 12)
+WRAP12TAP(convolve12_vert_neon, 12)
+WRAP12TAP(convolve12_neon, 12)
+#endif  // HAVE_NEON
+
+#if HAVE_SVE2
+WRAP12TAP(convolve12_horiz_sve2, 8)
+WRAP12TAP(convolve12_horiz_sve2, 10)
+WRAP12TAP(convolve12_horiz_sve2, 12)
+#endif  // HAVE_SVE2
+
 WRAP12TAP(convolve12_horiz_c, 8)
 WRAP12TAP(convolve12_vert_c, 8)
 WRAP12TAP(convolve12_c, 8)
@@ -2045,14 +2063,37 @@ INSTANTIATE_TEST_SUITE_P(NEON, ConvolveTest,
                          ::testing::ValuesIn(kArrayConvolve_neon));
 
 #if !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+#if CONFIG_VP9_HIGHBITDEPTH
+const ConvolveFunctions12Tap convolve12tap_8bit_neon(
+    wrap_convolve12_horiz_neon_8, wrap_convolve12_vert_neon_8,
+    wrap_convolve12_neon_8, 8);
+
+const ConvolveFunctions12Tap convolve12tap_10bit_neon(
+    wrap_convolve12_horiz_neon_10, wrap_convolve12_vert_neon_10,
+    wrap_convolve12_neon_10, 10);
+
+const ConvolveFunctions12Tap convolve12tap_12bit_neon(
+    wrap_convolve12_horiz_neon_12, wrap_convolve12_vert_neon_12,
+    wrap_convolve12_neon_12, 12);
+
+const Convolve12TapParam kArrayConvolve12Tap_neon[] = {
+  ALL_SIZES_12TAP(convolve12tap_8bit_neon),
+  ALL_SIZES_12TAP(convolve12tap_10bit_neon),
+  ALL_SIZES_12TAP(convolve12tap_12bit_neon)
+};
+
+#else
+
 const ConvolveFunctions12Tap convolve12Tap_neon(vpx_convolve12_horiz_neon,
                                                 vpx_convolve12_vert_neon,
                                                 vpx_convolve12_neon, 0);
 const Convolve12TapParam kArrayConvolve12Tap_neon[] = { ALL_SIZES_12TAP(
     convolve12Tap_neon) };
+#endif  // CONFIG_VP9_HIGHBITDEPTH
+
 INSTANTIATE_TEST_SUITE_P(NEON, ConvolveTest12Tap,
                          ::testing::ValuesIn(kArrayConvolve12Tap_neon));
-#endif
+#endif  // !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
 #endif  // HAVE_NEON
 
 #if HAVE_NEON_DOTPROD
@@ -2145,7 +2186,44 @@ const ConvolveParam kArrayConvolve_sve2[] = { ALL_SIZES(convolve8_sve2),
                                               ALL_SIZES(convolve12_sve2) };
 INSTANTIATE_TEST_SUITE_P(SVE2, ConvolveTest,
                          ::testing::ValuesIn(kArrayConvolve_sve2));
+
+#if !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+const ConvolveFunctions12Tap convolve12tap_8bit_sve2(
+    wrap_convolve12_horiz_sve2_8, wrap_convolve12_vert_c_8, wrap_convolve12_c_8,
+    8);
+
+const ConvolveFunctions12Tap convolve12tap_10bit_sve2(
+    wrap_convolve12_horiz_sve2_10, wrap_convolve12_vert_c_10,
+    wrap_convolve12_c_10, 10);
+
+const ConvolveFunctions12Tap convolve12tap_12bit_sve2(
+    wrap_convolve12_horiz_sve2_12, wrap_convolve12_vert_c_12,
+    wrap_convolve12_c_12, 12);
+
+const Convolve12TapParam kArrayConvolve12Tap_sve2[] = {
+  ALL_SIZES_12TAP(convolve12tap_8bit_sve2),
+  ALL_SIZES_12TAP(convolve12tap_10bit_sve2),
+  ALL_SIZES_12TAP(convolve12tap_12bit_sve2)
+};
+#endif  // !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+
+#else  // !CONFIG_VP9_HIGHBITDEPTH
+
+#if !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+const ConvolveFunctions12Tap convolve12Tap_sve2(vpx_convolve12_horiz_sve2,
+                                                vpx_convolve12_vert_c,
+                                                vpx_convolve12_c, 0);
+const Convolve12TapParam kArrayConvolve12Tap_sve2[] = { ALL_SIZES_12TAP(
+    convolve12Tap_sve2) };
+#endif  // !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+
 #endif  // CONFIG_VP9_HIGHBITDEPTH
+
+#if !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+INSTANTIATE_TEST_SUITE_P(SVE2, ConvolveTest12Tap,
+                         ::testing::ValuesIn(kArrayConvolve12Tap_sve2));
+#endif  // !CONFIG_REALTIME_ONLY && CONFIG_VP9_ENCODER
+
 #endif  // HAVE_SVE2
 
 #if HAVE_NEON_I8MM

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
@@ -1766,6 +1766,10 @@ TEST(EncodeAPI, Buganizer441668134) {
       img->planes[0][y * img->stride[0] + x] = ((x ^ y) * 127) & 0xFF;
     }
   }
+  const unsigned int uv_height = (img->d_h + 1) >> 1;
+  for (int i : { VPX_PLANE_U, VPX_PLANE_V }) {
+    memset(img->planes[i], 0, img->stride[i] * uv_height);
+  }
   // Encode some frames.
   int num_frames = 6;
   static constexpr int kChoices[6] = { 1, 1, 0, 0, 0, 0 };
@@ -1775,6 +1779,134 @@ TEST(EncodeAPI, Buganizer441668134) {
     if (dl_choice == 1) deadline = VPX_DL_BEST_QUALITY;
     // Encode frame.
     ASSERT_EQ(vpx_codec_encode(&ctx, img, frame, 1, 0, deadline), VPX_CODEC_OK);
+  }
+  vpx_img_free(img);
+  vpx_codec_destroy(&ctx);
+}
+
+// Encode a few frames, with realtime mode and tile_rows set to 1,
+// with row-mt enabled. This triggers an assertion in vp9_bitstream.c (in
+// function write_modes()), as in the issue:42105459. In this test it happens on
+// very first encoded frame since lag_in_frames = 0. Issue is due to enabling
+// TILE_ROWS, with number of tile_rows more than the number of superblocks.
+// This test sets 2 tile_rows with height corresponding to 1 superblock (sb).
+TEST(EncodeAPI, Buganizer442105459_2RowTiles) {
+  // Initialize VP9 encoder interface
+  vpx_codec_iface_t *iface = vpx_codec_vp9_cx();
+  // Get default encoder configuration
+  vpx_codec_enc_cfg_t cfg;
+  ASSERT_EQ(vpx_codec_enc_config_default(iface, &cfg, 0), VPX_CODEC_OK);
+  // Configure encoder
+  cfg.g_w = 946u;
+  cfg.g_h = 64u;  // 1 sb row, 2 tile_rows set below.
+  cfg.g_threads = 1;
+  cfg.g_profile = 0;
+  cfg.g_bit_depth = VPX_BITS_8;
+  // Rate control targeting deeper encoding paths
+  cfg.rc_target_bitrate = 100;
+  cfg.rc_min_quantizer = 0;
+  cfg.rc_max_quantizer = 0;
+  cfg.rc_end_usage = VPX_VBR;
+  cfg.ss_number_layers = 1;
+  cfg.g_lag_in_frames = 0;
+  // Initialize encoder context
+  vpx_codec_ctx_t ctx;
+  ASSERT_EQ(vpx_codec_enc_init(&ctx, iface, &cfg, 0), VPX_CODEC_OK);
+  // Set control parameters
+  vpx_codec_control_(&ctx, VP8E_SET_CPUUSED, -5);
+  vpx_codec_control_(&ctx, VP9E_SET_TILE_ROWS, 1);
+  vpx_codec_control_(&ctx, VP9E_SET_TILE_COLUMNS, 1);
+  vpx_codec_control_(&ctx, VP9E_SET_ROW_MT, 1);
+  // Image format selection
+  vpx_img_fmt_t img_fmt = VPX_IMG_FMT_I420;
+  // Allocate image with varied alignment
+  vpx_image_t *img = vpx_img_alloc(nullptr, img_fmt, cfg.g_w, cfg.g_h, 1);
+  // Encode with dynamic configuration changes
+  int num_frames = 2;
+  // Per-frame constants captured from the original run (indices consumed per
+  // frame)
+  const unsigned long frame_pts_mul[] = { 33333UL, 33333UL };
+  const unsigned long frame_durations[] = { 33333UL, 33333UL };
+  const vpx_enc_deadline_t frame_deadlines[] = { VPX_DL_REALTIME,
+                                                 VPX_DL_REALTIME };
+  for (int frame = 0; frame < num_frames; frame++) {
+    // Encode frame
+    vpx_codec_pts_t pts = frame * frame_pts_mul[frame];
+    unsigned long duration = frame_durations[frame];
+    vpx_enc_deadline_t deadline = frame_deadlines[frame];
+    ASSERT_EQ(vpx_codec_encode(&ctx, img, pts, duration, /*flags*/ 0, deadline),
+              VPX_CODEC_OK);
+  }
+  // Flush encoder.
+  ASSERT_EQ(vpx_codec_encode(&ctx, NULL, 0, 0, 0, VPX_DL_REALTIME), 0);
+  // Get remaining data
+  vpx_codec_iter_t iter = NULL;
+  while (vpx_codec_get_cx_data(&ctx, &iter) != NULL) {
+    // Process remaining packets
+  }
+  vpx_img_free(img);
+  vpx_codec_destroy(&ctx);
+}
+
+// Encode a few frames, with realtime mode and tile_rows set to 1,
+// with row-mt enabled. This triggers an assertion in vp9_bitstream.c (in
+// function write_modes()), as in the issue:42105459. In this test it happens on
+// very first encoded frame since lag_in_frames = 0. Issue is due to enabling
+// TILE_ROWS, with number of tile_rows more than the number of superblocks.
+// This test sets 4 tile_rows with height corresponding to 3 superblocks.
+TEST(EncodeAPI, Buganizer442105459_4RowTiles) {
+  // Initialize VP9 encoder interface
+  vpx_codec_iface_t *iface = vpx_codec_vp9_cx();
+  // Get default encoder configuration
+  vpx_codec_enc_cfg_t cfg;
+  ASSERT_EQ(vpx_codec_enc_config_default(iface, &cfg, 0), VPX_CODEC_OK);
+  // Configure encoder
+  cfg.g_w = 946u;
+  cfg.g_h = 192u;  // 3 sb rows, 4 tile_rows set below.
+  cfg.g_threads = 1;
+  cfg.g_profile = 0;
+  cfg.g_bit_depth = VPX_BITS_8;
+  // Rate control targeting deeper encoding paths
+  cfg.rc_target_bitrate = 100;
+  cfg.rc_min_quantizer = 0;
+  cfg.rc_max_quantizer = 0;
+  cfg.rc_end_usage = VPX_VBR;
+  cfg.ss_number_layers = 1;
+  cfg.g_lag_in_frames = 0;
+  // Initialize encoder context
+  vpx_codec_ctx_t ctx;
+  ASSERT_EQ(vpx_codec_enc_init(&ctx, iface, &cfg, 0), VPX_CODEC_OK);
+  // Set control parameters
+  vpx_codec_control_(&ctx, VP8E_SET_CPUUSED, -5);
+  vpx_codec_control_(&ctx, VP9E_SET_TILE_ROWS, 2);
+  vpx_codec_control_(&ctx, VP9E_SET_TILE_COLUMNS, 1);
+  vpx_codec_control_(&ctx, VP9E_SET_ROW_MT, 1);
+  // Image format selection
+  vpx_img_fmt_t img_fmt = VPX_IMG_FMT_I420;
+  // Allocate image with varied alignment
+  vpx_image_t *img = vpx_img_alloc(nullptr, img_fmt, cfg.g_w, cfg.g_h, 1);
+  // Encode with dynamic configuration changes
+  int num_frames = 2;
+  // Per-frame constants captured from the original run (indices consumed per
+  // frame)
+  const unsigned long frame_pts_mul[] = { 33333UL, 33333UL };
+  const unsigned long frame_durations[] = { 33333UL, 33333UL };
+  const vpx_enc_deadline_t frame_deadlines[] = { VPX_DL_REALTIME,
+                                                 VPX_DL_REALTIME };
+  for (int frame = 0; frame < num_frames; frame++) {
+    // Encode frame
+    vpx_codec_pts_t pts = frame * frame_pts_mul[frame];
+    unsigned long duration = frame_durations[frame];
+    vpx_enc_deadline_t deadline = frame_deadlines[frame];
+    ASSERT_EQ(vpx_codec_encode(&ctx, img, pts, duration, /*flags*/ 0, deadline),
+              VPX_CODEC_OK);
+  }
+  // Flush encoder.
+  ASSERT_EQ(vpx_codec_encode(&ctx, NULL, 0, 0, 0, VPX_DL_REALTIME), 0);
+  // Get remaining data
+  vpx_codec_iter_t iter = NULL;
+  while (vpx_codec_get_cx_data(&ctx, &iter) != NULL) {
+    // Process remaining packets
   }
   vpx_img_free(img);
   vpx_codec_destroy(&ctx);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/encoder/ratectrl.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/encoder/ratectrl.c
@@ -643,11 +643,10 @@ static void calc_pframe_target_size(VP8_COMP *cpi) {
         /* % Adjustment limited to the range 1% to 10% */
         Adjustment = (cpi->last_boost - 100) >> 5;
 
-        if (Adjustment < 1) {
-          Adjustment = 1;
-        } else if (Adjustment > 10) {
+        if (Adjustment > 10) {
           Adjustment = 10;
         }
+        assert(Adjustment >= 1);
 
         /* Convert to bits */
         Adjustment = (cpi->this_frame_target * Adjustment) / 100;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/common/vp9_postproc.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/common/vp9_postproc.h
@@ -30,6 +30,7 @@ struct postproc_state {
   MODE_INFO *prev_mi;
   int clamp;
   uint8_t *limits;
+  int limits_size;
   int8_t *generated_noise;
 };
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/common/vp9_rtcd_defs.pl
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/common/vp9_rtcd_defs.pl
@@ -206,13 +206,13 @@ if (vpx_config("CONFIG_REALTIME_ONLY") ne "yes") {
 
   if (vpx_config("CONFIG_VP9_HIGHBITDEPTH") eq "yes") {
     add_proto qw/void vpx_highbd_convolve12_vert/, "const uint16_t *src, ptrdiff_t src_stride, uint16_t *dst, ptrdiff_t dst_stride, const InterpKernel12 *filter, int x0_q4, int x_step_q4, int y0_q4, int y_step_q4, int w, int h, int bd";
-    specialize qw/vpx_highbd_convolve12_vert ssse3 avx2/;
+    specialize qw/vpx_highbd_convolve12_vert ssse3 avx2 neon/;
 
     add_proto qw/void vpx_highbd_convolve12_horiz/, "const uint16_t *src, ptrdiff_t src_stride, uint16_t *dst, ptrdiff_t dst_stride, const InterpKernel12 *filter, int x0_q4, int x_step_q4, int y0_q4, int y_step_q4, int w, int h, int bd";
-    specialize qw/vpx_highbd_convolve12_horiz ssse3 avx2/;
+    specialize qw/vpx_highbd_convolve12_horiz ssse3 avx2 neon sve2/;
 
     add_proto qw/void vpx_highbd_convolve12/, "const uint16_t *src, ptrdiff_t src_stride, uint16_t *dst, ptrdiff_t dst_stride, const InterpKernel12 *filter, int x0_q4, int x_step_q4, int y0_q4, int y_step_q4, int w, int h, int bd";
-    specialize qw/vpx_highbd_convolve12 ssse3 avx2/;
+    specialize qw/vpx_highbd_convolve12 ssse3 avx2 neon/;
   }
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_highbd_temporal_filter_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_highbd_temporal_filter_neon.c
@@ -14,6 +14,8 @@
 #include "./vp9_rtcd.h"
 #include "./vpx_config.h"
 #include "vpx/vpx_integer.h"
+#include "vpx_dsp/arm/mem_neon.h"
+#include "vpx_dsp/arm/transpose_neon.h"
 #include "vp9/encoder/vp9_encoder.h"
 #include "vp9/encoder/vp9_temporal_filter.h"
 #include "vp9/encoder/vp9_temporal_filter_constants.h"
@@ -870,3 +872,208 @@ void vp9_highbd_apply_temporal_filter_neon(
       strength, blk_fw, use_whole_blk, u_accum, u_count, v_accum, v_count,
       y_dist_ptr, u_dist_ptr, v_dist_ptr);
 }
+
+#if !CONFIG_REALTIME_ONLY // WEBRTC_WEBKIT_BUILD
+static INLINE uint16x8_t highbd_convolve12_8(
+    const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+    const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
+    const int16x8_t s6, const int16x8_t s7, const int16x8_t s8,
+    const int16x8_t s9, const int16x8_t sA, const int16x8_t sB,
+    const int16x8_t filter_0_7, const int16x4_t filter_8_11, uint16x8_t max) {
+  const int16x4_t filter_0_3 = vget_low_s16(filter_0_7);
+  const int16x4_t filter_4_7 = vget_high_s16(filter_0_7);
+
+  int32x4_t sum_lo = vmull_lane_s16(vget_low_s16(s0), filter_0_3, 0);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s1), filter_0_3, 1);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s2), filter_0_3, 2);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s3), filter_0_3, 3);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s4), filter_4_7, 0);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s5), filter_4_7, 1);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s6), filter_4_7, 2);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s7), filter_4_7, 3);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s8), filter_8_11, 0);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(s9), filter_8_11, 1);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(sA), filter_8_11, 2);
+  sum_lo = vmlal_lane_s16(sum_lo, vget_low_s16(sB), filter_8_11, 3);
+
+  int32x4_t sum_hi = vmull_lane_s16(vget_high_s16(s0), filter_0_3, 0);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s1), filter_0_3, 1);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s2), filter_0_3, 2);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s3), filter_0_3, 3);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s4), filter_4_7, 0);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s5), filter_4_7, 1);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s6), filter_4_7, 2);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s7), filter_4_7, 3);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s8), filter_8_11, 0);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(s9), filter_8_11, 1);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(sA), filter_8_11, 2);
+  sum_hi = vmlal_lane_s16(sum_hi, vget_high_s16(sB), filter_8_11, 3);
+
+  uint16x4_t sum_lo_s16 = vqrshrun_n_s32(sum_lo, FILTER_BITS);
+  uint16x4_t sum_hi_s16 = vqrshrun_n_s32(sum_hi, FILTER_BITS);
+
+  uint16x8_t sum = vcombine_u16(sum_lo_s16, sum_hi_s16);
+  return vminq_u16(sum, max);
+}
+
+void vpx_highbd_convolve12_horiz_neon(const uint16_t *src, ptrdiff_t src_stride,
+                                      uint16_t *dst, ptrdiff_t dst_stride,
+                                      const InterpKernel12 *filter, int x0_q4,
+                                      int x_step_q4, int y0_q4, int y_step_q4,
+                                      int w, int h, int bd) {
+  // Scaling not supported by Neon implementation.
+  if (x_step_q4 != 16) {
+    vpx_highbd_convolve12_horiz_c(src, src_stride, dst, dst_stride, filter,
+                                  x0_q4, x_step_q4, y0_q4, y_step_q4, w, h, bd);
+    return;
+  }
+
+  assert(w == 32 || w == 16 || w == 8);
+  assert(h % 4 == 0);
+
+  const int16x8_t filter_0_7 = vld1q_s16(filter[x0_q4]);
+  const int16x4_t filter_8_11 = vld1_s16(filter[x0_q4] + 8);
+  const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
+
+  src -= MAX_FILTER_TAP / 2 - 1;
+
+  do {
+    const int16_t *s = (const int16_t *)src;
+    uint16_t *d = dst;
+    int width = w;
+
+    do {
+      int16x8_t s0[12], s1[12];
+      load_s16_8x12(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3],
+                    &s0[4], &s0[5], &s0[6], &s0[7], &s0[8], &s0[9], &s0[10],
+                    &s0[11]);
+      load_s16_8x12(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3],
+                    &s1[4], &s1[5], &s1[6], &s1[7], &s1[8], &s1[9], &s1[10],
+                    &s1[11]);
+
+      uint16x8_t d0 = highbd_convolve12_8(
+          s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], s0[8], s0[9],
+          s0[10], s0[11], filter_0_7, filter_8_11, max);
+      uint16x8_t d1 = highbd_convolve12_8(
+          s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], s1[6], s1[7], s1[8], s1[9],
+          s1[10], s1[11], filter_0_7, filter_8_11, max);
+
+      vst1q_u16(d + 0 * dst_stride, d0);
+      vst1q_u16(d + 1 * dst_stride, d1);
+
+      s += 8;
+      d += 8;
+      width -= 8;
+    } while (width != 0);
+    src += 2 * src_stride;
+    dst += 2 * dst_stride;
+    h -= 2;
+  } while (h != 0);
+}
+
+void vpx_highbd_convolve12_vert_neon(const uint16_t *src, ptrdiff_t src_stride,
+                                     uint16_t *dst, ptrdiff_t dst_stride,
+                                     const InterpKernel12 *filter, int x0_q4,
+                                     int x_step_q4, int y0_q4, int y_step_q4,
+                                     int w, int h, int bd) {
+  // Scaling not supported by Neon implementation.
+  if (y_step_q4 != 16) {
+    vpx_highbd_convolve12_vert_c(src, src_stride, dst, dst_stride, filter,
+                                 x0_q4, x_step_q4, y0_q4, y_step_q4, w, h, bd);
+    return;
+  }
+
+  assert(w == 32 || w == 16 || w == 8);
+  assert(h == 32 || h == 16 || h == 8);
+
+  const int16x8_t filter_0_7 = vld1q_s16(filter[y0_q4]);
+  const int16x4_t filter_8_11 = vld1_s16(filter[y0_q4] + 8);
+  const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
+
+  src -= src_stride * (MAX_FILTER_TAP / 2 - 1);
+
+  do {
+    const int16_t *s = (const int16_t *)src;
+    uint16_t *d = dst;
+    int height = h;
+
+    int16x8_t s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA;
+    load_s16_8x11(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6, &s7, &s8,
+                  &s9, &sA);
+    s += 11 * src_stride;
+
+    do {
+      int16x8_t sB, sC, sD, sE;
+      load_s16_8x4(s, src_stride, &sB, &sC, &sD, &sE);
+
+      uint16x8_t d0 =
+          highbd_convolve12_8(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB,
+                              filter_0_7, filter_8_11, max);
+      uint16x8_t d1 =
+          highbd_convolve12_8(s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC,
+                              filter_0_7, filter_8_11, max);
+      uint16x8_t d2 =
+          highbd_convolve12_8(s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD,
+                              filter_0_7, filter_8_11, max);
+      uint16x8_t d3 =
+          highbd_convolve12_8(s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE,
+                              filter_0_7, filter_8_11, max);
+
+      store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
+
+      s0 = s4;
+      s1 = s5;
+      s2 = s6;
+      s3 = s7;
+      s4 = s8;
+      s5 = s9;
+      s6 = sA;
+      s7 = sB;
+      s8 = sC;
+      s9 = sD;
+      sA = sE;
+
+      s += 4 * src_stride;
+      d += 4 * dst_stride;
+      height -= 4;
+    } while (height != 0);
+    src += 8;
+    dst += 8;
+    w -= 8;
+  } while (w != 0);
+}
+
+void vpx_highbd_convolve12_neon(const uint16_t *src, ptrdiff_t src_stride,
+                                uint16_t *dst, ptrdiff_t dst_stride,
+                                const InterpKernel12 *filter, int x0_q4,
+                                int x_step_q4, int y0_q4, int y_step_q4, int w,
+                                int h, int bd) {
+  // Scaling not supported by Neon implementation.
+  if (x_step_q4 != 16 || y_step_q4 != 16) {
+    vpx_highbd_convolve12_c(src, src_stride, dst, dst_stride, filter, x0_q4,
+                            x_step_q4, y0_q4, y_step_q4, w, h, bd);
+    return;
+  }
+
+  assert(w == 32 || w == 16 || w == 8);
+  assert(h == 32 || h == 16 || h == 8);
+
+  DECLARE_ALIGNED(32, uint16_t, im_block[BW * (BH + MAX_FILTER_TAP)]);
+
+  const int im_stride = BW;
+  // Account for the vertical pass needing MAX_FILTER_TAP / 2 - 1 lines prior
+  // and MAX_FILTER_TAP / 2 lines post. (+1 to make total divisible by 2.)
+  const int im_height = h + MAX_FILTER_TAP;
+  const ptrdiff_t border_offset = MAX_FILTER_TAP / 2 - 1;
+
+  // Filter starting border_offset rows up.
+  vpx_highbd_convolve12_horiz_neon(
+      src - src_stride * border_offset, src_stride, im_block, im_stride, filter,
+      x0_q4, x_step_q4, y0_q4, y_step_q4, w, im_height, bd);
+
+  vpx_highbd_convolve12_vert_neon(im_block + im_stride * border_offset,
+                                  im_stride, dst, dst_stride, filter, x0_q4,
+                                  x_step_q4, y0_q4, y_step_q4, w, h, bd);
+}
+
+#endif // !CONFIG_REALTIME_ONLY for WEBRTC_WEBKIT_BUILD

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_highbd_temporal_filter_sve2.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_highbd_temporal_filter_sve2.c
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2025 The WebM project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <arm_neon.h>
+#include <arm_neon_sve_bridge.h>
+#include <arm_sve.h>
+#include <assert.h>
+
+#include "./vp9_rtcd.h"
+#include "./vpx_config.h"
+#include "vpx/vpx_integer.h"
+#include "vpx_dsp/arm/mem_neon.h"
+#include "vp9/encoder/vp9_temporal_filter.h"
+#include "vpx_dsp/arm/vpx_neon_sve_bridge.h"
+#include "vpx_dsp/arm/vpx_neon_sve2_bridge.h"
+
+DECLARE_ALIGNED(16, static const uint16_t, kDotProdPermuteTbl[32]) = {
+  // clang-format off
+  0,  1,  2,  3,  1,  2,  3,  4,
+  2,  3,  4,  5,  3,  4,  5,  6,
+  4,  5,  6,  7,  5,  6,  7,  0,
+  6,  7,  0,  1,  7,  0,  1,  2,
+  // clang-format on
+};
+
+static INLINE uint16x8_t highbd_convolve12_8_h(
+    const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+    const int16x8_t filter_0_7, const int16x8_t filter_4_11,
+    const uint16x8x4_t perm_tbl, const uint16x8_t max) {
+  int16x8_t perm_samples[8];
+
+  perm_samples[0] = vpx_tbl_s16(s0, perm_tbl.val[0]);
+  perm_samples[1] = vpx_tbl_s16(s0, perm_tbl.val[1]);
+  perm_samples[2] = vpx_tbl2_s16(s0, s1, perm_tbl.val[2]);
+  perm_samples[3] = vpx_tbl2_s16(s0, s1, perm_tbl.val[3]);
+  perm_samples[4] = vpx_tbl_s16(s1, perm_tbl.val[0]);
+  perm_samples[5] = vpx_tbl_s16(s1, perm_tbl.val[1]);
+  perm_samples[6] = vpx_tbl2_s16(s1, s2, perm_tbl.val[2]);
+  perm_samples[7] = vpx_tbl2_s16(s1, s2, perm_tbl.val[3]);
+
+  int64x2_t sum01 =
+      vpx_dotq_lane_s16(vdupq_n_s64(0), perm_samples[0], filter_0_7, 0);
+  sum01 = vpx_dotq_lane_s16(sum01, perm_samples[2], filter_0_7, 1);
+  sum01 = vpx_dotq_lane_s16(sum01, perm_samples[4], filter_4_11, 1);
+
+  int64x2_t sum23 =
+      vpx_dotq_lane_s16(vdupq_n_s64(0), perm_samples[1], filter_0_7, 0);
+  sum23 = vpx_dotq_lane_s16(sum23, perm_samples[3], filter_0_7, 1);
+  sum23 = vpx_dotq_lane_s16(sum23, perm_samples[5], filter_4_11, 1);
+
+  int64x2_t sum45 =
+      vpx_dotq_lane_s16(vdupq_n_s64(0), perm_samples[2], filter_0_7, 0);
+  sum45 = vpx_dotq_lane_s16(sum45, perm_samples[4], filter_0_7, 1);
+  sum45 = vpx_dotq_lane_s16(sum45, perm_samples[6], filter_4_11, 1);
+
+  int64x2_t sum67 =
+      vpx_dotq_lane_s16(vdupq_n_s64(0), perm_samples[3], filter_0_7, 0);
+  sum67 = vpx_dotq_lane_s16(sum67, perm_samples[5], filter_0_7, 1);
+  sum67 = vpx_dotq_lane_s16(sum67, perm_samples[7], filter_4_11, 1);
+
+  int32x4_t sum0123 = vcombine_s32(vmovn_s64(sum01), vmovn_s64(sum23));
+  int32x4_t sum4567 = vcombine_s32(vmovn_s64(sum45), vmovn_s64(sum67));
+
+  uint16x8_t res = vcombine_u16(vqrshrun_n_s32(sum0123, FILTER_BITS),
+                                vqrshrun_n_s32(sum4567, FILTER_BITS));
+  return vminq_u16(res, max);
+}
+
+void vpx_highbd_convolve12_horiz_sve2(const uint16_t *src, ptrdiff_t src_stride,
+                                      uint16_t *dst, ptrdiff_t dst_stride,
+                                      const InterpKernel12 *filter, int x0_q4,
+                                      int x_step_q4, int y0_q4, int y_step_q4,
+                                      int w, int h, int bd) {
+  // Scaling not supported by SVE2 implementation.
+  if (x_step_q4 != 16) {
+    vpx_highbd_convolve12_horiz_c(src, src_stride, dst, dst_stride, filter,
+                                  x0_q4, x_step_q4, y0_q4, y_step_q4, w, h, bd);
+    return;
+  }
+
+  assert(w == 32 || w == 16 || w == 8);
+  assert(h == 32 || h == 16 || h == 8);
+
+  const int16x8_t filter_0_7 = vld1q_s16(filter[x0_q4]);
+  const int16x8_t filter_4_11 = vld1q_s16(filter[x0_q4] + 4);
+  const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
+  uint16x8x4_t permute_tbl = vld1q_u16_x4(kDotProdPermuteTbl);
+
+  // Scale indices by size of the true vector length to avoid reading from an
+  // 'undefined' portion of a vector on a system with SVE vectors > 128-bit.
+  permute_tbl.val[2] = vsetq_lane_u16(svcnth(), permute_tbl.val[2], 7);
+  permute_tbl.val[3] = vsetq_lane_u16(svcnth(), permute_tbl.val[3], 5);
+  uint16x8_t permute_tbl_3_offsets =
+      vreinterpretq_u16_u64(vdupq_n_u64(svcnth() * 0x0001000100000000ULL));
+  permute_tbl.val[3] =
+      vaddq_u16(permute_tbl.val[3], permute_tbl_3_offsets);  // 2, 3, 6, 7
+
+  src -= MAX_FILTER_TAP / 2 - 1;
+
+  do {
+    const int16_t *s = (const int16_t *)src;
+    uint16_t *d = dst;
+    int width = w;
+
+    do {
+      int16x8_t s0[3], s1[3];
+
+      load_s16_8x3(s + 0 * src_stride, 8, &s0[0], &s0[1], &s0[2]);
+      load_s16_8x3(s + 1 * src_stride, 8, &s1[0], &s1[1], &s1[2]);
+
+      uint16x8_t d0 = highbd_convolve12_8_h(s0[0], s0[1], s0[2], filter_0_7,
+                                            filter_4_11, permute_tbl, max);
+      uint16x8_t d1 = highbd_convolve12_8_h(s1[0], s1[1], s1[2], filter_0_7,
+                                            filter_4_11, permute_tbl, max);
+
+      vst1q_u16(d + 0 * dst_stride, d0);
+      vst1q_u16(d + 1 * dst_stride, d1);
+
+      s += 8;
+      d += 8;
+      width -= 8;
+    } while (width != 0);
+    src += 2 * src_stride;
+    dst += 2 * dst_stride;
+    h -= 2;
+  } while (h != 0);
+}

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_temporal_filter_neon_i8mm.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/arm/neon/vp9_temporal_filter_neon_i8mm.c
@@ -15,6 +15,7 @@
 #include "./vpx_config.h"
 #include "vpx/vpx_integer.h"
 #include "vpx_dsp/arm/mem_neon.h"
+#include "vpx_dsp/arm/transpose_neon.h"
 #include "vp9/encoder/vp9_temporal_filter.h"
 
 DECLARE_ALIGNED(16, static const uint8_t, kMatMulPermuteTbl[32]) = {
@@ -139,32 +140,6 @@ static INLINE uint8x8_t convolve12_8_v(
   return vqrshrun_n_s16(sum, FILTER_BITS);
 }
 
-static INLINE void transpose_concat_8x4(uint8x8_t a0, uint8x8_t a1,
-                                        uint8x8_t a2, uint8x8_t a3,
-                                        uint8x16_t *b0, uint8x16_t *b1) {
-  // Transpose 8-bit elements and concatenate result rows as follows:
-  // a0: 00, 01, 02, 03, 04, 05, 06, 07
-  // a1: 10, 11, 12, 13, 14, 15, 16, 17
-  // a2: 20, 21, 22, 23, 24, 25, 26, 27
-  // a3: 30, 31, 32, 33, 34, 35, 36, 37
-  //
-  // b0: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
-  // b1: 04, 14, 24, 34, 05, 15, 25, 35, 06, 16, 26, 36, 07, 17, 27, 37
-
-  uint8x16_t a0q = vcombine_u8(a0, vdup_n_u8(0));
-  uint8x16_t a1q = vcombine_u8(a1, vdup_n_u8(0));
-  uint8x16_t a2q = vcombine_u8(a2, vdup_n_u8(0));
-  uint8x16_t a3q = vcombine_u8(a3, vdup_n_u8(0));
-
-  uint8x16_t a02 = vzipq_u8(a0q, a2q).val[0];
-  uint8x16_t a13 = vzipq_u8(a1q, a3q).val[0];
-
-  uint8x16x2_t a0123 = vzipq_u8(a02, a13);
-
-  *b0 = a0123.val[0];
-  *b1 = a0123.val[1];
-}
-
 void vpx_convolve12_vert_neon_i8mm(const uint8_t *src, ptrdiff_t src_stride,
                                    uint8_t *dst, ptrdiff_t dst_stride,
                                    const InterpKernel12 *filter, int x0_q4,
@@ -202,14 +177,14 @@ void vpx_convolve12_vert_neon_i8mm(const uint8_t *src, ptrdiff_t src_stride,
     uint8x16_t s0123_lo, s0123_hi, s1234_lo, s1234_hi, s2345_lo, s2345_hi,
         s3456_lo, s3456_hi, s4567_lo, s4567_hi, s5678_lo, s5678_hi, s6789_lo,
         s6789_hi, s789A_lo, s789A_hi;
-    transpose_concat_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
-    transpose_concat_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
-    transpose_concat_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
-    transpose_concat_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
-    transpose_concat_8x4(s4, s5, s6, s7, &s4567_lo, &s4567_hi);
-    transpose_concat_8x4(s5, s6, s7, s8, &s5678_lo, &s5678_hi);
-    transpose_concat_8x4(s6, s7, s8, s9, &s6789_lo, &s6789_hi);
-    transpose_concat_8x4(s7, s8, s9, sA, &s789A_lo, &s789A_hi);
+    transpose_concat_u8_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
+    transpose_concat_u8_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
+    transpose_concat_u8_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
+    transpose_concat_u8_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
+    transpose_concat_u8_8x4(s4, s5, s6, s7, &s4567_lo, &s4567_hi);
+    transpose_concat_u8_8x4(s5, s6, s7, s8, &s5678_lo, &s5678_hi);
+    transpose_concat_u8_8x4(s6, s7, s8, s9, &s6789_lo, &s6789_hi);
+    transpose_concat_u8_8x4(s7, s8, s9, sA, &s789A_lo, &s789A_hi);
 
     do {
       uint8x8_t sB, sC, sD, sE;
@@ -217,7 +192,7 @@ void vpx_convolve12_vert_neon_i8mm(const uint8_t *src, ptrdiff_t src_stride,
 
       uint8x16_t s89AB_lo, s89AB_hi, s9ABC_lo, s9ABC_hi, sABCD_lo, sABCD_hi,
           sBCDE_lo, sBCDE_hi;
-      transpose_concat_8x4(sB, sC, sD, sE, &sBCDE_lo, &sBCDE_hi);
+      transpose_concat_u8_8x4(sB, sC, sD, sE, &sBCDE_lo, &sBCDE_hi);
 
       // Merge new data into block from previous iteration.
       uint8x16x2_t samples_LUT_lo = { { s789A_lo, sBCDE_lo } };

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_ratectrl.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_ratectrl.c
@@ -856,15 +856,19 @@ int vp9_rc_regulate_q(const VP9_COMP *cpi, int target_bits_per_frame,
           frame_type, i, correction_factor, cm->bit_depth);
     }
 
+    int diff_bits = (int)VPXMIN(
+        VPXMAX(((int64_t)target_bits_per_mb - (int64_t)bits_per_mb_at_this_q),
+               -INT_MAX),
+        INT_MAX);
     if (bits_per_mb_at_this_q <= target_bits_per_mb) {
-      if ((target_bits_per_mb - bits_per_mb_at_this_q) <= last_error)
+      if (diff_bits <= last_error)
         q = i;
       else
         q = i - 1;
 
       break;
     } else {
-      last_error = bits_per_mb_at_this_q - target_bits_per_mb;
+      last_error = -diff_bits;
     }
   } while (++i <= active_worst_quality);
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_temporal_filter.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_temporal_filter.c
@@ -1329,6 +1329,7 @@ static void adjust_arnr_filter(VP9_COMP *cpi, int distance, int group_boost,
   *arnr_strength = strength;
 }
 
+#if !CONFIG_REALTIME_ONLY // WEBRTC_WEBKIT_BUILD
 void vp9_temporal_filter(VP9_COMP *cpi, int distance) {
   VP9_COMMON *const cm = &cpi->common;
   RATE_CONTROL *const rc = &cpi->rc;
@@ -1437,3 +1438,4 @@ void vp9_temporal_filter(VP9_COMP *cpi, int distance) {
   else
     vp9_temporal_filter_row_mt(cpi);
 }
+#endif // !CONFIG_REALTIME_ONLY for WEBRTC_WEBKIT_BUILD

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/vp9_cx_iface.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/vp9_cx_iface.c
@@ -1552,7 +1552,6 @@ static vpx_codec_err_t encoder_encode(vpx_codec_alg_priv_t *ctx,
           PSNR_STATS psnr;
           if (vp9_get_psnr(cpi, &psnr)) {
             vpx_codec_cx_pkt_t psnr_pkt = get_psnr_pkt(&psnr);
-            psnr_pkt.data.psnr.spatial_layer_id = cpi->svc.spatial_layer_id;
             vpx_codec_pkt_list_add(&ctx->pkt_list.head, &psnr_pkt);
           }
         }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/vp9cx.mk
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/vp9cx.mk
@@ -129,6 +129,7 @@ VP9_CX_SRCS-$(HAVE_SSSE3) += encoder/x86/highbd_temporal_filter_ssse3.c
 VP9_CX_SRCS-$(HAVE_SSE4_1) += encoder/x86/highbd_temporal_filter_sse4.c
 VP9_CX_SRCS-$(HAVE_AVX2) += encoder/x86/highbd_temporal_filter_avx2.c
 VP9_CX_SRCS-$(HAVE_NEON) += encoder/arm/neon/vp9_highbd_temporal_filter_neon.c
+VP9_CX_SRCS-$(HAVE_SVE2) += encoder/arm/neon/vp9_highbd_temporal_filter_sve2.c
 endif
 
 VP9_CX_SRCS-$(HAVE_SSE2) += encoder/x86/vp9_dct_sse2.asm
@@ -179,6 +180,7 @@ VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/arm/neon/vp9_temporal_filt
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/arm/neon/vp9_temporal_filter_neon_dotprod.c
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/arm/neon/vp9_temporal_filter_neon_i8mm.c
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/arm/neon/vp9_highbd_temporal_filter_neon.c
+VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/arm/neon/vp9_highbd_temporal_filter_sve2.c
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/vp9_alt_ref_aq.h
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/vp9_alt_ref_aq.c
 VP9_CX_SRCS_REMOVE-$(CONFIG_REALTIME_ONLY) += encoder/vp9_aq_variance.c

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vp8cx.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vp8cx.h
@@ -673,7 +673,7 @@ enum vp8e_enc_control_id {
    */
   VP9E_SET_TPL,
 
-  /*!\brief Codec control function to enable postencode frame drop.
+  /*!\brief Codec control function to enable post encode frame drop.
    *
    * This will allow encoder to drop frame after it's encoded.
    *

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vpx_ext_ratectrl.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vpx_ext_ratectrl.h
@@ -133,7 +133,7 @@ typedef void *vpx_rc_model_t;
 #define VPX_DEFAULT_RDMULT -1
 
 /*!\brief Superblock quantization parameters
- * Store the superblock quantiztaion parameters
+ * Store the superblock quantization parameters
  */
 typedef struct sb_parameters {
   int q_index; /**< Quantizer step index [0..255]*/

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vpx_image.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/vpx_image.h
@@ -130,7 +130,7 @@ typedef struct vpx_image_rect {
 /*!\brief Open a descriptor, allocating storage for the underlying image
  *
  * Returns a descriptor for storing an image of the given format. The
- * storage for the descriptor is allocated on the heap.
+ * storage for the image is allocated on the heap.
  *
  * \param[in]    img       Pointer to storage for descriptor. If this parameter
  *                         is NULL, the storage for the descriptor will be
@@ -155,7 +155,7 @@ vpx_image_t *vpx_img_alloc(vpx_image_t *img, vpx_img_fmt_t fmt,
 /*!\brief Open a descriptor, using existing storage for the underlying image
  *
  * Returns a descriptor for storing an image of the given format. The
- * storage for descriptor has been allocated elsewhere, and a descriptor is
+ * storage for the image has been allocated elsewhere, and a descriptor is
  * desired to "wrap" that storage.
  *
  * \param[in]    img           Pointer to storage for descriptor. If this
@@ -175,6 +175,35 @@ vpx_image_t *vpx_img_alloc(vpx_image_t *img, vpx_img_fmt_t fmt,
  * \return Returns a pointer to the initialized image descriptor. If the img
  *         parameter is non-null, the value of the img parameter will be
  *         returned.
+ *
+ * \note \a img_data is required to have a minimum allocation size that
+ *       satisfies the requirements of the \a fmt, \a d_w, \a d_h and \a
+ *       stride_align parameters. This size can be calculated as follows (see
+ *       \c img_alloc_helper in the vpx_image.c file in the libvpx source tree
+ *       for more detail):
+ * \code
+ * align = (1 << x_chroma_shift) - 1;
+ * w = (d_w + align) & ~align;
+ * align = (1 << y_chroma_shift) - 1;
+ * h = (d_h + align) & ~align;
+ *
+ * s = (fmt & VPX_IMG_FMT_PLANAR) ? w : (uint64_t)bps * w / 8;
+ * s = (fmt & VPX_IMG_FMT_HIGHBITDEPTH) ? s * 2 : s;
+ * s = (s + stride_align - 1) & ~((uint64_t)stride_align - 1);
+ * s = (fmt & VPX_IMG_FMT_HIGHBITDEPTH) ? s / 2 : s;
+ * alloc_size = (fmt & VPX_IMG_FMT_PLANAR) ? (uint64_t)h * s * bps / 8
+ *                                         : (uint64_t)h * s;
+ * \endcode
+ * \a x_chroma_shift, \a y_chroma_shift and \a bps can be obtained by calling
+ * \ref vpx_img_wrap with a non-\c NULL \a img_data parameter. The \c
+ * vpx_image_t pointer should \em not be used in other API calls until \em after
+ * a successful call to \ref vpx_img_wrap with a valid image buffer. For
+ * example:
+ * \code
+ * vpx_img_wrap(img, fmt, d_w, d_h, stride_align, (unsigned char *)1);
+ * ... calculate buffer size and allocate buffer as described earlier
+ * vpx_img_wrap(img, fmt, d_w, d_h, stride_align, img_data);
+ * \endcode
  */
 vpx_image_t *vpx_img_wrap(vpx_image_t *img, vpx_img_fmt_t fmt, unsigned int d_w,
                           unsigned int d_h, unsigned int stride_align,

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/highbd_vpx_convolve8_sve2.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/highbd_vpx_convolve8_sve2.c
@@ -36,72 +36,6 @@ DECLARE_ALIGNED(16, static const uint16_t, kDotProdMergeBlockTbl[24]) = {
 DECLARE_ALIGNED(16, static const uint16_t, kTblConv4_8[8]) = { 0, 2, 4, 6,
                                                                1, 3, 5, 7 };
 
-static INLINE void transpose_concat_4x4(const int16x4_t s0, const int16x4_t s1,
-                                        const int16x4_t s2, const int16x4_t s3,
-                                        int16x8_t res[2]) {
-  // Transpose 16-bit elements:
-  // s0: 00, 01, 02, 03
-  // s1: 10, 11, 12, 13
-  // s2: 20, 21, 22, 23
-  // s3: 30, 31, 32, 33
-  //
-  // res[0]: 00 10 20 30 01 11 21 31
-  // res[1]: 02 12 22 32 03 13 23 33
-
-  int16x8_t s0q = vcombine_s16(s0, vdup_n_s16(0));
-  int16x8_t s1q = vcombine_s16(s1, vdup_n_s16(0));
-  int16x8_t s2q = vcombine_s16(s2, vdup_n_s16(0));
-  int16x8_t s3q = vcombine_s16(s3, vdup_n_s16(0));
-
-  int16x8_t s02 = vzip1q_s16(s0q, s2q);
-  int16x8_t s13 = vzip1q_s16(s1q, s3q);
-
-  int16x8x2_t s0123 = vzipq_s16(s02, s13);
-
-  res[0] = s0123.val[0];
-  res[1] = s0123.val[1];
-}
-
-static INLINE void transpose_concat_8x4(const int16x8_t s0, const int16x8_t s1,
-                                        const int16x8_t s2, const int16x8_t s3,
-                                        int16x8_t res[4]) {
-  // Transpose 16-bit elements:
-  // s0: 00, 01, 02, 03, 04, 05, 06, 07
-  // s1: 10, 11, 12, 13, 14, 15, 16, 17
-  // s2: 20, 21, 22, 23, 24, 25, 26, 27
-  // s3: 30, 31, 32, 33, 34, 35, 36, 37
-  //
-  // res[0]: 00 10 20 30 01 11 21 31
-  // res[1]: 02 12 22 32 03 13 23 33
-  // res[2]: 04 14 24 34 05 15 25 35
-  // res[3]: 06 16 26 36 07 17 27 37
-
-  int16x8x2_t s02 = vzipq_s16(s0, s2);
-  int16x8x2_t s13 = vzipq_s16(s1, s3);
-
-  int16x8x2_t s0123_lo = vzipq_s16(s02.val[0], s13.val[0]);
-  int16x8x2_t s0123_hi = vzipq_s16(s02.val[1], s13.val[1]);
-
-  res[0] = s0123_lo.val[0];
-  res[1] = s0123_lo.val[1];
-  res[2] = s0123_hi.val[0];
-  res[3] = s0123_hi.val[1];
-}
-
-static INLINE void vpx_tbl2x4_s16(int16x8_t s0[4], int16x8_t s1[4],
-                                  int16x8_t res[4], uint16x8_t idx) {
-  res[0] = vpx_tbl2_s16(s0[0], s1[0], idx);
-  res[1] = vpx_tbl2_s16(s0[1], s1[1], idx);
-  res[2] = vpx_tbl2_s16(s0[2], s1[2], idx);
-  res[3] = vpx_tbl2_s16(s0[3], s1[3], idx);
-}
-
-static INLINE void vpx_tbl2x2_s16(int16x8_t s0[2], int16x8_t s1[2],
-                                  int16x8_t res[2], uint16x8_t idx) {
-  res[0] = vpx_tbl2_s16(s0[0], s1[0], idx);
-  res[1] = vpx_tbl2_s16(s0[1], s1[1], idx);
-}
-
 static INLINE uint16x4_t highbd_convolve8_4_v(int16x8_t s_lo[2],
                                               int16x8_t s_hi[2],
                                               int16x8_t filter,
@@ -169,10 +103,10 @@ static INLINE void highbd_convolve8_8tap_vert_sve2(
     s += 7 * src_stride;
 
     int16x8_t s0123[2], s1234[2], s2345[2], s3456[2];
-    transpose_concat_4x4(s0, s1, s2, s3, s0123);
-    transpose_concat_4x4(s1, s2, s3, s4, s1234);
-    transpose_concat_4x4(s2, s3, s4, s5, s2345);
-    transpose_concat_4x4(s3, s4, s5, s6, s3456);
+    transpose_concat_s16_4x4(s0, s1, s2, s3, &s0123[0], &s0123[1]);
+    transpose_concat_s16_4x4(s1, s2, s3, s4, &s1234[0], &s1234[1]);
+    transpose_concat_s16_4x4(s2, s3, s4, s5, &s2345[0], &s2345[1]);
+    transpose_concat_s16_4x4(s3, s4, s5, s6, &s3456[0], &s3456[1]);
 
     do {
       int16x4_t s7, s8, s9, sA;
@@ -180,7 +114,7 @@ static INLINE void highbd_convolve8_8tap_vert_sve2(
       load_s16_4x4(s, src_stride, &s7, &s8, &s9, &sA);
 
       int16x8_t s4567[2], s5678[2], s6789[2], s789A[2];
-      transpose_concat_4x4(s7, s8, s9, sA, s789A);
+      transpose_concat_s16_4x4(s7, s8, s9, sA, &s789A[0], &s789A[1]);
 
       vpx_tbl2x2_s16(s3456, s789A, s4567, merge_tbl_idx.val[0]);
       vpx_tbl2x2_s16(s3456, s789A, s5678, merge_tbl_idx.val[1]);
@@ -219,17 +153,22 @@ static INLINE void highbd_convolve8_8tap_vert_sve2(
       s += 7 * src_stride;
 
       int16x8_t s0123[4], s1234[4], s2345[4], s3456[4];
-      transpose_concat_8x4(s0, s1, s2, s3, s0123);
-      transpose_concat_8x4(s1, s2, s3, s4, s1234);
-      transpose_concat_8x4(s2, s3, s4, s5, s2345);
-      transpose_concat_8x4(s3, s4, s5, s6, s3456);
+      transpose_concat_s16_8x4(s0, s1, s2, s3, &s0123[0], &s0123[1], &s0123[2],
+                               &s0123[3]);
+      transpose_concat_s16_8x4(s1, s2, s3, s4, &s1234[0], &s1234[1], &s1234[2],
+                               &s1234[3]);
+      transpose_concat_s16_8x4(s2, s3, s4, s5, &s2345[0], &s2345[1], &s2345[2],
+                               &s2345[3]);
+      transpose_concat_s16_8x4(s3, s4, s5, s6, &s3456[0], &s3456[1], &s3456[2],
+                               &s3456[3]);
 
       do {
         int16x8_t s7, s8, s9, sA;
         load_s16_8x4(s, src_stride, &s7, &s8, &s9, &sA);
 
         int16x8_t s4567[4], s5678[5], s6789[4], s789A[4];
-        transpose_concat_8x4(s7, s8, s9, sA, s789A);
+        transpose_concat_s16_8x4(s7, s8, s9, sA, &s789A[0], &s789A[1],
+                                 &s789A[2], &s789A[3]);
 
         vpx_tbl2x4_s16(s3456, s789A, s4567, merge_tbl_idx.val[0]);
         vpx_tbl2x4_s16(s3456, s789A, s5678, merge_tbl_idx.val[1]);
@@ -343,10 +282,10 @@ void vpx_highbd_convolve8_avg_vert_sve2(const uint16_t *src,
     s += 7 * src_stride;
 
     int16x8_t s0123[2], s1234[2], s2345[2], s3456[2];
-    transpose_concat_4x4(s0, s1, s2, s3, s0123);
-    transpose_concat_4x4(s1, s2, s3, s4, s1234);
-    transpose_concat_4x4(s2, s3, s4, s5, s2345);
-    transpose_concat_4x4(s3, s4, s5, s6, s3456);
+    transpose_concat_s16_4x4(s0, s1, s2, s3, &s0123[0], &s0123[1]);
+    transpose_concat_s16_4x4(s1, s2, s3, s4, &s1234[0], &s1234[1]);
+    transpose_concat_s16_4x4(s2, s3, s4, s5, &s2345[0], &s2345[1]);
+    transpose_concat_s16_4x4(s3, s4, s5, s6, &s3456[0], &s3456[1]);
 
     do {
       int16x4_t s7, s8, s9, sA;
@@ -354,7 +293,7 @@ void vpx_highbd_convolve8_avg_vert_sve2(const uint16_t *src,
       load_s16_4x4(s, src_stride, &s7, &s8, &s9, &sA);
 
       int16x8_t s4567[2], s5678[2], s6789[2], s789A[2];
-      transpose_concat_4x4(s7, s8, s9, sA, s789A);
+      transpose_concat_s16_4x4(s7, s8, s9, sA, &s789A[0], &s789A[1]);
 
       vpx_tbl2x2_s16(s3456, s789A, s4567, merge_tbl_idx.val[0]);
       vpx_tbl2x2_s16(s3456, s789A, s5678, merge_tbl_idx.val[1]);
@@ -398,17 +337,22 @@ void vpx_highbd_convolve8_avg_vert_sve2(const uint16_t *src,
       s += 7 * src_stride;
 
       int16x8_t s0123[4], s1234[4], s2345[4], s3456[4];
-      transpose_concat_8x4(s0, s1, s2, s3, s0123);
-      transpose_concat_8x4(s1, s2, s3, s4, s1234);
-      transpose_concat_8x4(s2, s3, s4, s5, s2345);
-      transpose_concat_8x4(s3, s4, s5, s6, s3456);
+      transpose_concat_s16_8x4(s0, s1, s2, s3, &s0123[0], &s0123[1], &s0123[2],
+                               &s0123[3]);
+      transpose_concat_s16_8x4(s1, s2, s3, s4, &s1234[0], &s1234[1], &s1234[2],
+                               &s1234[3]);
+      transpose_concat_s16_8x4(s2, s3, s4, s5, &s2345[0], &s2345[1], &s2345[2],
+                               &s2345[3]);
+      transpose_concat_s16_8x4(s3, s4, s5, s6, &s3456[0], &s3456[1], &s3456[2],
+                               &s3456[3]);
 
       do {
         int16x8_t s7, s8, s9, sA;
         load_s16_8x4(s, src_stride, &s7, &s8, &s9, &sA);
 
         int16x8_t s4567[4], s5678[5], s6789[4], s789A[4];
-        transpose_concat_8x4(s7, s8, s9, sA, s789A);
+        transpose_concat_s16_8x4(s7, s8, s9, sA, &s789A[0], &s789A[1],
+                                 &s789A[2], &s789A[3]);
 
         vpx_tbl2x4_s16(s3456, s789A, s4567, merge_tbl_idx.val[0]);
         vpx_tbl2x4_s16(s3456, s789A, s5678, merge_tbl_idx.val[1]);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/mem_neon.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/mem_neon.h
@@ -646,6 +646,65 @@ static INLINE void load_s16_4x8(const int16_t *s, const ptrdiff_t p,
   *s7 = vld1_s16(s);
 }
 
+static INLINE void load_s16_8x11(const int16_t *s, const ptrdiff_t p,
+                                 int16x8_t *s0, int16x8_t *s1, int16x8_t *s2,
+                                 int16x8_t *s3, int16x8_t *s4, int16x8_t *s5,
+                                 int16x8_t *s6, int16x8_t *s7, int16x8_t *s8,
+                                 int16x8_t *s9, int16x8_t *s10) {
+  *s0 = vld1q_s16(s);
+  s += p;
+  *s1 = vld1q_s16(s);
+  s += p;
+  *s2 = vld1q_s16(s);
+  s += p;
+  *s3 = vld1q_s16(s);
+  s += p;
+  *s4 = vld1q_s16(s);
+  s += p;
+  *s5 = vld1q_s16(s);
+  s += p;
+  *s6 = vld1q_s16(s);
+  s += p;
+  *s7 = vld1q_s16(s);
+  s += p;
+  *s8 = vld1q_s16(s);
+  s += p;
+  *s9 = vld1q_s16(s);
+  s += p;
+  *s10 = vld1q_s16(s);
+}
+
+static INLINE void load_s16_8x12(const int16_t *s, const ptrdiff_t p,
+                                 int16x8_t *s0, int16x8_t *s1, int16x8_t *s2,
+                                 int16x8_t *s3, int16x8_t *s4, int16x8_t *s5,
+                                 int16x8_t *s6, int16x8_t *s7, int16x8_t *s8,
+                                 int16x8_t *s9, int16x8_t *s10,
+                                 int16x8_t *s11) {
+  *s0 = vld1q_s16(s);
+  s += p;
+  *s1 = vld1q_s16(s);
+  s += p;
+  *s2 = vld1q_s16(s);
+  s += p;
+  *s3 = vld1q_s16(s);
+  s += p;
+  *s4 = vld1q_s16(s);
+  s += p;
+  *s5 = vld1q_s16(s);
+  s += p;
+  *s6 = vld1q_s16(s);
+  s += p;
+  *s7 = vld1q_s16(s);
+  s += p;
+  *s8 = vld1q_s16(s);
+  s += p;
+  *s9 = vld1q_s16(s);
+  s += p;
+  *s10 = vld1q_s16(s);
+  s += p;
+  *s11 = vld1q_s16(s);
+}
+
 static INLINE void load_s16_8x8(const int16_t *s, const ptrdiff_t p,
                                 int16x8_t *s0, int16x8_t *s1, int16x8_t *s2,
                                 int16x8_t *s3, int16x8_t *s4, int16x8_t *s5,

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/transpose_neon.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/transpose_neon.h
@@ -1549,4 +1549,158 @@ static INLINE void load_and_transpose_s32_8x8(
 
   transpose_s32_8x8(a0, a1, a2, a3, a4, a5, a6, a7);
 }
+
+static INLINE void transpose_concat_s16_4x4(const int16x4_t a0,
+                                            const int16x4_t a1,
+                                            const int16x4_t a2,
+                                            const int16x4_t a3, int16x8_t *b0,
+                                            int16x8_t *b1) {
+  // Transpose 16-bit elements:
+  // a0: 00, 01, 02, 03
+  // a1: 10, 11, 12, 13
+  // a2: 20, 21, 22, 23
+  // a3: 30, 31, 32, 33
+  //
+  // b0: 00 10 20 30 01 11 21 31
+  // b1: 02 12 22 32 03 13 23 33
+
+  int16x8_t a0q = vcombine_s16(a0, vdup_n_s16(0));
+  int16x8_t a1q = vcombine_s16(a1, vdup_n_s16(0));
+  int16x8_t a2q = vcombine_s16(a2, vdup_n_s16(0));
+  int16x8_t a3q = vcombine_s16(a3, vdup_n_s16(0));
+
+  int16x8_t a02 = vzipq_s16(a0q, a2q).val[0];
+  int16x8_t a13 = vzipq_s16(a1q, a3q).val[0];
+
+  int16x8x2_t a0123 = vzipq_s16(a02, a13);
+
+  *b0 = a0123.val[0];
+  *b1 = a0123.val[1];
+}
+
+static INLINE void transpose_concat_s16_8x4(const int16x8_t a0,
+                                            const int16x8_t a1,
+                                            const int16x8_t a2,
+                                            const int16x8_t a3, int16x8_t *b0,
+                                            int16x8_t *b1, int16x8_t *b2,
+                                            int16x8_t *b3) {
+  // Transpose 16-bit elements:
+  // a0: 00, 01, 02, 03, 04, 05, 06, 07
+  // a1: 10, 11, 12, 13, 14, 15, 16, 17
+  // a2: 20, 21, 22, 23, 24, 25, 26, 27
+  // a3: 30, 31, 32, 33, 34, 35, 36, 37
+  //
+  // b0: 00 10 20 30 01 11 21 31
+  // b1: 02 12 22 32 03 13 23 33
+  // b2: 04 14 24 34 05 15 25 35
+  // b3: 06 16 26 36 07 17 27 37
+
+  int16x8x2_t a02 = vzipq_s16(a0, a2);
+  int16x8x2_t a13 = vzipq_s16(a1, a3);
+
+  int16x8x2_t a0123_lo = vzipq_s16(a02.val[0], a13.val[0]);
+  int16x8x2_t a0123_hi = vzipq_s16(a02.val[1], a13.val[1]);
+
+  *b0 = a0123_lo.val[0];
+  *b1 = a0123_lo.val[1];
+  *b2 = a0123_hi.val[0];
+  *b3 = a0123_hi.val[1];
+}
+
+static INLINE void transpose_concat_s8_8x4(int8x8_t a0, int8x8_t a1,
+                                           int8x8_t a2, int8x8_t a3,
+                                           int8x16_t *b0, int8x16_t *b1) {
+  // Transpose 8-bit elements and concatenate result rows as follows:
+  // a0: 00, 01, 02, 03, 04, 05, 06, 07
+  // a1: 10, 11, 12, 13, 14, 15, 16, 17
+  // a2: 20, 21, 22, 23, 24, 25, 26, 27
+  // a3: 30, 31, 32, 33, 34, 35, 36, 37
+  //
+  // b0: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
+  // b1: 04, 14, 24, 34, 05, 15, 25, 35, 06, 16, 26, 36, 07, 17, 27, 37
+
+  int8x16_t a0q = vcombine_s8(a0, vdup_n_s8(0));
+  int8x16_t a1q = vcombine_s8(a1, vdup_n_s8(0));
+  int8x16_t a2q = vcombine_s8(a2, vdup_n_s8(0));
+  int8x16_t a3q = vcombine_s8(a3, vdup_n_s8(0));
+
+  int8x16_t a02 = vzipq_s8(a0q, a2q).val[0];
+  int8x16_t a13 = vzipq_s8(a1q, a3q).val[0];
+
+  int8x16x2_t a0123 = vzipq_s8(a02, a13);
+
+  *b0 = a0123.val[0];
+  *b1 = a0123.val[1];
+}
+
+static INLINE void transpose_concat_u8_8x4(uint8x8_t a0, uint8x8_t a1,
+                                           uint8x8_t a2, uint8x8_t a3,
+                                           uint8x16_t *b0, uint8x16_t *b1) {
+  // Transpose 8-bit elements and concatenate result rows as follows:
+  // a0: 00, 01, 02, 03, 04, 05, 06, 07
+  // a1: 10, 11, 12, 13, 14, 15, 16, 17
+  // a2: 20, 21, 22, 23, 24, 25, 26, 27
+  // a3: 30, 31, 32, 33, 34, 35, 36, 37
+  //
+  // b0: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
+  // b1: 04, 14, 24, 34, 05, 15, 25, 35, 06, 16, 26, 36, 07, 17, 27, 37
+
+  uint8x16_t a0q = vcombine_u8(a0, vdup_n_u8(0));
+  uint8x16_t a1q = vcombine_u8(a1, vdup_n_u8(0));
+  uint8x16_t a2q = vcombine_u8(a2, vdup_n_u8(0));
+  uint8x16_t a3q = vcombine_u8(a3, vdup_n_u8(0));
+
+  uint8x16_t a02 = vzipq_u8(a0q, a2q).val[0];
+  uint8x16_t a13 = vzipq_u8(a1q, a3q).val[0];
+
+  uint8x16x2_t a0123 = vzipq_u8(a02, a13);
+
+  *b0 = a0123.val[0];
+  *b1 = a0123.val[1];
+}
+
+static INLINE void transpose_concat_s8_4x4(int8x8_t a0, int8x8_t a1,
+                                           int8x8_t a2, int8x8_t a3,
+                                           int8x16_t *b) {
+  // Transpose 8-bit elements and concatenate result rows as follows:
+  // a0: 00, 01, 02, 03, XX, XX, XX, XX
+  // a1: 10, 11, 12, 13, XX, XX, XX, XX
+  // a2: 20, 21, 22, 23, XX, XX, XX, XX
+  // a3: 30, 31, 32, 33, XX, XX, XX, XX
+  //
+  // b: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
+
+  int8x16_t a0q = vcombine_s8(a0, vdup_n_s8(0));
+  int8x16_t a1q = vcombine_s8(a1, vdup_n_s8(0));
+  int8x16_t a2q = vcombine_s8(a2, vdup_n_s8(0));
+  int8x16_t a3q = vcombine_s8(a3, vdup_n_s8(0));
+
+  int8x16_t a02 = vzipq_s8(a0q, a2q).val[0];
+  int8x16_t a13 = vzipq_s8(a1q, a3q).val[0];
+
+  *b = vzipq_s8(a02, a13).val[0];
+}
+
+static INLINE void transpose_concat_u8_4x4(uint8x8_t a0, uint8x8_t a1,
+                                           uint8x8_t a2, uint8x8_t a3,
+                                           uint8x16_t *b) {
+  // Transpose 8-bit elements and concatenate result rows as follows:
+  // a0: 00, 01, 02, 03, XX, XX, XX, XX
+  // a1: 10, 11, 12, 13, XX, XX, XX, XX
+  // a2: 20, 21, 22, 23, XX, XX, XX, XX
+  // a3: 30, 31, 32, 33, XX, XX, XX, XX
+  //
+  // b: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
+
+  uint8x16_t a0q = vcombine_u8(a0, vdup_n_u8(0));
+  uint8x16_t a1q = vcombine_u8(a1, vdup_n_u8(0));
+  uint8x16_t a2q = vcombine_u8(a2, vdup_n_u8(0));
+  uint8x16_t a3q = vcombine_u8(a3, vdup_n_u8(0));
+
+  uint8x16_t a02 = vzipq_u8(a0q, a2q).val[0];
+  uint8x16_t a13 = vzipq_u8(a1q, a3q).val[0];
+
+  *b = vzipq_u8(a02, a13).val[0];
+}
+
 #endif  // VPX_VPX_DSP_ARM_TRANSPOSE_NEON_H_

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_convolve8_neon_dotprod.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_convolve8_neon_dotprod.c
@@ -360,53 +360,6 @@ void vpx_convolve8_avg_horiz_neon_dotprod(const uint8_t *src,
   }
 }
 
-static INLINE void transpose_concat_4x4(int8x8_t a0, int8x8_t a1, int8x8_t a2,
-                                        int8x8_t a3, int8x16_t *b) {
-  // Transpose 8-bit elements and concatenate result rows as follows:
-  // a0: 00, 01, 02, 03, XX, XX, XX, XX
-  // a1: 10, 11, 12, 13, XX, XX, XX, XX
-  // a2: 20, 21, 22, 23, XX, XX, XX, XX
-  // a3: 30, 31, 32, 33, XX, XX, XX, XX
-  //
-  // b: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
-
-  int8x16_t a0q = vcombine_s8(a0, vdup_n_s8(0));
-  int8x16_t a1q = vcombine_s8(a1, vdup_n_s8(0));
-  int8x16_t a2q = vcombine_s8(a2, vdup_n_s8(0));
-  int8x16_t a3q = vcombine_s8(a3, vdup_n_s8(0));
-
-  int8x16_t a02 = vzipq_s8(a0q, a2q).val[0];
-  int8x16_t a13 = vzipq_s8(a1q, a3q).val[0];
-
-  *b = vzipq_s8(a02, a13).val[0];
-}
-
-static INLINE void transpose_concat_8x4(int8x8_t a0, int8x8_t a1, int8x8_t a2,
-                                        int8x8_t a3, int8x16_t *b0,
-                                        int8x16_t *b1) {
-  // Transpose 8-bit elements and concatenate result rows as follows:
-  // a0: 00, 01, 02, 03, 04, 05, 06, 07
-  // a1: 10, 11, 12, 13, 14, 15, 16, 17
-  // a2: 20, 21, 22, 23, 24, 25, 26, 27
-  // a3: 30, 31, 32, 33, 34, 35, 36, 37
-  //
-  // b0: 00, 10, 20, 30, 01, 11, 21, 31, 02, 12, 22, 32, 03, 13, 23, 33
-  // b1: 04, 14, 24, 34, 05, 15, 25, 35, 06, 16, 26, 36, 07, 17, 27, 37
-
-  int8x16_t a0q = vcombine_s8(a0, vdup_n_s8(0));
-  int8x16_t a1q = vcombine_s8(a1, vdup_n_s8(0));
-  int8x16_t a2q = vcombine_s8(a2, vdup_n_s8(0));
-  int8x16_t a3q = vcombine_s8(a3, vdup_n_s8(0));
-
-  int8x16_t a02 = vzipq_s8(a0q, a2q).val[0];
-  int8x16_t a13 = vzipq_s8(a1q, a3q).val[0];
-
-  int8x16x2_t a0123 = vzipq_s8(a02, a13);
-
-  *b0 = a0123.val[0];
-  *b1 = a0123.val[1];
-}
-
 static INLINE int16x4_t convolve8_4_v(const int8x16_t samples_lo,
                                       const int8x16_t samples_hi,
                                       const int8x8_t filters) {
@@ -464,10 +417,10 @@ static INLINE void convolve_8tap_vert_neon_dotprod(
     // This operation combines a conventional transpose and the sample permute
     // (see horizontal case) required before computing the dot product.
     int8x16_t s0123, s1234, s2345, s3456;
-    transpose_concat_4x4(s0, s1, s2, s3, &s0123);
-    transpose_concat_4x4(s1, s2, s3, s4, &s1234);
-    transpose_concat_4x4(s2, s3, s4, s5, &s2345);
-    transpose_concat_4x4(s3, s4, s5, s6, &s3456);
+    transpose_concat_s8_4x4(s0, s1, s2, s3, &s0123);
+    transpose_concat_s8_4x4(s1, s2, s3, s4, &s1234);
+    transpose_concat_s8_4x4(s2, s3, s4, s5, &s2345);
+    transpose_concat_s8_4x4(s3, s4, s5, s6, &s3456);
 
     do {
       uint8x8_t t7, t8, t9, t10;
@@ -479,7 +432,7 @@ static INLINE void convolve_8tap_vert_neon_dotprod(
       int8x8_t s10 = vreinterpret_s8_u8(vsub_u8(t10, vdup_n_u8(128)));
 
       int8x16_t s78910;
-      transpose_concat_4x4(s7, s8, s9, s10, &s78910);
+      transpose_concat_s8_4x4(s7, s8, s9, s10, &s78910);
 
       // Merge new data into block from previous iteration.
       int8x16x2_t samples_LUT = { { s3456, s78910 } };
@@ -531,10 +484,10 @@ static INLINE void convolve_8tap_vert_neon_dotprod(
       // (see horizontal case) required before computing the dot product.
       int8x16_t s0123_lo, s0123_hi, s1234_lo, s1234_hi, s2345_lo, s2345_hi,
           s3456_lo, s3456_hi;
-      transpose_concat_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
-      transpose_concat_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
-      transpose_concat_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
-      transpose_concat_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
+      transpose_concat_s8_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
+      transpose_concat_s8_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
+      transpose_concat_s8_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
+      transpose_concat_s8_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
 
       do {
         uint8x8_t t7, t8, t9, t10;
@@ -546,7 +499,7 @@ static INLINE void convolve_8tap_vert_neon_dotprod(
         int8x8_t s10 = vreinterpret_s8_u8(vsub_u8(t10, vdup_n_u8(128)));
 
         int8x16_t s78910_lo, s78910_hi;
-        transpose_concat_8x4(s7, s8, s9, s10, &s78910_lo, &s78910_hi);
+        transpose_concat_s8_8x4(s7, s8, s9, s10, &s78910_lo, &s78910_hi);
 
         // Merge new data into block from previous iteration.
         int8x16x2_t samples_LUT = { { s3456_lo, s78910_lo } };
@@ -655,10 +608,10 @@ void vpx_convolve8_avg_vert_neon_dotprod(const uint8_t *src,
     // This operation combines a conventional transpose and the sample permute
     // (see horizontal case) required before computing the dot product.
     int8x16_t s0123, s1234, s2345, s3456;
-    transpose_concat_4x4(s0, s1, s2, s3, &s0123);
-    transpose_concat_4x4(s1, s2, s3, s4, &s1234);
-    transpose_concat_4x4(s2, s3, s4, s5, &s2345);
-    transpose_concat_4x4(s3, s4, s5, s6, &s3456);
+    transpose_concat_s8_4x4(s0, s1, s2, s3, &s0123);
+    transpose_concat_s8_4x4(s1, s2, s3, s4, &s1234);
+    transpose_concat_s8_4x4(s2, s3, s4, s5, &s2345);
+    transpose_concat_s8_4x4(s3, s4, s5, s6, &s3456);
 
     do {
       uint8x8_t t7, t8, t9, t10;
@@ -670,7 +623,7 @@ void vpx_convolve8_avg_vert_neon_dotprod(const uint8_t *src,
       int8x8_t s10 = vreinterpret_s8_u8(vsub_u8(t10, vdup_n_u8(128)));
 
       int8x16_t s78910;
-      transpose_concat_4x4(s7, s8, s9, s10, &s78910);
+      transpose_concat_s8_4x4(s7, s8, s9, s10, &s78910);
 
       // Merge new data into block from previous iteration.
       int8x16x2_t samples_LUT = { { s3456, s78910 } };
@@ -728,10 +681,10 @@ void vpx_convolve8_avg_vert_neon_dotprod(const uint8_t *src,
       // (see horizontal case) required before computing the dot product.
       int8x16_t s0123_lo, s0123_hi, s1234_lo, s1234_hi, s2345_lo, s2345_hi,
           s3456_lo, s3456_hi;
-      transpose_concat_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
-      transpose_concat_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
-      transpose_concat_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
-      transpose_concat_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
+      transpose_concat_s8_8x4(s0, s1, s2, s3, &s0123_lo, &s0123_hi);
+      transpose_concat_s8_8x4(s1, s2, s3, s4, &s1234_lo, &s1234_hi);
+      transpose_concat_s8_8x4(s2, s3, s4, s5, &s2345_lo, &s2345_hi);
+      transpose_concat_s8_8x4(s3, s4, s5, s6, &s3456_lo, &s3456_hi);
 
       do {
         uint8x8_t t7, t8, t9, t10;
@@ -743,7 +696,7 @@ void vpx_convolve8_avg_vert_neon_dotprod(const uint8_t *src,
         int8x8_t s10 = vreinterpret_s8_u8(vsub_u8(t10, vdup_n_u8(128)));
 
         int8x16_t s78910_lo, s78910_hi;
-        transpose_concat_8x4(s7, s8, s9, s10, &s78910_lo, &s78910_hi);
+        transpose_concat_s8_8x4(s7, s8, s9, s10, &s78910_lo, &s78910_hi);
 
         // Merge new data into block from previous iteration.
         int8x16x2_t samples_LUT = { { s3456_lo, s78910_lo } };

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_neon_sve2_bridge.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_neon_sve2_bridge.h
@@ -29,4 +29,18 @@ static INLINE int16x8_t vpx_tbl2_s16(int16x8_t s0, int16x8_t s1,
       svtbl2_s16(samples, svset_neonq_u16(svundef_u16(), tbl)));
 }
 
+static INLINE void vpx_tbl2x4_s16(int16x8_t s0[4], int16x8_t s1[4],
+                                  int16x8_t res[4], uint16x8_t idx) {
+  res[0] = vpx_tbl2_s16(s0[0], s1[0], idx);
+  res[1] = vpx_tbl2_s16(s0[1], s1[1], idx);
+  res[2] = vpx_tbl2_s16(s0[2], s1[2], idx);
+  res[3] = vpx_tbl2_s16(s0[3], s1[3], idx);
+}
+
+static INLINE void vpx_tbl2x2_s16(int16x8_t s0[2], int16x8_t s1[2],
+                                  int16x8_t res[2], uint16x8_t idx) {
+  res[0] = vpx_tbl2_s16(s0[0], s1[0], idx);
+  res[1] = vpx_tbl2_s16(s0[1], s1[1], idx);
+}
+
 #endif  // VPX_VPX_DSP_ARM_VPX_NEON_SVE2_BRIDGE_H_

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_neon_sve_bridge.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/vpx_neon_sve_bridge.h
@@ -48,4 +48,9 @@ static INLINE uint16x8_t vpx_tbl_u16(uint16x8_t data, uint16x8_t indices) {
                                    svset_neonq_u16(svundef_u16(), indices)));
 }
 
+static INLINE int16x8_t vpx_tbl_s16(int16x8_t data, uint16x8_t indices) {
+  return svget_neonq_s16(svtbl_s16(svset_neonq_s16(svundef_s16(), data),
+                                   svset_neonq_u16(svundef_u16(), indices)));
+}
+
 #endif  // VPX_VPX_DSP_ARM_VPX_NEON_SVE_BRIDGE_H_

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/psnr.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/psnr.c
@@ -177,7 +177,8 @@ int64_t vpx_highbd_get_y_sse(const YV12_BUFFER_CONFIG *a,
 #if CONFIG_VP9_HIGHBITDEPTH
 void vpx_calc_highbd_psnr(const YV12_BUFFER_CONFIG *a,
                           const YV12_BUFFER_CONFIG *b, PSNR_STATS *psnr,
-                          uint32_t bit_depth, uint32_t in_bit_depth) {
+                          uint32_t bit_depth, uint32_t in_bit_depth,
+                          int spatial_layer_id) {
   const int widths[3] = { a->y_crop_width, a->uv_crop_width, a->uv_crop_width };
   const int heights[3] = { a->y_crop_height, a->uv_crop_height,
                            a->uv_crop_height };
@@ -219,12 +220,13 @@ void vpx_calc_highbd_psnr(const YV12_BUFFER_CONFIG *a,
   psnr->samples[0] = total_samples;
   psnr->psnr[0] =
       vpx_sse_to_psnr((double)total_samples, peak, (double)total_sse);
+  psnr->spatial_layer_id = spatial_layer_id;
 }
 
 #endif  // !CONFIG_VP9_HIGHBITDEPTH
 
 void vpx_calc_psnr(const YV12_BUFFER_CONFIG *a, const YV12_BUFFER_CONFIG *b,
-                   PSNR_STATS *psnr) {
+                   PSNR_STATS *psnr, int spatial_layer_id) {
   static const double peak = 255.0;
   const int widths[3] = { a->y_crop_width, a->uv_crop_width, a->uv_crop_width };
   const int heights[3] = { a->y_crop_height, a->uv_crop_height,
@@ -255,4 +257,5 @@ void vpx_calc_psnr(const YV12_BUFFER_CONFIG *a, const YV12_BUFFER_CONFIG *b,
   psnr->samples[0] = total_samples;
   psnr->psnr[0] =
       vpx_sse_to_psnr((double)total_samples, peak, (double)total_sse);
+  psnr->spatial_layer_id = spatial_layer_id;
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/psnr.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/psnr.h
@@ -39,10 +39,11 @@ int64_t vpx_highbd_get_y_sse(const YV12_BUFFER_CONFIG *a,
                              const YV12_BUFFER_CONFIG *b);
 void vpx_calc_highbd_psnr(const YV12_BUFFER_CONFIG *a,
                           const YV12_BUFFER_CONFIG *b, PSNR_STATS *psnr,
-                          unsigned int bit_depth, unsigned int in_bit_depth);
+                          unsigned int bit_depth, unsigned int in_bit_depth,
+                          int spatial_layer_id);
 #endif
 void vpx_calc_psnr(const YV12_BUFFER_CONFIG *a, const YV12_BUFFER_CONFIG *b,
-                   PSNR_STATS *psnr);
+                   PSNR_STATS *psnr, int spatial_layer_id);
 
 double vpx_psnrhvs(const YV12_BUFFER_CONFIG *source,
                    const YV12_BUFFER_CONFIG *dest, double *phvs_y,


### PR DESCRIPTION
#### 6783ddf182775f6571d61262a7db6b5ba1a34016
<pre>
Resync libvpx up to M143
<a href="https://rdar.apple.com/161667351">rdar://161667351</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304397">https://bugs.webkit.org/show_bug.cgi?id=304397</a>

Reviewed by Jean-Yves Avenard.

We reland after a build fix for some internal builds that are not doing code stripping.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/304738@main">https://commits.webkit.org/304738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fccdeb928ae6996b629de496ae5338ec2d1b56ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144143 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/165ebf1e-a00a-4397-af2c-b17273d523e0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104327 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89486fc4-dd5e-454c-8b1c-05d7ecb10c2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85163 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11106ccc-6cdf-4209-a478-1ee000c98b2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4212 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4735 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41014 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6487 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118549 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8518 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36601 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->