### PR TITLE
AX: rename UIAccessibilitySpeechAttributeIsLiveRegion to UIAccessibilityTokenLiveRegionAnnouncement

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt
@@ -2,8 +2,8 @@ This tests that live region notifications for elements with different languages 
 
 Announcement received, notification: AXAnnouncementRequested, attributed string: Manzana{
     UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
-    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
     UIAccessibilitySpeechAttributeLanguage = es;
+    UIAccessibilityTokenLiveRegionAnnouncement = 1;
 }
 
 

--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt
@@ -2,13 +2,13 @@ This test verifies that live region notifications are properly formatted on iOS 
 
 Announcement received, notification: AXAnnouncementRequested, attributed string: Price: $10{
     UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
-    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
     UIAccessibilitySpeechAttributeLanguage = en;
+    UIAccessibilityTokenLiveRegionAnnouncement = 1;
 }
 Announcement received, notification: AXAnnouncementRequested, attributed string: Count: 5{
     UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityDefault;
-    UIAccessibilitySpeechAttributeIsLiveRegion = 1;
     UIAccessibilitySpeechAttributeLanguage = en;
+    UIAccessibilityTokenLiveRegionAnnouncement = 1;
 }
 
 PASS successfullyParsed is true

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -157,7 +157,7 @@ void AXObjectCache::postPlatformARIANotifyNotification(AccessibilityObject&, con
 static NSString * const UIAccessibilityPriorityLow = @"UIAccessibilityPriorityLow";
 static NSString * const UIAccessibilityPriorityDefault = @"UIAccessibilityPriorityDefault";
 static NSString * const UIAccessibilitySpeechAttributeAnnouncementPriority = @"UIAccessibilitySpeechAttributeAnnouncementPriority";
-static NSString * const UIAccessibilitySpeechAttributeIsLiveRegion = @"UIAccessibilitySpeechAttributeIsLiveRegion";
+static NSString * const UIAccessibilityTokenLiveRegionAnnouncement = @"UIAccessibilityTokenLiveRegionAnnouncement";
 
 void AXObjectCache::postPlatformLiveRegionNotification(AccessibilityObject&, const LiveRegionAnnouncementData& notificationData)
 {
@@ -172,7 +172,7 @@ void AXObjectCache::postPlatformLiveRegionNotification(AccessibilityObject&, con
 
             auto mutableAttributedString = adoptNS([[NSMutableAttributedString alloc] initWithAttributedString:notificationData.message.nsAttributedString().get()]);
             [mutableAttributedString addAttribute:UIAccessibilitySpeechAttributeAnnouncementPriority value:priority.get() range:NSMakeRange(0, [mutableAttributedString length])];
-            [mutableAttributedString addAttribute:UIAccessibilitySpeechAttributeIsLiveRegion value:@(YES) range:NSMakeRange(0, [mutableAttributedString length])];
+            [mutableAttributedString addAttribute:UIAccessibilityTokenLiveRegionAnnouncement value:@(YES) range:NSMakeRange(0, [mutableAttributedString length])];
 
             [root->wrapper() accessibilityPostedNotification:notificationName.get() userInfo:@{ notificationName.get() : mutableAttributedString.get() }];
         }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -554,7 +554,7 @@ void PageClientImpl::relayAriaNotifyNotification(const WebCore::AriaNotifyData& 
 static NSString * const UIAccessibilityPriorityLow = @"UIAccessibilityPriorityLow";
 static NSString * const UIAccessibilityPriorityDefault = @"UIAccessibilityPriorityDefault";
 static NSString * const UIAccessibilitySpeechAttributeAnnouncementPriority = @"UIAccessibilitySpeechAttributeAnnouncementPriority";
-static NSString * const UIAccessibilitySpeechAttributeIsLiveRegion = @"UIAccessibilitySpeechAttributeIsLiveRegion";
+static NSString * const UIAccessibilityTokenLiveRegionAnnouncement = @"UIAccessibilityTokenLiveRegionAnnouncement";
 
 void PageClientImpl::relayLiveRegionNotification(const WebCore::LiveRegionAnnouncementData& notificationData)
 {
@@ -564,7 +564,7 @@ void PageClientImpl::relayLiveRegionNotification(const WebCore::LiveRegionAnnoun
     RetainPtr nsAttributedString = notificationData.message.nsAttributedString();
     auto mutableAttributedString = adoptNS([[NSMutableAttributedString alloc] initWithAttributedString:nsAttributedString.get()]);
     [mutableAttributedString addAttribute:UIAccessibilitySpeechAttributeAnnouncementPriority value:priority.get() range:NSMakeRange(0, [mutableAttributedString length])];
-    [mutableAttributedString addAttribute:UIAccessibilitySpeechAttributeIsLiveRegion value:@(YES) range:NSMakeRange(0, [mutableAttributedString length])];
+    [mutableAttributedString addAttribute:UIAccessibilityTokenLiveRegionAnnouncement value:@(YES) range:NSMakeRange(0, [mutableAttributedString length])];
 
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, mutableAttributedString.get());
 }


### PR DESCRIPTION
#### 1898e35bc89773602e21cffa2a3408a52fa414ef
<pre>
AX: rename UIAccessibilitySpeechAttributeIsLiveRegion to UIAccessibilityTokenLiveRegionAnnouncement
<a href="https://bugs.webkit.org/show_bug.cgi?id=304519">https://bugs.webkit.org/show_bug.cgi?id=304519</a>
<a href="https://rdar.apple.com/166905453">rdar://166905453</a>

Reviewed by Chris Fleizach.

Rename this attribute to be consistent with other attributes.

* LayoutTests/accessibility/ios-simulator/live-regions/live-region-languages-expected.txt:
* LayoutTests/accessibility/ios-simulator/live-regions/live-region-types-expected.txt:
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::relayLiveRegionNotification):

Canonical link: <a href="https://commits.webkit.org/304867@main">https://commits.webkit.org/304867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/695f5d3a7353738bb6a4e73c163e19c005d296b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6336b340-59f8-49a6-a12a-cca4f6965654) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f75864da-29fe-4d6e-bc6a-22fb8cc9a2a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85352 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c2dd40b-a792-4cec-a963-404010d4415d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4439 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147156 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6676 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62834 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36807 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->