### PR TITLE
Reduce number of memory copies needed to evaluate long JS strings

### DIFF
--- a/Source/WebKit/Platform/IPC/TransferString.h
+++ b/Source/WebKit/Platform/IPC/TransferString.h
@@ -54,6 +54,7 @@ public:
 #endif
 #if USE(FOUNDATION) && defined(__OBJC__)
     static std::optional<TransferString> create(NSString *);
+    static std::optional<TransferString> createCached(NSString *);
 #endif
 
     TransferString() = default;
@@ -66,7 +67,7 @@ public:
     TransferString(TransferString&&) = default;
     TransferString& operator=(TransferString&&) = default;
 
-    static constexpr size_t transferAsMappingSize = 16384 * 5;
+    static constexpr size_t transferAsMappingSize = 16384;
 
     // Release the string.
     // Pass maxCopySizeInBytes = transferAsMappingSize - 1 to release without copy, possibly holding the underlying virtual memory mapping.

--- a/Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TransferString.h"
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
+
+NS_DIRECT_MEMBERS
+@interface _WKTransferStringWrapper : NSObject {
+    IPC::TransferString _string;
+}
+- (instancetype)initWithString:(IPC::TransferString&&)string;
+- (IPC::TransferString&)string;
+@end
+
+@implementation _WKTransferStringWrapper
+
+- (instancetype)initWithString:(IPC::TransferString&&)string
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _string = WTF::move(string);
+    return self;
+}
+
+- (IPC::TransferString&)string
+{
+    return _string;
+}
+
+@end
+
+static void *transferStringWrapperKey = &transferStringWrapperKey;
+
+namespace IPC {
+
+std::optional<TransferString> TransferString::createCached(NSString *string)
+{
+    RetainPtr wrapper = (_WKTransferStringWrapper *)objc_getAssociatedObject(string, transferStringWrapperKey);
+    if (!wrapper) {
+        auto result = TransferString::create((__bridge CFStringRef)string);
+        if (!result)
+            return std::nullopt;
+
+        // Caching only makes sense if we can re-send a previously created shared memory handle.
+        bool shouldCache = WTF::switchOn(result->m_storage,
+            [](const String&) { return false; },
+            [](const RetainPtr<CFStringRef>& string) { return false; },
+            [](const SharedSpan8& handle) { return true; },
+            [](const SharedSpan16& handle) { return true; }
+        );
+        if (!shouldCache)
+            return result;
+
+        wrapper = adoptNS([[_WKTransferStringWrapper alloc] initWithString:WTF::move(*result)]);
+        objc_setAssociatedObject(string, transferStringWrapperKey, wrapper.get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    return TransferString { [wrapper string].toIPCData() };
+}
+
+}

--- a/Source/WebKit/Platform/SourcesCocoa.txt
+++ b/Source/WebKit/Platform/SourcesCocoa.txt
@@ -14,6 +14,7 @@ Platform/foundation/LoggingFoundation.mm @nonARC
 Platform/IPC/cocoa/ConnectionCocoa.mm @nonARC
 Platform/IPC/cocoa/DaemonConnectionCocoa.mm @nonARC
 Platform/IPC/cocoa/MachMessage.cpp
+Platform/IPC/cocoa/TransferStringCocoa.mm @nonARC
 
 Platform/IPC/darwin/IPCEventDarwin.cpp
 Platform/IPC/darwin/IPCSemaphoreDarwin.cpp

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
@@ -28,8 +28,11 @@
 #if ENABLE(NETWORK_ISSUE_REPORTING)
 
 #import <wtf/Forward.h>
+#import <wtf/HashSet.h>
+#import <wtf/Noncopyable.h>
 #import <wtf/SystemFree.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/text/WTFString.h>
 
 OBJC_CLASS NSURLSessionTaskMetrics;
 

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
@@ -31,6 +31,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/URL.h>
 
 SOFT_LINK_SYSTEM_LIBRARY(libsystem_networkextension)
 SOFT_LINK_OPTIONAL(libsystem_networkextension, ne_tracker_create_xcode_issue, void, __cdecl, (const char*, const void*, size_t))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1510,7 +1510,12 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
 
     auto removeTransientActivation = !_dontResetTransientActivationAfterRunJavaScript && WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
 
-    auto scriptString = IPC::TransferString::create(javaScriptString);
+    std::optional<IPC::TransferString> scriptString;
+    if (world->_contentWorld->allowAutofill())
+        scriptString = IPC::TransferString::createCached(javaScriptString);
+    else
+        scriptString = IPC::TransferString::create(javaScriptString);
+
     if (!scriptString) {
         if (handler) {
             RunLoop::mainSingleton().dispatch([handler = WTF::move(handler)] {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8574,6 +8574,7 @@
 		EB7D252A27B31B3F009CB586 /* com.apple.WebKit.webpushd.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.mac.sb; sourceTree = "<group>"; };
 		EB8322132D72600C009515DA /* AboutSchemeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AboutSchemeHandler.h; sourceTree = "<group>"; };
 		EB8322142D72600C009515DA /* AboutSchemeHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AboutSchemeHandler.cpp; sourceTree = "<group>"; };
+		EB93FAC92EEB885B00187360 /* TransferStringCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TransferStringCocoa.mm; sourceTree = "<group>"; };
 		EBA8D3AA27A5E31300CB7900 /* ApplePushServiceSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePushServiceSPI.h; sourceTree = "<group>"; };
 		EBA8D3AC27A5E33E00CB7900 /* ApplePushServiceConnection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplePushServiceConnection.mm; sourceTree = "<group>"; };
 		EBA8D3AD27A5E33E00CB7900 /* MockPushServiceConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockPushServiceConnection.h; sourceTree = "<group>"; };
@@ -16239,6 +16240,7 @@
 				1A6D86BF1DF75265007745E8 /* MachMessage.cpp */,
 				1A6D86C01DF75265007745E8 /* MachMessage.h */,
 				93468E6C2714AF88009983E3 /* SharedFileHandleCocoa.cpp */,
+				EB93FAC92EEB885B00187360 /* TransferStringCocoa.mm */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### b605852497fa2357b24d453a1a026eb83ea7d4ae
<pre>
Reduce number of memory copies needed to evaluate long JS strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=304037">https://bugs.webkit.org/show_bug.cgi?id=304037</a>
<a href="https://rdar.apple.com/166338115">rdar://166338115</a>

Reviewed by Alex Christensen.

This has the same goal as 304155@main, which is to reduce the number of string copies associated
with large JS scripts that are repeatedly evaluated in to multiple frames or web views.

This builds on the existing TransferString work (303899@main) and adds a new method
`TransferString::createCached(NSString *)`. This method will either create a new TransferString
instance associated with the NSString (and then cache it using an Obj-C associated object), or reuse
an existing TransferString. By reusing the cached TransferString, we end up reusing the same shared
memory mapping for that string&apos;s bytes across multiple evaluateJavaScript invocations and across
multiple processes.

For now, this optimization is only enabled on the autofill world, since we know this optimization is
profitable in that world. It might not be profitable to do this caching in other worlds (e.g. some
use cases might evaluate lots of large transient script strings). This seems fine for now until we
can develop a better heuristic around when it is profitable to cache the memory mapping.

Finally, reduce `transferAsMappingSize` to a single page so that this optimization applies to more
strings. On the receiving end (in `WebPage::runJavaScript`), the call to `TransferString::release`
uses `transferAsMappingSize` as a hint for whether to reuse the virtual copy or to create a new
physical copy of the bytes. Reduce this to a single page to maximize memory savings.

This is a reland of 304383@main, which got reverted in 304433@main due to a prerequesite patch
(303899@main) causing crashes on iOS.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
* Source/WebKit/Platform/IPC/TransferString.h:
* Source/WebKit/Platform/IPC/cocoa/TransferStringCocoa.mm: Added.
(-[_WKTransferStringWrapper initWithString:]):
(-[_WKTransferStringWrapper string]):
(IPC::TransferString::createCached):
* Source/WebKit/Platform/SourcesCocoa.txt:
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.h:
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)):

Canonical link: <a href="https://commits.webkit.org/304782@main">https://commits.webkit.org/304782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2547034c725ba5cd1bc0dc0d298e3a550ddd400a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144212 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ecd2b82-bec5-497a-87ca-782d20aed421) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/745f0069-1ec8-4a63-93be-760666b2ebbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85215 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/595661b0-278c-4ddc-acb2-600ec60443ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6608 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4271 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4805 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8538 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112722 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8555 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7175 "Found 1 new test failure: inspector/unit-tests/iterableweakset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6543 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36664 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8526 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->