### PR TITLE
[JSC] add support for Iterator.prototype.join

### DIFF
--- a/JSTests/stress/iterator-prototype-join.js
+++ b/JSTests/stress/iterator-prototype-join.js
@@ -1,0 +1,184 @@
+//@ requireOptions("--useIteratorJoin=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+sameValue([].values().join(), "");
+sameValue([].values().join(""), "");
+sameValue([].values().join(", "), "");
+
+{
+    let called = false;
+    sameValue([].values().join({ toString() { called = true; return ", "; } }), "");
+    sameValue(called, true);
+}
+
+sameValue([1].values().join(), "1");
+sameValue(["a"].values().join(), "a");
+sameValue([true].values().join(), "true");
+sameValue([false].values().join(), "false");
+sameValue([null].values().join(), "");
+sameValue([undefined].values().join(), "");
+
+sameValue([{ toString() { return 1; } }].values().join(), "1");
+sameValue([{ toString() { return true; } }].values().join(), "true");
+sameValue([{ toString() { return false; } }].values().join(), "false");
+sameValue([{ toString() { return null; } }].values().join(), "null");
+sameValue([{ toString() { return undefined; } }].values().join(), "undefined");
+sameValue([{ toString() { return ""; } }].values().join(), "");
+sameValue([{ toString() { return "a"; } }].values().join(), "a");
+sameValue([{ toString() { return "abc"; } }].values().join(), "abc");
+
+sameValue([1, undefined, 2, null, 3].values().join(), "1,2,3");
+sameValue([1, undefined, 2, null, 3].values().join(0), "10203");
+sameValue([1, undefined, 2, null, 3].values().join(null), "1null2null3");
+sameValue([1, undefined, 2, null, 3].values().join(undefined), "1,2,3");
+sameValue([1, undefined, 2, null, 3].values().join(""), "123");
+sameValue([1, undefined, 2, null, 3].values().join(","), "1,2,3");
+sameValue([1, undefined, 2, null, 3].values().join(", "), "1, 2, 3");
+
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return 0; } }), "10203");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return true; } }), "1true2true3");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return false; } }), "1false2false3");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return null; } }), "1null2null3");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return undefined; } }), "1undefined2undefined3");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return ""; } }), "123");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return ","; } }), "1,2,3");
+sameValue([1, undefined, 2, null, 3].values().join({ toString() { return ", "; } }), "1, 2, 3");
+
+{
+    let nextGetCount = 0;
+    class TestIterator extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iterator = new TestIterator;
+    sameValue(nextGetCount, 0);
+    sameValue(iterator.join(", "), "1, 2, 3, 4, 5");
+    sameValue(nextGetCount, 1);
+}
+
+{
+    function* gen() {
+        yield undefined;
+        yield null;
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+        yield null;
+        yield undefined;
+    }
+    sameValue(gen().join("|"), "1|2|3|4|5");
+}
+
+{
+    const arr = [undefined, null, 1, 2, 3, 4, 5, null, undefined];
+    const iterator = arr[Symbol.iterator]();
+    assert(iterator.join === Iterator.prototype.join);
+    sameValue(iterator.join(""), "12345");
+}
+
+{
+    class TestIterator extends Iterator {
+        value = 0;
+        isClosed = false;
+        isDone = false;
+        next() {
+            return {
+                done: false,
+                value: ++this.value,
+            };
+        }
+        return() {
+            this.isClosed = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+    }
+    const iterator = new TestIterator;
+    try {
+        iterator.join(Symbol(42));
+    } catch (e) {
+        sameValue(e.name, "TypeError");
+        sameValue(e.message, "Cannot convert a symbol to a string");
+    }
+    sameValue(iterator.isDone, false);
+    sameValue(iterator.isClosed, true);
+}
+
+{
+    class TestIterator extends Iterator {
+        value = 0;
+        isClosed = false;
+        isDone = false;
+        next() {
+            return {
+                done: false,
+                value: Symbol(++this.value),
+            };
+        }
+        return() {
+            this.isClosed = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+    }
+    const iterator = new TestIterator;
+    try {
+        iterator.join();
+    } catch (e) {
+        sameValue(e.name, "TypeError");
+        sameValue(e.message, "Cannot convert a symbol to a string");
+    }
+    sameValue(iterator.isDone, false);
+    sameValue(iterator.isClosed, true);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.join.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.join requires that |this| be an Object.");
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -58,6 +58,7 @@ static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoToStringTagSetter);
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncToArray);
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncForEach);
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncIncludes);
+static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncJoin);
 
 void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
@@ -103,6 +104,11 @@ void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     if (Options::useIteratorIncludes()) {
         // https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes
         JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().includesPublicName(), iteratorProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    }
+
+    if (Options::useIteratorJoin()) {
+        // https://tc39.es/proposal-iterator-join/
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->join, iteratorProtoFuncJoin, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     }
 
     if (Options::useExplicitResourceManagement())
@@ -318,6 +324,95 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
 
     RELEASE_ASSERT_NOT_REACHED();
     return { };
+}
+
+// https://tc39.es/proposal-iterator-join/
+JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype.join requires that |this| be an Object."_s);
+
+    JSValue separatorValue = callFrame->argument(0);
+    JSString* separatorString = nullptr;
+    if (separatorValue.isUndefined()) {
+        constexpr Latin1Character comma = ',';
+        separatorString = jsSingleCharacterString(vm, comma);
+        RETURN_IF_EXCEPTION(scope, { });
+    } else {
+        separatorString = separatorValue.toStringOrNull(globalObject);
+        EXCEPTION_ASSERT(!!scope.exception() == !separatorString);
+        if (!separatorString) {
+            scope.release();
+            iteratorClose(globalObject, thisValue);
+            return { };
+        }
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    IterationRecord iterationRecord = iteratorDirect(globalObject, thisValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue nextMethod = iterationRecord.nextMethod;
+    CallData callData = getCallDataInline(nextMethod);
+
+    std::optional<CachedCall> cachedCallHolder;
+    CachedCall* cachedCall = nullptr;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        cachedCall = &cachedCallHolder.value();
+    }
+
+    JSString* result = nullptr;
+    while (true) {
+        JSValue next;
+        if (cachedCall) [[likely]] {
+            cachedCall->clearArguments();
+            next = iteratorStepWithCachedCall(globalObject, iterationRecord, cachedCall);
+        } else
+            next = iteratorStep(globalObject, iterationRecord);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (next.isFalse())
+            break;
+
+        JSValue nextValue = iteratorValue(globalObject, next);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (nextValue.isUndefinedOrNull())
+            continue;
+
+        JSString* nextString = nextValue.toStringOrNull(globalObject);
+        EXCEPTION_ASSERT(!!scope.exception() == !nextString);
+        if (!nextString) {
+            scope.release();
+            iteratorClose(globalObject, thisValue);
+            return { };
+        }
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (!result)
+            result = nextString;
+        else {
+            result = jsString(globalObject, result, separatorString, nextString);
+            EXCEPTION_ASSERT(!!scope.exception() == !result);
+            if (!result) {
+                scope.release();
+                iteratorClose(globalObject, thisValue);
+                return { };
+            }
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    }
+    if (!result)
+        result = jsEmptyString(vm);
+    return JSValue::encode(result);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -662,6 +662,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorSequencing, true, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useIteratorIncludes, false, Normal, "Expose the Iterator.includes method."_s) \
+    v(Bool, useIteratorJoin, false, Normal, "Expose the Iterator.prototype.join method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useJSPI, true, Normal, "Enable the implementation of JavaScript Promise Integration."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \


### PR DESCRIPTION
#### 962ea27aa60eeb8eaac503ad94c5a3efde4a61a4
<pre>
[JSC] add support for Iterator.prototype.join
<a href="https://bugs.webkit.org/show_bug.cgi?id=304586">https://bugs.webkit.org/show_bug.cgi?id=304586</a>

Reviewed by Yusuke Suzuki.

Just like to `Array.prototype.join`, being able to `join` an iterator (i.e. `Iterator.prototype.join`) will make it even easier to use arrays and iterators interchangeably.

Spec: &lt;<a href="https://tc39.es/proposal-iterator-join/">https://tc39.es/proposal-iterator-join/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-iterator-join">https://github.com/tc39/proposal-iterator-join</a>&gt;

* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):
(JSC::iteratorProtoFuncJoin): Added.

* Source/JavaScriptCore/runtime/OptionsList.h:
Add a feature flag for this.

* JSTests/stress/iterator-prototype-join.js: Added.

Canonical link: <a href="https://commits.webkit.org/311097@main">https://commits.webkit.org/311097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d9ee04e97cf7f0facdd4517080693ae4aedbdbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164701 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20139 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12531 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147988 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167181 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16773 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128840 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34951 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86540 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16462 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92462 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48298 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->