### PR TITLE
Unreviewed, reverting 304723@main (66ebed132bc6)

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -177,7 +177,7 @@ void PopUpSOAuthorizationSession::close(WKWebView *webView)
         return;
     }
     m_secretWebView = nullptr;
-    AUTHORIZATIONSESSION_RELEASE_LOG("SecretWebView is cleaned.");
+    WTFLogAlways("SecretWebView is cleaned.");
 }
 
 void PopUpSOAuthorizationSession::initSecretWebView()
@@ -195,7 +195,7 @@ void PopUpSOAuthorizationSession::initSecretWebView()
     [m_secretWebView setNavigationDelegate:m_secretDelegate.get()];
 
     RELEASE_ASSERT(!m_secretWebView->_page->protectedPreferences()->isExtensibleSSOEnabled());
-    AUTHORIZATIONSESSION_RELEASE_LOG("SecretWebView is created.");
+    WTFLogAlways("SecretWebView is created.");
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -69,8 +69,7 @@ public:
     void shouldStart();
 
     // The following should only be called by SOAuthorizationDelegate methods.
-    enum class UserCancel : bool { No, Yes };
-    void fallBackToWebPath(UserCancel = UserCancel::No);
+    void fallBackToWebPath();
     void abort();
     // Only responses that meet all of the following requirements will be processed:
     // 1) it has the same origin as the request;
@@ -104,7 +103,6 @@ protected:
 private:
     virtual void shouldStartInternal() = 0;
     virtual void fallBackToWebPathInternal() = 0;
-    virtual void userCancel() { fallBackToWebPathInternal(); }
     virtual void abortInternal() = 0;
     virtual void completeInternal(const WebCore::ResourceResponse&, NSData *) = 0;
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -274,7 +274,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
     [m_soAuthorization beginAuthorizationWithURL:retainPtr(nsRequest.get().URL).get() httpHeaders:retainPtr(nsRequest.get().allHTTPHeaderFields).get() httpBody:retainPtr(nsRequest.get().HTTPBody).get()];
 }
 
-void SOAuthorizationSession::fallBackToWebPath(UserCancel userCancel)
+void SOAuthorizationSession::fallBackToWebPath()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPath");
 
@@ -285,10 +285,7 @@ void SOAuthorizationSession::fallBackToWebPath(UserCancel userCancel)
     }
 
     becomeCompleted();
-    if (userCancel == UserCancel::Yes)
-        this->userCancel();
-    else
-        fallBackToWebPathInternal();
+    fallBackToWebPathInternal();
 }
 
 void SOAuthorizationSession::abort()

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -53,7 +53,6 @@ private:
     // SOAuthorizationSession
     void fallBackToWebPathInternal() final;
     void abortInternal() final;
-    void userCancel() final;
     void completeInternal(const WebCore::ResourceResponse&, NSData *) final;
 
     // NavigationSOAuthorizationSession

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -50,7 +50,6 @@ namespace {
 
 constexpr auto soAuthorizationPostDidStartMessageToParent = "<script>parent.postMessage('SOAuthorizationDidStart', '*');</script>"_s;
 constexpr auto soAuthorizationPostDidCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidCancel', '*');</script>"_s;
-constexpr auto soAuthorizationPostDidUserCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidUserCancel', '*');</script>"_s;
 
 } // namespace
 
@@ -78,14 +77,6 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
     appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidCancelMessageToParent.span8()));
-    appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
-}
-
-void SubFrameSOAuthorizationSession::userCancel()
-{
-    AUTHORIZATIONSESSION_RELEASE_LOG("userCancel: navigationAction=%p", navigationAction());
-    ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidUserCancelMessageToParent.span8()));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
@@ -146,14 +146,6 @@
         ASSERT_NOT_REACHED();
         return;
     }
-
-    NSString *authenticationErrorDomain = @"AKAuthenticationError"; // AKAppleIDAuthenticationErrorDomain
-    constexpr NSInteger userCanceled = -7003; // AKAuthenticationErrorUserCanceled
-    if ([error.domain isEqualToString:authenticationErrorDomain] && error.code == userCanceled) {
-        WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: User cancelled");
-        return session->fallBackToWebPath(WebKit::SOAuthorizationSession::UserCancel::Yes);
-    }
-
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: Falling back to web path.");
     session->fallBackToWebPath();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -2663,32 +2663,6 @@ TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
     EXPECT_FALSE(policyForAppSSOPerformed);
 }
 
-TEST(SOAuthorizationSubFrame, UserCancel)
-{
-    resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
-    SWIZZLE_AKAUTH();
-
-    RetainPtr baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
-    String testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
-
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
-    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
-    configureSOAuthorizationWebView(webView.get(), delegate.get());
-
-    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
-    Util::run(&allMessagesReceived);
-
-    [messageHandler extendExpectations:@[@"null", @"SOAuthorizationDidUserCancel", @""]];
-    [gDelegate authorization:gAuthorization didCompleteWithError:adoptNS([[NSError alloc] initWithDomain:@"AKAuthenticationError" code:-7003 userInfo:nil]).get()];
-    Util::run(&allMessagesReceived);
-}
-
 TEST(SOAuthorizationSubFrame, InterceptionError)
 {
     resetState();


### PR DESCRIPTION
#### 9a541decb4d3f63917194d3e842ce5036ccb4322
<pre>
Unreviewed, reverting 304723@main (66ebed132bc6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304497">https://bugs.webkit.org/show_bug.cgi?id=304497</a>
<a href="https://rdar.apple.com/166882156">rdar://166882156</a>

REGRESSION(304723@main): Broke Internal macOS builds

Reverted change:

    SubFrameSOAuthorizationSession should post new message to parent when authorization cancels with a UserCanceled error
    <a href="https://bugs.webkit.org/show_bug.cgi?id=304350">https://bugs.webkit.org/show_bug.cgi?id=304350</a>
    <a href="https://rdar.apple.com/164667729">rdar://164667729</a>
    304723@main (66ebed132bc6)

Canonical link: <a href="https://commits.webkit.org/304755@main">https://commits.webkit.org/304755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d42f5b4b186e6e89f68c0fd17a0327cfb2af8f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136467 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47747 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/144180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138339 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/9510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/8668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/144180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7951283-b3c8-4991-b745-227151daa213) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139412 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/9510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/144180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2bd9beeb-1de5-460f-9d35-ffe10221fc98) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/9510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/4773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/9510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/8506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/146929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/8523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/8668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/146929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/118584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62494 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21036 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/8554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/8273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/72113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/8494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/8346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->