### PR TITLE
Resync `css-transitions` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml
@@ -1,7 +1,32 @@
 features:
+- name: transitions
+  files:
+  - "*"
+  - "!starting-style-*"
+  - "!transition-behavior*"
+  - "!transition-timing-function-010-manual.html"
+  - "!transition-timing-function-002-manual.html"
+  - "!transition-timing-function-003-manual.html"
+  - "!transition-timing-function-004-manual.html"
+  - "!transition-timing-function-005-manual.html"
+  - "!transition-timing-function-006-manual.html"
+  - "!transition-property-017-manual.html"
 - name: starting-style
   files:
   - starting-style-*
 - name: transition-behavior
   files:
-  - transition-behavior.html
+  - "transition-behavior*"
+- name: steps-easing
+  files:
+  - transition-timing-function-010-manual.html
+- name: cubic-bezier-easing
+  files:
+  - transition-timing-function-002-manual.html
+  - transition-timing-function-003-manual.html
+  - transition-timing-function-004-manual.html
+  - transition-timing-function-005-manual.html
+  - transition-timing-function-006-manual.html
+- name: clip
+  files:
+  - transition-property-017-manual.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: transitions
+  files:
+  - change-duration-during-transition.html
+  - move-after-transition.html
+  - transition-end-event-shorthands.html
+  - transition-timing-function.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/change-duration-during-transition.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/color-transition-premultiplied.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: transitions
+  files:
+  - "*"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/delete-image-set.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/size-container-transition-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/transition-during-style-attr-mutation.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml
@@ -1,4 +1,9 @@
 features:
+- name: transitions
+  files:
+  - "*"
+  - "!starting-style-*"
+  - "!transition-behavior.html"
 - name: starting-style
   files:
   - starting-style-*

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid-expected.txt
@@ -5,4 +5,5 @@ PASS e.style['transition-property'] = "one" should set the property value
 PASS e.style['transition-property'] = "one-two-three" should set the property value
 PASS e.style['transition-property'] = "one, two, three" should set the property value
 PASS e.style['transition-property'] = "width, all" should set the property value
+FAIL e.style['transition-property'] = "ALL, INVALID, SYNTAX, SRC" should set the property value assert_equals: serialization should be canonical expected "all, INVALID, SYNTAX, SRC" but got "all, INVALID, syntax, src"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid.html
@@ -17,6 +17,7 @@ test_valid_value("transition-property", 'one');
 test_valid_value("transition-property", 'one-two-three');
 test_valid_value("transition-property", 'one, two, three');
 test_valid_value("transition-property", 'width, all');
+test_valid_value("transition-property", 'ALL, INVALID, SYNTAX, SRC', 'all, INVALID, SYNTAX, SRC');
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: transitions
+  files:
+  - "*"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/no-transition-from-ua-to-blocking-stylesheet-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/no-transition-from-ua-to-blocking-stylesheet-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/no-transition-from-ua-to-blocking-stylesheet.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-003.html
@@ -17,7 +17,7 @@
 <script>
 promise_test(async t => {
   const div = addDiv(t, {
-    style: 'transition: width 100ms; width: 0px;'
+    style: 'transition: width 5000ms; width: 0px;'
   });
 
   // Flush initial state
@@ -29,8 +29,8 @@ promise_test(async t => {
     div.addEventListener('transitionrun', resolve, { once: true });
   });
 
-  // MID-TRANSITION CHANGE: Switch to 0s duration + 100ms delay
-  div.style.transition = 'width 0s 100ms';
+  // MID-TRANSITION CHANGE: Switch to 0s duration + 5000ms delay
+  div.style.transition = 'width 0s 5000ms';
   assert_not_equals(
     getComputedStyle(div).width,
     '100px',
@@ -38,12 +38,12 @@ promise_test(async t => {
   );
 
   // Trigger new width change mid-transition
-  div.style.width = '0px';
+  div.style.width = '200px';
 
   assert_not_equals(
     getComputedStyle(div).width,
-    '0px',
-    'Width should not changed to 0px immediately'
+    '200px',
+    'Width should not change to 0px immediately'
   );
 
   await waitForTransitionEnd(div);
@@ -51,8 +51,8 @@ promise_test(async t => {
   // Final computed style
   assert_equals(
     getComputedStyle(div).width,
-    '0px',
-    'Final width should be 0px'
+    '200px',
+    'Final width should be 200px'
   );
 }, 'Mid-transition transition changes affect subsequent transitions');
 </script>


### PR DESCRIPTION
#### f5d93d68541042909930f2fc9faf71c3aac3eb3a
<pre>
Resync `css-transitions` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=304565">https://bugs.webkit.org/show_bug.cgi?id=304565</a>
<a href="https://rdar.apple.com/166965319">rdar://166965319</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4c3501d15f30c97b02c4375164a8258539c07a84">https://github.com/web-platform-tests/wpt/commit/4c3501d15f30c97b02c4375164a8258539c07a84</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-property-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/render-blocking/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-003.html:

Canonical link: <a href="https://commits.webkit.org/304843@main">https://commits.webkit.org/304843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1abce0bc5f6ba78492ee449f2da694b1971223e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89593 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/513e6e49-2fd7-484c-87f8-7e60598b6055) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104466 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122411 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85303 "Found 1 new API test failure: WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9a7de1fd-265e-4b70-9f35-e27a98fd56c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4386 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4940 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147103 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112814 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6631 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62735 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8711 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36760 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8651 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->