### PR TITLE
Align ref and weakRef counting on uint32_t

### DIFF
--- a/Source/WTF/wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
+++ b/Source/WTF/wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
@@ -36,7 +36,7 @@ public:
 
 private:
     template<typename> friend class ThreadSafeWeakHashSet;
-    virtual size_t weakRefCount() const = 0;
+    virtual uint32_t weakRefCount() const = 0;
 };
 
 }
@@ -48,6 +48,5 @@ using WTF::AbstractThreadSafeRefCountedAndCanMakeWeakPtr;
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); } \
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); } \
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); } \
-    size_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); } \
+    uint32_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); } \
     using __Unused_type_for_semicolon = int
-

--- a/Source/WTF/wtf/DeferrableRefCounted.h
+++ b/Source/WTF/wtf/DeferrableRefCounted.h
@@ -38,8 +38,8 @@ namespace WTF {
 // sometimes even for some additional functionality.
 
 class DeferrableRefCountedBase {
-    static constexpr unsigned deferredFlag = 1;
-    static constexpr unsigned normalIncrement = 2;
+    static constexpr uint32_t deferredFlag = 1;
+    static constexpr uint32_t normalIncrement = 2;
 
 public:
     void ref() const
@@ -52,7 +52,7 @@ public:
         return refCount() == 1;
     }
 
-    unsigned refCount() const
+    uint32_t refCount() const
     {
         return m_refCount / normalIncrement;
     }
@@ -89,7 +89,7 @@ protected:
     }
 
 private:
-    mutable unsigned m_refCount;
+    mutable uint32_t m_refCount;
 };
 
 template<typename T>

--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -36,7 +36,7 @@ public:
     }
 
     bool hasOneRef() const { return m_refCount == 1; }
-    unsigned refCount() const { return m_refCount; }
+    uint32_t refCount() const { return m_refCount; }
 
     // Debug APIs
     void adopted() { m_refCountDebugger.adopted(); }
@@ -58,7 +58,7 @@ protected:
     {
         m_refCountDebugger.willDeref(m_refCount);
 
-        unsigned tempRefCount = m_refCount - 1;
+        auto tempRefCount = m_refCount - 1;
         if (!tempRefCount) {
             m_refCountDebugger.willDelete();
             return true;
@@ -69,7 +69,7 @@ protected:
     }
 
 private:
-    mutable unsigned m_refCount { 1 };
+    mutable uint32_t m_refCount { 1 };
     NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -45,7 +45,7 @@ public:
     }
 
     bool hasOneRef() const { return m_refCount == 1; }
-    unsigned refCount() const { return m_refCount; }
+    uint32_t refCount() const { return m_refCount; }
 
     // Debug APIs
     void adopted() { m_refCountDebugger.adopted(); }
@@ -84,7 +84,7 @@ protected:
     }
 
 private:
-    mutable std::atomic<unsigned> m_refCount { 1 };
+    mutable std::atomic<uint32_t> m_refCount { 1 };
     NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -47,7 +47,7 @@ public:
     }
 
     bool hasOneRef() const { return m_refCount == 1; }
-    unsigned refCount() const { return m_refCount; }
+    uint32_t refCount() const { return m_refCount; }
 
     // Debug APIs
     void adopted() { m_refCountDebugger.adopted(); }
@@ -86,7 +86,7 @@ protected:
     }
 
 private:
-    mutable std::atomic<unsigned> m_refCount { 1 };
+    mutable std::atomic<uint32_t> m_refCount { 1 };
     NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
 };
 

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -152,13 +152,13 @@ public:
         Locker locker { m_lock };
         return !m_object;
     }
-    size_t weakRefCount() const
+    uint32_t weakRefCount() const
     {
         Locker locker { m_lock };
         return m_weakReferenceCount;
     }
 
-    size_t refCount() const
+    uint32_t refCount() const
     {
         Locker locker { m_lock };
         return m_strongReferenceCount;
@@ -177,11 +177,11 @@ private:
         : m_object(const_cast<T*>(static_cast<const T*>(object)))
     { }
 
-    void setStrongReferenceCountDuringInitialization(size_t count) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { m_strongReferenceCount = count; }
+    void setStrongReferenceCountDuringInitialization(uint32_t count) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { m_strongReferenceCount = count; }
 
     mutable WordLock m_lock;
-    mutable size_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
-    mutable size_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    mutable uint32_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
+    mutable uint32_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable void* m_object WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
 };
 
@@ -263,7 +263,7 @@ public:
         std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed())->template strongDeref<T, destructionThread>();
     }
 
-    size_t refCount() const
+    uint32_t refCount() const
     {
         uintptr_t bits = m_bits.loadRelaxed();
         if (isStrongOnly(bits)) {
@@ -280,7 +280,7 @@ public:
 
     // Ideally this would have been private but AbstractRefCounted subclasses need to be able to access this function
     // to provide its result to ThreadSafeWeakHashSet.
-    size_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
+    uint32_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
 
 protected:
     ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;

--- a/Source/WebCore/Modules/webdatabase/DatabaseThread.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseThread.cpp
@@ -105,7 +105,7 @@ void DatabaseThread::databaseThread()
     // Clean up the list of all pending transactions on this database thread
     m_transactionCoordinator->shutdown();
 
-    LOG(StorageAPI, "About to detach thread %p and clear the ref to DatabaseThread %p, which currently has %zu ref(s)", m_thread.get(), this, refCount());
+    LOG(StorageAPI, "About to detach thread %p and clear the ref to DatabaseThread %p, which currently has %i ref(s)", m_thread.get(), this, refCount());
 
     // Close the databases that we ran transactions on. This ensures that if any transactions are still open, they are rolled back and we don't leave the database in an
     // inconsistent or locked state.

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -82,7 +82,7 @@ public:
 #if USE(AUDIO_SESSION)
     // WebCore::AudioSession.
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::controlBlock(); }
-    size_t weakRefCount() const final { return REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::weakRefCount(); }
+    uint32_t weakRefCount() const final { return REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::weakRefCount(); }
 #endif
 
     const Ref<WebProcessProxy> process() const { return m_process; }

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -191,7 +191,7 @@ public:
     void ref() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::ref(); }
     void deref() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::controlBlock(); }
-    size_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::weakRefCount(); }
+    uint32_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::weakRefCount(); }
 
     WorkQueue& workQueue() const { return m_queue; }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -65,7 +65,7 @@ public:
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame&);
 
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::controlBlock(); }
-    size_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::weakRefCount(); }
+    uint32_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::weakRefCount(); }
 
     void ref() const final { IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::ref(); }
     void deref() const final { IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>::deref(); }


### PR DESCRIPTION
#### 26d2fd2eb3613de67453dbb8e74315831d7b85bb
<pre>
Align ref and weakRef counting on uint32_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=304564">https://bugs.webkit.org/show_bug.cgi?id=304564</a>

Reviewed by Simon Fraser.

uint32_t is more explicit than unsigned and can reduce memory compared
to size_t on 64-bit platforms. And given that only ThreadSafeWeakPtr is
using size_t at the moment, this should be a reasonable change to make.

Canonical link: <a href="https://commits.webkit.org/304921@main">https://commits.webkit.org/304921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70a5d1253f14b4cba976ea7bba9e57120c898c52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4aa41d8b-42ae-4b1a-b3b0-8b2bda43c392) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104529 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d95fa29-9a36-405b-ae98-bd6f37187b5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/67003a03-d0b0-48b1-b97d-c69d2d6fa08c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4456 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5008 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147173 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135174 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8731 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112881 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113210 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6693 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118770 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62865 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36824 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167954 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72345 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43822 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->