### PR TITLE
[AutoFill Debugging] Add form elements and more text form control DOM attributes

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -1,3 +1,5 @@
+-- texttree
+
 root
     role='banner'
         aria-label='Main Page Title','Welcome to Test Page'
@@ -14,7 +16,7 @@ root
             input,'text',uid=…,placeholder='Enter text here'
             role='button','Clickable Div'
         section,aria-label='Content with Roles'
-            article,role='article','Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.'
+            article,role='article','Article Title\n\nJanuary 1, 2024\nThis is some article content with highlighted text.'
             role='complementary',aria-label='Related information'
                 'Related Links'
                 list
@@ -29,9 +31,79 @@ root
             contentEditable,uid=…,role='textbox'
                 subscript
                     'WebKit home page:'
-                    link
+                    link,'webkit.org'
+            form,autocomplete='on',name='signup'
+                'Sign up for our newsletter'
+                input,'text',uid=…,placeholder='Username',name='username',minlength=3,maxlength=20,required
+                input,'text',uid=…,placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
+                input,'text',uid=…,placeholder='Zip Code',pattern='[0-9]{5}',name='zipcode',minlength=5,maxlength=5
     role='contentinfo'
         'Footer content with'
         role='img',aria-label='copyright symbol','©'
         '2024'
 version=2
+
+-- html
+
+<body>
+    <div role='banner'>
+        <h1 aria-label='Main Page Title'>Welcome to Test Page</h1>
+    </div>
+    <nav role='navigation' aria-label='Main navigation'>
+        <ul>
+            <li>
+                <a>Section 1</a>
+            </li>
+            <li>
+                <a>Section 2</a>
+            </li>
+        </ul>
+    </nav>
+    <main role='main'>
+        <section aria-label='Interactive Elements'>
+            <button aria-describedby='This button does nothing' aria-label='Test button'>Click Me</button>
+            This button does nothing
+            <input type='text' uid=… placeholder='Enter text here'>
+            <div role='button'>Clickable Div</div>
+        </section>
+        <section aria-label='Content with Roles'>
+            <article role='article'>Article Title  January 1, 2024 This is some article content with highlighted text.</article>
+            <aside role='complementary' aria-label='Related information'>
+                Related Links
+                <ul>
+                    <li>
+                        <a>Example Link</a>
+                    </li>
+                    <li>
+                        <a>Test Link</a>
+                    </li>
+                </ul>
+            </aside>
+            <div role='region'>
+                <div role='status'>Ready</div>
+                <button>Update Status</button>
+            </div>
+            <textarea uid=…>This is a text box</textarea>
+            <div uid=… role='textbox'> contenteditable
+                <sub>
+                    WebKit home page:
+                    <a>webkit.org</a>
+                </sub>
+            </div>
+            <form autocomplete='on' name='signup'>
+                Sign up for our newsletter
+                <input type='text' uid=… placeholder='Username' name='username' minlength=3 maxlength=20 required>
+                <input type='text' uid=… placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
+                <input type='text' uid=… placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
+            </form>
+        </section>
+    </main>
+    <footer role='contentinfo'>
+        Footer content with
+        <span role='img' aria-label='copyright symbol'>©</span>
+        2024
+    </footer>
+</body>
+<!-- version=2 -->
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <head>
 <style>
-body {
+.text-representation {
     white-space: pre-wrap;
 }
 
@@ -69,6 +69,12 @@ body {
         <div contenteditable role="textbox">
             <sub>WebKit home page:<a href="https://webkit.org">webkit.org</a></sub>
         </div>
+        <form name="signup" autocomplete="on">
+            <h4>Sign up for our newsletter</h4>
+            <input name="username" placeholder="Username" minlength="3" maxlength="20" required />
+            <input name="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" required />
+            <input name="zipcode" placeholder="Zip Code" pattern="[0-9]{5}" minlength="5" maxlength="5" />
+        </form>
     </section>
 </main>
 <footer role="contentinfo">
@@ -85,16 +91,29 @@ addEventListener("load", async () => {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    document.body.textContent = await UIHelper.requestDebugText({
-        normalize: true,
-        includeRects: false,
-        includeURLs: false,
-        nodeIdentifierInclusion: "editableOnly",
-        includeEventListeners: false,
-        includeAccessibilityAttributes: true,
-        includeTextInAutoFilledControls: true,
-    });
+    const results = [];
+    for (let outputFormat of ["texttree", "html"]) {
+        const heading = document.createElement("h1");
+        heading.textContent = `-- ${outputFormat}`;
 
+        const container = document.createElement("pre");
+        container.classList.add("text-representation");
+        container.textContent = await UIHelper.requestDebugText({
+            normalize: true,
+            includeRects: false,
+            includeURLs: false,
+            nodeIdentifierInclusion: "editableOnly",
+            includeEventListeners: false,
+            includeAccessibilityAttributes: true,
+            includeTextInAutoFilledControls: true,
+            outputFormat,
+        });
+        results.push(heading);
+        results.push(container);
+        results.push(document.createElement("br"));
+    }
+
+    document.body.replaceChildren(...results);
     testRunner.notifyDone();
 });
 </script>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -36,7 +36,10 @@ addEventListener("load", async () => {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    document.body.textContent = await UIHelper.requestDebugText({ outputFormat: "markdown" });
+    document.body.textContent = await UIHelper.requestDebugText({
+        includeURLs: true,
+        outputFormat: "markdown",
+    });
     document.body.classList.add("done");
 
     testRunner.notifyDone();

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -127,10 +127,20 @@ struct ContentEditableData {
     bool isFocused { false };
 };
 
+struct FormData {
+    String autocomplete;
+    String name;
+};
+
 struct TextFormControlData {
     Editable editable;
     String controlType;
     String autocomplete;
+    String pattern;
+    String name;
+    std::optional<int> minLength;
+    std::optional<int> maxLength;
+    bool isRequired { false };
     bool isReadonly { false };
     bool isDisabled { false };
     bool isChecked { false };
@@ -157,7 +167,7 @@ enum class ContainerType : uint8_t {
     Generic,
 };
 
-using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData, SelectData, ContentEditableData, TextFormControlData, LinkItemData>;
+using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData, SelectData, ContentEditableData, TextFormControlData, FormData, LinkItemData>;
 
 struct Item {
     ItemData data;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6864,10 +6864,21 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::FormData {
+    String autocomplete;
+    String name;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::TextFormControlData {
     WebCore::TextExtraction::Editable editable;
     String controlType;
     String autocomplete;
+    String pattern;
+    String name;
+    std::optional<int> minLength;
+    std::optional<int> maxLength;
+    bool isRequired;
     bool isReadonly;
     bool isDisabled;
     bool isChecked;
@@ -6907,7 +6918,7 @@ header: <WebCore/TextExtractionTypes.h>
 
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Item {
-    Variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::ImageItemData, WebCore::TextExtraction::SelectData, WebCore::TextExtraction::ContentEditableData, WebCore::TextExtraction::TextFormControlData, WebCore::TextExtraction::LinkItemData> data;
+    Variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::ImageItemData, WebCore::TextExtraction::SelectData, WebCore::TextExtraction::ContentEditableData, WebCore::TextExtraction::TextFormControlData, WebCore::TextExtraction::FormData, WebCore::TextExtraction::LinkItemData> data;
     WebCore::FloatRect rectInRootView;
     Vector<WebCore::TextExtraction::Item> children;
     String nodeName;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -65,6 +65,40 @@ extension WKTextExtractionItem {
 }
 
 @_objcImplementation
+extension WKTextExtractionFormItem {
+    let autocomplete: String
+    let name: String
+
+    init(
+        autocomplete: String,
+        name: String,
+        rectInWebView: CGRect,
+        children: [WKTextExtractionItem],
+        eventListeners: WKTextExtractionEventListenerTypes,
+        ariaAttributes: [String: String],
+        accessibilityRole: String,
+        nodeIdentifier: String?
+    ) {
+        self.autocomplete = autocomplete
+        self.name = name
+        super
+            .init(
+                with: rectInWebView,
+                children: children,
+                eventListeners: eventListeners,
+                ariaAttributes: ariaAttributes,
+                accessibilityRole: accessibilityRole,
+                nodeIdentifier: nodeIdentifier
+            )
+    }
+
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
+}
+
+@_objcImplementation
 extension WKTextExtractionContainerItem {
     let container: WKTextExtractionContainer
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -136,6 +136,12 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @property (nonatomic, readonly) WKTextExtractionContainer container;
 @end
 
+@interface WKTextExtractionFormItem : WKTextExtractionItem
+- (instancetype)initWithAutocomplete:(NSString *)autocomplete name:(NSString *)name rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
+@property (nonatomic, readonly) NSString *autocomplete;
+@property (nonatomic, readonly) NSString *name;
+@end
+
 @interface WKTextExtractionLinkItem : WKTextExtractionItem
 - (instancetype)initWithTarget:(NSString *)target url:(nullable NSURL *)url rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *target;

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -185,6 +185,16 @@ inline static RetainPtr<WKTextExtractionItem> createItemWithChildren(const TextE
                 ariaAttributes:ariaAttributes.get()
                 accessibilityRole:accessibilityRole.get()
                 nodeIdentifier:nodeIdentifier.get()]);
+        }, [&](const TextExtraction::FormData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([[WKTextExtractionFormItem alloc]
+                initWithAutocomplete:data.autocomplete.createNSString().get()
+                name:data.name.createNSString().get()
+                rectInWebView:rectInWebView
+                children:children
+                eventListeners:eventListeners
+                ariaAttributes:ariaAttributes.get()
+                accessibilityRole:accessibilityRole.get()
+                nodeIdentifier:nodeIdentifier.get()]);
         }, [&](const TextExtraction::TextFormControlData& data) -> RetainPtr<WKTextExtractionItem> {
             return adoptNS([[WKTextExtractionTextFormControlItem alloc]
                 initWithEditable:createWKEditable(data.editable).get()

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
@@ -134,6 +134,15 @@ static void buildDescriptionIgnoringChildren(TextStream& stream, WKTextExtractio
         return;
     }
 
+    if (auto form = downcastItem(item, WKTextExtractionFormItem)) {
+        stream << "FORM"_s;
+        if (form.autocomplete.length)
+            stream << " autocomplete='"_s << form.autocomplete << '\'';
+        if (form.name.length)
+            stream << " name='"_s << form.name << '\'';
+        return;
+    }
+
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### f17dbeaad4bbcfd451f867400d6ec70976a2b9a7
<pre>
[AutoFill Debugging] Add form elements and more text form control DOM attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304508">https://bugs.webkit.org/show_bug.cgi?id=304508</a>
<a href="https://rdar.apple.com/166750217">rdar://166750217</a>

Reviewed by Aditya Keerthi.

Add several new DOM attributes to the text extraction output on text fields:

- `pattern`
- `minlength`
- `maxlength`
- `name`

...and also introduce a new container type, `form`, which represents a `form` element with
attributes:

- `name`
- `autocomplete`

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:

Augment an existing test to include a new `form` that contains a few text fields.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Drive-by fix: address an issue where a single text child node can be incorrectly flagged as
&quot;redundant with the HREF&quot; in the case where the client has opted out of including URLs. I spotted
this while looking through the augmented layout test&apos;s HTML text representation above, since the
anchor tags were just getting surfaced as `&lt;a&gt;` with no text or href.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::createItemWithChildren):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::buildDescriptionIgnoringChildren):

Canonical link: <a href="https://commits.webkit.org/304785@main">https://commits.webkit.org/304785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eac03383faf910a459a61186d036028f72cdadc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e53b9818-2917-47d8-a802-47f9a8c1bf8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104384 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/56d4db91-9552-45a9-93a5-e91bc2c44878) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122308 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85219 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b8d28ae3-b291-462f-b6d8-f4e907c1cc0b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4278 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4810 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146966 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8543 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6553 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36668 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->