### PR TITLE
[LOL] Add support for bitwise bytecodes

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1209,9 +1209,15 @@ public:
         xor32(imm, dest);
     }
 
+    void not32(RegisterID src, RegisterID dest)
+    {
+        move32IfNeeded(src, dest);
+        m_assembler.notl_r(dest);
+    }
+
     void not32(RegisterID srcDest)
     {
-        m_assembler.notl_r(srcDest);
+        not32(srcDest, srcDest);
     }
 
     void not32(Address dest)

--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -68,6 +68,10 @@ namespace JSC::LOL {
     macro(op_to_numeric) \
     macro(op_rshift) \
     macro(op_urshift) \
+    macro(op_bitnot) \
+    macro(op_bitand) \
+    macro(op_bitor) \
+    macro(op_bitxor) \
 
 
 #define FOR_EACH_OP_WITH_SLOW_CASE(macro) \

--- a/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
+++ b/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
@@ -227,6 +227,7 @@ using ReplayRegisterAllocator = RegisterAllocator<ReplayBackend>;
     macro(OpToString, m_operand, 0) \
     macro(OpToObject, m_operand, 0) \
     macro(OpToNumeric, m_operand, 0) \
+    macro(OpBitnot, m_operand, 0) \
     macro(OpGetFromScope, m_scope, 1)
 
 #define ALLOCATE_USE_DEFS_FOR_UNARY_OP(Struct, operand, scratchCount) \
@@ -253,7 +254,10 @@ FOR_EACH_UNARY_OP(ALLOCATE_USE_DEFS_FOR_UNARY_OP)
     macro(OpGreatereq) \
     macro(OpLshift) \
     macro(OpRshift) \
-    macro(OpUrshift)
+    macro(OpUrshift) \
+    macro(OpBitand) \
+    macro(OpBitor) \
+    macro(OpBitxor)
 
 #define ALLOCATE_USE_DEFS_FOR_BINARY_OP(Struct) \
 template<typename Backend> \


### PR DESCRIPTION
#### 2ddabc56b7e2173c26f1420aad0d5697b384d2ea
<pre>
[LOL] Add support for bitwise bytecodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304516">https://bugs.webkit.org/show_bug.cgi?id=304516</a>
<a href="https://rdar.apple.com/problem/166899891">rdar://problem/166899891</a>

Reviewed by Mark Lam.

Add support for bit_not/or/xor/and opcodes. It&apos;s a pretty trivial
migration, with the only notable change being to use a two operand
not for bitnot so it doesn&apos;t clobber the use.

It&apos;s worth noting that these use CommonSlowPaths slow paths so those
work out of the box, albeit inefficiently.

No new behavior, covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/304786@main">https://commits.webkit.org/304786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f331140d2ce214af7aac4709df213ed7dcb1a46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144221 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d6c59bf-dbcc-45d4-884b-a396b38f1e63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/72bee8d6-496b-4701-97f1-d4a8dc4b4fbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6618 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4814 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128465 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146970 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134992 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8547 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112729 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113073 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6555 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8595 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36671 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72154 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43759 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->