### PR TITLE
SVG markers don't re-render when marker attributes change dynamically

### DIFF
--- a/LayoutTests/svg/dynamic-updates/dynamic-marker-creation-expected.html
+++ b/LayoutTests/svg/dynamic-updates/dynamic-marker-creation-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .line-path {
+        stroke: #444;
+        fill: none;
+        stroke-width: 2;
+    }
+</style>
+</head>
+<body>
+    <svg viewBox="0 0 600 100" width="600" height="100">
+        <defs>
+            <marker id="arrowStart" viewBox="0 0 10 10" refX="5" refY="5"
+                    markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto">
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="red"/>
+            </marker>
+            <marker id="arrowMid" viewBox="0 0 10 10" refX="5" refY="5"
+                    markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto">
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="green"/>
+            </marker>
+            <marker id="arrowEnd" viewBox="0 0 10 10" refX="5" refY="5"
+                    markerUnits="strokeWidth" markerWidth="8" markerHeight="6" orient="auto">
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="blue"/>
+            </marker>
+        </defs>
+        <path class="line-path" d="M 20 50 L 180 50" marker-start="url(#arrowStart)"/>
+        <path class="line-path" d="M 220 50 L 300 50 L 380 50" marker-mid="url(#arrowMid)"/>
+        <path class="line-path" d="M 420 50 L 580 50" marker-end="url(#arrowEnd)"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/dynamic-updates/dynamic-marker-creation.html
+++ b/LayoutTests/svg/dynamic-updates/dynamic-marker-creation.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+    .line-path {
+        stroke: #444;
+        fill: none;
+        stroke-width: 2;
+    }
+</style>
+</head>
+<body>
+    <svg viewBox="0 0 600 100" width="600" height="100">
+        <g></g>
+    </svg>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+        }
+
+        const pathData = [
+            { d: 'M 20 50 L 180 50', attr: 'marker-start', val: 'arrowStart' },
+            { d: 'M 220 50 L 300 50 L 380 50', attr: 'marker-mid', val: 'arrowMid' },
+            { d: 'M 420 50 L 580 50', attr: 'marker-end', val: 'arrowEnd' },
+        ];
+
+        function createMarker(parent, id, color) {
+            const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+            marker.setAttribute("id", id);
+            marker.setAttribute("viewBox", "0 0 10 10");
+            marker.setAttribute("refX", "5");
+            marker.setAttribute("refY", "5");
+            marker.setAttribute("markerUnits", "strokeWidth");
+            marker.setAttribute("markerWidth", "8");
+            marker.setAttribute("markerHeight", "6");
+            marker.setAttribute("orient", "auto");
+            parent.appendChild(marker);
+
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
+            path.setAttribute("fill", color);
+            marker.appendChild(path);
+        }
+
+        function render(count) {
+            const svg = document.querySelector("svg");
+            const group = svg.querySelector("g");
+
+            const paths = Array.from(group.querySelectorAll("line-path"));
+
+            while (paths.length < pathData.length) {
+                paths.push(document.createElementNS('http://www.w3.org/2000/svg', 'path'));
+            }
+
+            paths.forEach((path, idx) => {
+                path.setAttribute('class', 'line-path');
+                path.setAttribute('d', pathData[idx].d);
+                path.setAttribute(pathData[idx].attr, `url(#${pathData[idx].val}${count})`);
+
+                group.appendChild(path);
+            })
+
+            svg.querySelectorAll("defs *").forEach(el => el.remove());
+
+            let defs = document.querySelector('defs');
+            if (!defs) {
+                defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+            }
+
+            group.appendChild(defs);
+            createMarker(defs, `arrowStart${count}`, "red");
+            createMarker(defs, `arrowMid${count}`, "green");
+            createMarker(defs, `arrowEnd${count}`, "blue");
+        }
+
+        window.addEventListener("load", async () => {
+            render(0);
+            await UIHelper.renderingUpdate();
+            render(1);
+
+            if (window.testRunner) {
+                testRunner.notifyDone();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -188,6 +188,15 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, Style::Diffe
         if (oldStyle->stroke().urlDisregardingType() != newStyle.stroke().urlDisregardingType())
             return true;
 
+        if (oldStyle->markerStart() != newStyle.markerStart())
+            return true;
+
+        if (oldStyle->markerMid() != newStyle.markerMid())
+            return true;
+
+        if (oldStyle->markerEnd() != newStyle.markerEnd())
+            return true;
+
         return false;
     };
 


### PR DESCRIPTION
#### a36f3b30d40fb5303d182b72ec3190bcbecdaad5
<pre>
SVG markers don&apos;t re-render when marker attributes change dynamically
<a href="https://rdar.apple.com/130678384">rdar://130678384</a>

Reviewed by Brent Fulgham and Simon Fraser.

When the marker-start, marker-mid, or marker-end attributes are changed
dynamically on SVG elements, markers fail to re-render in the legacy SVG engine.

This happens because SVGResourcesCache detects style changes for
clipPath, mask, filter, fill, and stroke, but not for marker properties.

The fix adds missing marker checks to ensure the cache resources
are rebuilt correctly.

* LayoutTests/svg/dynamic-updates/dynamic-marker-creation-expected.html: Added.
* LayoutTests/svg/dynamic-updates/dynamic-marker-creation.html: Added.
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientStyleChanged):

Canonical link: <a href="https://commits.webkit.org/304880@main">https://commits.webkit.org/304880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/981d65dac479873c53b9b96b4a132bda000616ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89695 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3512a218-5c1f-4190-a25c-fdb2f4ce8d54) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104549 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6715391f-05d2-48d5-83c5-593f91531643) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85388 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4484 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5042 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112903 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6714 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62917 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8813 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36850 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8753 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->