### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in TinyPtrSet.h

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
@@ -64,10 +64,9 @@ void StructureAbstractValue::clobber()
             makeTopWhenThin();
         return;
     }
-    
-    RegisteredStructureSet::OutOfLineList* list = m_set.list();
-    for (unsigned i = list->m_length; i--;) {
-        if (!list->list()[i]->dfgShouldWatch()) {
+
+    for (auto& item : m_set.list()->lengthSpan() | std::views::reverse) {
+        if (!item->dfgShouldWatch()) {
             makeTop();
             return;
         }


### PR DESCRIPTION
#### 0a5c36b11c56954ed064e6e211ad74f41ecb5139
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in TinyPtrSet.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=304537">https://bugs.webkit.org/show_bug.cgi?id=304537</a>

Reviewed by Darin Adler.

Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in TinyPtrSet.h, bringing
bounds safety to this container type. This tested as performance neutral
on Speedometer and JetStream.

* Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp:
(JSC::DFG::StructureAbstractValue::clobber):
* Source/WTF/wtf/TinyPtrSet.h:
(WTF::TinyPtrSet::onlyEntry const):
(WTF::TinyPtrSet::add):
(WTF::TinyPtrSet::remove):
(WTF::TinyPtrSet::forEach const):
(WTF::TinyPtrSet::genericFilter):
(WTF::TinyPtrSet::isSubsetOf const):
(WTF::TinyPtrSet::overlaps const):
(WTF::TinyPtrSet::at const):
(WTF::TinyPtrSet::last const):
(WTF::TinyPtrSet::addOutOfLine):
(WTF::TinyPtrSet::mergeOtherOutOfLine):
(WTF::TinyPtrSet::containsOutOfLine const):
(WTF::TinyPtrSet::copyFromOutOfLine):
(WTF::TinyPtrSet::OutOfLineList::capacitySpan):
(WTF::TinyPtrSet::OutOfLineList::lengthSpan):
(WTF::TinyPtrSet::OutOfLineList::list): Deleted.

Canonical link: <a href="https://commits.webkit.org/304827@main">https://commits.webkit.org/304827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cb9c4f2be6571fc90759ce34d83cc325d365195

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/188b0717-f497-49f6-8548-d7b60510c0eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104415 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/74980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/784a2065-0330-401b-93d8-e16ed8a128f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85250 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f767171f-1171-4162-a02b-3360f0561575) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6649 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4319 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4870 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128511 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147032 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135036 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113098 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6576 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62619 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36697 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72207 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43770 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->