### PR TITLE
[Swift in WebKit] Work towards having a proper JSC module (part 1)

### DIFF
--- a/Source/JavaScriptCore/API/JSWeakObjectMapRefInternal.h
+++ b/Source/JavaScriptCore/API/JSWeakObjectMapRefInternal.h
@@ -27,6 +27,7 @@
 #define JSWeakObjectMapRefInternal_h
 
 #include <JavaScriptCore/WeakGCMap.h>
+#include <wtf/PtrTag.h>
 #include <wtf/RefCounted.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/API/OpaqueJSString.h
+++ b/Source/JavaScriptCore/API/OpaqueJSString.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <atomic>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -618,6 +618,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/RegisterInfo.h
     assembler/SecureARM64EHashPins.h
     assembler/SecureARM64EHashPinsInlines.h
+    assembler/TargetAssemblerDefinitions.h
     assembler/X86Assembler.h
     assembler/X86_64Registers.h
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		072F53502E3C0F3300389E15 /* JITSubGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = FE98B5B61BB9AE110073E7A6 /* JITSubGenerator.h */; };
 		072F53512E3C3F8700389E15 /* BytecodeGeneratorBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C5AD6522F1866C00F1FB83 /* BytecodeGeneratorBase.h */; };
 		072F53522E3C3FDA00389E15 /* ProfileTypeBytecodeFlag.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BA7752211A8E5F008D0B05 /* ProfileTypeBytecodeFlag.h */; };
+		07CEB6A22EF90E4B008DCDEC /* TargetAssemblerDefinitions.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CEB6A12EF90E37008DCDEC /* TargetAssemblerDefinitions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F0123331944EA1B00843A0C /* DFGValueStrength.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0123311944EA1B00843A0C /* DFGValueStrength.h */; };
 		0F0332C418B01763005F979A /* GetByVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0332C218B01763005F979A /* GetByVariant.h */; };
 		0F0332C618B53FA9005F979A /* FTLWeight.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0332C518B53FA9005F979A /* FTLWeight.h */; };
@@ -2730,6 +2731,7 @@
 		05517CA12C74004700ED0CD5 /* JSIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIterator.h; sourceTree = "<group>"; };
 		05517CA22C74004700ED0CD5 /* JSIteratorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSIteratorConstructor.cpp; sourceTree = "<group>"; };
 		07A564652E6250D900DEC7C4 /* JavaScriptCore_Private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = JavaScriptCore_Private.modulemap; sourceTree = "<group>"; };
+		07CEB6A12EF90E37008DCDEC /* TargetAssemblerDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TargetAssemblerDefinitions.h; sourceTree = "<group>"; };
 		0F0123301944EA1B00843A0C /* DFGValueStrength.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGValueStrength.cpp; path = dfg/DFGValueStrength.cpp; sourceTree = "<group>"; };
 		0F0123311944EA1B00843A0C /* DFGValueStrength.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGValueStrength.h; path = dfg/DFGValueStrength.h; sourceTree = "<group>"; };
 		0F0332BF18ADFAE1005F979A /* ExitingJITType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExitingJITType.cpp; sourceTree = "<group>"; };
@@ -9826,6 +9828,7 @@
 				52CAEC732790B8F600DDBAAF /* SecureARM64EHashPins.cpp */,
 				52CAEC742790B8F600DDBAAF /* SecureARM64EHashPins.h */,
 				52CAEC722790B8F600DDBAAF /* SecureARM64EHashPinsInlines.h */,
+				07CEB6A12EF90E37008DCDEC /* TargetAssemblerDefinitions.h */,
 				FE533CA01F217C310016A1FE /* testmasm.cpp */,
 				9688CB140ED12B4E001D6492 /* X86_64Registers.h */,
 				9688CB140ED12B4E001D649F /* X86Assembler.h */,
@@ -12230,6 +12233,7 @@
 				A784A26411D16622005776AC /* SyntaxChecker.h in Headers */,
 				E3C4131D289E08EA001150F8 /* SyntheticModuleRecord.h in Headers */,
 				DC7997831CDE9FA0004D4A09 /* TagRegistersMode.h in Headers */,
+				07CEB6A22EF90E4B008DCDEC /* TargetAssemblerDefinitions.h in Headers */,
 				70ECA6091AFDBEA200449739 /* TemplateObjectDescriptor.h in Headers */,
 				E32D4DE926DAFD4300D4533A /* TemporalCalendar.h in Headers */,
 				E32D4DEA26DAFD4300D4533A /* TemporalCalendarConstructor.h in Headers */,

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/MacroAssemblerHelpers.h>
 #include <JavaScriptCore/Options.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Platform.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SharedTask.h>
 #include <wtf/StringPrintStream.h>

--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -36,8 +36,12 @@ enum class MemoryRestriction {
 };
 
 #if USE(APPLE_INTERNAL_SDK)
+// FIXME: Properly support using WKA in modules.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
 #include <WebKitAdditions/FastJITPermissionsAdditions.h>
 #include <WebKitAdditions/JSGlobalObjectAdditions.h>
+#pragma clang diagnostic pop
 #endif
 
 #if defined(OS_THREAD_SELF_RESTRICT) != defined(OS_THREAD_SELF_RESTRICT_SUPPORTED)

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/TargetAssemblerDefinitions.h>
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
@@ -32,66 +33,23 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(ASSEMBLER)
 
-#include <JavaScriptCore/JSCJSValue.h>
-
-#define DEFINE_SIMD_FUNC(name, func, lane) \
-    template <typename ...Args> \
-    void name(Args&&... args) { func(lane, std::forward<Args>(args)...); }
-
-#define DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name, func, lane, mode) \
-    template <typename ...Args> \
-    void name(Args&&... args) { func(lane, mode, std::forward<Args>(args)...); }
-
-#define DEFINE_SIMD_FUNCS(name) \
-    DEFINE_SIMD_FUNC(name##Int8, name, SIMDLane::i8x16) \
-    DEFINE_SIMD_FUNC(name##Int16, name, SIMDLane::i16x8) \
-    DEFINE_SIMD_FUNC(name##Int32, name, SIMDLane::i32x4) \
-    DEFINE_SIMD_FUNC(name##Int64, name, SIMDLane::i64x2) \
-    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
-    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
-
-#define DEFINE_SIGNED_SIMD_FUNCS(name) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Signed) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Unsigned) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Signed) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Unsigned) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int32, name, SIMDLane::i32x4, SIMDSignMode::None) \
-    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int64, name, SIMDLane::i64x2, SIMDSignMode::None) \
-    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
-    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
-
-#if CPU(ADDRESS64)
-#define DEFINE_PTR_FUNC(name) \
-    template <typename ...Args> \
-    auto name##Ptr(Args&&... args) -> decltype(auto) { return name##64(std::forward<Args>(args)...); }
-#else
-#define DEFINE_PTR_FUNC(name) \
-    template <typename ...Args> \
-    auto name##Ptr(Args&&... args) -> decltype(auto) { return name##32(std::forward<Args>(args)...); }
-#endif
-
 #if CPU(ARM_THUMB2)
-#define TARGET_ASSEMBLER ARMv7Assembler
 #define TARGET_MACROASSEMBLER MacroAssemblerARMv7
 #include <JavaScriptCore/MacroAssemblerARMv7.h>
 
 #elif CPU(ARM64E)
-#define TARGET_ASSEMBLER ARM64EAssembler
 #define TARGET_MACROASSEMBLER MacroAssemblerARM64E
 #include <JavaScriptCore/MacroAssemblerARM64E.h>
 
 #elif CPU(ARM64)
-#define TARGET_ASSEMBLER ARM64Assembler
 #define TARGET_MACROASSEMBLER MacroAssemblerARM64
 #include <JavaScriptCore/MacroAssemblerARM64.h>
 
 #elif CPU(X86_64)
-#define TARGET_ASSEMBLER X86Assembler
 #define TARGET_MACROASSEMBLER MacroAssemblerX86_64
 #include <JavaScriptCore/MacroAssemblerX86_64.h>
 
 #elif CPU(RISCV64)
-#define TARGET_ASSEMBLER RISCV64Assembler
 #define TARGET_MACROASSEMBLER MacroAssemblerRISCV64
 #include "MacroAssemblerRISCV64.h"
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -30,8 +30,10 @@
 #if ENABLE(ASSEMBLER) && CPU(ARM64)
 
 #include <JavaScriptCore/ARM64Assembler.h>
+#include <JavaScriptCore/ARM64EAssembler.h>
 #include <JavaScriptCore/AbstractMacroAssembler.h>
 #include <JavaScriptCore/JITOperationValidation.h>
+#include <JavaScriptCore/TargetAssemblerDefinitions.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/assembler/MacroAssemblerHelpers.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerHelpers.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <utility>
+
 namespace JSC {
 namespace MacroAssemblerHelpers {
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/Printer.h>
 #include <JavaScriptCore/ProbeContext.h>
+#include <wtf/Platform.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(X86_64)
 
 #include <JavaScriptCore/AbstractMacroAssembler.h>

--- a/Source/JavaScriptCore/assembler/OSCheck.h
+++ b/Source/JavaScriptCore/assembler/OSCheck.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 namespace JSC {
 
 ALWAYS_INLINE constexpr bool isDarwin()

--- a/Source/JavaScriptCore/assembler/ProbeContext.h
+++ b/Source/JavaScriptCore/assembler/ProbeContext.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/ProbeStack.h>
+#include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 
 #if ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/CPU.h>
 #include <wtf/HashMap.h>
+#include <wtf/Platform.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPins.h
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPins.h
@@ -25,8 +25,12 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if CPU(ARM64E) && ENABLE(JIT)
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Atomics.h>
 #include <wtf/BitSet.h>
 

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
@@ -25,7 +25,11 @@
 
 #pragma once
 
+#include <JavaScriptCore/ExecutableAllocator.h>
+#include <JavaScriptCore/JSCConfig.h>
 #include <JavaScriptCore/SecureARM64EHashPins.h>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 #if CPU(ARM64E) && ENABLE(JIT)
 

--- a/Source/JavaScriptCore/assembler/TargetAssemblerDefinitions.h
+++ b/Source/JavaScriptCore/assembler/TargetAssemblerDefinitions.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#if ENABLE(ASSEMBLER)
+
+#include <JavaScriptCore/JSCJSValue.h>
+
+#define DEFINE_SIMD_FUNC(name, func, lane) \
+    template <typename ...Args> \
+    void name(Args&&... args) { func(lane, std::forward<Args>(args)...); }
+
+#define DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name, func, lane, mode) \
+    template <typename ...Args> \
+    void name(Args&&... args) { func(lane, mode, std::forward<Args>(args)...); }
+
+#define DEFINE_SIMD_FUNCS(name) \
+    DEFINE_SIMD_FUNC(name##Int8, name, SIMDLane::i8x16) \
+    DEFINE_SIMD_FUNC(name##Int16, name, SIMDLane::i16x8) \
+    DEFINE_SIMD_FUNC(name##Int32, name, SIMDLane::i32x4) \
+    DEFINE_SIMD_FUNC(name##Int64, name, SIMDLane::i64x2) \
+    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
+    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
+
+#define DEFINE_SIGNED_SIMD_FUNCS(name) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Signed) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Unsigned) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Signed) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Unsigned) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int32, name, SIMDLane::i32x4, SIMDSignMode::None) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int64, name, SIMDLane::i64x2, SIMDSignMode::None) \
+    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
+    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
+
+#if CPU(ADDRESS64)
+#define DEFINE_PTR_FUNC(name) \
+    template <typename ...Args> \
+    auto name##Ptr(Args&&... args) -> decltype(auto) { return name##64(std::forward<Args>(args)...); }
+#else
+#define DEFINE_PTR_FUNC(name) \
+    template <typename ...Args> \
+    auto name##Ptr(Args&&... args) -> decltype(auto) { return name##32(std::forward<Args>(args)...); }
+#endif
+
+#if CPU(ARM_THUMB2)
+#define TARGET_ASSEMBLER ARMv7Assembler
+
+#elif CPU(ARM64E)
+#define TARGET_ASSEMBLER ARM64EAssembler
+
+#elif CPU(ARM64)
+#define TARGET_ASSEMBLER ARM64Assembler
+
+#elif CPU(X86_64)
+#define TARGET_ASSEMBLER X86Assembler
+
+#elif CPU(RISCV64)
+#define TARGET_ASSEMBLER RISCV64Assembler
+
+#else
+#error "The MacroAssembler is not supported on this platform."
+#endif
+
+#endif // ENABLE(ASSEMBLER)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include <JavaScriptCore/CPU.h>

--- a/Source/JavaScriptCore/b3/B3Compile.h
+++ b/Source/JavaScriptCore/b3/B3Compile.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include <JavaScriptCore/B3Common.h>

--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT) || ENABLE(WEBASSEMBLY_BBQJIT)
 
 #include <JavaScriptCore/B3Common.h>

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.h
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include <JavaScriptCore/CPU.h>

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.h
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include <JavaScriptCore/MacroAssembler.h>

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/CodeSpecializationKind.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SixCharacterHash.h>
 #include <wtf/text/StringImpl.h>

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/BytecodeIndex.h>
+#include <JavaScriptCore/JSExportMacros.h>
 
 #include <limits.h>
 #include <wtf/HashMap.h>

--- a/Source/JavaScriptCore/bytecode/CodeType.h
+++ b/Source/JavaScriptCore/bytecode/CodeType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum CodeType : uint8_t { GlobalCode, EvalCode, FunctionCode, ModuleCode };

--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.h
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(DFG_JIT)
 
 #include <JavaScriptCore/ConcurrentJSLock.h>

--- a/Source/JavaScriptCore/bytecode/ExitingInlineKind.h
+++ b/Source/JavaScriptCore/bytecode/ExitingInlineKind.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum ExitingInlineKind : uint8_t {

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSCBuiltins.h>
+#include <cstdint>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/bytecode/OpcodeSize.h
+++ b/Source/JavaScriptCore/bytecode/OpcodeSize.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/SourceID.h
+++ b/Source/JavaScriptCore/bytecode/SourceID.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/SuperSampler.h
+++ b/Source/JavaScriptCore/bytecode/SuperSampler.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <atomic>
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Atomics.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/FastMalloc.h>

--- a/Source/JavaScriptCore/debugger/Breakpoint.h
+++ b/Source/JavaScriptCore/debugger/Breakpoint.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/DebuggerPrimitives.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/JavaScriptCore/dfg/DFGCodeOriginPool.h
+++ b/Source/JavaScriptCore/dfg/DFGCodeOriginPool.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(DFG_JIT)
 
 #include <JavaScriptCore/CallFrame.h>

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JITCompilationMode.h>
+#include <wtf/Platform.h>
 
 #if ENABLE(DFG_JIT)
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
+++ b/Source/JavaScriptCore/dfg/DFGDoesGCCheck.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <cstdint>
 #include <wtf/Assertions.h>
 

--- a/Source/JavaScriptCore/domjit/DOMJITCallDOMGetterSnippet.h
+++ b/Source/JavaScriptCore/domjit/DOMJITCallDOMGetterSnippet.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/DOMJITEffect.h>

--- a/Source/JavaScriptCore/domjit/DOMJITHeapRange.h
+++ b/Source/JavaScriptCore/domjit/DOMJITHeapRange.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
 

--- a/Source/JavaScriptCore/ftl/FTLAbbreviatedTypes.h
+++ b/Source/JavaScriptCore/ftl/FTLAbbreviatedTypes.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 #include <JavaScriptCore/DFGCommon.h>

--- a/Source/JavaScriptCore/ftl/FTLExitArgument.h
+++ b/Source/JavaScriptCore/ftl/FTLExitArgument.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 #include <JavaScriptCore/DataFormat.h>

--- a/Source/JavaScriptCore/ftl/FTLLocation.h
+++ b/Source/JavaScriptCore/ftl/FTLLocation.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 #include <JavaScriptCore/DFGCommon.h>

--- a/Source/JavaScriptCore/ftl/FTLRecoveryOpcode.h
+++ b/Source/JavaScriptCore/ftl/FTLRecoveryOpcode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 namespace JSC { namespace FTL {

--- a/Source/JavaScriptCore/ftl/FTLSaveRestore.h
+++ b/Source/JavaScriptCore/ftl/FTLSaveRestore.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 #include <JavaScriptCore/FPRInfo.h>

--- a/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
+++ b/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(FTL_JIT)
 
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>

--- a/Source/JavaScriptCore/heap/Allocator.h
+++ b/Source/JavaScriptCore/heap/Allocator.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/AllocationFailureMode.h>
 #include <climits>
+#include <cstdint>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/CollectionScope.h
+++ b/Source/JavaScriptCore/heap/CollectionScope.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class CollectionScope : uint8_t { Eden, Full };

--- a/Source/JavaScriptCore/heap/CollectorPhase.h
+++ b/Source/JavaScriptCore/heap/CollectorPhase.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 // We track collector phase in order to allow either the collector thread or the mutator thread to

--- a/Source/JavaScriptCore/heap/DeferGC.h
+++ b/Source/JavaScriptCore/heap/DeferGC.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/DisallowScope.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadSpecific.h>
 

--- a/Source/JavaScriptCore/heap/DestructionMode.h
+++ b/Source/JavaScriptCore/heap/DestructionMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class DestructionMode : uint8_t {

--- a/Source/JavaScriptCore/heap/FreeList.h
+++ b/Source/JavaScriptCore/heap/FreeList.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/Compiler.h>
 #include <wtf/MathExtras.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>

--- a/Source/JavaScriptCore/heap/GCConductor.h
+++ b/Source/JavaScriptCore/heap/GCConductor.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 // Either the mutator has the conn (https://en.wikipedia.org/wiki/Conn_(nautical)), meaning that the

--- a/Source/JavaScriptCore/heap/GCIncomingRefCountedSet.h
+++ b/Source/JavaScriptCore/heap/GCIncomingRefCountedSet.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <JavaScriptCore/CollectionScope.h>
 #include <JavaScriptCore/GCIncomingRefCounted.h>
 
 namespace JSC {
+
+class VM;
 
 // T = some subtype of GCIncomingRefCounted, must support a gcSizeEstimateInBytes()
 // method.

--- a/Source/JavaScriptCore/heap/GCSegmentedArray.h
+++ b/Source/JavaScriptCore/heap/GCSegmentedArray.h
@@ -25,8 +25,11 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/Compiler.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/DoublyLinkedList.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/heap/HandleBlock.h
+++ b/Source/JavaScriptCore/heap/HandleBlock.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/DoublyLinkedList.h>
+#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -27,6 +27,9 @@
 
 #include <JavaScriptCore/DestructionMode.h>
 #include <JavaScriptCore/EnsureStillAliveHere.h>
+#include <bit>
+#include <cstdint>
+#include <wtf/Compiler.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/heap/IsoSubspaceInlines.h
+++ b/Source/JavaScriptCore/heap/IsoSubspaceInlines.h
@@ -25,7 +25,14 @@
 
 #pragma once
 
+#include <JavaScriptCore/AllocationFailureMode.h>
+#include <cstdint>
+#include <wtf/Compiler.h>
+
 namespace JSC {
+
+class GCDeferralContext;
+class VM;
 
 namespace GCClient {
 

--- a/Source/JavaScriptCore/heap/MutatorState.h
+++ b/Source/JavaScriptCore/heap/MutatorState.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class MutatorState : uint8_t {

--- a/Source/JavaScriptCore/heap/Synchronousness.h
+++ b/Source/JavaScriptCore/heap/Synchronousness.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum Synchronousness : uint8_t {

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <JavaScriptCore/JSCast.h>

--- a/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
+++ b/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include <JavaScriptCore/AugmentableInspectorController.h>

--- a/Source/JavaScriptCore/inspector/augmentable/AugmentableInspectorController.h
+++ b/Source/JavaScriptCore/inspector/augmentable/AugmentableInspectorController.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include <JavaScriptCore/AugmentableInspectorControllerClient.h>

--- a/Source/JavaScriptCore/interpreter/CLoopStack.h
+++ b/Source/JavaScriptCore/interpreter/CLoopStack.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(C_LOOP)
 
 #include <JavaScriptCore/Register.h>

--- a/Source/JavaScriptCore/interpreter/CLoopStackInlines.h
+++ b/Source/JavaScriptCore/interpreter/CLoopStackInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(C_LOOP)
 
 #include <JavaScriptCore/CLoopStack.h>

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/NativeFunction.h>
 #include <JavaScriptCore/Opcode.h>
 #include <wtf/HashMap.h>
+#include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 
 

--- a/Source/JavaScriptCore/interpreter/ProtoCallFrame.h
+++ b/Source/JavaScriptCore/interpreter/ProtoCallFrame.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/Register.h>
 #include <JavaScriptCore/StackAlignment.h>
 #include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Platform.h>
 
 #if ENABLE(WEBASSEMBLY)
 #include <JavaScriptCore/JSWebAssemblyInstance.h>

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/CodeBlock.h>

--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/AssemblyHelpers.h>

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/GPRInfo.h>

--- a/Source/JavaScriptCore/jit/BinarySwitch.h
+++ b/Source/JavaScriptCore/jit/BinarySwitch.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/GPRInfo.h>

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/AssemblyHelpers.h>

--- a/Source/JavaScriptCore/jit/CallFrameShuffleData.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffleData.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/RegisterMap.h>

--- a/Source/JavaScriptCore/jit/FPRInfo.h
+++ b/Source/JavaScriptCore/jit/FPRInfo.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <JavaScriptCore/MacroAssembler.h>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -29,6 +29,7 @@
 #include <array>
 #include <wtf/FunctionTraits.h>
 #include <wtf/MathExtras.h>
+#include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/jit/GdbJIT.h
+++ b/Source/JavaScriptCore/jit/GdbJIT.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include <JavaScriptCore/LinkBuffer.h>

--- a/Source/JavaScriptCore/jit/JITAllocator.h
+++ b/Source/JavaScriptCore/jit/JITAllocator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Allocator.h>
+#include <wtf/Assertions.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/jit/JITCodeMap.h
+++ b/Source/JavaScriptCore/jit/JITCodeMap.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/BytecodeIndex.h>

--- a/Source/JavaScriptCore/jit/JITCompilation.h
+++ b/Source/JavaScriptCore/jit/JITCompilation.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>

--- a/Source/JavaScriptCore/jit/JITMathICForwards.h
+++ b/Source/JavaScriptCore/jit/JITMathICForwards.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 namespace JSC {

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/JITMathICForwards.h>
@@ -34,7 +36,6 @@
 #include <JavaScriptCore/ParserModes.h>
 #include <JavaScriptCore/PrivateFieldPutKind.h>
 #include <JavaScriptCore/UGPRPair.h>
-#include <wtf/Platform.h>
 #include <wtf/text/UniquedStringImpl.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -25,10 +25,13 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/Width.h>
+#include <wtf/Assertions.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/jit/RegisterAtOffset.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffset.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include <JavaScriptCore/Reg.h>

--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include <JavaScriptCore/RegisterAtOffset.h>

--- a/Source/JavaScriptCore/jit/RegisterMap.h
+++ b/Source/JavaScriptCore/jit/RegisterMap.h
@@ -25,12 +25,15 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include <JavaScriptCore/FPRInfo.h>
 #include <JavaScriptCore/GPRInfo.h>
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/Reg.h>
+#include <array>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if !ENABLE(C_LOOP)
 
 #include <JavaScriptCore/FPRInfo.h>

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/Compiler.h>
 #include <wtf/PrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/FPRInfo.h>

--- a/Source/JavaScriptCore/jit/Snippet.h
+++ b/Source/JavaScriptCore/jit/Snippet.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/CCallHelpers.h>

--- a/Source/JavaScriptCore/jit/ThunkGenerator.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT)
 
 #include <JavaScriptCore/JSCPtrTag.h>

--- a/Source/JavaScriptCore/llint/LLIntOpcode.h
+++ b/Source/JavaScriptCore/llint/LLIntOpcode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(C_LOOP)
 
 #define FOR_EACH_LLINT_NOJIT_NATIVE_HELPER(macro) \

--- a/Source/JavaScriptCore/parser/ParserTokens.h
+++ b/Source/JavaScriptCore/parser/ParserTokens.h
@@ -27,6 +27,8 @@
 
 #include <limits.h>
 #include <stdint.h>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
 
 namespace WTF {
 class PrintStream;

--- a/Source/JavaScriptCore/parser/ResultType.h
+++ b/Source/JavaScriptCore/parser/ResultType.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/PrintStream.h>
+
 namespace JSC {
 
     // FIXME: Consider whether this is actually necessary. Is LLInt and Baseline's profiling information enough?

--- a/Source/JavaScriptCore/parser/SourceTaintedOrigin.h
+++ b/Source/JavaScriptCore/parser/SourceTaintedOrigin.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <utility>
 #include <wtf/Forward.h>
 #include <wtf/TriState.h>
 

--- a/Source/JavaScriptCore/runtime/ArityCheckMode.h
+++ b/Source/JavaScriptCore/runtime/ArityCheckMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class ArityCheckMode : uint8_t {

--- a/Source/JavaScriptCore/runtime/CodeSpecializationKind.h
+++ b/Source/JavaScriptCore/runtime/CodeSpecializationKind.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class CodeSpecializationKind : uint8_t { CodeForCall, CodeForConstruct };

--- a/Source/JavaScriptCore/runtime/ConstructAbility.h
+++ b/Source/JavaScriptCore/runtime/ConstructAbility.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class ConstructAbility : uint8_t {

--- a/Source/JavaScriptCore/runtime/ConstructorKind.h
+++ b/Source/JavaScriptCore/runtime/ConstructorKind.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class ConstructorKind : uint8_t {

--- a/Source/JavaScriptCore/runtime/ECMAMode.h
+++ b/Source/JavaScriptCore/runtime/ECMAMode.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+
 namespace WTF {
 class PrintStream;
 };

--- a/Source/JavaScriptCore/runtime/EnsureStillAliveHere.h
+++ b/Source/JavaScriptCore/runtime/EnsureStillAliveHere.h
@@ -27,6 +27,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <wtf/Compiler.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/EnumerationMode.h
+++ b/Source/JavaScriptCore/runtime/EnumerationMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class PropertyNameMode : uint8_t {

--- a/Source/JavaScriptCore/runtime/Gate.h
+++ b/Source/JavaScriptCore/runtime/Gate.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 namespace JSC {
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY) || CPU(ARM64E)

--- a/Source/JavaScriptCore/runtime/ImplementationVisibility.h
+++ b/Source/JavaScriptCore/runtime/ImplementationVisibility.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class ImplementationVisibility : uint8_t {

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/SpeculatedType.h>
+#include <cstdint>
 #include <wtf/LockAlgorithm.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/JavaScriptCore/runtime/InlineAttribute.h
+++ b/Source/JavaScriptCore/runtime/InlineAttribute.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 enum class InlineAttribute : uint8_t {

--- a/Source/JavaScriptCore/runtime/IterationKind.h
+++ b/Source/JavaScriptCore/runtime/IterationKind.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
     
 enum class IterationKind : uint32_t {

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -44,8 +44,11 @@
 #pragma once
 
 #include <JavaScriptCore/DateInstanceCache.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/Compiler.h>
 #include <wtf/DateMath.h>
 #include <wtf/GregorianDateTime.h>
+#include <wtf/Platform.h>
 #include <wtf/SaturatedArithmetic.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -37,7 +37,11 @@
 #include <wtf/WeakPtr.h>
 
 #if USE(APPLE_INTERNAL_SDK)
+// FIXME: Properly support using WKA in modules.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
 #include <WebKitAdditions/JSGlobalObjectAdditions.h>
+#pragma clang diagnostic pop
 #else
 #define JS_GLOBAL_OBJECT_ADDITIONS_1
 #define JS_GLOBAL_OBJECT_ADDITIONS_2

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <mutex>
 #include <wtf/Assertions.h>
 #include <wtf/ForbidHeapAllocation.h>

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace JSC {
 
 // macro(JSType, DirectSpeculatedType)

--- a/Source/JavaScriptCore/runtime/JSTypeInfo.h
+++ b/Source/JavaScriptCore/runtime/JSTypeInfo.h
@@ -30,6 +30,8 @@
 // in the STL on systems without case-sensitive file systems. 
 
 #include <JavaScriptCore/JSType.h>
+#include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <array>
 #include <wtf/text/AtomStringImpl.h>
 
 namespace JSC {
 
+class JSString;
 class VM;
 
 class KeyAtomStringCache {

--- a/Source/JavaScriptCore/runtime/MemoryMode.h
+++ b/Source/JavaScriptCore/runtime/MemoryMode.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
+#include <cstdint>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -29,8 +29,10 @@
 #include <JavaScriptCore/Microtask.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <wtf/CompactRefPtrTuple.h>
+#include <wtf/Compiler.h>
 #include <wtf/Deque.h>
 #include <wtf/SentinelLinkedList.h>
+#include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
@@ -29,6 +29,7 @@
 
 namespace JSC {
 
+class SymbolTable;
 class UnlinkedModuleProgramCodeBlock;
 
 class ModuleProgramExecutable final : public GlobalExecutable {

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -27,12 +27,14 @@
 
 #include <array>
 #include <wtf/HashFunctions.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
 
 class JSString;
 class SmallStrings;
+class VM;
 
 class NumericStrings {
 public:

--- a/Source/JavaScriptCore/runtime/PrivateFieldPutKind.h
+++ b/Source/JavaScriptCore/runtime/PrivateFieldPutKind.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+
 namespace WTF {
 class PrintStream;
 };

--- a/Source/JavaScriptCore/runtime/PropertyNameArray.h
+++ b/Source/JavaScriptCore/runtime/PropertyNameArray.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/EnumerationMode.h>
 #include <JavaScriptCore/Identifier.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/runtime/ResourceExhaustion.h
+++ b/Source/JavaScriptCore/runtime/ResourceExhaustion.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/Assertions.h>
+
 namespace JSC {
 
 enum ResourceExhaustionCode {

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include <JavaScriptCore/CollectionScope.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/TypeofType.h>
+#include <wtf/Compiler.h>
 #include <wtf/Noncopyable.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <utility>
 #include <wtf/IterationStatus.h>
 

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -28,6 +28,9 @@
 
 #include <array>
 #include <wtf/DebugHeap.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSCellButterfly.h>
 #include <JavaScriptCore/JSPropertyNameEnumerator.h>
 #include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/PackedCellPtr.h>
 #include <JavaScriptCore/StructureChain.h>
 #include <JavaScriptCore/StructureRareData.h>
 #include <JavaScriptCore/VM.h>

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/CollectionScope.h>
 #include <JavaScriptCore/IndexingType.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <wtf/HashFunctions.h>

--- a/Source/JavaScriptCore/runtime/TypedArrayType.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayType.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/JSType.h>
 #include <wtf/Float16.h>
 #include <wtf/PrintStream.h>

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/StackManager.h>
 #include <wtf/AutomaticThread.h>
 #include <wtf/Box.h>

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>

--- a/Source/JavaScriptCore/wasm/WasmContext.h
+++ b/Source/JavaScriptCore/wasm/WasmContext.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/MacroAssembler.h>
+#include <cstdint>
 #include <wtf/Lock.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/Vector.h>

--- a/Source/JavaScriptCore/wasm/WasmCreationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCreationMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 namespace JSC { namespace Wasm {

--- a/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
+++ b/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/WasmBaselineData.h>

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <wtf/Compiler.h>

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/JITCompilation.h>

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/JSObject.h>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/CallLinkInfo.h>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/JSObject.h>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/JSObject.h>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/ArityCheckMode.h>

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <JavaScriptCore/YarrErrorCode.h>
+#include <climits>
 #include <limits>
 
 namespace JSC { namespace Yarr {

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Forward.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/yarr/YarrFlags.h
+++ b/Source/JavaScriptCore/yarr/YarrFlags.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+#include <array>
 #include <optional>
 #include <wtf/Forward.h>
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(YARR_JIT)
 
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>

--- a/Source/JavaScriptCore/yarr/YarrUnicodeProperties.h
+++ b/Source/JavaScriptCore/yarr/YarrUnicodeProperties.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Yarr.h>
+#include <memory>
 #include <optional>
 #include <wtf/Forward.h>
 


### PR DESCRIPTION
#### d5630ce5f014d2d643c1e49c1e16c2309f3d32d4
<pre>
[Swift in WebKit] Work towards having a proper JSC module (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304589">https://bugs.webkit.org/show_bug.cgi?id=304589</a>
<a href="https://rdar.apple.com/167004331">rdar://167004331</a>

Reviewed by Marcus Plutowski.

Work towards being able to properly verify JSC modularization.

* &lt;a lot of files&gt;

Add missing header includes.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
* Source/JavaScriptCore/assembler/TargetAssemblerDefinitions.h: Added.

The way `TARGET_ASSEMBLER` was being used was ill-formed with modules, since it was depending on &quot;outside&quot;
context, and modules require that all headers be self-contained. Fix this by refactoring the definitions
into a different file, and then including that.

Canonical link: <a href="https://commits.webkit.org/304877@main">https://commits.webkit.org/304877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fdad683d64be20863b4f97d2dab4e39913822bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89675 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/62990f8f-52ca-49c0-8eef-193384b343cd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104539 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee8e8265-0fa1-43cc-9e40-5ca567977c69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85378 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c766803-21e5-43d9-b2cb-facb26c90877) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6783 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4471 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5022 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128663 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147187 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135188 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112893 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113222 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28767 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6703 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62888 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8793 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36838 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72359 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43823 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->