### PR TITLE
[WIP] Fix invalid and initial fallback value for `SVGAnimatedEnumeration` values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt
@@ -1,50 +1,50 @@
 
-FAIL SVGAnimatedEnumeration, initial values, SVGClipPathElement.prototype.clipPathUnits (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGClipPathElement.prototype.clipPathUnits (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGComponentTransferFunctionElement.prototype.type (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGComponentTransferFunctionElement.prototype.type (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEBlendElement.prototype.mode (remove) assert_equals: initial after expected 1 but got 3
-FAIL SVGAnimatedEnumeration, initial values, SVGFEBlendElement.prototype.mode (invalid value) assert_equals: initial after expected 1 but got 3
-FAIL SVGAnimatedEnumeration, initial values, SVGFEColorMatrixElement.prototype.type (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEColorMatrixElement.prototype.type (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFECompositeElement.prototype.operator (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFECompositeElement.prototype.operator (invalid value) assert_equals: initial after expected 1 but got 2
+PASS SVGAnimatedEnumeration, initial values, SVGClipPathElement.prototype.clipPathUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGClipPathElement.prototype.clipPathUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGComponentTransferFunctionElement.prototype.type (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGComponentTransferFunctionElement.prototype.type (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFEBlendElement.prototype.mode (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFEBlendElement.prototype.mode (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFEColorMatrixElement.prototype.type (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFEColorMatrixElement.prototype.type (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFECompositeElement.prototype.operator (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFECompositeElement.prototype.operator (invalid value)
 FAIL SVGAnimatedEnumeration, initial values, SVGFEConvolveMatrixElement.prototype.edgeMode (remove) assert_equals: initial after expected 1 but got 2
 FAIL SVGAnimatedEnumeration, initial values, SVGFEConvolveMatrixElement.prototype.edgeMode (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.xChannelSelector (remove) assert_equals: initial after expected 4 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.xChannelSelector (invalid value) assert_equals: initial after expected 4 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.yChannelSelector (remove) assert_equals: initial after expected 4 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.yChannelSelector (invalid value) assert_equals: initial after expected 4 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEMorphologyElement.prototype.operator (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFEMorphologyElement.prototype.operator (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.stitchTiles (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.stitchTiles (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.type (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.type (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.filterUnits (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.filterUnits (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.primitiveUnits (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.primitiveUnits (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.gradientUnits (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.gradientUnits (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.spreadMethod (remove) assert_equals: initial after expected 1 but got 3
-FAIL SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.spreadMethod (invalid value) assert_equals: initial after expected 1 but got 3
-FAIL SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.markerUnits (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.markerUnits (invalid value) assert_equals: initial after expected 2 but got 1
+PASS SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.xChannelSelector (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.xChannelSelector (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.yChannelSelector (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFEDisplacementMapElement.prototype.yChannelSelector (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFEMorphologyElement.prototype.operator (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFEMorphologyElement.prototype.operator (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.stitchTiles (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.stitchTiles (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.type (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFETurbulenceElement.prototype.type (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.filterUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.filterUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.primitiveUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGFilterElement.prototype.primitiveUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.gradientUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.gradientUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.spreadMethod (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGGradientElement.prototype.spreadMethod (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.markerUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.markerUnits (invalid value)
 PASS SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.orientType (remove)
 FAIL SVGAnimatedEnumeration, initial values, SVGMarkerElement.prototype.orientType (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskUnits (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskUnits (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskContentUnits (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskContentUnits (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternUnits (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternUnits (invalid value) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (remove) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (invalid value) assert_equals: initial after expected 1 but got 2
-FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.spacing (remove) assert_equals: initial after expected 2 but got 1
-FAIL SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.spacing (invalid value) assert_equals: initial after expected 2 but got 1
+PASS SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskContentUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGMaskElement.prototype.maskContentUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGPatternElement.prototype.patternContentUnits (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGTextContentElement.prototype.lengthAdjust (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.method (invalid value)
+PASS SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.spacing (remove)
+PASS SVGAnimatedEnumeration, initial values, SVGTextPathElement.prototype.spacing (invalid value)
 

--- a/LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive-expected.txt
+++ b/LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive-expected.txt
@@ -34,22 +34,22 @@ Check invalid case feFuncR 'type'
 transferFunctionElement.setAttribute('type', 'table')
 PASS transferFunctionElement.setAttribute('type', 'IDENTITY') is undefined.
 PASS transferFunctionElement.getAttribute('type') is "IDENTITY"
-PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_TABLE
+PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY
 
 transferFunctionElement.setAttribute('type', 'discrete')
 PASS transferFunctionElement.setAttribute('type', 'TABLE') is undefined.
 PASS transferFunctionElement.getAttribute('type') is "TABLE"
-PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE
+PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY
 
 transferFunctionElement.setAttribute('type', 'linear')
 PASS transferFunctionElement.setAttribute('type', 'DISCRETE') is undefined.
 PASS transferFunctionElement.getAttribute('type') is "DISCRETE"
-PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_LINEAR
+PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY
 
 transferFunctionElement.setAttribute('type', 'gamma')
 PASS transferFunctionElement.setAttribute('type', 'LINEAR') is undefined.
 PASS transferFunctionElement.getAttribute('type') is "LINEAR"
-PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_GAMMA
+PASS transferFunctionElement.type.baseVal is SVGComponentTransferFunctionElement.SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY
 
 transferFunctionElement.setAttribute('type', 'identity')
 PASS transferFunctionElement.setAttribute('type', 'GAMMA') is undefined.
@@ -127,77 +127,77 @@ Check invalid case feBlend 'mode'
 feBlendElement.setAttribute('mode', 'multiply')
 PASS feBlendElement.setAttribute('mode', 'NORMAL') is undefined.
 PASS feBlendElement.getAttribute('mode') is "NORMAL"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_MULTIPLY
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'screen')
 PASS feBlendElement.setAttribute('mode', 'MULTIPLY') is undefined.
 PASS feBlendElement.getAttribute('mode') is "MULTIPLY"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_SCREEN
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'darken')
 PASS feBlendElement.setAttribute('mode', 'SCREEN') is undefined.
 PASS feBlendElement.getAttribute('mode') is "SCREEN"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_DARKEN
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'lighten')
 PASS feBlendElement.setAttribute('mode', 'DARKEN') is undefined.
 PASS feBlendElement.getAttribute('mode') is "DARKEN"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_LIGHTEN
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'overlay')
 PASS feBlendElement.setAttribute('mode', 'LIGHTEN') is undefined.
 PASS feBlendElement.getAttribute('mode') is "LIGHTEN"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_OVERLAY
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'color-dodge')
 PASS feBlendElement.setAttribute('mode', 'OVERLAY') is undefined.
 PASS feBlendElement.getAttribute('mode') is "OVERLAY"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_COLOR_DODGE
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'color-burn')
 PASS feBlendElement.setAttribute('mode', 'COLOR-DODGE') is undefined.
 PASS feBlendElement.getAttribute('mode') is "COLOR-DODGE"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_COLOR_BURN
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'hard-light')
 PASS feBlendElement.setAttribute('mode', 'COLOR-BURN') is undefined.
 PASS feBlendElement.getAttribute('mode') is "COLOR-BURN"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_HARD_LIGHT
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'soft-light')
 PASS feBlendElement.setAttribute('mode', 'HARD-LIGHT') is undefined.
 PASS feBlendElement.getAttribute('mode') is "HARD-LIGHT"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_SOFT_LIGHT
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'difference')
 PASS feBlendElement.setAttribute('mode', 'SOFT-LIGHT') is undefined.
 PASS feBlendElement.getAttribute('mode') is "SOFT-LIGHT"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_DIFFERENCE
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'exclusion')
 PASS feBlendElement.setAttribute('mode', 'DIFFERENCE') is undefined.
 PASS feBlendElement.getAttribute('mode') is "DIFFERENCE"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_EXCLUSION
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'hue')
 PASS feBlendElement.setAttribute('mode', 'EXCLUSION') is undefined.
 PASS feBlendElement.getAttribute('mode') is "EXCLUSION"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_HUE
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'saturation')
 PASS feBlendElement.setAttribute('mode', 'HUE') is undefined.
 PASS feBlendElement.getAttribute('mode') is "HUE"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_SATURATION
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'color')
 PASS feBlendElement.setAttribute('mode', 'SATURATION') is undefined.
 PASS feBlendElement.getAttribute('mode') is "SATURATION"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_COLOR
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'luminosity')
 PASS feBlendElement.setAttribute('mode', 'COLOR') is undefined.
 PASS feBlendElement.getAttribute('mode') is "COLOR"
-PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_LUMINOSITY
+PASS feBlendElement.mode.baseVal is SVGFEBlendElement.SVG_FEBLEND_MODE_NORMAL
 
 feBlendElement.setAttribute('mode', 'normal')
 PASS feBlendElement.setAttribute('mode', 'LUMINOSITY') is undefined.
@@ -227,17 +227,17 @@ Check invalid case feColorMatrix 'type'
 feColorMatrixElement.setAttribute('type', 'saturate')
 PASS feColorMatrixElement.setAttribute('type', 'MATRIX') is undefined.
 PASS feColorMatrixElement.getAttribute('type') is "MATRIX"
-PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_SATURATE
+PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_MATRIX
 
 feColorMatrixElement.setAttribute('type', 'hueRotate')
 PASS feColorMatrixElement.setAttribute('type', 'SATURATE') is undefined.
 PASS feColorMatrixElement.getAttribute('type') is "SATURATE"
-PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_HUEROTATE
+PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_MATRIX
 
 feColorMatrixElement.setAttribute('type', 'luminanceToAlpha')
 PASS feColorMatrixElement.setAttribute('type', 'HUEROTATE') is undefined.
 PASS feColorMatrixElement.getAttribute('type') is "HUEROTATE"
-PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA
+PASS feColorMatrixElement.type.baseVal is SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_MATRIX
 
 feColorMatrixElement.setAttribute('type', 'matrix')
 PASS feColorMatrixElement.setAttribute('type', 'LUMINANCETOALPHA') is undefined.
@@ -275,27 +275,27 @@ Check invalid case feComposite 'operator'
 feCompositeElement.setAttribute('operator', 'in')
 PASS feCompositeElement.setAttribute('operator', 'OVER') is undefined.
 PASS feCompositeElement.getAttribute('operator') is "OVER"
-PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_IN
+PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OVER
 
 feCompositeElement.setAttribute('operator', 'out')
 PASS feCompositeElement.setAttribute('operator', 'IN') is undefined.
 PASS feCompositeElement.getAttribute('operator') is "IN"
-PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OUT
+PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OVER
 
 feCompositeElement.setAttribute('operator', 'atop')
 PASS feCompositeElement.setAttribute('operator', 'OUT') is undefined.
 PASS feCompositeElement.getAttribute('operator') is "OUT"
-PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_ATOP
+PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OVER
 
 feCompositeElement.setAttribute('operator', 'xor')
 PASS feCompositeElement.setAttribute('operator', 'ATOP') is undefined.
 PASS feCompositeElement.getAttribute('operator') is "ATOP"
-PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_XOR
+PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OVER
 
 feCompositeElement.setAttribute('operator', 'arithmetic')
 PASS feCompositeElement.setAttribute('operator', 'XOR') is undefined.
 PASS feCompositeElement.getAttribute('operator') is "XOR"
-PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_ARITHMETIC
+PASS feCompositeElement.operator.baseVal is SVGFECompositeElement.SVG_FECOMPOSITE_OPERATOR_OVER
 
 feCompositeElement.setAttribute('operator', 'over')
 PASS feCompositeElement.setAttribute('operator', 'ARITHMETIC') is undefined.
@@ -321,12 +321,12 @@ Check invalid case feConvolveMatrix 'edgeMode'
 feConvolveMatrixElement.setAttribute('edgeMode', 'wrap')
 PASS feConvolveMatrixElement.setAttribute('edgeMode', 'DUPLICATE') is undefined.
 PASS feConvolveMatrixElement.getAttribute('edgeMode') is "DUPLICATE"
-PASS feConvolveMatrixElement.edgeMode.baseVal is SVGFEConvolveMatrixElement.SVG_EDGEMODE_WRAP
+FAIL feConvolveMatrixElement.edgeMode.baseVal should be 1. Was 2.
 
 feConvolveMatrixElement.setAttribute('edgeMode', 'none')
 PASS feConvolveMatrixElement.setAttribute('edgeMode', 'WRAP') is undefined.
 PASS feConvolveMatrixElement.getAttribute('edgeMode') is "WRAP"
-PASS feConvolveMatrixElement.edgeMode.baseVal is SVGFEConvolveMatrixElement.SVG_EDGEMODE_NONE
+FAIL feConvolveMatrixElement.edgeMode.baseVal should be 1. Was 3.
 
 feConvolveMatrixElement.setAttribute('edgeMode', 'duplicate')
 PASS feConvolveMatrixElement.setAttribute('edgeMode', 'NONE') is undefined.
@@ -356,22 +356,22 @@ Check invalid case feDisplacementMap 'xChannelSelector'
 feDisplacementMapElement.setAttribute('xChannelSelector', 'G')
 PASS feDisplacementMapElement.setAttribute('xChannelSelector', 'r') is undefined.
 PASS feDisplacementMapElement.getAttribute('xChannelSelector') is "r"
-PASS feDisplacementMapElement.xChannelSelector.baseVal is SVGFEDisplacementMapElement.SVG_CHANNEL_G
+FAIL feDisplacementMapElement.xChannelSelector.baseVal should be 1. Was 4.
 
 feDisplacementMapElement.setAttribute('xChannelSelector', 'B')
 PASS feDisplacementMapElement.setAttribute('xChannelSelector', 'g') is undefined.
 PASS feDisplacementMapElement.getAttribute('xChannelSelector') is "g"
-PASS feDisplacementMapElement.xChannelSelector.baseVal is SVGFEDisplacementMapElement.SVG_CHANNEL_B
+FAIL feDisplacementMapElement.xChannelSelector.baseVal should be 1. Was 4.
 
 feDisplacementMapElement.setAttribute('xChannelSelector', 'A')
 PASS feDisplacementMapElement.setAttribute('xChannelSelector', 'b') is undefined.
 PASS feDisplacementMapElement.getAttribute('xChannelSelector') is "b"
-PASS feDisplacementMapElement.xChannelSelector.baseVal is SVGFEDisplacementMapElement.SVG_CHANNEL_A
+FAIL feDisplacementMapElement.xChannelSelector.baseVal should be 1. Was 4.
 
 feDisplacementMapElement.setAttribute('xChannelSelector', 'R')
 PASS feDisplacementMapElement.setAttribute('xChannelSelector', 'a') is undefined.
 PASS feDisplacementMapElement.getAttribute('xChannelSelector') is "a"
-PASS feDisplacementMapElement.xChannelSelector.baseVal is SVGFEDisplacementMapElement.SVG_CHANNEL_R
+FAIL feDisplacementMapElement.xChannelSelector.baseVal should be 1. Was 4.
 
 Check valid feMorphology 'operator'
 
@@ -388,7 +388,7 @@ Check invalid case feMorphology 'operator'
 feMorphologyElement.setAttribute('operator', 'dilate')
 PASS feMorphologyElement.setAttribute('operator', 'ERODE') is undefined.
 PASS feMorphologyElement.getAttribute('operator') is "ERODE"
-PASS feMorphologyElement.operator.baseVal is SVGFEMorphologyElement.SVG_MORPHOLOGY_OPERATOR_DILATE
+PASS feMorphologyElement.operator.baseVal is SVGFEMorphologyElement.SVG_MORPHOLOGY_OPERATOR_ERODE
 
 feMorphologyElement.setAttribute('operator', 'erode')
 PASS feMorphologyElement.setAttribute('operator', 'DILATE') is undefined.
@@ -410,12 +410,12 @@ Check invalid case feTurbulence 'type'
 feTurbulenceElement.setAttribute('type', 'turbulence')
 PASS feTurbulenceElement.setAttribute('type', 'FRACTALNOISE') is undefined.
 PASS feTurbulenceElement.getAttribute('type') is "FRACTALNOISE"
-PASS feTurbulenceElement.type.baseVal is SVGFETurbulenceElement.SVG_TURBULENCE_TYPE_TURBULENCE
+FAIL feTurbulenceElement.type.baseVal should be 1. Was 2.
 
 feTurbulenceElement.setAttribute('type', 'fractalNoise')
 PASS feTurbulenceElement.setAttribute('type', 'TURBULENCE') is undefined.
 PASS feTurbulenceElement.getAttribute('type') is "TURBULENCE"
-PASS feTurbulenceElement.type.baseVal is SVGFETurbulenceElement.SVG_TURBULENCE_TYPE_FRACTALNOISE
+FAIL feTurbulenceElement.type.baseVal should be 1. Was 2.
 
 Check valid feTurbulence 'stitchTiles'
 
@@ -432,12 +432,12 @@ Check invalid case feTurbulence 'stitchTiles'
 feTurbulenceElement.setAttribute('stitchTiles', 'noStitch')
 PASS feTurbulenceElement.setAttribute('stitchTiles', 'STITCH') is undefined.
 PASS feTurbulenceElement.getAttribute('stitchTiles') is "STITCH"
-PASS feTurbulenceElement.stitchTiles.baseVal is SVGFETurbulenceElement.SVG_STITCHTYPE_NOSTITCH
+FAIL feTurbulenceElement.stitchTiles.baseVal should be 1. Was 2.
 
 feTurbulenceElement.setAttribute('stitchTiles', 'stitch')
 PASS feTurbulenceElement.setAttribute('stitchTiles', 'NOSTITCH') is undefined.
 PASS feTurbulenceElement.getAttribute('stitchTiles') is "NOSTITCH"
-PASS feTurbulenceElement.stitchTiles.baseVal is SVGFETurbulenceElement.SVG_STITCHTYPE_STITCH
+FAIL feTurbulenceElement.stitchTiles.baseVal should be 1. Was 2.
 
 Check valid linearGradient 'spreadMethod'
 
@@ -458,12 +458,12 @@ Check invalid case linearGradient 'spreadMethod'
 gradientElement.setAttribute('spreadMethod', 'reflect')
 PASS gradientElement.setAttribute('spreadMethod', 'PAD') is undefined.
 PASS gradientElement.getAttribute('spreadMethod') is "PAD"
-PASS gradientElement.spreadMethod.baseVal is SVGGradientElement.SVG_SPREADMETHOD_REFLECT
+PASS gradientElement.spreadMethod.baseVal is SVGGradientElement.SVG_SPREADMETHOD_PAD
 
 gradientElement.setAttribute('spreadMethod', 'repeat')
 PASS gradientElement.setAttribute('spreadMethod', 'REFLECT') is undefined.
 PASS gradientElement.getAttribute('spreadMethod') is "REFLECT"
-PASS gradientElement.spreadMethod.baseVal is SVGGradientElement.SVG_SPREADMETHOD_REPEAT
+PASS gradientElement.spreadMethod.baseVal is SVGGradientElement.SVG_SPREADMETHOD_PAD
 
 gradientElement.setAttribute('spreadMethod', 'pad')
 PASS gradientElement.setAttribute('spreadMethod', 'REPEAT') is undefined.
@@ -485,12 +485,12 @@ Check invalid case linearGradient 'gradientUnits'
 gradientElement.setAttribute('gradientUnits', 'objectBoundingBox')
 PASS gradientElement.setAttribute('gradientUnits', 'USERSPACEONUSE') is undefined.
 PASS gradientElement.getAttribute('gradientUnits') is "USERSPACEONUSE"
-PASS gradientElement.gradientUnits.baseVal is SVGUnitTypes.SVG_UNIT_TYPE_OBJECTBOUNDINGBOX
+FAIL gradientElement.gradientUnits.baseVal should be 1. Was 2.
 
 gradientElement.setAttribute('gradientUnits', 'userSpaceOnUse')
 PASS gradientElement.setAttribute('gradientUnits', 'OBJECTBOUNDINGBOX') is undefined.
 PASS gradientElement.getAttribute('gradientUnits') is "OBJECTBOUNDINGBOX"
-PASS gradientElement.gradientUnits.baseVal is SVGUnitTypes.SVG_UNIT_TYPE_USERSPACEONUSE
+FAIL gradientElement.gradientUnits.baseVal should be 1. Was 2.
 
 Check valid marker 'markerUnits'
 
@@ -507,12 +507,12 @@ Check invalid case marker 'markerUnits'
 markerElement.setAttribute('markerUnits', 'strokeWidth')
 PASS markerElement.setAttribute('markerUnits', 'USERSPACEONUSE') is undefined.
 PASS markerElement.getAttribute('markerUnits') is "USERSPACEONUSE"
-PASS markerElement.markerUnits.baseVal is SVGMarkerElement.SVG_MARKERUNITS_STROKEWIDTH
+FAIL markerElement.markerUnits.baseVal should be 1. Was 2.
 
 markerElement.setAttribute('markerUnits', 'userSpaceOnUse')
 PASS markerElement.setAttribute('markerUnits', 'STROKEWIDTH') is undefined.
 PASS markerElement.getAttribute('markerUnits') is "STROKEWIDTH"
-PASS markerElement.markerUnits.baseVal is SVGMarkerElement.SVG_MARKERUNITS_USERSPACEONUSE
+FAIL markerElement.markerUnits.baseVal should be 1. Was 2.
 
 Check valid text 'lengthAdjust'
 
@@ -529,7 +529,7 @@ Check invalid case text 'lengthAdjust'
 textContentElement.setAttribute('lengthAdjust', 'spacingAndGlyphs')
 PASS textContentElement.setAttribute('lengthAdjust', 'SPACING') is undefined.
 PASS textContentElement.getAttribute('lengthAdjust') is "SPACING"
-PASS textContentElement.lengthAdjust.baseVal is SVGTextContentElement.LENGTHADJUST_SPACINGANDGLYPHS
+PASS textContentElement.lengthAdjust.baseVal is SVGTextContentElement.LENGTHADJUST_SPACING
 
 textContentElement.setAttribute('lengthAdjust', 'spacing')
 PASS textContentElement.setAttribute('lengthAdjust', 'SPACINGANDGLYPHS') is undefined.
@@ -551,7 +551,7 @@ Check invalid case textPath 'method'
 textPathElement.setAttribute('method', 'stretch')
 PASS textPathElement.setAttribute('method', 'ALIGN') is undefined.
 PASS textPathElement.getAttribute('method') is "ALIGN"
-PASS textPathElement.method.baseVal is SVGTextPathElement.TEXTPATH_METHODTYPE_STRETCH
+PASS textPathElement.method.baseVal is SVGTextPathElement.TEXTPATH_METHODTYPE_ALIGN
 
 textPathElement.setAttribute('method', 'align')
 PASS textPathElement.setAttribute('method', 'STRETCH') is undefined.
@@ -573,14 +573,15 @@ Check invalid case textPath 'spacing'
 textPathElement.setAttribute('spacing', 'exact')
 PASS textPathElement.setAttribute('spacing', 'AUTO') is undefined.
 PASS textPathElement.getAttribute('spacing') is "AUTO"
-PASS textPathElement.spacing.baseVal is SVGTextPathElement.TEXTPATH_SPACINGTYPE_EXACT
+FAIL textPathElement.spacing.baseVal should be 1. Was 2.
 
 textPathElement.setAttribute('spacing', 'auto')
 PASS textPathElement.setAttribute('spacing', 'EXACT') is undefined.
 PASS textPathElement.getAttribute('spacing') is "EXACT"
-PASS textPathElement.spacing.baseVal is SVGTextPathElement.TEXTPATH_SPACINGTYPE_AUTO
+FAIL textPathElement.spacing.baseVal should be 1. Was 2.
 
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive.html
+++ b/LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -146,17 +146,18 @@ function testCaseSensitivity(elementType, element, enumType)
     for (var i = 0; i < enumValues.length; i++) {
         var val = enumValues[i].id;
         var alt_val = enumValues[((i + 1) % enumValues.length)];
-    
+
         debug("");
-       
+
         debug(element.id + ".setAttribute('" + enumType + "', '" + alt_val.id + "')");
         element.setAttribute(enumType, alt_val.id);
 
         var val_check = (val.toUpperCase() == val) ? val.toLowerCase() : val.toUpperCase();
         shouldBeUndefined(element.id + ".setAttribute('" + enumType + "', '" + val_check + "')");
         shouldBeEqualToString(element.id + ".getAttribute('" + enumType + "')", val_check);
-        shouldBe(element.id + "." + enumType + ".baseVal", elementType + "." + alt_val.val);
-    } 
+        // Invalid values should reset to the default (first enum value)
+        shouldBe(element.id + "." + enumType + ".baseVal", elementType + "." + enumValues[0].val);
+    }
 }
 
 // SVGComponentTransferFunctionElement
@@ -226,6 +227,5 @@ debug("");
 
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -67,8 +67,7 @@ void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     if (name == SVGNames::clipPathUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            m_clipPathUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        m_clipPathUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE);
     }
 
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -55,8 +55,7 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
         ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(*this, newValue);
-        if (enumToUnderlyingType(propertyValue))
-            m_type->setBaseValInternal<ComponentTransferType>(propertyValue);
+        m_type->setBaseValInternal<ComponentTransferType>(enumToUnderlyingType(propertyValue) ? propertyValue : ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY);
         break;
     }
     case AttributeNames::tableValuesAttr:

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -57,8 +57,7 @@ void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomSt
     switch (name.nodeName()) {
     case AttributeNames::modeAttr: {
         BlendMode mode = BlendMode::Normal;
-        if (parseBlendMode(newValue, mode))
-        Ref { m_mode }->setBaseValInternal<BlendMode>(mode);
+        Ref { m_mode }->setBaseValInternal<BlendMode>(parseBlendMode(newValue, mode) ? mode : BlendMode::Normal);
         break;
     }
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -66,8 +66,7 @@ void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const 
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
         auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(*this, newValue);
-        if (enumToUnderlyingType(propertyValue))
-            Ref { m_type }->setBaseValInternal<ColorMatrixType>(propertyValue);
+        Ref { m_type }->setBaseValInternal<ColorMatrixType>(enumToUnderlyingType(propertyValue) ? propertyValue : ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX);
         break;
     }
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -60,8 +60,7 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
     switch (name.nodeName()) {
     case AttributeNames::operatorAttr: {
         CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(*this, newValue);
-        if (enumToUnderlyingType(propertyValue))
-            Ref { m_svgOperator }->setBaseValInternal<CompositeOperationType>(propertyValue);
+        Ref { m_svgOperator }->setBaseValInternal<CompositeOperationType>(enumToUnderlyingType(propertyValue) ? propertyValue : CompositeOperationType::FECOMPOSITE_OPERATOR_OVER);
         break;
     }
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -58,14 +58,12 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
     switch (name.nodeName()) {
     case AttributeNames::xChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(*this, newValue);
-        if (enumToUnderlyingType(propertyValue))
-            Ref { m_xChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
+        Ref { m_xChannelSelector }->setBaseValInternal<ChannelSelectorType>(enumToUnderlyingType(propertyValue) ? propertyValue : ChannelSelectorType::CHANNEL_A);
         break;
     }
     case AttributeNames::yChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(*this, newValue);
-        if (enumToUnderlyingType(propertyValue))
-            Ref { m_yChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
+        Ref { m_yChannelSelector }->setBaseValInternal<ChannelSelectorType>(enumToUnderlyingType(propertyValue) ? propertyValue : ChannelSelectorType::CHANNEL_A);
         break;
     }
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -58,8 +58,7 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
     switch (name.nodeName()) {
     case AttributeNames::operatorAttr: {
         MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(*this, newValue);
-        if (propertyValue != MorphologyOperatorType::Unknown)
-            Ref { m_svgOperator }->setBaseValInternal<MorphologyOperatorType>(propertyValue);
+        Ref { m_svgOperator }->setBaseValInternal<MorphologyOperatorType>(propertyValue != MorphologyOperatorType::Unknown ? propertyValue : MorphologyOperatorType::Erode);
         break;
     }
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -62,14 +62,12 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
         TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(*this, newValue);
-        if (propertyValue != TurbulenceType::Unknown)
-            Ref { m_type }->setBaseValInternal<TurbulenceType>(propertyValue);
+        Ref { m_type }->setBaseValInternal<TurbulenceType>(propertyValue != TurbulenceType::Unknown ? propertyValue : TurbulenceType::Turbulence);
         break;
     }
     case AttributeNames::stitchTilesAttr: {
         SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_stitchTiles }->setBaseValInternal<SVGStitchOptions>(propertyValue);
+        Ref { m_stitchTiles }->setBaseValInternal<SVGStitchOptions>(propertyValue > 0 ? propertyValue : SVG_STITCHTYPE_NOSTITCH);
         break;
     }
     case AttributeNames::baseFrequencyAttr:

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -75,14 +75,12 @@ void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomStr
     switch (name.nodeName()) {
     case AttributeNames::filterUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_filterUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_filterUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX);
         break;
     }
     case AttributeNames::primitiveUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_primitiveUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_primitiveUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE);
         break;
     }
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -59,8 +59,7 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
     switch (name.nodeName()) {
     case AttributeNames::gradientUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_gradientUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_gradientUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX);
         break;
     }
     case AttributeNames::gradientTransformAttr:
@@ -68,8 +67,7 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
         break;
     case AttributeNames::spreadMethodAttr: {
         auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_spreadMethod }->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
+        Ref { m_spreadMethod }->setBaseValInternal<SVGSpreadMethodType>(propertyValue > 0 ? propertyValue : SVGSpreadMethodPad);
         break;
     }
     default:

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -73,8 +73,7 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
     switch (name.nodeName()) {
     case AttributeNames::markerUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(*this, newValue);
-        if (propertyValue != SVGMarkerUnitsType::Unknown)
-            Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
+        Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue != SVGMarkerUnitsType::Unknown ? propertyValue : SVGMarkerUnitsType::StrokeWidth);
         return;
     }
     case AttributeNames::orientAttr: {

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -79,14 +79,12 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
     switch (name.nodeName()) {
     case AttributeNames::maskUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_maskUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_maskUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX);
         break;
     }
     case AttributeNames::maskContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_maskContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_maskContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE);
         break;
     }
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -82,14 +82,12 @@ void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomSt
     switch (name.nodeName()) {
     case AttributeNames::patternUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_patternUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_patternUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX);
         break;
     }
     case AttributeNames::patternContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_patternContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+        Ref { m_patternContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue > 0 ? propertyValue : SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE);
         break;
     }
     case AttributeNames::patternTransformAttr: {

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -174,8 +174,7 @@ void SVGTextContentElement::attributeChanged(const QualifiedName& name, const At
 
     if (name == SVGNames::lengthAdjustAttr) {
         auto propertyValue = SVGPropertyTraits<SVGLengthAdjustType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            m_lengthAdjust->setBaseValInternal<SVGLengthAdjustType>(propertyValue);
+        Ref { m_lengthAdjust }->setBaseValInternal<SVGLengthAdjustType>(propertyValue > 0 ? propertyValue : SVGLengthAdjustSpacing);
     } else if (name == SVGNames::textLengthAttr)
         m_textLength->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
 

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -81,14 +81,12 @@ void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomS
         break;
     case AttributeNames::methodAttr: {
         SVGTextPathMethodType propertyValue = SVGPropertyTraits<SVGTextPathMethodType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_method }->setBaseValInternal<SVGTextPathMethodType>(propertyValue);
+        Ref { m_method }->setBaseValInternal<SVGTextPathMethodType>(propertyValue > 0 ? propertyValue : SVGTextPathMethodAlign);
         break;
     }
     case AttributeNames::spacingAttr: {
         SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(*this, newValue);
-        if (propertyValue > 0)
-            Ref { m_spacing }->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
+        Ref { m_spacing }->setBaseValInternal<SVGTextPathSpacingType>(propertyValue > 0 ? propertyValue : SVGTextPathSpacingExact);
         break;
     }
     default:


### PR DESCRIPTION
#### 2e83424321205f8f3d37df271ff9f45e0ebad529
<pre>
[WIP] Fix invalid and initial fallback value for `SVGAnimatedEnumeration` values
<a href="https://bugs.webkit.org/show_bug.cgi?id=304578">https://bugs.webkit.org/show_bug.cgi?id=304578</a>
<a href="https://rdar.apple.com/166983809">rdar://166983809</a>

Reviewed by NOBODY (OOPS!).

Draft

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-initial-values-expected.txt:
* LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive-expected.txt:
* LayoutTests/svg/dom/SVGAnimatedEnumeration-case-sensitive.html:
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::attributeChanged):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
* Source/WebCore/svg/SVGFEBlendElement.cpp:
(WebCore::SVGFEBlendElement::attributeChanged):
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::attributeChanged):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::attributeChanged):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::attributeChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e83424321205f8f3d37df271ff9f45e0ebad529

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89620 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b103d168-c833-4505-a557-24ca2d2e0f71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76305 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b48305f-c9f3-42f9-8cd1-b8ae47695548) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85325 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d989903b-ec7c-43a2-b81b-5f37537d7f4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6732 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4416 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147130 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112843 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113172 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6656 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118731 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62801 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36785 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->