### PR TITLE
SourceBufferParserWebM will not compile if AV1 is not enabled.

### DIFF
--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
@@ -51,6 +51,7 @@ typedef void (*VTDecompressionOutputCallback)(void * decompressionOutputRefCon, 
 
 static RetainPtr<CMVideoFormatDescriptionRef> computeAV1InputFormat(std::span<const uint8_t> data, int32_t width, int32_t height)
 {
+#if ENABLE(AV1)
     RefPtr videoInfo = createVideoInfoFromAV1Stream(data);
     if (!videoInfo)
         return { };
@@ -61,6 +62,13 @@ static RetainPtr<CMVideoFormatDescriptionRef> computeAV1InputFormat(std::span<co
         return { };
 
     return createFormatDescriptionFromTrackInfo(*videoInfo);
+#else
+    UNUSED_PARAM(data);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    ASSERT_NOT_REACHED();
+    return { };
+#endif
 }
 
 struct RTCFrameDecodeParams {


### PR DESCRIPTION
#### 25b4c4a5a86d37abdd22509fc4fbe70685943a6d
<pre>
SourceBufferParserWebM will not compile if AV1 is not enabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304485">https://bugs.webkit.org/show_bug.cgi?id=304485</a>
<a href="https://rdar.apple.com/166863150">rdar://166863150</a>

Reviewed by Youenn Fablet.

Ensure code conditional on ENABLE(AV1) is only called if ENABLE(AV1) is set.

* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnTrackEntry):
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
(WebCore::WebMParser::isSupportedVideoCodec):
(WebCore::SourceBufferParserWebM::isContentTypeSupported):
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(computeAV1InputFormat):

Canonical link: <a href="https://commits.webkit.org/304745@main">https://commits.webkit.org/304745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5416d3faddc7050bd4861e564c3d5c5d71fc4542

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144154 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/46bda025-67dd-48f9-aeaf-371a18b6753d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8643 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c3ec710-41ed-4727-8315-81b534640f59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122247 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ec165a62-e740-478c-bca2-a3d4be0cfe28) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6557 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4746 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146901 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41022 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7125 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/113022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6495 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118557 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8529 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->