### PR TITLE
[JSC] add support for Promise.isPromise

### DIFF
--- a/JSTests/stress/promise-isPromise.js
+++ b/JSTests/stress/promise-isPromise.js
@@ -1,0 +1,34 @@
+//@ requireOptions("--usePromiseIsPromise=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+shouldBe(Promise.isPromise(undefined), false);
+shouldBe(Promise.isPromise(null), false);
+shouldBe(Promise.isPromise(true), false);
+shouldBe(Promise.isPromise(42), false);
+shouldBe(Promise.isPromise("test"), false);
+shouldBe(Promise.isPromise([]), false);
+shouldBe(Promise.isPromise({}), false);
+
+shouldBe(Promise.isPromise(Promise), false);
+shouldBe(Promise.isPromise(Promise.prototype), false);
+shouldBe(Promise.isPromise(new Promise(() => {})), true);
+shouldBe(Promise.isPromise(Promise.resolve()), true);
+shouldBe(Promise.isPromise(Promise.reject()), true);
+
+shouldBe(Promise.isPromise((async function() { })()), true);
+
+class CustomPromise extends Promise { }
+shouldBe(Promise.isPromise(CustomPromise), false);
+shouldBe(Promise.isPromise(CustomPromise.prototype), false);
+shouldBe(Promise.isPromise(new CustomPromise(() => {})), true);
+
+class Thenable {
+    then() { }
+}
+shouldBe(Promise.isPromise(Thenable), false);
+shouldBe(Promise.isPromise(Thenable.prototype), false);
+shouldBe(Promise.isPromise(new Thenable), false);

--- a/LayoutTests/js/promise-isPromise-expected.txt
+++ b/LayoutTests/js/promise-isPromise-expected.txt
@@ -1,0 +1,18 @@
+IDL promises should work with Promise.isPromise
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Promise.isPromise((new Blob).text()) is true
+PASS Promise.isPromise((new Blob).arrayBuffer()) is true
+PASS Promise.isPromise((new Blob).bytes()) is true
+PASS Promise.isPromise(document.createElement("img").decode()) is true
+PASS Promise.isPromise((new ReadableStream).cancel()) is true
+PASS Promise.isPromise((new ReadableStream).pipeTo(new WritableStream)) is true
+PASS Promise.isPromise((new WritableStream).abort()) is true
+PASS Promise.isPromise((new WritableStream).close()) is true
+PASS Promise.isPromise(event.promise) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/promise-isPromise.html
+++ b/LayoutTests/js/promise-isPromise.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--usePromiseIsPromise=true ] -->
+<html>
+<head>
+<title>Growable SharedArrayBuffers should be serializable</title>
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("IDL promises should work with Promise.isPromise");
+window.jsTestIsAsync = true;
+
+window.addEventListener("unhandledrejection", (event) => {
+    shouldBeTrue(`Promise.isPromise(event.promise)`);
+
+    finishJSTest();
+});
+
+shouldBeTrue(`Promise.isPromise((new Blob).text())`);
+shouldBeTrue(`Promise.isPromise((new Blob).arrayBuffer())`);
+shouldBeTrue(`Promise.isPromise((new Blob).bytes())`);
+
+shouldBeTrue(`Promise.isPromise(document.createElement("img").decode())`);
+
+shouldBeTrue(`Promise.isPromise((new ReadableStream).cancel())`);
+shouldBeTrue(`Promise.isPromise((new ReadableStream).pipeTo(new WritableStream))`);
+
+shouldBeTrue(`Promise.isPromise((new WritableStream).abort())`);
+shouldBeTrue(`Promise.isPromise((new WritableStream).close())`);
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -53,6 +53,7 @@ static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncAny);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncRace);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncAll);
 static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncAllSettled);
+static JSC_DECLARE_HOST_FUNCTION(promiseConstructorFuncIsPromise);
 
 }
 
@@ -103,6 +104,9 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
 
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, globalObject->promiseSpeciesGetterSetter(), PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->tryKeyword, promiseConstructorTryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::usePromiseIsPromise())
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isPromise"_s, promiseConstructorFuncIsPromise, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1422,6 +1426,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     }
 
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncIsPromise, (JSGlobalObject*, CallFrame* callFrame))
+{
+    return JSValue::encode(jsBoolean(callFrame->argument(0).inherits<JSPromise>()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -665,6 +665,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useJSPI, true, Normal, "Enable the implementation of JavaScript Promise Integration."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
+    v(Bool, usePromiseIsPromise, false, Normal, nullptr) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \


### PR DESCRIPTION
#### a3250c92026a3f8b4599037aaf1eed7babdce062
<pre>
[JSC] add support for Promise.isPromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=304580">https://bugs.webkit.org/show_bug.cgi?id=304580</a>

Reviewed by Keith Miller.

Similar to `Array.isArray` and `Error.isError`, this will give developers a simpler and much more reliable way to know if a given object is a `Promise`.

Spec: &lt;<a href="https://tc39.es/proposal-native-promise-predicate/">https://tc39.es/proposal-native-promise-predicate/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-native-promise-predicate/">https://github.com/tc39/proposal-native-promise-predicate/</a>&gt;

* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):
(JSC::promiseConstructorFuncIsPromise): Added.

* Source/JavaScriptCore/runtime/OptionsList.h:
Add a feature flag for this.

* JSTests/stress/promise-isPromise.js: Added.
* LayoutTests/js/promise-isPromise.html: Added.
* LayoutTests/js/promise-isPromise-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/311095@main">https://commits.webkit.org/311095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adaa5d60428f44c3a7fe8ab7ae702097e532acfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85006 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20086 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12476 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147932 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167126 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16714 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128792 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34949 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28610 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139637 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86481 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16412 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92407 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48281 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->