### PR TITLE
Reduce unsafe member variables in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -29,7 +29,7 @@
 #include <optional>
 #include <wtf/MachSendRight.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -42,7 +42,7 @@ enum class TextureFormat : uint8_t;
 class DestinationColorSpace;
 class ImageBuffer;
 
-class GPUCompositorIntegration : public RefCounted<GPUCompositorIntegration> {
+class GPUCompositorIntegration : public RefCountedAndCanMakeWeakPtr<GPUCompositorIntegration> {
 public:
     static Ref<GPUCompositorIntegration> create(Ref<WebGPU::CompositorIntegration>&& backing)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContextDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContextDescriptor.h
@@ -34,11 +34,11 @@ struct GPUPresentationContextDescriptor {
     WebGPU::PresentationContextDescriptor convertToBacking() const
     {
         return {
-            layout.backing(),
+            layout->backing(),
         };
     }
 
-    GPUCompositorIntegration& layout;
+    WeakRef<GPUCompositorIntegration> layout;
 };
 
 }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -281,7 +281,7 @@ private:
     const std::unique_ptr<PeerConnectionBackend> m_backend;
 
     RTCConfiguration m_configuration;
-    RTCController* m_controller { nullptr };
+    WeakPtr<RTCController> m_controller;
     Vector<RefPtr<RTCCertificate>> m_certificates;
     bool m_shouldDelayTasks { false };
     Deque<std::pair<Ref<DeferredPromise>, Function<void(Ref<DeferredPromise>&&)>>> m_operations;

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -78,9 +78,10 @@ void NotificationResourcesLoader::start(CompletionHandler<void(RefPtr<Notificati
 
     // If the notification platform supports icons, fetch notification’s icon URL, if icon URL is set.
     if (resourceIsSupportedInPlatform(Resource::Icon)) {
-        const URL& iconURL = m_notification.icon();
+        Ref notification = m_notification.get();
+        const URL& iconURL = notification->icon();
         if (!iconURL.isEmpty()) {
-            Ref loader = ResourceLoader::create(*m_notification.protectedScriptExecutionContext(), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
+            Ref loader = ResourceLoader::create(*notification->protectedScriptExecutionContext(), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
                 if (m_stopped)
                     return;
 

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -41,6 +41,7 @@ class NetworkLoadMetrics;
 class NotificationResources;
 class ResourceError;
 class ResourceResponse;
+class WeakPtrImplWithEventTargetData;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
 class NotificationResourcesLoader {
@@ -87,7 +88,7 @@ private:
 
     void didFinishLoadingResource(ResourceLoader*);
 
-    Notification& m_notification;
+    WeakRef<Notification, WeakPtrImplWithEventTargetData> m_notification;
     bool m_stopped { false };
     CompletionHandler<void(RefPtr<NotificationResources>&&)> m_completionHandler;
     HashSet<Ref<ResourceLoader>> m_loaders;

--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -64,12 +64,12 @@ Vector<String> PushManager::supportedContentEncodings()
 
 void PushManager::ref() const
 {
-    m_pushSubscriptionOwner.ref();
+    m_pushSubscriptionOwner->ref();
 }
 
 void PushManager::deref() const
 {
-    m_pushSubscriptionOwner.deref();
+    m_pushSubscriptionOwner->deref();
 }
 
 void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushSubscriptionOptionsInit>&& options, DOMPromiseDeferred<IDLInterface<PushSubscription>>&& promise)
@@ -109,7 +109,7 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
             return;
         }
 
-        if (!m_pushSubscriptionOwner.isActive()) {
+        if (!m_pushSubscriptionOwner->isActive()) {
             // Only PushSubscriptionOwner objects related to service workers will ever return `false` for isActive(),
             // so this error message is correct.
             promise.reject(Exception { ExceptionCode::InvalidStateError, "Subscribing for push requires an active service worker"_s });
@@ -158,26 +158,26 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
                     return;
                 }
 
-                protectedThis->m_pushSubscriptionOwner.subscribeToPushService(WTF::move(keyData), WTF::move(promise));
+                protectedThis->m_pushSubscriptionOwner->subscribeToPushService(WTF::move(keyData), WTF::move(promise));
             });
             return;
         }
 
         RELEASE_ASSERT(permission == NotificationPermission::Granted);
-        m_pushSubscriptionOwner.subscribeToPushService(keyDataResult.releaseReturnValue(), WTF::move(promise));
+        m_pushSubscriptionOwner->subscribeToPushService(keyDataResult.releaseReturnValue(), WTF::move(promise));
     });
 }
 
 void PushManager::getSubscription(ScriptExecutionContext& context, DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&& promise)
 {
-    context.eventLoop().queueTask(TaskSource::Networking, [protectedThis = Ref { *this }, promise = WTF::move(promise)]() mutable {
-        protectedThis->m_pushSubscriptionOwner.getPushSubscription(WTF::move(promise));
+    context.eventLoop().queueTask(TaskSource::Networking, [protectedThis = Ref { *this }, promise = WTF::move(promise)] mutable {
+        protectedThis->m_pushSubscriptionOwner->getPushSubscription(WTF::move(promise));
     });
 }
 
 void PushManager::permissionState(ScriptExecutionContext& context, std::optional<PushSubscriptionOptionsInit>&&, DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&& promise)
 {
-    context.eventLoop().queueTask(TaskSource::Networking, [context = Ref { context }, promise = WTF::move(promise)]() mutable {
+    context.eventLoop().queueTask(TaskSource::Networking, [context = Ref { context }, promise = WTF::move(promise)] mutable {
         auto client = context->notificationClient();
         auto permission = client ? client->checkPermission(context.ptr()) : NotificationPermission::Denied;
 

--- a/Source/WebCore/Modules/push-api/PushManager.h
+++ b/Source/WebCore/Modules/push-api/PushManager.h
@@ -54,7 +54,7 @@ public:
     void permissionState(ScriptExecutionContext&, std::optional<PushSubscriptionOptionsInit>&&, DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&);
 
 private:
-    PushSubscriptionOwner& m_pushSubscriptionOwner;
+    WeakRef<PushSubscriptionOwner> m_pushSubscriptionOwner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
@@ -27,7 +27,7 @@
 
 #include <WebCore/JSDOMPromiseDeferredForward.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,7 +35,7 @@ class PushSubscription;
 
 enum class PushPermissionState : uint8_t;
 
-class PushSubscriptionOwner : public AbstractRefCounted {
+class PushSubscriptionOwner : public AbstractRefCountedAndCanMakeWeakPtr<PushSubscriptionOwner> {
 public:
     virtual ~PushSubscriptionOwner() = default;
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -21,7 +21,6 @@ Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
 Modules/WebGPU/Implementation/WebGPUTextureViewImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
-Modules/mediastream/RTCPeerConnection.h
 Modules/notifications/NotificationController.h
 Modules/webdatabase/DatabaseManager.h
 Modules/webdatabase/DatabaseThread.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,8 +1,4 @@
-Modules/WebGPU/GPUPresentationContextDescriptor.h
-Modules/mediastream/RTCPeerConnection.h
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
-Modules/notifications/NotificationResourcesLoader.h
-Modules/push-api/PushManager.h
 accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp


### PR DESCRIPTION
#### 15517453933047f4f44a45dafc03bcff2a1d476b
<pre>
Reduce unsafe member variables in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=304577">https://bugs.webkit.org/show_bug.cgi?id=304577</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304854@main">https://commits.webkit.org/304854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/484f0b6842d573ea96719112e760693a95f13c27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89652 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7314041f-8425-470b-a58e-1868e5180796) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e3dccaf2-b088-4ea4-ba3b-6ef5c7497e13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e56ffd1a-ff8c-4a5b-b249-59200e9d4ae4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4447 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112874 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113203 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6685 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62855 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8770 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36816 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8562 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->