### PR TITLE
Fix outstanding static analyzer warnings in UniqueIDBDatabaseTransaction, AudioNodeInput, and InspectorLayerTreeAgent

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -52,19 +52,21 @@ UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConn
     if (m_transactionInfo.mode() == IDBTransactionMode::Versionchange)
         m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(checkedDatabase()->info());
 
-    if (!m_databaseConnection)
+    RefPtr databaseConnection = m_databaseConnection.get();
+    if (!databaseConnection)
         return;
 
-    if (CheckedPtr manager = m_databaseConnection->manager())
+    if (CheckedPtr manager = databaseConnection->manager())
         manager->registerTransaction(*this);
 }
 
 UniqueIDBDatabaseTransaction::~UniqueIDBDatabaseTransaction()
 {
-    if (!m_databaseConnection)
+    RefPtr databaseConnection = m_databaseConnection.get();
+    if (!databaseConnection)
         return;
 
-    if (CheckedPtr manager = m_databaseConnection->manager())
+    if (CheckedPtr manager = databaseConnection->manager())
         manager->unregisterTransaction(*this);
 }
 
@@ -578,8 +580,8 @@ void UniqueIDBDatabaseTransaction::didActivateInBackingStore(const IDBError& err
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::didActivateInBackingStore");
 
-    if (m_databaseConnection)
-        m_databaseConnection->protectedConnectionToClient()->didStartTransaction(m_transactionInfo.identifier(), error);
+    if (RefPtr connection = m_databaseConnection.get())
+        connection->protectedConnectionToClient()->didStartTransaction(m_transactionInfo.identifier(), error);
 }
 
 void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData, const IDBIndexInfo& indexInfo)

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -185,7 +185,7 @@ AudioBus& AudioNodeInput::bus()
 
     // Handle single connection specially to allow for in-place processing.
     if (numberOfRenderingConnections() == 1 && node()->channelCountMode() == ChannelCountMode::Max)
-        return renderingOutput(0)->bus();
+        SUPPRESS_UNCHECKED_ARG return renderingOutput(0)->bus();
 
     // Multiple connections case or complex ChannelCountMode (or no connections).
     return m_internalSummingBus;

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -346,7 +346,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::LayerTree::Compositi
 
 Inspector::CommandResult<String> InspectorLayerTreeAgent::requestContent(const Inspector::Protocol::LayerTree::LayerId& layerId)
 {
-    auto* renderLayer = m_idToLayer.get(layerId);
+    CheckedPtr renderLayer = m_idToLayer.get(layerId);
     if (!renderLayer)
         return makeUnexpected("Missing render layer for given layerId"_s);
 
@@ -354,7 +354,7 @@ Inspector::CommandResult<String> InspectorLayerTreeAgent::requestContent(const I
     if (!backing)
         return makeUnexpected("Layer is not composited"_s);
 
-    auto* graphicsLayer = backing->graphicsLayer();
+    RefPtr graphicsLayer = backing->graphicsLayer();
     if (!graphicsLayer)
         return makeUnexpected("Missing graphics layer"_s);
 
@@ -387,7 +387,7 @@ String InspectorLayerTreeAgent::bind(const RenderLayer* layer)
         return emptyString();
     return m_documentLayerToIdMap.ensure(layer, [this, layer] {
         auto identifier = IdentifiersFactory::createIdentifier();
-        m_idToLayer.set(identifier, layer);
+        m_idToLayer.set(identifier, InlineWeakPtr { layer });
         return identifier;
     }).iterator->value;
 }

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/InlineWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
@@ -89,7 +90,7 @@ private:
     const Ref<Inspector::LayerTreeBackendDispatcher> m_backendDispatcher;
 
     HashMap<const RenderLayer*, Inspector::Protocol::LayerTree::LayerId> m_documentLayerToIdMap;
-    HashMap<Inspector::Protocol::LayerTree::LayerId, const RenderLayer*> m_idToLayer;
+    HashMap<Inspector::Protocol::LayerTree::LayerId, InlineWeakPtr<const RenderLayer>> m_idToLayer;
 
     WeakHashMap<PseudoElement, Inspector::Protocol::LayerTree::PseudoElementId, WeakPtrImplWithEventTargetData> m_pseudoElementToIdMap;
     HashMap<Inspector::Protocol::LayerTree::PseudoElementId, WeakPtr<PseudoElement, WeakPtrImplWithEventTargetData>> m_idToPseudoElement;


### PR DESCRIPTION
#### d3f61673397603f7e29f41501125187b264757df
<pre>
Fix outstanding static analyzer warnings in UniqueIDBDatabaseTransaction, AudioNodeInput, and InspectorLayerTreeAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=304520">https://bugs.webkit.org/show_bug.cgi?id=304520</a>

Reviewed by Mike Wyrzykowski, John Wilander, and Wenson Hsieh.

Fix the outstanding clang static analyzers warnings.

No new tests since there should be no behavioral differences.

* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::~UniqueIDBDatabaseTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::didActivateInBackingStore):
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::bus):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::requestContent):
(WebCore::InspectorLayerTreeAgent::bind):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h:

Canonical link: <a href="https://commits.webkit.org/304808@main">https://commits.webkit.org/304808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d13f2434c1e28b1a65100202f74a2f37b28d3c1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144227 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1224df94-063a-4733-ab5d-a62cec9b96eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4f0c47a4-ab8a-4193-b81d-465c7e201f07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85226 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/76366204-6f53-442d-8297-205bc77a1829) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4301 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4820 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146977 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8553 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41094 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112732 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 57 flakes 70 failures; Uploaded test results; 14 flakes 44 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113076 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6558 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62561 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8601 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36678 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->