### PR TITLE
[Skia] Fix GrDirectContext management for GPU resources

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -497,7 +497,11 @@ Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeT
     RefPtr<NativeImage> image = MIMETypeRegistry::isJPEGMIMEType(mimeType) ? copyImageBufferToOpaqueNativeImage(WTF::move(source), preserveResolution) : copyImageBufferToNativeImage(WTF::move(source), DontCopyBackingStore, preserveResolution);
     if (!image)
         return { };
+#if USE(SKIA)
+    return encodeData(*image, mimeType, quality);
+#elif USE(CG) || USE(CAIRO)
     return encodeData(image->platformImage().get(), mimeType, quality);
+#endif
 }
 
 RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NativeImage);
 
-#if !USE(CG)
+#if !USE(CG) && !USE(SKIA)
 RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage)
 {
     if (!platformImage)
@@ -50,11 +50,13 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
 }
 #endif
 
+#if !USE(SKIA)
 NativeImage::NativeImage(PlatformImagePtr&& platformImage)
     : m_platformImage(WTF::move(platformImage))
 {
     computeHeadroom();
 }
+#endif
 
 NativeImage::~NativeImage()
 {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -145,7 +145,7 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
             return nullptr;
 
         auto data = SkData::MakeUninitialized(size);
-        GrDirectContext* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        auto* grContext = image.grContext();
         if (!platformImage->readPixels(grContext, imageInfo, static_cast<uint8_t*>(data->writable_data()), strides[0], 0, 0))
             return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -41,6 +41,8 @@ class SkSurface;
 
 namespace WebCore {
 
+class Pattern;
+
 using SkiaImageToFenceMap = HashMap<const SkImage*, std::unique_ptr<GLFence>>;
 
 class WEBCORE_EXPORT GraphicsContextSkia final : public GraphicsContext {
@@ -117,7 +119,7 @@ public:
     void drawSkiaText(const sk_sp<SkTextBlob>&, SkScalar, SkScalar, bool, bool);
 
     static std::unique_ptr<GLFence> createAcceleratedRenderingFence(SkSurface*);
-    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(const sk_sp<SkImage>&);
+    static std::unique_ptr<GLFence> createAcceleratedRenderingFence(const sk_sp<SkImage>&, GrDirectContext*);
 
 private:
     enum class ContextMode : bool {
@@ -126,8 +128,8 @@ private:
     };
 
     bool makeGLContextCurrentIfNeeded() const;
-    void trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>&);
-    void trackAcceleratedRenderingFenceIfNeeded(SkPaint&);
+    void trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>&, GrDirectContext*);
+    void trackAcceleratedRenderingFenceIfNeeded(Pattern&);
 
     void setupFillSource(SkPaint&);
     void setupStrokeSource(SkPaint&);

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.h
@@ -29,11 +29,11 @@
 
 #include <wtf/Vector.h>
 
-class SkImage;
-
 namespace WebCore {
 
-Vector<uint8_t> encodeData(SkImage*, const String& mimeType, std::optional<double> quality);
+class NativeImage;
+
+Vector<uint8_t> encodeData(NativeImage&, const String& mimeType, std::optional<double> quality);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -71,7 +71,7 @@ CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeI
     if (!display.skiaGLContext()->makeContextCurrent())
         return;
 
-    auto* grContext = display.skiaGrContext();
+    auto* grContext = m_image->grContext();
     RELEASE_ASSERT(grContext);
     grContext->flushAndSubmit(GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -214,7 +214,13 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
 
 void CoordinatedAcceleratedTileBuffer::completePainting()
 {
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    auto* recordingContext = m_surface->recordingContext();
+    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
+    if (!grContext) {
+        CoordinatedTileBuffer::completePainting();
+        return;
+    }
+
     auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
     if (GLFence::isSupported(glDisplay)) {
         grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);


### PR DESCRIPTION
#### 8ba6cece950097ec28e13e6cb79fd8049e0efee4
<pre>
[Skia] Fix GrDirectContext management for GPU resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=304568">https://bugs.webkit.org/show_bug.cgi?id=304568</a>

Reviewed by Carlos Garcia Campos.

WebKit stores GrDirectContext instances in thread_local statics within
PlatformDisplay. Operations on GPU-backed resources must use the context
that created them, not the current thread&apos;s context obtained via
PlatformDisplay::sharedDisplay().skiaGrContext().

The GL contexts used are sharing contexts, also stored in thread_local
statics. Therefore we can safely make the current thread&apos;s GL context
current before flushing with the correct GrDirectContext.

For NativeImage, store the GrDirectContext at creation time and access
it via grContext(). The following places previously used the shared
display&apos;s context incorrectly:
- GraphicsContextGLSkia::extractImage() for readPixels on texture-backed images
- VideoFrameGStreamer::fromNativeImage() for readPixels
- NativeImageSkia::singlePixelSolidColor() for readPixels
- ImageBufferUtilitiesSkia::encodeAcceleratedImage() for encoding
- CoordinatedPlatformLayerBufferNativeImage for flushAndSubmit

Storing a pointer to GrDirectContext is safe, as the GrDirectContext lives
as long as PlatformDisplay::clearGLContexts() is called, which only happens
upon process destruction for the Gtk/WPE ports.

For SkSurface, use surface-&gt;recordingContext()-&gt;asDirectContext() to
obtain the surface&apos;s own context. The following places previously used
the shared display&apos;s context incorrectly:
- ImageBufferSkiaAcceleratedBackend::createNativeImageReference() for flush
- CoordinatedTileBuffer::completePainting() for flushAndSubmit

Note: When checking a SkImage for validity to decide if we need texture
rewrapping, we need to use the destination context (from current thread)
not the source image&apos;s context.

Covered by existing tests (when run with SKIA_DEBUG=ON builds).
We cannot yet turn on SKIA_DEBUG in our debug builds, as there are other
kind of assertions that need to be fixed first.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::toData):
* Source/WebCore/platform/graphics/NativeImage.cpp:
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImage::grContext const):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::fromNativeImage):
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::setupFillSource):
(WebCore::GraphicsContextSkia::setupStrokeSource):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::createFenceAfterFlush):
(WebCore::GraphicsContextSkia::createAcceleratedRenderingFence):
(WebCore::GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded):
(WebCore::createAcceleratedRenderingFenceInternal): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::createNativeImageReference):
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp:
(WebCore::encodeAcceleratedImage):
(WebCore::encodeData):
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.h:
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::createTransient):
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedAcceleratedTileBuffer::completePainting):

Canonical link: <a href="https://commits.webkit.org/304898@main">https://commits.webkit.org/304898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6cf7cfdc4e217d40edbbb0199a4468b79a93caf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104502 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4428 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6668 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8752 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36798 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72318 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->