### PR TITLE
outlook.com: Microsoft OWA: ETS:Font Mingliu renders malpositioned numbers in Safari

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta charset=utf-8>
+<title>CSS Reference: generic font families should resolve correctly with lang attribute</title>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+body { font-size: 48px; line-height: 1.2; }
+.serif { font-family: serif; }
+.sans-serif { font-family: sans-serif; }
+.monospace { font-family: monospace; }
+.cursive { font-family: cursive; }
+.fantasy { font-family: fantasy; }
+.system-ui { font-family: system-ui; }
+.ui-serif { font-family: ui-serif; }
+.ui-sans-serif { font-family: ui-sans-serif; }
+.ui-monospace { font-family: ui-monospace; }
+.ui-rounded { font-family: ui-rounded; }
+</style>
+</head>
+<body>
+<p>Test that generic font families with lang="en-US" resolve correctly:</p>
+<div class="serif">serif</div>
+<div class="sans-serif">sans-serif</div>
+<div class="monospace">monospace</div>
+<div class="cursive">cursive</div>
+<div class="fantasy">fantasy</div>
+<div class="system-ui">system-ui</div>
+<div class="ui-serif">ui-serif</div>
+<div class="ui-sans-serif">ui-sans-serif</div>
+<div class="ui-monospace">ui-monospace</div>
+<div class="ui-rounded">ui-rounded</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta charset=utf-8>
+<title>CSS Reference: generic font families should resolve correctly with lang attribute</title>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+body { font-size: 48px; line-height: 1.2; }
+.serif { font-family: serif; }
+.sans-serif { font-family: sans-serif; }
+.monospace { font-family: monospace; }
+.cursive { font-family: cursive; }
+.fantasy { font-family: fantasy; }
+.system-ui { font-family: system-ui; }
+.ui-serif { font-family: ui-serif; }
+.ui-sans-serif { font-family: ui-sans-serif; }
+.ui-monospace { font-family: ui-monospace; }
+.ui-rounded { font-family: ui-rounded; }
+</style>
+</head>
+<body>
+<p>Test that generic font families with lang="en-US" resolve correctly:</p>
+<div class="serif">serif</div>
+<div class="sans-serif">sans-serif</div>
+<div class="monospace">monospace</div>
+<div class="cursive">cursive</div>
+<div class="fantasy">fantasy</div>
+<div class="system-ui">system-ui</div>
+<div class="ui-serif">ui-serif</div>
+<div class="ui-sans-serif">ui-sans-serif</div>
+<div class="ui-monospace">ui-monospace</div>
+<div class="ui-rounded">ui-rounded</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta charset=utf-8>
+<title>CSS Test: lang attribute should not cause generic families to resolve to unusable system font names</title>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#generic-font-families"/>
+<link rel="match" href="generic-family-lang-attr-cascade-ref.html"/>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="When lang='en-US' is set, generic font families should resolve to usable fonts, not fall through to fallback font in the cascade"/>
+<style>
+body { font-size: 48px; line-height: 1.2; }
+.serif { font-family: serif, ahem; }
+.sans-serif { font-family: sans-serif, ahem; }
+.monospace { font-family: monospace, ahem; }
+.cursive { font-family: cursive, ahem; }
+.fantasy { font-family: fantasy, ahem; }
+.system-ui { font-family: system-ui, ahem; }
+.ui-serif { font-family: ui-serif, ahem; }
+.ui-sans-serif { font-family: ui-sans-serif, ahem; }
+.ui-monospace { font-family: ui-monospace, ahem; }
+.ui-rounded { font-family: ui-rounded, ahem; }
+</style>
+</head>
+<body>
+<p>Test that generic font families with lang="en-US" resolve correctly:</p>
+<div class="serif" lang="en-US">serif</div>
+<div class="sans-serif" lang="en-US">sans-serif</div>
+<div class="monospace" lang="en-US">monospace</div>
+<div class="cursive" lang="en-US">cursive</div>
+<div class="fantasy" lang="en-US">fantasy</div>
+<div class="system-ui" lang="en-US">system-ui</div>
+<div class="ui-serif" lang="en-US">ui-serif</div>
+<div class="ui-sans-serif" lang="en-US">ui-sans-serif</div>
+<div class="ui-monospace" lang="en-US">ui-monospace</div>
+<div class="ui-rounded" lang="en-US">ui-rounded</div>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1634,3 +1634,6 @@ webkit.org/b/304053 [ Debug ] imported/w3c/web-platform-tests/html/cross-origin-
 webkit.org/b/304053 [ Debug ] imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https.html [ Crash Pass ]
 
 webkit.org/b/304278 [ Debug ] inspector/worker/debugger-pause-subworker.html [ Crash Timeout ]
+
+# webkit.org/b/304535 ui-serif, ui-sans-serif, ui-monospace, ui-rounded generic families not implemented on GTK
+imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4615,3 +4615,6 @@ imported/w3c/web-platform-tests/css/CSS2/box-display/display-008.xht [ ImageOnly
 imported/w3c/web-platform-tests/css/CSS2/box-display/display-009.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/CSS2/box-display/display-012.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/CSS2/box-display/display-013.xht [ ImageOnlyFailure ]
+
+# webkit.org/b/304535 ui-serif, ui-sans-serif, ui-monospace, ui-rounded generic families not implemented on Windows
+imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1313,3 +1313,6 @@ webkit.org/b/303866 imported/w3c/web-platform-tests/css/css-anchor-position/scro
 webkit.org/b/303677 imported/w3c/web-platform-tests/fetch/cross-origin-resource-policy/fetch-in-iframe.html [ Pass Crash ]
 
 webkit.org/b/304272 [ Debug ] imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.html [ Failure Pass ]
+
+# webkit.org/b/304535 ui-serif, ui-sans-serif, ui-monospace, ui-rounded generic families not implemented on WPE
+imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 1ecb160d72f75c57927794c9b5967f71b75f034c
<pre>
outlook.com: Microsoft OWA: ETS:Font Mingliu renders malpositioned numbers in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=304530">https://bugs.webkit.org/show_bug.cgi?id=304530</a>
<a href="https://rdar.apple.com/139338599">rdar://139338599</a>

Reviewed by Elika Etemad.

CoreText returns reserved font names like &quot;.Times Fallback&quot; when
resolving generic families for certain locales (e.g., lang=&quot;en-US&quot;
with font-family: serif). Font names starting with &apos;.&apos; are reserved
for system use and must be created via CTFontCreateUIFontForLanguage(),
not standard font lookup.

WebKit cannot look up these reserved names, causing the generic family
to fail and the cascade to continue. This resulted in incorrect font
selection where text would fall through to emoji fonts.

Fix by rejecting font names starting with &apos;.&apos; in platformResolveGenericFamily()
and using settings-based resolution instead.

Tests: imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-ref.html
       imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/generic-family-lang-attr-cascade.html: Added.
* Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp:
(WebCore::FontDescription::platformResolveGenericFamily):

Canonical link: <a href="https://commits.webkit.org/304809@main">https://commits.webkit.org/304809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f53a7a9ded163087b7fadb72cc91b7bf74f12133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144268 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8cb391b-022e-4990-94d6-42e8bc52cc83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d87b4e71-a75f-4868-a51b-f8933fb0dfeb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85247 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c3c77b8-2728-4502-8e9b-16e424eb8fd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4317 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4864 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8590 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112751 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6574 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118641 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8638 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36695 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->