### PR TITLE
Assert that m_ptr is non-null in RefPtr's `operator->`

### DIFF
--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -72,8 +72,8 @@ public:
 
     WARN_UNUSED_RETURN T* leakRef();
 
-    T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return &**this; }
 
     bool operator!() const { return !m_ptr; }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -682,17 +682,20 @@ WKRetainPtr<WKStringRef> InjectedBundle::backgroundFetchState(WKStringRef identi
 
 void InjectedBundle::textDidChangeInTextField()
 {
-    m_testRunner->textDidChangeInTextFieldCallback();
+    if (m_testRunner)
+        m_testRunner->textDidChangeInTextFieldCallback();
 }
 
 void InjectedBundle::textFieldDidBeginEditing()
 {
-    m_testRunner->textFieldDidBeginEditingCallback();
+    if (m_testRunner)
+        m_testRunner->textFieldDidBeginEditingCallback();
 }
 
 void InjectedBundle::textFieldDidEndEditing()
 {
-    m_testRunner->textFieldDidEndEditingCallback();
+    if (m_testRunner)
+        m_testRunner->textFieldDidEndEditingCallback();
 }
 
 void postMessage(const char* name)


### PR DESCRIPTION
#### e018e14a52a36302d6477e82a4bac29cb64ba283
<pre>
Assert that m_ptr is non-null in RefPtr&apos;s `operator-&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=304490">https://bugs.webkit.org/show_bug.cgi?id=304490</a>

Reviewed by Alan Baradlay.

Assert that m_ptr is non-null in RefPtr&apos;s `operator-&gt;`, to make it more
likely to catch bugs in debug builds. Unfortunately, we are not able to
use a RELEASE_ASSERT() due to performance constraints. However, a null
dereference is undefined behavior so it will not necessarily crash and get
caught unless we have an assertion in place.

* Source/WTF/wtf/RefPtr.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::textDidChangeInTextField):
(WTR::InjectedBundle::textFieldDidBeginEditing):
(WTR::InjectedBundle::textFieldDidEndEditing):

Canonical link: <a href="https://commits.webkit.org/304890@main">https://commits.webkit.org/304890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac8654160029ec830cb1b7fd668b37d26afeae36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89747 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e924df67-f38a-4990-99fc-d6bb80cb22bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0ea66db-d41d-4963-9e0e-a68779584f76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3405186e-a2e4-4af9-8954-aa91bdf53a7b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4521 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5094 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128735 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147262 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135260 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112946 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6753 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36889 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72431 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43841 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->