### PR TITLE
[webkitapipy] Use of ObjC SPI methods ignored when a binary has a method with the same selector

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py
@@ -48,7 +48,8 @@ class APIReport:
         class_: str
 
     @classmethod
-    def from_binary(cls, binary_path: Path, *, arch: str, exports_only=False):
+    def from_binary(cls, binary_path: Path, *, arch: str,
+                    exports_only: bool = False) -> APIReport:
         dyld_args = ['-arch', arch, '-exports', '-objc']
         if not exports_only:
             dyld_args.extend(('-imports',

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
@@ -306,8 +306,8 @@ def main(argv: Optional[list[str]] = None):
 
     for binary_path in args.input_files:
         add_corresponding_sdkdb(binary_path)
-        report = APIReport.from_binary(use_input(binary_path), arch=args.arch_name)
-        db.add_for_auditing(report)
+        db.add_binary(use_input(binary_path), arch=args.arch_name,
+                      for_auditing=True)
     for diagnostic in db.audit():
         reporter.emit_diagnostic(diagnostic)
 

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py
@@ -120,11 +120,11 @@ class CLITest(TestCase):
         # When invoked with a ld-style framework argument:
         result = self.call(self.dylib, '-framework', 'foo')
         # It loads the framework binary...
-        result.sdkdb.add_binary.assert_called_with(
+        result.sdkdb.add_binary.assert_any_call(
             self.framework / 'foo', arch='arm64e'
         )
         # ...and the corresponding partial SDKDB.
-        result.sdkdb.add_partial_sdkdb.assert_called_with(
+        result.sdkdb.add_partial_sdkdb.assert_any_call(
             self.local_sdkdb, spi=True, abi=True
         )
 


### PR DESCRIPTION
#### 648846326ad49d8df7698f76d4fdc65f48b5f5ef
<pre>
[webkitapipy] Use of ObjC SPI methods ignored when a binary has a method with the same selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=304532">https://bugs.webkit.org/show_bug.cgi?id=304532</a>
<a href="https://rdar.apple.com/166914163">rdar://166914163</a>

Reviewed by Sam Sneddon.

When an SPI allowlist has an entry like:
    { name = &quot;setHighFrameRateReason:&quot;, class = &quot;CADisplayLink&quot; },

and a binary has some other method in it with the same name:
    -[WKDisplayLinkHandler setHighFrameRateReason:]

audit-spi should NOT issue an &quot;unnecessary allowed name&quot; diagnostic. It
should assume that use of setHighFrameRateReason: in the code might be a
call to the SPI method.

This is in contrast to when an SPI allowlist has a classless entry like:
    { name = &quot;setHighFrameRateReason:&quot;, class = &quot;?&quot; },

There, we continue to emit a diagnostic that the entry should be
cleaned up.

Implement this by changing how we load the binaries under audit: First,
add them to the exports table like any other binaries containing allowed
declarations. Then, add their bindings and selectors to the imports
table. The auditing query already takes a selector&apos;s class name into
consideration, so the only change needed is the logic used to populate
the database.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py:
(APIReport.from_binary): Fix return type annotation.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py:
(CLITest.test_loads_partial_sdkdb_for_framework):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(DeclarationKind.from_sql): Fix return type annotation.
(SDKDB.add_binary):
(SDKDB._add_imports):
(SDKDB.add_for_auditing): Deleted.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.audit_with):
(TestSDKDB.test_audit_unused_allow_multiple_allowlists):
(TestSDKDB):
(TestSDKDB.test_audit_allow_different_fully_qualified_methods_same_name):
(TestSDKDB.test_audit_unnecessary_allow_unqualified_methods_same_name):

Canonical link: <a href="https://commits.webkit.org/304887@main">https://commits.webkit.org/304887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/362cf2160f835931cb9f8e092415fd857f03399d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144504 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2bc5e7fa-59f8-48eb-8bb9-8f4e725913b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6044f03-31c5-4332-a7e5-e6d053abe998) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85426 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43ccad4b-79d6-486d-9ed0-769b93d004f5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/136121 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5093 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/116154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147261 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41300 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6748 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62970 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8864 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36884 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8804 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->