### PR TITLE
WebTransport WT-Protocol header should be able to handle structured field item parameters

### DIFF
--- a/Source/WebCore/platform/network/RFC8941.h
+++ b/Source/WebCore/platform/network/RFC8941.h
@@ -40,7 +40,7 @@ private:
     String m_token;
 };
 
-using BareItem = Variant<String, Token, bool>; // FIXME: The specification supports more BareItem types.
+using BareItem = Variant<int64_t, double, String, Token, Vector<uint8_t>, bool>;
 
 class Parameters {
 public:

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -39,6 +39,7 @@
 #import <WebCore/ClientOrigin.h>
 #import <WebCore/Exception.h>
 #import <WebCore/ExceptionCode.h>
+#import <WebCore/RFC8941.h>
 #import <WebCore/WebTransportConnectionInfo.h>
 #import <WebCore/WebTransportConnectionStats.h>
 #import <WebCore/WebTransportReceiveStreamStats.h>
@@ -327,7 +328,12 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
                     if (canLoad_Network_nw_webtransport_metadata_copy_connect_response()) {
                         RetainPtr response = adoptNS(softLink_Network_nw_webtransport_metadata_copy_connect_response(metadata.get()));
                         nw_http_fields_access_value_by_name(response.get(), "wt-protocol", ^void(const char *value) {
-                            protocol = String::fromUTF8(unsafeSpan(value));
+                            if (auto parsedItem = RFC8941::parseItemStructuredFieldValue(String::fromUTF8(unsafeSpan(value)))) {
+                                if (auto* stringValue = std::get_if<String>(&parsedItem->first)) {
+                                    if (protectedThis->m_options.protocols.contains(*stringValue))
+                                        protocol = *stringValue;
+                                }
+                            }
                         });
                     }
                     if (canLoad_Network_nw_webtransport_metadata_get_transport_mode()) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
@@ -163,6 +163,296 @@ TEST(RFC8941, ParseItemStructuredFieldValue)
     parameterValueString = result->second.getIf<String>("report-to"_s);
     EXPECT_TRUE(!!parameterValueString);
     EXPECT_STREQ("http://example.com", parameterValueString->utf8().data());
+
+    // Integer BareItem tests.
+    result = RFC8941::parseItemStructuredFieldValue("42"_s);
+    EXPECT_TRUE(!!result);
+    auto* intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 42);
+
+    result = RFC8941::parseItemStructuredFieldValue("0"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 0);
+
+    result = RFC8941::parseItemStructuredFieldValue("-42"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, -42);
+
+    result = RFC8941::parseItemStructuredFieldValue("-0"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 0);
+
+    result = RFC8941::parseItemStructuredFieldValue("042"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 42);
+
+    result = RFC8941::parseItemStructuredFieldValue("-042"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, -42);
+
+    result = RFC8941::parseItemStructuredFieldValue("999999999999999"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 999999999999999LL);
+
+    result = RFC8941::parseItemStructuredFieldValue("-999999999999999"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, -999999999999999LL);
+
+    result = RFC8941::parseItemStructuredFieldValue("000000000000000"_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 0);
+
+    // Invalid Integer BareItem.
+    result = RFC8941::parseItemStructuredFieldValue("0000000000000000"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("9999999999999999"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-9999999999999999"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-."_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("--0"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("- 42"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("2,3"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-a23"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("4-2"_s);
+    EXPECT_FALSE(!!result);
+
+    // Decimal BareItem tests.
+    result = RFC8941::parseItemStructuredFieldValue("1.5"_s);
+    EXPECT_TRUE(!!result);
+    auto* decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 1.5);
+
+    result = RFC8941::parseItemStructuredFieldValue("-1.5"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, -1.5);
+
+    result = RFC8941::parseItemStructuredFieldValue("0.0"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 0.0);
+
+    result = RFC8941::parseItemStructuredFieldValue("1.123"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 1.123);
+
+    result = RFC8941::parseItemStructuredFieldValue("-1.123"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, -1.123);
+
+    result = RFC8941::parseItemStructuredFieldValue("1.000"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 1.0);
+
+    result = RFC8941::parseItemStructuredFieldValue("123456789012.123"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 123456789012.123);
+
+    result = RFC8941::parseItemStructuredFieldValue("000000000100.123"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 100.123);
+
+    result = RFC8941::parseItemStructuredFieldValue("-999999999999.999"_s);
+    EXPECT_TRUE(!!result);
+    decimalValue = std::get_if<double>(&result->first);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, -999999999999.999);
+
+    // Invalid Decimal BareItem.
+    result = RFC8941::parseItemStructuredFieldValue("0000000000000.1"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1.0000"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-1.1234"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1."_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-1."_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1.1234"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1234567890123.0"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("-1234567890123.0"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1. 23"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1 .23"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1..4"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("1.5.4"_s);
+    EXPECT_FALSE(!!result);
+
+    // Byte sequence BareItem tests.
+    result = RFC8941::parseItemStructuredFieldValue("::"_s);
+    EXPECT_TRUE(!!result);
+    auto* bytes = std::get_if<Vector<uint8_t>>(&result->first);
+    EXPECT_TRUE(!!bytes);
+    EXPECT_TRUE(bytes->isEmpty());
+
+    result = RFC8941::parseItemStructuredFieldValue(":aGVsbG8=:"_s);
+    EXPECT_TRUE(!!result);
+    bytes = std::get_if<Vector<uint8_t>>(&result->first);
+    EXPECT_TRUE(!!bytes);
+    EXPECT_EQ(bytes->size(), 5u);
+    EXPECT_EQ((*bytes)[0], 'h');
+    EXPECT_EQ((*bytes)[1], 'e');
+    EXPECT_EQ((*bytes)[2], 'l');
+    EXPECT_EQ((*bytes)[3], 'l');
+    EXPECT_EQ((*bytes)[4], 'o');
+
+    result = RFC8941::parseItemStructuredFieldValue(":cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBjb250ZW50Lg==:"_s);
+    EXPECT_TRUE(!!result);
+    bytes = std::get_if<Vector<uint8_t>>(&result->first);
+    EXPECT_TRUE(!!bytes);
+    EXPECT_EQ(bytes->size(), 31u);
+
+    result = RFC8941::parseItemStructuredFieldValue(":/+Ah:"_s);
+    EXPECT_TRUE(!!result);
+    bytes = std::get_if<Vector<uint8_t>>(&result->first);
+    EXPECT_TRUE(!!bytes);
+    EXPECT_EQ(bytes->size(), 3u);
+
+    // Invalid Byte sequence BareItem.
+    result = RFC8941::parseItemStructuredFieldValue("aGVsbG8=:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":aGVsbG8="_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue("aGVsbG8="_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":=aGVsbG8=:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":a=GVsbG8=:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":aGVsbG8.:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":aGVsb G8=:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":aGVsbG!8=:"_s);
+    EXPECT_FALSE(!!result);
+
+    result = RFC8941::parseItemStructuredFieldValue(":_-Ah:"_s);
+    EXPECT_FALSE(!!result);
+
+    // Integer parameter tests.
+    result = RFC8941::parseItemStructuredFieldValue("token;count=42"_s);
+    EXPECT_TRUE(!!result);
+    auto* token = std::get_if<RFC8941::Token>(&result->first);
+    EXPECT_TRUE(!!token);
+    EXPECT_STREQ("token", token->string().utf8().data());
+    EXPECT_EQ(result->second.map().size(), 1U);
+    auto* paramIntValue = result->second.getIf<int64_t>("count"_s);
+    EXPECT_TRUE(!!paramIntValue);
+    EXPECT_EQ(*paramIntValue, 42);
+
+    // Negative integer parameter tests.
+    result = RFC8941::parseItemStructuredFieldValue("token;offset=-10"_s);
+    EXPECT_TRUE(!!result);
+    token = std::get_if<RFC8941::Token>(&result->first);
+    EXPECT_TRUE(!!token);
+    paramIntValue = result->second.getIf<int64_t>("offset"_s);
+    EXPECT_TRUE(!!paramIntValue);
+    EXPECT_EQ(*paramIntValue, -10);
+
+    // Decimal parameter tests.
+    result = RFC8941::parseItemStructuredFieldValue("token;ratio=1.5"_s);
+    EXPECT_TRUE(!!result);
+    token = std::get_if<RFC8941::Token>(&result->first);
+    EXPECT_TRUE(!!token);
+    auto* paramDecimal = result->second.getIf<double>("ratio"_s);
+    EXPECT_TRUE(!!paramDecimal);
+    EXPECT_DOUBLE_EQ(*paramDecimal, 1.5);
+
+    // String with multiple parameters (token and integer values).
+    result = RFC8941::parseItemStructuredFieldValue("\"b\"; a=c; c=2"_s);
+    EXPECT_TRUE(!!result);
+    auto* stringValue = std::get_if<String>(&result->first);
+    EXPECT_TRUE(!!stringValue);
+    EXPECT_STREQ("b", stringValue->utf8().data());
+    EXPECT_EQ(result->second.map().size(), 2U);
+    auto* paramTokenValue = result->second.getIf<RFC8941::Token>("a"_s);
+    EXPECT_TRUE(!!paramTokenValue);
+    EXPECT_STREQ("c", paramTokenValue->string().utf8().data());
+    auto* paramIntValue2 = result->second.getIf<int64_t>("c"_s);
+    EXPECT_TRUE(!!paramIntValue2);
+    EXPECT_EQ(*paramIntValue2, 2);
+
+    // Empty item.
+    result = RFC8941::parseItemStructuredFieldValue(""_s);
+    EXPECT_FALSE(!!result);
+
+    // Leading and trailing whitespace
+    result = RFC8941::parseItemStructuredFieldValue("     1  "_s);
+    EXPECT_TRUE(!!result);
+    intValue = std::get_if<int64_t>(&result->first);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 1);
 }
 
 TEST(RFC8941, ParseDictionaryStructuredFieldValue)
@@ -216,6 +506,52 @@ TEST(RFC8941, ParseDictionaryStructuredFieldValue)
     valueList = std::get_if<RFC8941::InnerList>(&valueAndParameters.first);
     EXPECT_TRUE(!!valueList);
     EXPECT_TRUE(valueList->isEmpty());
+
+    result = RFC8941::parseDictionaryStructuredFieldValue("count=42"_s);
+    EXPECT_TRUE(!!result);
+    EXPECT_EQ(result->size(), 1U);
+    EXPECT_TRUE(result->contains("count"_s));
+    valueAndParameters = result->get("count"_s);
+    bareItem = std::get_if<RFC8941::BareItem>(&valueAndParameters.first);
+    EXPECT_TRUE(!!bareItem);
+    auto* intValue = std::get_if<int64_t>(bareItem);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 42);
+
+    result = RFC8941::parseDictionaryStructuredFieldValue("ratio=1.5"_s);
+    EXPECT_TRUE(!!result);
+    EXPECT_TRUE(result->contains("ratio"_s));
+    valueAndParameters = result->get("ratio"_s);
+    bareItem = std::get_if<RFC8941::BareItem>(&valueAndParameters.first);
+    EXPECT_TRUE(!!bareItem);
+    auto* decimalValue = std::get_if<double>(bareItem);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 1.5);
+
+    result = RFC8941::parseDictionaryStructuredFieldValue("count=42, ratio=1.5, offset=-10"_s);
+    EXPECT_TRUE(!!result);
+    EXPECT_EQ(result->size(), 3U);
+    EXPECT_TRUE(result->contains("count"_s));
+    valueAndParameters = result->get("count"_s);
+    bareItem = std::get_if<RFC8941::BareItem>(&valueAndParameters.first);
+    EXPECT_TRUE(!!bareItem);
+    intValue = std::get_if<int64_t>(bareItem);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, 42);
+    EXPECT_TRUE(result->contains("ratio"_s));
+    valueAndParameters = result->get("ratio"_s);
+    bareItem = std::get_if<RFC8941::BareItem>(&valueAndParameters.first);
+    EXPECT_TRUE(!!bareItem);
+    decimalValue = std::get_if<double>(bareItem);
+    EXPECT_TRUE(!!decimalValue);
+    EXPECT_DOUBLE_EQ(*decimalValue, 1.5);
+    EXPECT_TRUE(result->contains("offset"_s));
+    valueAndParameters = result->get("offset"_s);
+    bareItem = std::get_if<RFC8941::BareItem>(&valueAndParameters.first);
+    EXPECT_TRUE(!!bareItem);
+    intValue = std::get_if<int64_t>(bareItem);
+    EXPECT_TRUE(!!intValue);
+    EXPECT_EQ(*intValue, -10);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 65ba3d111e3d12ebfa9b44d191e35b725c0d29a4
<pre>
WebTransport WT-Protocol header should be able to handle structured field item parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=304477">https://bugs.webkit.org/show_bug.cgi?id=304477</a>
<a href="https://rdar.apple.com/166853550">rdar://166853550</a>

Reviewed by Alex Christensen.

This PR adds integer, decimal and byte sequence bare items parsing support.
It also fixes the parsing of wt-protocol to use parseItemStructuredFieldValue.

Test: Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp

* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseNumber):
(RFC8941::parseByteSequence):
(RFC8941::parseBareItem):
* Source/WebCore/platform/network/RFC8941.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
* Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp:
(TestWebKitAPI::TEST(RFC8941, ParseItemStructuredFieldValue)):
(TestWebKitAPI::TEST(RFC8941, ParseDictionaryStructuredFieldValue)):

Canonical link: <a href="https://commits.webkit.org/304872@main">https://commits.webkit.org/304872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13288536c4bddeb95d5a16037ee512e1160ed78f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/74940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4253 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115890 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40488 "Found 1 new test failure: fast/block/basic/015.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113045 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6530 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118592 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62503 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21079 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36644 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72122 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->