### PR TITLE
Do not use WTFMove

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -549,13 +549,13 @@ Ref<A> a = A::create();
 ```
 
 When passing the ownership of a ref-counted object to a function,
-use rvalue reference with `WTFMove` (equivalent to `std::move` with some safety checks),
+use rvalue reference with `WTF::move` (equivalent to `std::move` with some safety checks),
 and use a regular reference when there is a guarantee for the caller to keep the object alive as follows:
 
 ```cpp
 class B {
 public:
-    void setA(Ref<A>&& a) { m_a = WTFMove(a); }
+    void setA(Ref<A>&& a) { m_a = WTF::move(a); }
 private:
     Ref<A> m_a;
 };
@@ -567,7 +567,7 @@ void createA(B& b) {
 }
 ```
 
-Note that there is no `WTFMove` on `A::create` due to copy elision.
+Note that there is no `WTF::move` on `A::create` due to copy elision.
 
 ### Forwarding ref and deref
 

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -177,7 +177,7 @@ RefPtr<BaselineJITCode> LOLJIT::compileAndLinkWithoutFinalizing(JITCompilationEf
     RELEASE_ASSERT(!JITCode::isJIT(m_profiledCodeBlock->jitType()));
 
     if (sizeMarker) [[unlikely]]
-        m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, Ref(m_plan));
+        m_vm->jitSizeStatistics->markEnd(WTF::move(*sizeMarker), *this, Ref(m_plan));
 
     privateCompileMainPass();
     privateCompileLinkPass();
@@ -526,7 +526,7 @@ void LOLJIT::privateCompileMainPass()
             RELEASE_ASSERT_NOT_REACHED();
         }
         if (sizeMarker) [[unlikely]]
-            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, Ref(m_plan));
+            m_vm->jitSizeStatistics->markEnd(WTF::move(*sizeMarker), *this, Ref(m_plan));
 
         if (LOLJITInternal::verbose)
             dataLogLn("At ", bytecodeOffset, ": added ", m_slowCases.size() - previousSlowCasesSize, "(", m_slowCases.size(), ") allocator: ", m_fastAllocator);
@@ -733,7 +733,7 @@ void LOLJIT::privateCompileSlowCases()
 
         if (sizeMarker) [[unlikely]] {
             m_bytecodeIndex = BytecodeIndex(m_bytecodeIndex.offset() + currentInstruction->size());
-            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, Ref(m_plan));
+            m_vm->jitSizeStatistics->markEnd(WTF::move(*sizeMarker), *this, Ref(m_plan));
         }
 
         nextBytecodeIndexWithFlushForJumpTargetsIfNeeded(m_replayAllocator, false);

--- a/Source/WTF/wtf/InlineWeakPtr.h
+++ b/Source/WTF/wtf/InlineWeakPtr.h
@@ -115,7 +115,7 @@ inline InlineWeakPtr<T>& InlineWeakPtr<T>::operator=(const InlineWeakPtr& o)
 template<typename T>
 inline InlineWeakPtr<T>& InlineWeakPtr<T>::operator=(InlineWeakPtr&& o)
 {
-    InlineWeakPtr ptr = WTFMove(o);
+    InlineWeakPtr ptr = WTF::move(o);
     swap(ptr);
     return *this;
 }
@@ -173,7 +173,7 @@ template<typename P> struct InlineWeakPtrHashTraits : public SimpleClassHashTrai
     static PeekType peek(P* value) { return value; }
 
     using TakeType = InlineWeakPtr<P>;
-    static TakeType take(InlineWeakPtr<P>&& value) { return isEmptyValue(value) ? nullptr : InlineWeakPtr<P>(WTFMove(value)); }
+    static TakeType take(InlineWeakPtr<P>&& value) { return isEmptyValue(value) ? nullptr : InlineWeakPtr<P>(WTF::move(value)); }
 };
 
 template<typename P> struct HashTraits<InlineWeakPtr<P>> : InlineWeakPtrHashTraits<P> { };

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1563,9 +1563,6 @@ static constexpr auto dereferenceView = std::views::transform([](auto&& x) -> de
 
 } // namespace WTF
 
-// FIXME: get rid of WTF::move() and use WTF::move() directly.
-#define WTFMove(value) WTF::move(value)
-
 namespace WTF {
 namespace detail {
 template<typename T, typename U> using copy_const = std::conditional_t<std::is_const_v<T>, const U, U>;

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -463,7 +463,7 @@ void SQLTransaction::deliverSuccessCallback()
     // Spec 4.3.2.8: Deliver success callback.
     RefPtr<VoidCallback> successCallback = m_successCallbackWrapper.unwrap();
     if (successCallback) {
-        m_database->document().checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback)]() mutable {
+        m_database->document().checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback)]() mutable {
             successCallback->invoke();
         });
     }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -505,7 +505,7 @@ void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeB
     DEBUG_LOG(logSiteIdentifier, timeBoundary);
     UNUSED_PARAM(logSiteIdentifier);
 
-    m_currentTimeObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times.get() queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, timeBoundary, logSiteIdentifier, callback = WTFMove(callback)]() mutable {
+    m_currentTimeObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times.get() queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, timeBoundary, logSiteIdentifier, callback = WTF::move(callback)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/bmalloc/bmalloc/SegmentedVector.h
+++ b/Source/bmalloc/bmalloc/SegmentedVector.h
@@ -153,7 +153,7 @@ public:
     T takeLast()
     {
         BASSERT(!isEmpty());
-        T result = WTFMove(last());
+        T result = std::move(last());
         --m_size;
         return result;
     }

--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -1029,7 +1029,7 @@ for (Vector<RefPtr<FrameView> >::iterator it = frameViews.begin(); it != end; ++
 
 ```cpp
 [this] { return m_member; }
-[this]() mutable { return doWork(WTFMove(m_object)); }
+[this]() mutable { return doWork(WTF::move(m_object)); }
 ```
 
 ###### Wrong:


### PR DESCRIPTION
#### d0c2f303b61df6a455265e461cf45c6529a11516
<pre>
Do not use WTFMove
<a href="https://bugs.webkit.org/show_bug.cgi?id=304539">https://bugs.webkit.org/show_bug.cgi?id=304539</a>
<a href="https://rdar.apple.com/166926521">rdar://166926521</a>

Reviewed by Anne van Kesteren and Mark Lam.

Remove remaining WTFMove use in WebKit. Also, replace some of std::move
in JSC with WTF::move.

* Introduction.md:
* Source/JavaScriptCore/lol/LOLJIT.cpp:
(JSC::LOL::LOLJIT::compileAndLinkWithoutFinalizing):
(JSC::LOL::LOLJIT::privateCompileMainPass):
(JSC::LOL::LOLJIT::privateCompileSlowCases):
* Source/WTF/wtf/InlineWeakPtr.h:
(WTF::=):
(WTF::InlineWeakPtrHashTraits::take):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::deliverSuccessCallback):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
* Source/bmalloc/bmalloc/SegmentedVector.h:
* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/304817@main">https://commits.webkit.org/304817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e0b72549f073061982c8046a67ae48edcf32fd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136553 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89526 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1888fe14-130c-4d88-ab4e-ca16e504971d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104420 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/74984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c88ea60-a4c1-4b38-b8ce-4e0cf6b160de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fb8aed4b-a318-48b0-bdd9-9486f54de4e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4326 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4872 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128514 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147034 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135039 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8596 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112760 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113102 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62620 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8644 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36703 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167818 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72210 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43784 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->