### PR TITLE
ASSERTION FAILED: iterator != m_sessionToPageIDsMap.end() in WebProcessPool::pageEndUsingWebsiteDataStore

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5439,6 +5439,8 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+    // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
+    auto preventProcessShutdownScope = protectedLegacyMainFrameProcess()->shutdownPreventingScope();
     protectedLegacyMainFrameProcess()->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);
 
     if (RefPtr mainFrameWebsitePolicies = provisionalPage->mainFrameWebsitePolicies())


### PR DESCRIPTION
#### 68a3b2f07d2e7905d5ef0260d04efb3f49997873
<pre>
ASSERTION FAILED: iterator != m_sessionToPageIDsMap.end() in WebProcessPool::pageEndUsingWebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=304518">https://bugs.webkit.org/show_bug.cgi?id=304518</a>
<a href="https://rdar.apple.com/164973265">rdar://164973265</a>

Reviewed by Chris Dumez.

According to crash log, the assertion failure can happen in the following flow:
1. WKWebView performs navigation and provisional load is committed: WebPageProxy::commitProvisionalPage() is invoked.
2. WebProcessProxy::removeWebPage() is invoked with WebPageProxy::m_legacyMainFrameProcess, which may shut down the web
process.
3. When web process is shut down, async message reply handlers will be invoked immediately, and some WebKit API
completion handler can get invoked. In the completeion handler, WebKit client might ask to close the WKWebView.
4. WebPageProxy::close() invokes WebProcessProxy::removeWebPage() with the same WebPageProxy::m_legacyMainFrameProcess
and WebPageProxy::m_webisteDataStore again. The assertion fails as `WebProcessPool::pageEndUsingWebsiteDataStore()`
notices WebPageProxy is not using the WebsiteDataStore (the usage is removed in the first removeWebPage() call).

To fix this problem, this patch defers web process shutdown in step 2 to after WebPageProxy::swapToProvisionalPage()
updates WebPageProxy::m_legacyMainFrameProcess and WebPageProxy::m_webisteDataStore (it also invokes
WebProcessPool::addExistingWebPage()), so that when WebPageProxy::close() is invoked as in step 4,
WebProcessProxy::removeWebPage() will be called on updated WebProcessProxy with updated WebsiteDataStore.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):

Canonical link: <a href="https://commits.webkit.org/304892@main">https://commits.webkit.org/304892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd6a7e407a69c7e674f463cb177532d0840f36c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89752 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aa9bb572-f949-45a1-bd3c-e723e0de30c0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104593 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8e2dab4-903e-454b-a010-dd25d7d44e7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85431 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/635e3371-0521-4f89-8915-026adfda08c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6834 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4523 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5099 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116156 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147267 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112949 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113278 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28777 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6751 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62976 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8870 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36885 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->