### PR TITLE
Reduce unsafeness in WebCore/inspector

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -43,7 +43,6 @@ editing/TextIterator.cpp
 html/HTMLMediaElement.cpp
 html/canvas/PlaceholderRenderingContext.cpp
 html/shadow/DateTimeEditElement.h
-[ Mac ] inspector/InspectorFrontendHost.h
 inspector/InspectorInstrumentation.h
 inspector/InspectorStyleSheet.h
 inspector/InstrumentingAgents.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -3,12 +3,6 @@ Modules/mediastream/RTCPeerConnection.h
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
 Modules/notifications/NotificationResourcesLoader.h
 Modules/push-api/PushManager.h
-[ Mac ] inspector/InspectorFrontendHost.cpp
-[ Mac ] inspector/InspectorFrontendHost.h
-[ iOS ] page/ios/ContentChangeObserver.h
-[ iOS ] platform/audio/ios/AudioSessionIOS.mm
-[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
-[ iOS ] platform/ios/wak/WAKWindow.h
 accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
@@ -29,15 +23,14 @@ dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h
 dom/TreeScope.h
-inspector/InspectorShaderProgram.h
-inspector/InspectorStyleSheet.h
-inspector/InspectorWebAgentBase.h
 layout/formattingContexts/inline/InlineItemsBuilder.h
 page/FrameSnapshotting.cpp
 page/WheelEventTestMonitor.h
+[ iOS ] page/ios/ContentChangeObserver.h
 page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingTreeGestureState.h
 platform/PODInterval.h
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/graphics/GraphicsLayer.h
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -47,6 +40,8 @@ platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
 platform/graphics/filters/software/FELightingSoftwareApplier.h
 platform/graphics/filters/software/FEMorphologySoftwareApplier.h
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+[ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
+[ iOS ] platform/ios/wak/WAKWindow.h
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
 platform/mock/ScrollbarsControllerMock.h

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -57,7 +57,7 @@ class CSSStyleImageValue;
 
 template<typename> struct InspectorCanvasArgumentProcessor;
 
-class InspectorCanvas final : public RefCounted<InspectorCanvas> {
+class InspectorCanvas final : public RefCountedAndCanMakeWeakPtr<InspectorCanvas> {
 public:
     static Ref<InspectorCanvas> create(CanvasRenderingContext&);
 

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -151,7 +151,7 @@ private:
         m_items.clear();
     }
 
-    InspectorFrontendHost* m_frontendHost;
+    WeakPtr<InspectorFrontendHost> m_frontendHost;
     JSC::JSGlobalObject* m_globalObject;
     JSC::Strong<JSC::JSObject> m_frontendApiObject;
     Vector<ContextMenuItem> m_items;
@@ -176,8 +176,8 @@ void InspectorFrontendHost::disconnectClient()
 {
     m_client = nullptr;
 #if ENABLE(CONTEXT_MENUS)
-    if (m_menuProvider)
-        m_menuProvider->disconnect();
+    if (RefPtr menuProvider = m_menuProvider.get())
+        menuProvider->disconnect();
 #endif
     m_frontendPage = nullptr;
 }
@@ -595,8 +595,8 @@ void InspectorFrontendHost::showContextMenu(Event& event, Vector<ContextMenuItem
     ContextMenu menu;
     populateContextMenu(WTF::move(items), menu);
 
-    auto menuProvider = FrontendMenuProvider::create(this, &globalObject, frontendAPIObject, menu.items());
-    m_menuProvider = menuProvider.ptr();
+    Ref menuProvider = FrontendMenuProvider::create(this, &globalObject, frontendAPIObject, menu.items());
+    m_menuProvider = menuProvider;
     m_frontendPage->contextMenuController().showContextMenu(event, menuProvider);
 #else
     UNUSED_PARAM(event);

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -32,7 +32,7 @@
 #include <WebCore/ContextMenu.h>
 #include <WebCore/ContextMenuProvider.h>
 #include <WebCore/InspectorFrontendClient.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -51,7 +51,7 @@ class Page;
 class Path2D;
 template<typename> class ExceptionOr;
 
-class InspectorFrontendHost : public RefCounted<InspectorFrontendHost> {
+class InspectorFrontendHost : public RefCountedAndCanMakeWeakPtr<InspectorFrontendHost> {
 public:
     static Ref<InspectorFrontendHost> create(InspectorFrontendClient* client, Page* frontendPage)
     {
@@ -189,7 +189,7 @@ private:
     InspectorFrontendClient* m_client;
     WeakPtr<Page> m_frontendPage;
 #if ENABLE(CONTEXT_MENUS)
-    FrontendMenuProvider* m_menuProvider;
+    WeakPtr<FrontendMenuProvider> m_menuProvider;
 #endif
 };
 

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -39,8 +39,8 @@ public:
     static Ref<InspectorShaderProgram> create(WebGLProgram&, InspectorCanvas&);
 
     const String& identifier() const { return m_identifier; }
-    InspectorCanvas& canvas() const { return m_canvas; }
-    WebGLProgram& program() const { return m_program; }
+    InspectorCanvas& canvas() const { return m_canvas.get(); }
+    WebGLProgram& program() const { return m_program.get(); }
 
     String requestShaderSource(Inspector::Protocol::Canvas::ShaderType);
     bool updateShader(Inspector::Protocol::Canvas::ShaderType, const String& source);
@@ -57,8 +57,8 @@ private:
     InspectorShaderProgram(WebGLProgram&, InspectorCanvas&);
 
     String m_identifier;
-    InspectorCanvas& m_canvas;
-    WebGLProgram& m_program;
+    WeakRef<InspectorCanvas> m_canvas;
+    WeakRef<WebGLProgram> m_program;
     bool m_disabled { false };
     bool m_highlighted { false };
 };

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -145,10 +146,10 @@ private:
 
     InspectorCSSId m_styleId;
     const Ref<CSSStyleDeclaration> m_style;
-    InspectorStyleSheet* m_parentStyleSheet;
+    WeakPtr<InspectorStyleSheet> m_parentStyleSheet;
 };
 
-class InspectorStyleSheet : public RefCounted<InspectorStyleSheet> {
+class InspectorStyleSheet : public RefCountedAndCanMakeWeakPtr<InspectorStyleSheet> {
 public:
     class Listener {
     public:

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -44,7 +44,7 @@ struct WebAgentContext : public Inspector::AgentContext {
     {
     }
 
-    InstrumentingAgents& instrumentingAgents;
+    WeakRef<InstrumentingAgents> instrumentingAgents;
 };
 
 struct PageAgentContext : public WebAgentContext {

--- a/Source/WebCore/page/ContextMenuProvider.h
+++ b/Source/WebCore/page/ContextMenuProvider.h
@@ -41,7 +41,7 @@ namespace WebCore {
 class ContextMenu;
 class ContextMenuContext;
 
-class ContextMenuProvider : public RefCounted<ContextMenuProvider> {
+class ContextMenuProvider : public RefCountedAndCanMakeWeakPtr<ContextMenuProvider> {
 public:
     virtual ~ContextMenuProvider() { };
 


### PR DESCRIPTION
#### b97920ee6560d21e8c07dde197b7790356eb5c8f
<pre>
Reduce unsafeness in WebCore/inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=304492">https://bugs.webkit.org/show_bug.cgi?id=304492</a>

Reviewed by Chris Dumez.

As a first pass we get rid of the remaining unsafe member variables.
See also <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304815@main">https://commits.webkit.org/304815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b5e1ee7963f789e449986392603ceec9b249253

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144286 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef258171-7c4b-4483-af09-0f6e510cf5a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/32270e6f-deaf-4d1d-97da-6d007ba6414f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139507 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/7014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ac2edd7f-41dc-4875-867e-d700721db6b8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4330 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4882 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147044 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8605 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7231 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/113106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6586 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62623 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21059 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8653 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->