### PR TITLE
Dispatch and Network OS Object types should use DefaultOSObjectRetainTraits

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -27,10 +27,9 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 
-#import <dispatch/dispatch.h>
 #import <wtf/Lock.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/darwin/DispatchOSObject.h>
 #import <wtf/darwin/XPCObjectPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4628C0952E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46335BED2E778B1300860373 /* DispatchExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BEC2E778B1300860373 /* DispatchExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46335BEE2E778B1300860374 /* DispatchOSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BED2E778B1300860374 /* DispatchOSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46335BEF2E778B1300860375 /* NetworkOSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BEE2E778B1300860375 /* NetworkOSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		465005D82CD2840A00950C5F /* MallocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 465005D72CD2840A00950C5F /* MallocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1332,6 +1334,8 @@
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
 		4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractCanMakeCheckedPtr.h; sourceTree = "<group>"; };
 		46335BEC2E778B1300860373 /* DispatchExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DispatchExtras.h; sourceTree = "<group>"; };
+		46335BED2E778B1300860374 /* DispatchOSObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DispatchOSObject.h; sourceTree = "<group>"; };
+		46335BEE2E778B1300860375 /* NetworkOSObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOSObject.h; sourceTree = "<group>"; };
 		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		465005D72CD2840A00950C5F /* MallocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocSpan.h; sourceTree = "<group>"; };
@@ -2208,8 +2212,10 @@
 			isa = PBXGroup;
 			children = (
 				46335BEC2E778B1300860373 /* DispatchExtras.h */,
+				46335BED2E778B1300860374 /* DispatchOSObject.h */,
 				6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */,
 				6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */,
+				46335BEE2E778B1300860375 /* NetworkOSObject.h */,
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
 				449EEC7D2D93788B008E7C80 /* TypeCastsOSObject.h */,
@@ -3581,6 +3587,7 @@
 				DD3DC94B27A4BF8E007E5B61 /* Deque.h in Headers */,
 				E361DB68289115D000B2A2B8 /* digit_comparison.h in Headers */,
 				46335BED2E778B1300860373 /* DispatchExtras.h in Headers */,
+				46335BEE2E778B1300860374 /* DispatchOSObject.h in Headers */,
 				DDF306E727C08654006A526F /* DispatchSPI.h in Headers */,
 				FFE39CB32B1D7472004972B0 /* div.h in Headers */,
 				DDF3079427C086CD006A526F /* diy-fp.h in Headers */,
@@ -3738,6 +3745,7 @@
 				5164042D2AB1D46B0042B1C3 /* NativePromise.h in Headers */,
 				DD3DC8D827A4BF8E007E5B61 /* NaturalLoops.h in Headers */,
 				E396C11D2BE885D9000CBAE1 /* neon.h in Headers */,
+				46335BEF2E778B1300860375 /* NetworkOSObject.h in Headers */,
 				DD3DC8AC27A4BF8E007E5B61 /* NeverDestroyed.h in Headers */,
 				DD3DC98C27A4BF8E007E5B61 /* NoLock.h in Headers */,
 				DD3DC8EF27A4BF8E007E5B61 /* Noncopyable.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -719,6 +719,8 @@ elseif (APPLE)
         cocoa/VectorCocoa.h
 
         darwin/DispatchExtras.h
+        darwin/DispatchOSObject.h
+        darwin/NetworkOSObject.h
         darwin/OSLogPrintStream.h
         darwin/WeakLinking.h
         darwin/XPCExtras.h

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -39,7 +39,7 @@
 #endif
 
 #if PLATFORM(COCOA)
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #endif
 
 namespace WTF {

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -33,8 +33,7 @@
 #include <wtf/Threading.h>
 
 #if USE(COCOA_EVENT_LOOP)
-#include <dispatch/dispatch.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #else
 #include <wtf/RunLoop.h>
 #endif

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -32,10 +32,10 @@
 
 #include <wtf/BlockPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/cocoa/SpanCocoa.h>
 #include <wtf/darwin/DispatchExtras.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/darwin/DispatchOSObject.h
+++ b/Source/WTF/wtf/darwin/DispatchOSObject.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dispatch/dispatch.h>
+#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/TypeCastsOSObject.h>
+
+#define WTF_OS_OBJECT_DISPATCH_TYPES(M) \
+    M(dispatch_data) \
+    M(dispatch_group) \
+    M(dispatch_io) \
+    M(dispatch_object) \
+    M(dispatch_queue) \
+    M(dispatch_queue_global) \
+    M(dispatch_semaphore) \
+    M(dispatch_source)
+
+// Forward declarations for dispatch base struct types.
+WTF_EXTERN_C_BEGIN
+#define WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT(TypeName) \
+struct TypeName##_s;
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT)
+#undef WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT
+WTF_EXTERN_C_END
+
+namespace WTF {
+
+// Dispatch OSObject type cast traits.
+#define WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS(TypeName) \
+WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, _s)
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS)
+#undef WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS
+
+// Dispatch isOSObject functions.
+#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH(TypeName) WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName##_t, STRINGIZE_VALUE_OF(OS_OBJECT_CLASS(TypeName)))
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH)
+#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH
+
+#if !__has_feature(objc_arc)
+// Template specializations for dispatch retain/release traits (non-ARC only).
+#define WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS(TypeName) \
+template<> \
+struct DefaultOSObjectRetainTraits<TypeName##_t, std::false_type> { \
+    static ALWAYS_INLINE void retain(TypeName##_t ptr) \
+    { \
+        dispatch_retain(ptr); \
+    } \
+    static ALWAYS_INLINE void release(TypeName##_t ptr) \
+    { \
+        dispatch_release(ptr); \
+    } \
+}; \
+
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS)
+#undef WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS
+#endif // !__has_feature(objc_arc)
+
+} // namespace WTF

--- a/Source/WTF/wtf/darwin/NetworkOSObject.h
+++ b/Source/WTF/wtf/darwin/NetworkOSObject.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Network/Network.h>
+#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/TypeCastsOSObject.h>
+
+#define WTF_OS_OBJECT_NETWORK_TYPES(M) \
+    M(nw_endpoint) \
+    M(nw_path) \
+    M(nw_resolution_report) \
+    M(nw_resolver_config)
+
+// Forward declarations for network base struct types.
+WTF_EXTERN_C_BEGIN
+#define WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT(TypeName) \
+struct TypeName;
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT)
+#undef WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT
+WTF_EXTERN_C_END
+
+namespace WTF {
+
+// Network OSObject type cast traits.
+#define WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS(TypeName) \
+WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, )
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS)
+#undef WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS
+
+// Network isOSObject functions.
+#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK(TypeName) WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName##_t, STRINGIZE_VALUE_OF(OS_OBJECT_CLASS(TypeName)))
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK)
+#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK
+
+#if !__has_feature(objc_arc)
+// Template specializations for network retain/release traits (non-ARC only).
+#define WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS(TypeName) \
+template<> \
+struct DefaultOSObjectRetainTraits<TypeName##_t, std::false_type> { \
+    static ALWAYS_INLINE void retain(TypeName##_t ptr) \
+    { \
+        nw_retain(ptr); \
+    } \
+    static ALWAYS_INLINE void release(TypeName##_t ptr) \
+    { \
+        nw_release(ptr); \
+    } \
+}; \
+
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS)
+#undef WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS
+#endif // !__has_feature(objc_arc)
+
+} // namespace WTF

--- a/Source/WTF/wtf/darwin/TypeCastsOSObject.h
+++ b/Source/WTF/wtf/darwin/TypeCastsOSObject.h
@@ -30,44 +30,8 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 
-// To add support for a new OSObject type:
-// 1. Import header that defines OSObject type.
-// 2. Add type to an existing WTF_OS_OBJECT_*_TYPES(M) macro, or create a new one.
-//    a. If a new macro is created, add macro to WTF_OS_OBJECT_TYPES(M).
-//    b. If a new macro is created, create OSObjectTypeCastTraits declarations.
-
-#import <Network/Network.h>
-#import <dispatch/dispatch.h>
-
-#define WTF_OS_OBJECT_DISPATCH_TYPES(M) \
-    M(dispatch_group) \
-    M(dispatch_object) \
-    M(dispatch_queue) \
-    M(dispatch_queue_global) \
-    M(dispatch_source)
-
-WTF_EXTERN_C_BEGIN
-#define WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT(TypeName) \
-struct TypeName##_s;
-WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT)
-#undef WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT
-WTF_EXTERN_C_END
-
-#define WTF_OS_OBJECT_NETWORK_TYPES(M) \
-    M(nw_endpoint) \
-    M(nw_path) \
-    M(nw_resolution_report)
-
-WTF_EXTERN_C_BEGIN
-#define WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT(TypeName) \
-struct TypeName;
-WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT)
-#undef WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT
-WTF_EXTERN_C_END
-
-#define WTF_OS_OBJECT_TYPES(M) \
-    WTF_OS_OBJECT_DISPATCH_TYPES(M) \
-    WTF_OS_OBJECT_NETWORK_TYPES(M)
+// See DispatchOSObject.h or NetworkOSObject.h for how to add support
+// for a new OSObject type.
 
 // Because ARC enablement is a compile-time choice, and we compile this header
 // both ways, we need a separate copy of our code when ARC is enabled.
@@ -79,22 +43,12 @@ WTF_EXTERN_C_END
 namespace WTF {
 
 template<typename> struct OSObjectTypeCastTraits;
+
+// Common macro for declaring OSObjectTypeCastTraits.
 #define WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, Suffix) \
 template<> struct OSObjectTypeCastTraits<TypeName##_t> { \
     using BaseType = struct TypeName##Suffix*; \
-};
-
-#define WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS(TypeName) \
-WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, _s)
-WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS)
-#undef WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS
-
-#define WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS(TypeName) \
-WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, )
-WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS)
-#undef WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS
-
-#undef WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL
+}; \
 
 // Must define this for isOSObject<T>() when not building with Objective-C.
 #ifndef OS_OBJECT_CLASS
@@ -103,17 +57,13 @@ WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS)
 
 template<typename T> bool isOSObject(CFTypeRef);
 
-#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS(TypeName) WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName##_t, STRINGIZE_VALUE_OF(OS_OBJECT_CLASS(TypeName)))
+// Common macro for implementing isOSObject functions.
 #define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName, ProtocolString) \
 template<> inline bool isOSObject<OSObjectTypeCastTraits<TypeName>::BaseType>(CFTypeRef object) \
 { \
     Class cls = object_getClass(bridge_id_cast(object)); \
     return class_conformsToProtocol(cls, objc_getProtocol(ProtocolString)); \
 } \
-
-WTF_OS_OBJECT_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS)
-#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL
-#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS
 
 #ifdef __OBJC__
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -28,7 +28,6 @@ accessibility/AccessibilityObject.cpp
 bindings/js/GarbageCollectionController.cpp
 bindings/js/JSLocationCustom.cpp
 bindings/js/JSPaintRenderingContext2DCustom.cpp
-bridge/objc/objc_runtime.h
 css/CSSStyleProperties.h
 css/CSSToLengthConversionData.h
 css/StyleSheetContents.cpp

--- a/Source/WebCore/platform/FileMonitor.h
+++ b/Source/WebCore/platform/FileMonitor.h
@@ -31,8 +31,7 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(COCOA_EVENT_LOOP)
-#include <dispatch/dispatch.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #endif
 
 #if USE(GLIB)

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -30,10 +30,10 @@
 #include <WebCore/PlatformContentFilter.h>
 #include <objc/NSObjCRuntime.h>
 #include <wtf/Compiler.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 enum NEFilterSourceStatus : NSInteger;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -111,8 +111,8 @@
 #import <wtf/ListHashSet.h>
 #import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RuntimeApplicationChecks.h>
+#import <wtf/darwin/DispatchOSObject.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -32,7 +32,7 @@
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
 #include <pal/spi/cocoa/AVFoundationSPI.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -37,10 +37,10 @@
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_CLASS AVSampleBufferVideoRenderer;

--- a/Source/WebCore/platform/mac/PowerObserverMac.h
+++ b/Source/WebCore/platform/mac/PowerObserverMac.h
@@ -35,9 +35,9 @@
 #import <wtf/CheckedRef.h>
 #import <wtf/Function.h>
 #import <wtf/Noncopyable.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -34,8 +34,8 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSError;

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -42,7 +42,7 @@
 #include <wtf/cf/VectorCF.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/darwin/DispatchExtras.h>
-#include <wtf/darwin/TypeCastsOSObject.h>
+#include <wtf/darwin/NetworkOSObject.h>
 #include <wtf/posix/SocketPOSIX.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -70,7 +70,8 @@
 
 #if PLATFORM(COCOA)
 #include <notify.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
+#include <wtf/darwin/NetworkOSObject.h>
 typedef struct OpaqueCFHTTPCookieStorage*  CFHTTPCookieStorageRef;
 #endif
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -36,7 +36,7 @@
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #endif
 
 #if USE(GLIB)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -73,7 +73,7 @@
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
-#import <wtf/darwin/TypeCastsOSObject.h>
+#import <wtf/darwin/NetworkOSObject.h>
 #import <wtf/darwin/WeakLinking.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -33,14 +33,13 @@
 #include "NetworkRTCUtilitiesCocoa.h"
 #include "RTCSocketCreationFlags.h"
 #include <WebCore/STUNMessageParsing.h>
-#include <dispatch/dispatch.h>
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/cocoa/VectorCocoa.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <webrtc/api/packet_socket_factory.h>

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -33,19 +33,18 @@
 #include "NetworkRTCUtilitiesCocoa.h"
 #include "RTCSocketCreationFlags.h"
 #include <WebCore/STUNMessageParsing.h>
-#include <dispatch/dispatch.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <webrtc/rtc_base/async_packet_socket.h>
 #include <webrtc/rtc_base/time_utils.h>
 #include <wtf/BlockPtr.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/SystemFree.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/cocoa/SpanCocoa.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #include <wtf/posix/SocketPOSIX.h>
 
 namespace WebKit {

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -75,7 +75,7 @@
 
 #if OS(DARWIN)
 #include <mach/mach_port.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 #include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #if HAVE(XPC_API)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -85,7 +85,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/FileSystem.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/StdLibExtras.h>
@@ -95,6 +94,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/darwin/DispatchOSObject.h>
 #import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 #import <wtf/spi/cocoa/XTSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -34,9 +34,9 @@
 #import <Metal/Metal.h>
 #import <WebCore/PlatformXR.h>
 #import <WebCore/PlatformXRPose.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 #import "ARKitSoftLink.h"
 

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -36,11 +36,11 @@
 #import <WebCore/SecurityOrigin.h>
 #import <pal/spi/cocoa/NSFileManagerSPI.h>
 #import <wtf/Deque.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/NotificationCenterCF.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/darwin/DispatchOSObject.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 
 SOFT_LINK_FRAMEWORK(CoreLocation)

--- a/Source/WebKit/UIProcess/mac/ServicesController.h
+++ b/Source/WebKit/UIProcess/mac/ServicesController.h
@@ -30,8 +30,8 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -27,8 +27,8 @@
 #import "_WKMockUserNotificationCenter.h"
 
 #import <wtf/BlockPtr.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -52,12 +52,12 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Compiler.h>
 #import <wtf/MainThread.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 using namespace WebCore;
 

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -40,7 +40,7 @@
 
 #if PLATFORM(COCOA)
 #include <pal/spi/cocoa/NetworkSPI.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/NetworkOSObject.h>
 #endif // PLATFORM(COCOA)
 
 extern FILE* testResult;

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -29,7 +29,7 @@
 #import <Network/Network.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/CoroutineUtilities.h>
-#import <wtf/OSObjectPtr.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
@@ -25,10 +25,8 @@
 
 #include "config.h"
 
-#include <wtf/OSObjectPtr.h>
-
 #include <CoreFoundation/CoreFoundation.h>
-#include <dispatch/dispatch.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 #if __has_feature(objc_arc) && !defined(NDEBUG)
 // Debug builds with ARC enabled cause objects to be autoreleased

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
@@ -26,11 +26,9 @@
 #import <wtf/darwin/TypeCastsOSObject.h>
 
 #import "WTFTestUtilities.h"
-#import <dispatch/group.h>
-#import <dispatch/queue.h>
-#import <dispatch/source.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/darwin/DispatchOSObject.h>
 
 #ifdef __OBJC__
 #error This tests TypeCastsOSObject.h in non-Cocoa source.

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
@@ -27,9 +27,9 @@
  */
 
 #import "config.h"
-#import <wtf/darwin/TypeCastsOSObject.h>
 
 #import "WTFTestUtilities.h"
+#import <wtf/darwin/DispatchOSObject.h>
 
 #if __has_feature(objc_arc)
 #ifndef TYPE_CASTS_OSOBJECT_PTR_TEST_NAME

--- a/Tools/TestWebKitAPI/mac/VirtualGamepad.h
+++ b/Tools/TestWebKitAPI/mac/VirtualGamepad.h
@@ -27,11 +27,10 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#include <dispatch/dispatch.h>
 #include <wtf/FastMalloc.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/darwin/DispatchOSObject.h>
 
 OBJC_CLASS HIDDevice;
 OBJC_CLASS HIDUserDevice;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -46,7 +46,7 @@
 #include "InstanceMethodSwizzler.h"
 #if !ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
 #include <pal/spi/cocoa/NetworkSPI.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/NetworkOSObject.h>
 #endif // !ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
 #endif // PLATFORM(COCOA)
 


### PR DESCRIPTION
#### 19967f9979a4d04f866009dfa181cc0d8829f15a
<pre>
Dispatch and Network OS Object types should use DefaultOSObjectRetainTraits
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=304581">https://bugs.webkit.org/show_bug.cgi?id=304581</a>&gt;
&lt;<a href="https://rdar.apple.com/166988644">rdar://166988644</a>&gt;

Reviewed by Chris Dumez.

Extract DispatchOSObject.h and NetworkOSObject.h from
TypeCastsOSObject.h, then add template specializations for
WTF::DefaultOSObjectRetainTraits&lt;&gt; that are only active when ARC is
disabled since the default implementation in OSObjectPtr.h may be used
when ARC is enabled.

All of the uncommented changes below are to include the new headers.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
- Add DispatchOSObject.h and NetworkOSObject.h to the Xcode project.
* Source/WTF/wtf/CMakeLists.txt:
- Add DispatchOSObject.h and NetworkOSObject.h to CMake.
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WTF/wtf/WorkQueue.h:
* Source/WTF/wtf/cocoa/VectorCocoa.h:
* Source/WTF/wtf/darwin/DispatchOSObject.h: Add.
- Extract type cast support for libdispatch objects from
  TypeCastsOSObject.h.
- Add template specialization for WTF::DefaultOSObjectRetainTraits&lt;&gt;.
* Source/WTF/wtf/darwin/NetworkOSObject.h: Add.
- Extract type cast support for Network.framework objects from
  TypeCastsOSObject.h.
- Add template specialization for WTF::DefaultOSObjectRetainTraits&lt;&gt;.
* Source/WTF/wtf/darwin/TypeCastsOSObject.h:
- Move libdispatch and Network.framework code into DispatchOSObject.h
  and NetworkOSObject.h, respectively.
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
- Remove bridge/objc/objc_runtime.h since it is now fixed.
* Source/WebCore/platform/FileMonitor.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/mac/PowerObserverMac.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
* Source/WebKit/UIProcess/mac/ServicesController.h:
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
* Tools/DumpRenderTree/TestRunner.h:
* Tools/TestWebKitAPI/NetworkConnection.h:
* Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp:
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm:
* Tools/TestWebKitAPI/mac/VirtualGamepad.h:
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/304891@main">https://commits.webkit.org/304891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0149c9d13db5af25b44e82cfa32b0c71a3d8e57a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b11319ef-a49c-496d-ad00-4e9fe0530477) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b95e0a30-4707-4a7e-8bc6-b59d6dc1c306) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85394 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6796 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4482 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5036 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128677 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147202 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135202 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8759 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112904 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113233 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6715 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62911 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21090 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8807 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36848 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167982 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72373 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43826 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->