### PR TITLE
Inspector: TypeError: layerGroup.clear is not a function.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
@@ -321,7 +321,8 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
                     return;
                 }
 
-                layerGroup.clear();
+                while (layerGroup.children.length > 0)
+                    layerGroup.remove(layerGroup.children[0]);
 
                 fillMesh.geometry?.dispose();
                 fillMesh.material?.map?.dispose();
@@ -547,7 +548,8 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
                 child.material?.map?.dispose();
                 child.material?.dispose();
             }
-            layerGroup.clear();
+            while (layerGroup.children.length > 0)
+                layerGroup.remove(layerGroup.children[0]);
 
             this._populateLayerGroup(layerGroup, layer);
         }


### PR DESCRIPTION
#### 9dd8793cb3ee3c57b311566d62552b2c03d863d3
<pre>
Inspector: TypeError: layerGroup.clear is not a function.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304509">https://bugs.webkit.org/show_bug.cgi?id=304509</a>
<a href="https://rdar.apple.com/166891010">rdar://166891010</a>

Reviewed by BJ Burg.

Replace layerGroup.clear() calls with manual child removal for compatibility
with older Three.js versions that don&apos;t support the Group.clear() method.
This fixes TypeError crashes when refreshing layer contents or loading layer
textures in the 3D Layers view.

* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView.prototype._populateLayerGroup):
(WI.Layers3DContentView.prototype._refreshAllLayers):

Canonical link: <a href="https://commits.webkit.org/305665@main">https://commits.webkit.org/305665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c2c5b70042f56054ca3f6ee06554f9638ec892c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147214 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f7976e8-5082-4295-a52b-e72cb98be842) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87335 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6519 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7507 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149994 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/492 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9065 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120931 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11188 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74846 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->