### PR TITLE
Fix SVGTextContentElement lengthAdjust not resetting when attribute removed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt
@@ -41,8 +41,8 @@ FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.pattern
 FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternUnits (invalid value) assert_equals: initial after expected 2 but got 1
 FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (remove) assert_equals: initial after expected 1 but got 2
 FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (invalid value) assert_equals: initial after expected 1 but got 2
+PASS SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (invalid value)
 FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (remove) assert_equals: initial after expected 1 but got 2
 FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (invalid value) assert_equals: initial after expected 1 but got 2
 FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.spacing (remove) assert_equals: initial after expected 2 but got 1

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -174,8 +174,7 @@ void SVGTextContentElement::attributeChanged(const QualifiedName& name, const At
 
     if (name == SVGNames::lengthAdjustAttr) {
         auto propertyValue = SVGPropertyTraits<SVGLengthAdjustType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            m_lengthAdjust->setBaseValInternal<SVGLengthAdjustType>(propertyValue);
+        m_lengthAdjust->setBaseValInternal<SVGLengthAdjustType>(propertyValue > 0 ? propertyValue : SVGLengthAdjustSpacing);
     } else if (name == SVGNames::textLengthAttr)
         m_textLength->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
 


### PR DESCRIPTION
#### 35035bb6a8b96795b04d22b9d144951e5033eaf6
<pre>
Fix SVGTextContentElement lengthAdjust not resetting when attribute removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=304567">https://bugs.webkit.org/show_bug.cgi?id=304567</a>
<a href="https://rdar.apple.com/166967295">rdar://166967295</a>

Reviewed by NOBODY (OOPS!).

When the lengthAdjust attribute is removed from an SVG text content element,
the baseVal property should reset to the default value (SVGLengthAdjustSpacing).
Previously, it would remain at the last set value because the code only updated
the internal value when fromString() returned a valid enum value greater than 0.

When the attribute is removed, fromString() returns SVGLengthAdjustUnknown (0),
causing the condition to fail and leaving the old value in place.

Fix by explicitly setting the value to SVGLengthAdjustSpacing when fromString()
returns an invalid value (0), ensuring proper reset to the default state.

* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::attributeChanged):
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35035bb6a8b96795b04d22b9d144951e5033eaf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e4916ca6-7a76-4042-9cbd-469096e681de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8827 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104470 "Found 1 new test failure: imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76303 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 21498 tests run. 60 failures; Uploaded test results; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/370c3c05-229e-4a61-9851-d83fbaad2970) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139567 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7068 "Found 1 new test failure: svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/51f8199e-fdc8-4241-a719-82a1d75c7584) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6712 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4390 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4942 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116026 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40606 "Found 2 new test failures: fast/block/basic/015.html svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147105 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8665 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41180 "Found 1 new test failure: svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112820 "Found 1 new test failure: svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8683 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7287 "Found 1 new test failure: svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113155 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6635 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62737 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8713 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36764 "Found 1 new test failure: svg/dom/SVGAnimatedEnumeration-case-sensitive.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8505 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->