### PR TITLE
[AutoFill Debugging] Include tooltips (title DOM attribute) in text extraction output

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -14,7 +14,7 @@ root
             button,aria-describedby='This button does nothing',aria-label='Test button','Click Me'
             'This button does nothing'
             input,'text',uid=…,placeholder='Enter text here'
-            role='button','Clickable Div'
+            role='button',title='Test action','Clickable Div'
         section,aria-label='Content with Roles'
             article,role='article','Article Title\n\nJanuary 1, 2024\nThis is some article content with highlighted text.'
             role='complementary',aria-label='Related information'
@@ -64,7 +64,7 @@ version=2
             <button aria-describedby='This button does nothing' aria-label='Test button'>Click Me</button>
             This button does nothing
             <input type='text' uid=… placeholder='Enter text here'>
-            <div role='button'>Clickable Div</div>
+            <div role='button' title='Test action'>Clickable Div</div>
         </section>
         <section aria-label='Content with Roles'>
             <article role='article'>Article Title  January 1, 2024 This is some article content with highlighted text.</article>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -44,7 +44,7 @@
         <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
         <div id="btn-help" aria-hidden="true">This button does nothing</div>
         <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
-        <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+        <div class="interactive" tabindex="0" title="Test action" role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
     </section>
     <section id="section2" aria-label="Content with Roles">
         <article role="article">

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -178,6 +178,7 @@ struct Item {
     OptionSet<EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
+    String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber { 0 };
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -439,6 +439,9 @@ static Vector<String> partsForItem(const TextExtraction::Item& item, const TextE
     if (!item.accessibilityRole.isEmpty())
         parts.append(makeString("role='"_s, escapeString(item.accessibilityRole), '\''));
 
+    if (!item.title.isEmpty())
+        parts.append(makeString("title='"_s, escapeString(item.title), '\''));
+
     auto listeners = eventListenerTypesToStringArray(item.eventListeners);
     if (!listeners.isEmpty() && !aggregator.useHTMLOutput())
         parts.append(makeString("events=["_s, commaSeparatedString(listeners), ']'));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6926,6 +6926,7 @@ header: <WebCore/TextExtractionTypes.h>
     OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;
+    String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber;
 };


### PR DESCRIPTION
#### 4e1a0a1d21d980825fa8ec85eb6c2806070081c8
<pre>
[AutoFill Debugging] Include tooltips (title DOM attribute) in text extraction output
<a href="https://bugs.webkit.org/show_bug.cgi?id=304553">https://bugs.webkit.org/show_bug.cgi?id=304553</a>
<a href="https://rdar.apple.com/166950912">rdar://166950912</a>

Reviewed by Richard Robinson.

Include the `title` DOM attribute during text extraction, and surface it through
`-_debugTextWithConfiguration` output (if non-empty).

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:

Adjust an existing layout test to exercise this.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::pruneEmptyContainersRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::partsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/304832@main">https://commits.webkit.org/304832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f875f0b7794778788e0d8fb99a029277aedfb7c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89559 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/737263db-cc64-4fde-a5b1-f46fced142f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104441 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0042f90d-9aac-4a24-88b1-c6b8d711d2db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/706bc88e-d5bd-40a1-8dd1-c0be2a214761) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4357 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4906 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115991 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40572 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_keyPath.any.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112785 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6606 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62678 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8677 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36731 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->