### PR TITLE
[git-webkit] Allow landing removals of OOPs

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -43,7 +43,7 @@ class Land(Command):
     help = 'If on a pull-request or commit-queue branch, rebase the ' \
            'current branch onto the target production branch and push.'
 
-    OOPS_RE = re.compile(r'\(O+P+S!*\)')
+    OOPS_RE = re.compile(r'^[^-]+\(O+P+S!*\)')
     REVIEWED_BY_RE = re.compile('Reviewed by (?P<approver>.+)')
     GIT_SVN_COMMITTED_RE = re.compile(r'Committed r(?P<revision>\d+)')
     REMOTE = 'origin'


### PR DESCRIPTION
#### f3407ff50afc354cd61fc75e2e1d26e33b99727b
<pre>
[git-webkit] Allow landing removals of OOPs
<a href="https://bugs.webkit.org/show_bug.cgi?id=304524">https://bugs.webkit.org/show_bug.cgi?id=304524</a>
<a href="https://rdar.apple.com/166910811">rdar://166910811</a>

Reviewed by Alexey Proskuryakov.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land): Exclude OOPs strings in removal lines.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.test_with_removed_oops): Added.

Canonical link: <a href="https://commits.webkit.org/305056@main">https://commits.webkit.org/305056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf85c4bbac88ceaffacfd44e390f0d596e192ce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e8bae48-8bf7-4d69-8ccb-1c532f5664c3) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/32c7f69b-7139-48f1-8ce7-eb2a3cf1231a) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/de902b47-08b2-4b42-b7eb-15c0e9c2854e) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21155 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->