### PR TITLE
[Site Isolation] Web Inspector: Remote iframe still can't console log with frame target console support

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1885,6 +1885,8 @@ inspector/unit-tests/heap-snapshot-collection-event.html [ Skip ]
 # WK1 Inspector cannot leverage InspectorAdditions runtime enabled features
 inspector/canvas/recording-html-2d.html
 
+inspector/dom/setOuterHTML-no-document-element.html [ Skip ]
+
 webkit.org/b/188708 inspector/dom-debugger/event-breakpoint-with-navigation.html [ Pass Timeout Failure ]
 
 # These tests check ScrollAnimator events for main frame scrollbars that use native widgets in WK1.

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -56,14 +56,7 @@ struct EventListenerInfo;
 class CommandLineAPIHost : public RefCounted<CommandLineAPIHost> {
 public:
     static Ref<CommandLineAPIHost> create();
-    ~CommandLineAPIHost();
-
-    void init(InstrumentingAgents& instrumentingAgents)
-    {
-        m_instrumentingAgents = &instrumentingAgents;
-    }
-
-    void disconnect();
+    ~CommandLineAPIHost() = default;
 
     void copyText(const String& text);
 
@@ -99,7 +92,6 @@ public:
 private:
     CommandLineAPIHost();
 
-    WeakPtr<InstrumentingAgents> m_instrumentingAgents;
     std::unique_ptr<InspectableObject> m_inspectedObject; // $0
     Inspector::PerGlobalObjectWrapperWorld m_wrappers;
 };

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -130,6 +130,7 @@ void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& front
 
     if (connectedFirstFrontend) {
         m_agents.didCreateFrontendAndBackend();
+        m_injectedScriptManager->addClient();
         InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
     }
 }
@@ -142,6 +143,7 @@ void FrameInspectorController::disconnectFrontend(Inspector::FrontendChannel& fr
     bool disconnectedLastFrontend = !m_frontendRouter->hasFrontends();
     if (disconnectedLastFrontend) {
         InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+        m_injectedScriptManager->removeClient();
         m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectorDestroyed);
     }
 }
@@ -157,6 +159,7 @@ void FrameInspectorController::inspectedFrameDestroyed()
     InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
     m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);
 
+    m_injectedScriptManager->removeClient();
     m_frontendRouter->disconnectAllFrontends();
 
     m_agents.discardValues();

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -81,6 +81,8 @@ public:
 
     void inspectedFrameDestroyed();
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -50,7 +50,25 @@ WebInjectedScriptManager::WebInjectedScriptManager(InspectorEnvironment& environ
 
 WebInjectedScriptManager::~WebInjectedScriptManager()
 {
-    if (isConnected())
+    ASSERT(!m_clientCount);
+    if (m_clientCount > 0) {
+        m_clientCount = 0;
+        disconnect();
+    }
+}
+
+void WebInjectedScriptManager::addClient()
+{
+    ++m_clientCount;
+    if (m_clientCount == 1)
+        connect();
+}
+
+void WebInjectedScriptManager::removeClient()
+{
+    ASSERT(m_clientCount > 0);
+    --m_clientCount;
+    if (!m_clientCount)
         disconnect();
 }
 
@@ -65,10 +83,7 @@ void WebInjectedScriptManager::disconnect()
 {
     InjectedScriptManager::disconnect();
 
-    if (m_commandLineAPIHost) {
-        m_commandLineAPIHost->disconnect();
-        m_commandLineAPIHost = nullptr;
-    }
+    m_commandLineAPIHost = nullptr;
 }
 
 void WebInjectedScriptManager::discardInjectedScripts()

--- a/Source/WebCore/inspector/WebInjectedScriptManager.h
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.h
@@ -45,6 +45,9 @@ public:
 
     CommandLineAPIHost* commandLineAPIHost() const { return m_commandLineAPIHost.get(); }
 
+    void addClient();
+    void removeClient();
+
     void connect() final;
     void disconnect() final;
     void discardInjectedScripts() final;
@@ -56,10 +59,10 @@ private:
 
     WebInjectedScriptManager(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
 
-    bool isConnected() const { return m_commandLineAPIHost; }
     void didCreateInjectedScript(const Inspector::InjectedScript&) final;
 
     RefPtr<CommandLineAPIHost> m_commandLineAPIHost;
+    int m_clientCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -69,6 +69,8 @@ public:
 
     void dispatchMessageFromFrontend(const String&);
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override { return true; }
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override { return true; }


### PR DESCRIPTION
#### 283db2619c855c84e9ed6294218cfbbbeec8d402
<pre>
[Site Isolation] Web Inspector: Remote iframe still can&apos;t console log with frame target console support
<a href="https://rdar.apple.com/166892920">rdar://166892920</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304511">https://bugs.webkit.org/show_bug.cgi?id=304511</a>

Reviewed by BJ Burg.

Summary: Introduce client-counting to WebInjectedScriptManager to auto
set up for remote frame targets without a parent page target.

With our recent site isolation work in [1] to move the Console agent
into frame target, we intend to let frame targets use its parent page&apos;s
WebInjectedScriptManager, maintaining the &quot;one InjectedScriptManager per
page&quot; pattern. However, a remote web process doesn&apos;t surface a page
target to the frontend that would set up the manager upon connection.
As a result, any remote frame target will try to use an unprepared
InjectedScriptManager and its CommandLineAPIHost when adding a
console message.

[1] Related landed work:
   - Shared InjectedScriptManager: <a href="https://github.com/WebKit/WebKit/pull/53561">https://github.com/WebKit/WebKit/pull/53561</a>
   - Move Console agent to frame target: <a href="https://github.com/WebKit/WebKit/pull/51217">https://github.com/WebKit/WebKit/pull/51217</a>

This patch makes WebInjectedScriptManager set up or torn down
automatically by introducing a client-counting strategy, to ensure the
manager is ready independently as long as there&apos;s any client connection
(page, frame, worker). Further, while not necessarily attached to one
target, the internal CommandLineAPIHost must now work with more than
one potential targets and sets of InstrumentingAgents. We address that
by making the host access the right agents according to the
JSGlobalObject, so that it can adapt to any execution context
(document, worker) without requiring explicit initialization.

The reason we kept one manager per page was that other domains that also
work with InjectedScriptManager (like Debugger and Runtime) still live
in page target. We are avoiding agents having out-of-sync states due to
being moved into frame as we go through this site isolation transition.
However, it should be worth revisiting whether objects like
InjectedScriptManager should either still be frame-isolated even in the
same process or become per-VM instead (filed follow-up <a href="https://webkit.org/b/304949).">https://webkit.org/b/304949).</a>

No new tests. The existing inspector test message-from-iframe should now
progress with --site-isolation turned on (Timeout -&gt; Pass).

* LayoutTests/platform/mac-wk1/TestExpectations:
   WK1 inspector test&apos;s teardown process when done from within a promise
   doesn&apos;t seem to work well with this multi-target InjectedScriptManager
   support, resulting in a crash when setOuterHTML-no-document-element
   completes. This is likely about how inspector test handles completion
   when there are unresolved promises, but I couldn&apos;t figure out why
   that directly relates to this patch.

   Given we are avoiding spending too much effort maintaining WK1
   testing support (see e.g. b/299207), skip this test for now.
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::instrumentingAgentsForGlobalObject):
(WebCore::CommandLineAPIHost::inspect):
(WebCore::CommandLineAPIHost::~CommandLineAPIHost): Deleted.
(WebCore::CommandLineAPIHost::disconnect): Deleted.
   Adapt to being used by more than one inspector targets and figure out
   the right InstrumentingAgents to use automatically.

   Remove init and disconnect which are no longer useful due to this
   autonomy.

* Source/WebCore/inspector/CommandLineAPIHost.h:
(WebCore::CommandLineAPIHost::init): Deleted.
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::inspectedFrameDestroyed):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::createLazyAgents):
(WebCore::PageInspectorController::connectFrontend):
(WebCore::PageInspectorController::disconnectFrontend):
(WebCore::PageInspectorController::disconnectAllFrontends):
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
(WebCore::WebInjectedScriptManager::~WebInjectedScriptManager):
(WebCore::WebInjectedScriptManager::addClient):
(WebCore::WebInjectedScriptManager::removeClient):
(WebCore::WebInjectedScriptManager::disconnect):
* Source/WebCore/inspector/WebInjectedScriptManager.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::workerTerminating):
(WebCore::WorkerInspectorController::connectFrontend):
(WebCore::WorkerInspectorController::disconnectFrontend):
(WebCore::WorkerInspectorController::createLazyAgents):
* Source/WebCore/inspector/WorkerInspectorController.h:
   Make WebInjectedScriptManager client-counted. Before and after using
   the manager, update the client count rather than explicitly
   connecting or disconnecting the manager.

   In page and worker, move the client count updating work to be in sync
   with connecting and disconnecting the frontend rather than the
   agents&apos; lifetime. This creates consistency with the frame target, as
   no client should dictate WebInjectedScriptManager&apos;s connection
   anymore.

   Expose m_instrumentingAgents in frame and worker for
   CommandLineAPIHost to access.

Canonical link: <a href="https://commits.webkit.org/305166@main">https://commits.webkit.org/305166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df98e1a66d53c2d22e27d2950f52fc6d43a8ad95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90551 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4931c310-39c8-4859-9d75-f9b26edb4f51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86073 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/52fd503d-f77d-4bcd-b4b7-8a53b1b7b989) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5256 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5918 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9621 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113601 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113943 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7456 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64277 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9670 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37590 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->