### PR TITLE
[WebDriver][BiDi]

### DIFF
--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -34,6 +34,7 @@
 
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
@@ -48,11 +49,14 @@ class ConsoleMessage;
 
 namespace WebCore {
 
+
+class LocalFrame;
+
 class WEBCORE_EXPORT AutomationInstrumentationClient : public AbstractRefCountedAndCanMakeWeakPtr<AutomationInstrumentationClient> {
 public:
     virtual ~AutomationInstrumentationClient() = default;
 
-    virtual void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) = 0;
+    virtual void addMessageToConsole(std::optional<FrameIdentifier>, const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) = 0;
 };
 
 
@@ -61,7 +65,8 @@ public:
     static void setClient(const AutomationInstrumentationClient&);
     static void clearClient();
 
-    static void addMessageToConsole(const std::unique_ptr<Inspector::ConsoleMessage>&);
+    static void addMessageToConsole(LocalFrame&, const std::unique_ptr<Inspector::ConsoleMessage>&);
+    static void addMessageToConsole(std::optional<FrameIdentifier>, const std::unique_ptr<Inspector::ConsoleMessage>&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -167,7 +167,7 @@ void FrameConsoleClient::addMessage(std::unique_ptr<Inspector::ConsoleMessage>&&
     }
 
 #if ENABLE(WEBDRIVER_BIDI)
-    AutomationInstrumentation::addMessageToConsole(consoleMessage);
+    AutomationInstrumentation::addMessageToConsole(frame.get(), consoleMessage);
 #endif
     InspectorInstrumentation::addMessageToConsole(frame.get(), WTF::move(consoleMessage));
 }
@@ -219,10 +219,10 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
     unsigned lineNumber = message->line();
     unsigned columnNumber = message->column();
 
-#if ENABLE(WEBDRIVER_BIDI)
-    AutomationInstrumentation::addMessageToConsole(message);
-#endif
     Ref frame = m_frame.get();
+#if ENABLE(WEBDRIVER_BIDI)
+    AutomationInstrumentation::addMessageToConsole(frame.get(), message);
+#endif
     InspectorInstrumentation::addMessageToConsole(frame.get(), WTF::move(message));
 
     RefPtr page = frame->page();

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -485,7 +485,8 @@ void WorkerGlobalScope::addConsoleMessage(std::unique_ptr<Inspector::ConsoleMess
         FrameConsoleClient::logMessageToSystemConsole(*message);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    AutomationInstrumentation::addMessageToConsole(message);
+    // FIXME What's the related browsing context for Workers?
+    AutomationInstrumentation::addMessageToConsole(std::nullopt, message);
 #endif
     InspectorInstrumentation::addMessageToConsole(*this, WTF::move(message));
 }
@@ -509,7 +510,8 @@ void WorkerGlobalScope::addMessage(MessageSource source, MessageLevel level, con
         message = makeUnique<Inspector::ConsoleMessage>(source, MessageType::Log, level, messageText, sourceURL, lineNumber, columnNumber, state, requestIdentifier);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    AutomationInstrumentation::addMessageToConsole(message);
+    // FIXME What's the related browsing context for Workers?
+    AutomationInstrumentation::addMessageToConsole(std::nullopt, message);
 #endif
     InspectorInstrumentation::addMessageToConsole(*this, WTF::move(message));
 }

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -3297,10 +3297,6 @@ void Session::dispatchBidiMessage(RefPtr<JSON::Object>&& message)
         }
 
         auto bidiMethod = bidiMessage->getString("method"_s);
-        if (!eventIsEnabled(bidiMethod, { })) {
-            RELEASE_LOG(WebDriverBiDi, "Message %s is an unknown event or not enabled, ignoring.", bidiMethod.utf8().data());
-            return;
-        }
         if (bidiMethod == "log.entryAdded"_s)
             bidiMessage = processLogEntryAdded(WTF::move(bidiMessage));
 
@@ -3383,125 +3379,6 @@ RefPtr<JSON::Object> Session::processLogEntryAdded(RefPtr<JSON::Object>&& messag
     // https://bugs.webkit.org/show_bug.cgi?id=282980
 
     return body;
-}
-
-bool Session::eventIsEnabled(const String& eventName, const Vector<String>&)
-{
-    // https://w3c.github.io/webdriver-bidi/#event-is-enabled
-
-    AtomString atomEventName { eventName };
-
-    if (!m_eventSubscriptionCounts.contains(atomEventName))
-        return false;
-
-    for (const auto& subscription : m_eventSubscriptions) {
-        // FIXME: Add support to subscribe to specific browsing contexts
-        // https://bugs.webkit.org/show_bug.cgi?id=282981
-        if (!subscription.value.isGlobal())
-            continue;
-
-        if (subscription.value.events.contains(atomEventName))
-            return true;
-    }
-
-    return false;
-}
-
-void Session::subscribeForEvents(const Vector<String>& events, Vector<String>&& browsingContextIDs, Vector<String>&& userContextIDs, Function<void(CommandResult&&)>&& completionHandler)
-{
-    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
-    // https://bugs.webkit.org/show_bug.cgi?id=291371
-    auto subscriptionID = WTF::createVersion4UUIDString();
-
-    for (const auto& event : events) {
-        auto addResult = m_eventSubscriptionCounts.add(AtomString { event }, 1);
-        if (!addResult.isNewEntry)
-            addResult.iterator->value++;
-    }
-
-    Vector<AtomString> atomEventNames;
-    for (const auto& event : events)
-        atomEventNames.append(AtomString { event });
-
-    m_eventSubscriptions.add(subscriptionID, EventSubscription { subscriptionID, WTF::move(atomEventNames), WTF::move(browsingContextIDs), WTF::move(userContextIDs) });
-    completionHandler(CommandResult::success(JSON::Value::create(subscriptionID)));
-}
-
-void Session::unsubscribeByIDs(const Vector<EventSubscriptionID>& subscriptionIDs, Function<void(CommandResult&&)>&& completionHandler)
-{
-    for (const auto& id : subscriptionIDs) {
-        if (!m_eventSubscriptions.contains(id)) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "At least one subscription id is unknown"_s));
-            return;
-        }
-    }
-
-    for (const auto& id : subscriptionIDs) {
-        const auto& subscription = m_eventSubscriptions.get(id);
-
-        for (const auto& event : subscription.events) {
-            auto removeResult = m_eventSubscriptionCounts.find(event);
-            if (removeResult != m_eventSubscriptionCounts.end()) {
-                if (!(--removeResult->value))
-                    m_eventSubscriptionCounts.remove(event);
-            }
-        }
-        m_eventSubscriptions.remove(id);
-    }
-    completionHandler(CommandResult::success());
-}
-
-void Session::unsubscribeByEventName(const Vector<String>& eventNames, Function<void(CommandResult&&)>&& completionHandler)
-
-{
-    HashMap<String, EventSubscription> subscriptionsToKeep;
-    HashSet<String> matchedEvents;
-    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
-    // https://bugs.webkit.org/show_bug.cgi?id=291371
-    for (const auto& eventName : eventNames) {
-        auto atomEventName = AtomString { eventName };
-        for (const auto& subscription : m_eventSubscriptions) {
-            if (!subscription.value.events.contains(atomEventName)) {
-                subscriptionsToKeep.add(subscription.value.id, subscription.value);
-                continue;
-            }
-
-            // FIXME: Add support to subscribe to specific browsing contexts
-            // https://bugs.webkit.org/show_bug.cgi?id=282981
-            // In this case, only process them if we were given the "contexts" parameter
-            if (!subscription.value.isGlobal()) {
-                subscriptionsToKeep.add(subscription.value.id, subscription.value);
-                continue;
-            }
-
-            auto currentSubscriptionEventNames = subscription.value.events;
-            currentSubscriptionEventNames.removeAll(atomEventName);
-            matchedEvents.add(eventName);
-            if (!currentSubscriptionEventNames.isEmpty()) {
-                auto clonedSubscription = subscription.value;
-                clonedSubscription.events = currentSubscriptionEventNames;
-                subscriptionsToKeep.add(clonedSubscription.id, WTF::move(clonedSubscription));
-            }
-        }
-    }
-
-    if (matchedEvents.size() != eventNames.size()) {
-        completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument));
-        return;
-    }
-
-    // Only modify the actual subscriptions after we validated all requested events.
-    m_eventSubscriptions = WTF::move(subscriptionsToKeep);
-    m_eventSubscriptionCounts.clear();
-    for (const auto& subscription : m_eventSubscriptions.values()) {
-        for (const auto& event : subscription.events) {
-            auto addResult = m_eventSubscriptionCounts.add(event, 1);
-            if (!addResult.isNewEntry)
-                addResult.iterator->value++;
-        }
-    }
-
-    completionHandler(CommandResult::success());
 }
 
 void Session::relayBidiCommand(const String& message, unsigned commandId, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)

--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -49,22 +49,6 @@ namespace WebDriver {
 class CommandResult;
 class SessionHost;
 
-#if ENABLE(WEBDRIVER_BIDI)
-using EventSubscriptionID = String;
-
-struct EventSubscription {
-    EventSubscriptionID id;
-    Vector<AtomString> events;
-    Vector<String> browsingContextIDs;
-    Vector<String> userContextIDs;
-
-    bool isGlobal() const
-    {
-        return browsingContextIDs.isEmpty() && userContextIDs.isEmpty();
-    }
-};
-#endif
-
 class Session :
 #if ENABLE(WEBDRIVER_BIDI)
 public BidiMessageHandler // Inherits RefCounted
@@ -175,9 +159,6 @@ public:
     void takeScreenshot(std::optional<String> elementID, std::optional<bool> scrollIntoView, Function<void(CommandResult&&)>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    void subscribeForEvents(const Vector<String>& events, Vector<String>&& browsingContextIDs, Vector<String>&& userContextIDs, Function<void(CommandResult&&)>&&);
-    void unsubscribeByIDs(const Vector<EventSubscriptionID>&, Function<void(CommandResult&&)>&&);
-    void unsubscribeByEventName(const Vector<String>& events, Function<void(CommandResult&&)>&&);
     void dispatchBidiMessage(RefPtr<JSON::Object>&&);
     void relayBidiCommand(const String&, unsigned commandId, Function<void(WebSocketMessageHandler::Message&&)>&&);
 #endif
@@ -290,14 +271,7 @@ private:
 #if ENABLE(WEBDRIVER_BIDI)
     bool m_hasBiDiEnabled { false };
 
-    // https://w3c.github.io/webdriver-bidi/#events
-    HashMap<AtomString, unsigned> m_eventSubscriptionCounts;
-    HashMap<EventSubscriptionID, EventSubscription> m_eventSubscriptions;
     WeakPtr<WebSocketServer> m_bidiServer;
-
-    bool eventIsEnabled(const String&, const Vector<String>&);
-    void emitEvent(const String&, RefPtr<JSON::Object>&&);
-    String toInternalEventName(const String&);
 
     // Actual event handlers
     RefPtr<JSON::Object> processLogEntryAdded(RefPtr<JSON::Object>&&);

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -297,8 +297,6 @@ const WebDriverService::Command WebDriverService::s_commands[] = {
 #if ENABLE(WEBDRIVER_BIDI)
 const WebDriverService::BidiCommand WebDriverService::s_bidiCommands[] = {
     { "session.status"_s, &WebDriverService::bidiSessionStatus },
-    { "session.subscribe"_s, &WebDriverService::bidiSessionSubscribe },
-    { "session.unsubscribe"_s, &WebDriverService::bidiSessionUnsubscribe },
 };
 #endif
 
@@ -2737,95 +2735,6 @@ void WebDriverService::bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Fu
         result->setString("message"_s, "Maximum number of sessions created"_s);
 
     completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, WTF::move(result)));
-}
-
-void WebDriverService::bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&parameters, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)
-{
-    // https://w3c.github.io/webdriver-bidi/#command-session-subscribe
-    auto eventNamesJSON = parameters->getArray("events"_s);
-
-    if (!eventNamesJSON) {
-        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing 'events' parameter"_s, id));
-        return;
-    }
-
-    // FIXME: Support event priorities.
-    // https://bugs.webkit.org/show_bug.cgi?id=282436
-    // FIXME: Support by-context subscriptions.
-    // https://bugs.webkit.org/show_bug.cgi?id=282981
-    Vector<String> eventNames;
-    for (auto& eventNameJS : *eventNamesJSON) {
-        auto eventName = eventNameJS->asString();
-        if (!eventName) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid event name"_s, id));
-            return;
-        }
-        eventNames.append(eventName);
-    }
-    m_session->subscribeForEvents(eventNames, { }, { }, [id, completionHandler = WTF::move(completionHandler)](CommandResult&& subscriptionResult) mutable {
-        if (subscriptionResult.isError()) {
-            auto errorMessage = subscriptionResult.errorMessage() ? subscriptionResult.errorMessage() : "Failed to subscribe"_s;
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, errorMessage, id));
-            return;
-        }
-        auto result = JSON::Object::create();
-        result->setString("subscription"_s, subscriptionResult.result()->asString());
-
-        completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, WTF::move(result)));
-    });
-}
-
-void WebDriverService::bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&&parameters, Function<void(WebSocketMessageHandler::Message&&)>&& completionHandler)
-{
-    // https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe
-    auto subscriptions = parameters->getArray("subscriptions"_s);
-    if (!subscriptions) {
-        auto events = parameters->getArray("events"_s);
-        if (!events) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing either 'events' or 'subscriptions' parameter"_s, id));
-            return;
-        }
-
-        Vector<String> eventNames;
-        for (auto& event : *events) {
-            auto eventName = event->asString();
-            if (!eventName) {
-                completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid event name"_s, id));
-                return;
-            }
-
-            eventNames.append(eventName);
-        }
-
-        m_session->unsubscribeByEventName(eventNames, [id, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
-            if (result.isError()) {
-                auto errorMessage = result.errorMessage() ? result.errorMessage() : "Failed to unsubscribe"_s;
-                completionHandler(WebSocketMessageHandler::Message::fail(result.errorCode(), std::nullopt, errorMessage, id));
-                return;
-            }
-            completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, JSON::Value::null()));
-        });
-        return;
-    }
-
-    Vector<String> subscriptionsIDs;
-    for (auto& subscription : *subscriptions) {
-        auto subscriptionID = subscription->asString();
-        if (!subscriptionID) {
-            completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Invalid subscription ID"_s, id));
-            return;
-        }
-        subscriptionsIDs.append(subscriptionID);
-    }
-
-    m_session->unsubscribeByIDs(WTF::move(subscriptionsIDs), [id, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
-        if (result.isError()) {
-            auto errorMessage = result.errorMessage() ? result.errorMessage() : "Failed to unsubscribe"_s;
-            completionHandler(WebSocketMessageHandler::Message::fail(result.errorCode(), std::nullopt, errorMessage, id));
-            return;
-        }
-        completionHandler(WebSocketMessageHandler::Message::reply("success"_s, id, JSON::Value::null()));
-    });
 }
 
 void WebDriverService::clientDisconnected(const WebSocketMessageHandler::Connection& connection)

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -139,8 +139,6 @@ private:
 
 #if ENABLE(WEBDRIVER_BIDI)
     void bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
-    void bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
-    void bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
 #endif
 
     static Capabilities platformCapabilities();

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -595,6 +595,7 @@ UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
 UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
 UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify
 UIProcess/Automation/BidiScriptAgent.cpp @no-unify
+UIProcess/Automation/BidiSessionAgent.cpp @no-unify
 UIProcess/Automation/BidiStorageAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiSessionAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "Logging.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include <wtf/HashSet.h>
+#include <wtf/UUID.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiSessionAgent);
+
+BidiSessionAgent::BidiSessionAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_sessionDomainDispatcher(BidiSessionBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiSessionAgent::~BidiSessionAgent() = default;
+
+void BidiSessionAgent::subscribe(Ref<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, RefPtr<JSON::Array>&& userContexts, Inspector::CommandCallback<Inspector::Protocol::BidiSession::Subscription>&& callback)
+{
+    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
+    // https://bugs.webkit.org/show_bug.cgi?id=291371
+
+    auto subscriptionID = WTF::createVersion4UUIDString();
+
+    HashSet<AtomString> atomEventNames;
+    for (const auto& event : events.get()) {
+        auto eventName = event->asString();
+        if (eventName.isEmpty())
+            return callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "Event name must be a valid string."_s)));
+        atomEventNames.add(AtomString { eventName });
+    }
+
+    if (contexts && userContexts && (contexts->length() > 0) && (userContexts->length() > 0))
+        return callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "Contexts and user contexts cannot be used together."_s)));
+
+    for (const auto& event : atomEventNames) {
+        auto addResult = m_eventSubscriptionCounts.add(event, 1);
+        if (!addResult.isNewEntry)
+            addResult.iterator->value++;
+    }
+
+    // FIXME: Support by-context subscriptions.
+    // https://bugs.webkit.org/show_bug.cgi?id=282981
+    // Also: spec says we need to convert into top-level browsing contexts.
+    if (contexts && contexts->length())
+        LOG(Automation, "BidiSessionAgent::subscribe: Ignoring contexts parameter, as by-context subscriptions are not supported yet.");
+
+    if (userContexts && userContexts->length())
+        LOG(Automation, "BidiSessionAgent::subscribe: Ignoring userContexts parameter, as by-user-context subscriptions are not supported yet.");
+
+    LOG(Automation, "BidiSessionAgent::subscribe: adding subscriptionID=%s, events=%s",
+        subscriptionID.utf8().data(),
+        events->toJSONString().utf8().data());
+    m_eventSubscriptions.add(subscriptionID, BidiEventSubscription { subscriptionID, WTF::move(atomEventNames), { }, { } });
+
+    callback({ subscriptionID });
+}
+
+void BidiSessionAgent::unsubscribeByEventName(RefPtr<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, Inspector::CommandCallback<void>&& callback)
+{
+    RELEASE_LOG(Automation, "BidiSessionAgent::unsubscribeByEventName: events=%s, contexts=%s",
+        events ? events->toJSONString().utf8().data() : "null",
+        contexts ? contexts->toJSONString().utf8().data() : "null");
+
+    if (!events || !events->length()) {
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "At least one event name must be provided."_s)));
+        return;
+    }
+
+    // FIXME: Support by-context subscriptions.
+    // https://bugs.webkit.org/show_bug.cgi?id=282981
+    // Maybe we'll don't need to support this at all at unsubscribe(), as this parameter is deprecated in the spec.
+    if (contexts && contexts->length())
+        LOG(Automation, "BidiSessionAgent::unsubscribe: Ignoring contexts parameter, as by-context subscriptions are not supported yet.");
+
+    HashMap<String, BidiEventSubscription> subscriptionsToKeep;
+    HashSet<String> matchedEvents;
+    // FIXME: Process/validate list of event names (e.g. expanding if given only the module name)
+    // https://bugs.webkit.org/show_bug.cgi?id=291371
+    HashSet<AtomString> eventNames;
+    for (const auto& event : *events) {
+        auto eventName = event->asString();
+        if (eventName.isEmpty()) {
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "Event name must be a valid non-empty string."_s)));
+            return;
+        }
+        eventNames.add(AtomString { eventName });
+    }
+
+    for (const auto& subscription : m_eventSubscriptions) {
+        auto commonEventNames = eventNames.intersectionWith(subscription.value.events);
+        if (!commonEventNames.size()) {
+            subscriptionsToKeep.add(subscription.value.id, subscription.value);
+            continue;
+        }
+
+        // FIXME: Add support to subscribe to specific browsing contexts
+        // https://bugs.webkit.org/show_bug.cgi?id=282981
+        // In this case, only process them if we were given the "contexts" parameter
+        if (!subscription.value.isGlobal()) {
+            subscriptionsToKeep.add(subscription.value.id, subscription.value);
+            continue;
+        }
+
+        auto currentSubscriptionEventNames = subscription.value.events;
+        for (const auto& eventName : commonEventNames) {
+            matchedEvents.add(eventName);
+            currentSubscriptionEventNames.remove(eventName);
+        }
+        if (!currentSubscriptionEventNames.isEmpty()) {
+            auto clonedSubscription = subscription.value;
+            clonedSubscription.events = currentSubscriptionEventNames;
+            subscriptionsToKeep.add(clonedSubscription.id, WTF::move(clonedSubscription));
+        }
+    }
+
+    if (matchedEvents.size() != eventNames.size()) {
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "Some events are not subscribed to."_s)));
+        return;
+    }
+
+    // Only modify the actual subscriptions after we validated all requested events.
+    m_eventSubscriptions = WTF::move(subscriptionsToKeep);
+    m_eventSubscriptionCounts.clear();
+    for (const auto& subscription : m_eventSubscriptions.values()) {
+        for (const auto& event : subscription.events) {
+            auto addResult = m_eventSubscriptionCounts.add(event, 1);
+            if (!addResult.isNewEntry)
+                addResult.iterator->value++;
+        }
+    }
+
+    callback({ });
+}
+
+void BidiSessionAgent::unsubscribe(RefPtr<JSON::Array>&& subscriptions, RefPtr<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, Inspector::CommandCallback<void>&& callback)
+{
+    RELEASE_LOG(Automation, "BidiSessionAgent::unsubscribe: subscriptions=%s, events=%s, contexts=%s",
+        subscriptions ? subscriptions->toJSONString().utf8().data() : "null",
+        events ? events->toJSONString().utf8().data() : "null",
+        contexts ? contexts->toJSONString().utf8().data() : "null");
+
+    if (!subscriptions) {
+        unsubscribeByEventName(WTF::move(events), WTF::move(contexts), WTF::move(callback));
+        return;
+    }
+
+    Vector<String> subscriptionIDs;
+    for (auto& subscription : *subscriptions) {
+        auto subscriptionID = subscription->asString();
+        if (!subscriptionID) {
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "Subscription ID must be a valid string."_s)));
+            return;
+        }
+
+        if (!m_eventSubscriptions.contains(subscriptionID)) {
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InvalidParameter, "At least one subscription ID is unknown."_s)));
+            return;
+        }
+        subscriptionIDs.append(subscriptionID);
+    }
+
+    for (const auto& id : subscriptionIDs) {
+        const auto& subscription = m_eventSubscriptions.get(id);
+
+        for (const auto& event : subscription.events) {
+            auto removeResult = m_eventSubscriptionCounts.find(event);
+            if (removeResult != m_eventSubscriptionCounts.end()) {
+                if (!(--removeResult->value))
+                    m_eventSubscriptionCounts.remove(event);
+            }
+        }
+        m_eventSubscriptions.remove(id);
+    }
+
+    callback({ });
+};
+
+bool BidiSessionAgent::eventIsEnabled(const String& eventName, const HashSet<String>& browsingContexts)
+{
+    // https://w3c.github.io/webdriver-bidi/#event-is-enabled
+
+    AtomString atomEventName { eventName };
+
+    if (!m_eventSubscriptionCounts.contains(atomEventName))
+        return false;
+
+    for (const auto& subscription : m_eventSubscriptions) {
+        // FIXME: Add support to subscribe to specific browsing contexts
+        // https://bugs.webkit.org/show_bug.cgi?id=282981
+        if (!subscription.value.isGlobal())
+            continue;
+
+        if (subscription.value.events.contains(atomEventName))
+            return true;
+    }
+
+    return false;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "WebDriverBidiBackendDispatchers.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+using Subscription = Inspector::Protocol::BidiSession::Subscription;
+using UserContext = Inspector::Protocol::BidiBrowser::UserContext;
+
+struct BidiEventSubscription {
+    Subscription id;
+    HashSet<AtomString> events;
+    HashSet<BrowsingContext> browsingContextIDs;
+    HashSet<UserContext> userContextIDs;
+
+    bool isGlobal() const
+    {
+        return browsingContextIDs.isEmpty() && userContextIDs.isEmpty();
+    }
+};
+
+class BidiSessionAgent final : public Inspector::BidiSessionBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiSessionAgent);
+public:
+    BidiSessionAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiSessionAgent() override;
+
+    void subscribe(Ref<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, RefPtr<JSON::Array>&& userContexts, Inspector::CommandCallback<Inspector::Protocol::BidiSession::Subscription>&&) override;
+    void unsubscribe(RefPtr<JSON::Array>&& subscriptions, RefPtr<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, Inspector::CommandCallback<void>&&) override;
+
+    bool eventIsEnabled(const String& eventName, const HashSet<String>& browsingContexts);
+
+private:
+
+    void unsubscribeByEventName(RefPtr<JSON::Array>&& events, RefPtr<JSON::Array>&& contexts, Inspector::CommandCallback<void>&&);
+
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiSessionBackendDispatcher> m_sessionDomainDispatcher;
+
+    // https://w3c.github.io/webdriver-bidi/#events
+    HashMap<AtomString, unsigned> m_eventSubscriptionCounts;
+    HashMap<Subscription, BidiEventSubscription> m_eventSubscriptions;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiSessionAgent.h
@@ -31,6 +31,7 @@
 #include "WebDriverBidiBackendDispatchers.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -54,6 +55,8 @@ struct BidiEventSubscription {
     {
         return browsingContextIDs.isEmpty() && userContextIDs.isEmpty();
     }
+
+    String asString() const;
 };
 
 class BidiSessionAgent final : public Inspector::BidiSessionBackendDispatcherHandler {

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -809,7 +809,8 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page, const St
 
         // FIXME: propagate the 'userPromptHandler' from session capabilities.
         auto userPromptHandlerType = Inspector::Protocol::BidiSession::UserPromptHandlerType::Accept;
-        m_bidiProcessor->browsingContextDomainNotifier().userPromptOpened(handleForWebPageProxy(page), userPromptType, userPromptHandlerType, message, m_client->defaultTextOfCurrentJavaScriptDialogOnPage(*this, page).value_or(defaultText.value_or(emptyString())));
+        if (m_bidiProcessor->eventIsEnabled("browsingContext.userPromptOpened"_s, { }))
+            m_bidiProcessor->browsingContextDomainNotifier().userPromptOpened(handleForWebPageProxy(page), userPromptType, userPromptHandlerType, message, m_client->defaultTextOfCurrentJavaScriptDialogOnPage(*this, page).value_or(defaultText.value_or(emptyString())));
 #endif
 
         if (page->protectedPageLoadState()->isLoading()) {
@@ -985,7 +986,8 @@ static String navigationIDToProtocolString(std::optional<WebCore::NavigationIden
 void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.domContentLoaded"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
 #endif
 
     if (frame.isMainFrame()) {
@@ -1008,7 +1010,8 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
 void WebAutomationSession::loadCompletedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.load"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
 #endif
 }
 
@@ -1057,27 +1060,32 @@ void WebAutomationSession::didCreatePage(WebPageProxy& page)
 
 void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.navigationStarted"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
 }
 
 void WebAutomationSession::navigationCommittedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.navigationCommitted"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
 }
 
 void WebAutomationSession::navigationFailedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.navigationFailed"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
 }
 
 void WebAutomationSession::navigationAbortedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.navigationAborted"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
 }
 
 void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.fragmentNavigated"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
 }
 
 void WebAutomationSession::emitContextCreatedEvent(const WebPageProxy& page)
@@ -1144,7 +1152,8 @@ void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.contextCreated"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
 }
 
 void WebAutomationSession::recursivelyEmitContextCreatedEvent(const FrameTreeNodeData& tree, std::optional<String>&& parentContext)
@@ -1173,7 +1182,8 @@ void WebAutomationSession::recursivelyEmitContextCreatedEvent(const FrameTreeNod
     // FIXME: Use JSON null instead of string "null" when Inspector::Protocol supports RefPtr<String> or std::optional<String>
     String parentContextHandle = parentContext.value_or("null"_s);
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, originalOpenerHandle, parentContextHandle, WTF::move(children), clientWindow, userContext);
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.contextCreated"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, originalOpenerHandle, parentContextHandle, WTF::move(children), clientWindow, userContext);
 
     for (const auto& child : tree.children)
         recursivelyEmitContextCreatedEvent(child, contextHandle);
@@ -1196,7 +1206,8 @@ void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
 
     auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, originalOpenerHandle, parentContext, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.contextDestroyed"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, originalOpenerHandle, parentContext, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
 
     m_handleWebPageMap.remove(contextHandle);
     m_webPageHandleMap.remove(page.identifier());
@@ -1219,7 +1230,8 @@ void WebAutomationSession::contextDestroyedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.contextDestroyed"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
 
     // Note: Frame handle cleanup is done by didDestroyFrame(), so we don't duplicate that here
 }
@@ -1574,7 +1586,8 @@ CommandResult<void> WebAutomationSession::dismissCurrentJavaScriptDialog(const I
     auto apiDialogType = m_client->typeOfCurrentJavaScriptDialogOnPage(*this, *page);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!apiDialogType, InternalError);
 
-    m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), false, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.userPromptClosed"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), false, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
 #endif
     m_client->dismissCurrentJavaScriptDialogOnPage(*this, *page);
 
@@ -1596,7 +1609,8 @@ CommandResult<void> WebAutomationSession::acceptCurrentJavaScriptDialog(const In
     auto apiDialogType = m_client->typeOfCurrentJavaScriptDialogOnPage(*this, *page);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!apiDialogType, InternalError);
 
-    m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), true, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
+    if (m_bidiProcessor->eventIsEnabled("browsingContext.userPromptClosed"_s, { }))
+        m_bidiProcessor->browsingContextDomainNotifier().userPromptClosed(handleForWebPageProxy(*page), toProtocolUserPromptType(apiDialogType.value()), true, m_client->userInputOfCurrentJavaScriptDialogOnPage(*this, *page).value_or(emptyString()));
 #endif
 
     m_client->acceptCurrentJavaScriptDialogOnPage(*this, *page);
@@ -2884,6 +2898,8 @@ static String logEntryTypeForMessage(const JSC::MessageSource& messageSource)
 void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource, const JSC::MessageLevel& messageLevel, const String& messageText, const JSC::MessageType& messageType, const WallTime& timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
+    if (!m_bidiProcessor->eventIsEnabled("log.entryAdded"_s, { }))
+        return;
     // FIXME Support getting source information
     // https://bugs.webkit.org/show_bug.cgi?id=282978
     String sourceString;

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -313,6 +313,7 @@ public:
     String effectiveHandleForWebFrameProxy(const WebFrameProxy&);
     String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
     String handleForWebPageProxy(const WebPageProxy&);
+    String topLevelHandleForHandle(const String&);
 
     Expected<PageAndFrameHandle, AutomationCommandError> extractBrowsingContextHandles(const String&);
 
@@ -342,7 +343,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Called by WebAutomationSession messages.
-    void logEntryAdded(const JSC::MessageSource&, const JSC::MessageLevel&, const String& messageText, const JSC::MessageType&, const WallTime&);
+    void logEntryAdded(std::optional<WebCore::FrameIdentifier>, const JSC::MessageSource&, const JSC::MessageLevel&, const String& messageText, const JSC::MessageType&, const WallTime&);
 
     // Platform-dependent implementations.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
@@ -26,5 +26,5 @@
     ExceptionForEnabledBy
 ]
 messages -> WebAutomationSession {
-    LogEntryAdded(enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String messageText, enum:uint8_t JSC::MessageType messageType, WallTime timestamp)
+    LogEntryAdded(std::optional<WebCore::FrameIdentifier> frameID, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String messageText, enum:uint8_t JSC::MessageType messageType, WallTime timestamp)
 }

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -35,6 +35,7 @@
 #include "BidiBrowsingContextAgent.h"
 #include "BidiPermissionsAgent.h"
 #include "BidiScriptAgent.h"
+#include "BidiSessionAgent.h"
 #include "BidiStorageAgent.h"
 #include "Logging.h"
 #include "WebAutomationSession.h"
@@ -57,6 +58,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_browsingContextAgent(makeUniqueRef<BidiBrowsingContextAgent>(session, m_backendDispatcher))
     , m_permissionsAgent(makeUniqueRef<BidiPermissionsAgent>(session, m_backendDispatcher))
     , m_scriptAgent(makeUniqueRef<BidiScriptAgent>(session, m_backendDispatcher))
+    , m_sessionAgent(makeUniqueRef<BidiSessionAgent>(session, m_backendDispatcher))
     , m_storageAgent(makeUniqueRef<BidiStorageAgent>(session, m_backendDispatcher))
     , m_browsingContextDomainNotifier(makeUniqueRef<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
     , m_logDomainNotifier(makeUniqueRef<BidiLogFrontendDispatcher>(m_frontendRouter))
@@ -211,6 +213,10 @@ void WebDriverBidiProcessor::sendBidiMessage(const String& message)
     session->sendBidiMessage(msgObj->toJSONString());
 }
 
+bool WebDriverBidiProcessor::eventIsEnabled(const String& eventName, const HashSet<String>& contexts)
+{
+    return m_sessionAgent->eventIsEnabled(eventName, contexts);
+}
 
 // MARK: Inspector::FrontendChannel methods.
 

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -40,6 +40,7 @@ class BidiBrowserAgent;
 class BidiBrowsingContextAgent;
 class BidiPermissionsAgent;
 class BidiScriptAgent;
+class BidiSessionAgent;
 class BidiStorageAgent;
 class WebAutomationSession;
 class WebPageProxy;
@@ -64,6 +65,8 @@ public:
     Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const { return m_browsingContextDomainNotifier; }
     Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const { return m_logDomainNotifier; }
 
+    bool eventIsEnabled(const String& eventName, const HashSet<String>& contexts);
+
 private:
     WeakPtr<WebAutomationSession> m_session;
 
@@ -74,6 +77,7 @@ private:
     const UniqueRef<BidiBrowsingContextAgent> m_browsingContextAgent;
     const UniqueRef<BidiPermissionsAgent> m_permissionsAgent;
     const UniqueRef<BidiScriptAgent> m_scriptAgent;
+    const UniqueRef<BidiSessionAgent> m_sessionAgent;
     const UniqueRef<BidiStorageAgent> m_storageAgent;
     const UniqueRef<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
     const UniqueRef<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
@@ -7,11 +7,46 @@
     "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session",
     "types": [
         {
+            "id": "Subscription",
+            "description": "A unique identifier for a subscription.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-session-Subscription",
+            "type": "string"
+        },
+        {
             "id": "UserPromptHandlerType",
             "description": "A type that represents the behavior of the user prompt handler.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Target",
             "type": "string",
             "enum": [ "accept", "dismiss", "ignore" ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "subscribe",
+            "description": "Subscribes to events from the remote end.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-session-subscribe",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session/subscribe/",
+            "async": true,
+            "parameters": [
+                { "name": "events", "type": "array", "items": { "type": "string" }, "description": "The list of events to subscribe to." },
+                { "name": "contexts", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "description": "Browsing contexts to subscribe to", "optional": true },
+                { "name": "userContexts", "type": "array", "items": { "$ref": "BidiBrowser.UserContext" }, "description": "User contexts to subscribe to", "optional": true }
+            ],
+            "returns": [
+                { "name": "subscription", "$ref": "Subscription", "description": "A unique identifier for the subscription.", "optional": true }
+            ]
+        },
+        {
+            "name": "unsubscribe",
+            "description": "Unsubscribes from events from the remote end.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session/subscribe/",
+            "async": true,
+            "parameters": [
+                { "name": "subscriptions", "type": "array", "items": { "$ref": "Subscription" }, "description": "A unique identifier for the subscription.", "optional": true },
+                { "name": "events", "type": "array", "items": { "type": "string" }, "description": "The list of events to subscribe to.", "optional": true },
+                { "name": "contexts", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "description": "Browsing contexts to subscribe to", "optional": true }
+            ]
         }
     ]
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1561,6 +1561,8 @@
 		5CFFD8482DEF511C00C421F5 /* SwiftDemoLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */; };
 		5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */; };
 		5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */; };
+		5EEC72522DC1B32300D012DD /* BidiSessionAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */; };
+		5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */; };
 		5F4D67D682584880B7E5A569 /* RemoteLayerTreeCommitBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EB76B251B844C7BCAAAF04 /* RemoteLayerTreeCommitBundle.h */; };
 		63108F961F96719C00A0DB84 /* _WKApplicationManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		63108F991F9671F700A0DB84 /* _WKApplicationManifestInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */; };
@@ -6721,6 +6723,8 @@
 		5EB592AB2DC2049A0058664B /* BidiStorage.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiStorage.json; sourceTree = "<group>"; };
 		5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiStorageAgent.cpp; sourceTree = "<group>"; };
 		5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiStorageAgent.h; sourceTree = "<group>"; };
+		5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiSessionAgent.cpp; sourceTree = "<group>"; };
+		5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiSessionAgent.h; sourceTree = "<group>"; };
 		63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifest.h; sourceTree = "<group>"; };
 		63108F951F96719C00A0DB84 /* _WKApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKApplicationManifest.mm; sourceTree = "<group>"; };
 		63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifestInternal.h; sourceTree = "<group>"; };
@@ -14787,6 +14791,8 @@
 				997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */,
 				F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */,
 				F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */,
+				5EEC724F2DC1B32000D012DD /* BidiSessionAgent.cpp */,
+				5EEC72512DC1B32200D012DD /* BidiSessionAgent.h */,
 				5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */,
 				5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */,
 				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
@@ -17763,6 +17769,7 @@
 				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
 				997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */,
 				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
+				5EEC72522DC1B32300D012DD /* BidiSessionAgent.h in Headers */,
 				5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */,
 				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,
@@ -21513,6 +21520,7 @@
 				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
 				997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */,
 				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
+				5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */,
 				5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1090,9 +1090,9 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
 }
 
 #if ENABLE(WEBDRIVER_BIDI)
-void WebAutomationSessionProxy::addMessageToConsole(const JSC::MessageSource& source, const JSC::MessageLevel& level, const String& messageText, const JSC::MessageType& type, const WallTime& timestamp)
+void WebAutomationSessionProxy::addMessageToConsole(std::optional<WebCore::FrameIdentifier> frameID, const JSC::MessageSource& source, const JSC::MessageLevel& level, const String& messageText, const JSC::MessageType& type, const WallTime& timestamp)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebAutomationSession::LogEntryAdded(source, level, messageText, type, timestamp), 0);
+    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebAutomationSession::LogEntryAdded(frameID, source, level, messageText, type, timestamp), 0);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -109,7 +109,7 @@ private:
     void deleteCookie(WebCore::PageIdentifier, std::optional<WebCore::FrameIdentifier>, String cookieName, CompletionHandler<void(std::optional<String>)>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) override;
+    void addMessageToConsole(std::optional<WebCore::FrameIdentifier>, const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) override;
 #endif
 
     String m_sessionIdentifier;

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -3959,13 +3959,13 @@
     "imported/w3c/webdriver/tests/bidi/session/subscribe/events.py": {
         "subtests": {
             "test_subscribe_to_module": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/291371"}}
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
             },
             "test_subscribe_to_one_event_and_then_to_module": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/291371"}}
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
             },
             "test_subscribe_to_module_and_then_to_one_event_again": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/291371"}}
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
@@ -4019,13 +4019,24 @@
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288107"}}
     },
+    "imported/w3c/webdriver/tests/bidi/session/unsubscribe/contexts.py": {
+        "subtests": {
+            "test_unsubscribe_from_one_context_after_navigation": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unsubscribe_from_one_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}
+    },
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/events.py": {
         "subtests": {
             "test_unsubscribe_from_module": {
                 "expected": {"all": {"status": ["PASS"]}}
             },
             "test_subscribe_to_module_unsubscribe_from_one_event": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/291371"}}
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}
@@ -4091,7 +4102,7 @@
                 "expected": {"all": {"status": ["PASS"]}}
             },
             "test_unsubscribe_partially_from_one_context": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/287930"}}
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -3973,7 +3973,12 @@
     "imported/w3c/webdriver/tests/bidi/session/subscribe/invalid.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286763"}},
         "subtests": {
+            "test_params_contexts_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_contexts_invalid_type[value3]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_empty": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_value_invalid_event_name[]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[None]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
@@ -3993,7 +3998,14 @@
             },
             "test_params_events_value_invalid_type[value4]": {
                 "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/286793"}}
-            }
+            },
+            "test_params_user_context_and_contexts": {
+                "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_user_context_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_user_context_invalid_type[value3]": {"expected": {"all": {"status": ["PASS"]}}}
         }
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/user_contexts.py": {
@@ -4022,6 +4034,7 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}},
         "subtests": {
             "test_params_empty": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_empty": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[None]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},


### PR DESCRIPTION
#### 47cbe3584dc5399c7ad970dfc4265760c68a1912
<pre>
[WebDriver][BiDi] Allow subscription to events from specific navigables/browsing contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=282981">https://bugs.webkit.org/show_bug.cgi?id=282981</a>

Reviewed by NOBODY (OOPS!).

Note: Tests from WPT are still failing because they use
`script.callFunction` with parameters, which requires deserialization of
these parameters, not yet implemented.

This patch depends on the bug295497, moving the event subscription
inside the browser.

* Source/WebCore/automation/AutomationInstrumentation.cpp:
(WebCore::AutomationInstrumentation::addMessageToConsole):
* Source/WebCore/automation/AutomationInstrumentation.h:
* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::addMessage):
(WebCore::FrameConsoleClient::messageWithTypeAndLevel):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::addConsoleMessage):
(WebCore::WorkerGlobalScope::addMessage):
* Source/WebKit/UIProcess/Automation/BidiSessionAgent.cpp:
(WebKit::BidiSessionAgent::subscribe):
(WebKit::BidiSessionAgent::eventIsEnabled):
* Source/WebKit/UIProcess/Automation/BidiSessionAgent.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::topLevelHandleForHandle):
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::documentLoadedForFrame):
(WebKit::WebAutomationSession::loadCompletedForFrame):
(WebKit::WebAutomationSession::navigationStartedForFrame):
(WebKit::WebAutomationSession::navigationCommittedForFrame):
(WebKit::WebAutomationSession::navigationFailedForFrame):
(WebKit::WebAutomationSession::navigationAbortedForFrame):
(WebKit::WebAutomationSession::fragmentNavigatedForFrame):
(WebKit::WebAutomationSession::contextCreatedForFrame):
(WebKit::WebAutomationSession::recursivelyEmitContextCreatedEvent):
(WebKit::WebAutomationSession::contextDestroyedForPage):
(WebKit::WebAutomationSession::contextDestroyedForFrame):
(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::logEntryAdded):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::addMessageToConsole):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* WebDriverTests/TestExpectations.json:
</pre>
----------------------------------------------------------------------
#### 3e6ef33b5f8af5ed34b5242f6fdcc6143abdb12c
<pre>
[WebDriver][BiDi] Move event subscription inside the browser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295497">https://bugs.webkit.org/show_bug.cgi?id=295497</a>

Reviewed by NOBODY (OOPS!).

Moving the implementation from Source/WebDriver into the
UIProcess&apos;s Bidi automation code.

Having subscription on the browser will make it easier checking which
events are enabled, especially non-global events, alongside avoiding
excessive message exchange between the browser and driver from the
increasing number of events supported.

For example, as of around <a href="https://commits.webkit.org/302979@main">302979@main</a>, without this patch, the Selenium
`api_example_tests.py` sends 303 events back to the driver, despite not
enabling any WebDriver-BiDi event. With this patch, all events are
filtered at the browser level.

In this commit, we also replace the Vectors used to track the
subscription fields with HashSets, preparing the way to support
subscriptions by individual browsing contexts. This helped refactor the
unsubscription logic to better match the spec, looping through the
current subscriptions instead of through the individual event names.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47cbe3584dc5399c7ad970dfc4265760c68a1912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87617 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6817 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7864 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150347 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11497 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115467 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9927 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11540 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/823 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11275 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75207 "Found 2 new failures in UIProcess/Automation/BidiSessionAgent.cpp") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->