### PR TITLE
Prototype MediaStreamTrackHandle

### DIFF
--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Transfer MediaStreamTrackHandle
+

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
+    const worker = await createWorker(`
+        let processor;
+        let reader;
+        self.onmessage = async (event) => {
+            self.postMessage(event.data, [event.data]);
+        }
+    `);
+
+    const handle1 = new MediaStreamTrackHandle(stream.getVideoTracks()[0]);
+    assert_true(handle1 instanceof MediaStreamTrackHandle);
+
+    worker.postMessage(handle1, [handle1]);
+    const handle2 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+
+    assert_true(handle2 instanceof MediaStreamTrackHandle);
+}, "Transfer MediaStreamTrackHandle");
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5279,6 +5279,21 @@ MediaSourceUseRemoteAudioVideoRenderer:
       default: false
   sharedPreferenceForWebProcess: true
 
+MediaStreamTrackHandleEnabled:
+  type: bool
+  status: preview
+  category: media
+  humanReadableName: "MediaStreamTrackHandle"
+  humanReadableDescription: "Enable MediaStreamTrackHandle"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 MediaStreamTrackProcessingEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -538,6 +538,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/MediaStream.idl
     Modules/mediastream/MediaStreamTrack.idl
     Modules/mediastream/MediaStreamTrackEvent.idl
+    Modules/mediastream/MediaStreamTrackHandle.idl
     Modules/mediastream/MediaStreamTrackProcessor.idl
     Modules/mediastream/MediaTrackCapabilities.idl
     Modules/mediastream/MediaTrackConstraints.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -598,6 +598,7 @@ $(PROJECT_DIR)/Modules/mediastream/MediaSettingsRange.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStream.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrack.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackEvent.idl
+$(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackHandle.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackProcessor.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackCapabilities.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackConstraints.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1979,6 +1979,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrack.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrack.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackHandle.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackHandle.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackProcessor.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackProcessor.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaTrackCapabilities.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -459,6 +459,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/MediaStream.idl \
     $(WebCore)/Modules/mediastream/MediaStreamTrack.idl \
     $(WebCore)/Modules/mediastream/MediaStreamTrackEvent.idl \
+    $(WebCore)/Modules/mediastream/MediaStreamTrackHandle.idl \
     $(WebCore)/Modules/mediastream/MediaStreamTrackProcessor.idl \
     $(WebCore)/Modules/mediastream/MediaTrackCapabilities.idl \
     $(WebCore)/Modules/mediastream/MediaTrackConstraints.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -586,6 +586,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/mediastream/MediaDevices.h
     Modules/mediastream/MediaStreamTrack.h
     Modules/mediastream/MediaStreamTrackEvent.h
+    Modules/mediastream/MediaStreamTrackHandle.h
     Modules/mediastream/MediaTrackCapabilities.h
     Modules/mediastream/MediaTrackConstraints.h
     Modules/mediastream/RTCController.h

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -141,11 +141,6 @@ const AtomString& MediaStreamTrack::kind() const
     return m_kind;
 }
 
-const String& MediaStreamTrack::id() const
-{
-    return m_private->id();
-}
-
 const String& MediaStreamTrack::label() const
 {
     return m_private->label();
@@ -622,7 +617,7 @@ void MediaStreamTrack::suspend(ReasonForSuspension reason)
 
 bool MediaStreamTrack::virtualHasPendingActivity() const
 {
-    return !m_ended && hasEventListeners();
+    return !m_ended && (hasEventListeners() || m_keeper.get());
 }
 
 #if ENABLE(WEB_AUDIO)
@@ -684,6 +679,17 @@ RefPtr<MediaSessionManagerInterface> MediaStreamTrack::mediaSessionManager() con
 ScriptExecutionContext* MediaStreamTrack::scriptExecutionContext() const
 {
     return ActiveDOMObject::scriptExecutionContext();
+}
+
+Ref<MediaStreamTrack::Keeper> MediaStreamTrack::keeper()
+{
+    RefPtr keeper = m_keeper.get();
+    if (!keeper) {
+        keeper = Keeper::create();
+        m_keeper = *keeper;
+    }
+
+    return keeper.releaseNonNull();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -86,7 +86,7 @@ public:
     virtual bool isCanvas() const { return false; }
 
     const AtomString& kind() const;
-    WEBCORE_EXPORT const String& id() const;
+    const String& id() const { return m_private->id(); }
     const String& label() const;
 
     const AtomString& contentHint() const;
@@ -190,10 +190,20 @@ public:
     void setMediaStreamId(const String& id) { m_mediaStreamId = id; }
     const String& mediaStreamId() const { return m_mediaStreamId; }
 
+    ScriptExecutionContext* scriptExecutionContext() const final;
+
+    class Keeper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Keeper> {
+    public:
+        static Ref<Keeper> create() { return adoptRef(*new Keeper);}
+    private:
+        Keeper() = default;
+    };
+
+    Ref<Keeper> keeper();
+
 protected:
     MediaStreamTrack(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
 
-    ScriptExecutionContext* scriptExecutionContext() const final;
     using ActiveDOMObject::protectedScriptExecutionContext;
 
 private:
@@ -245,6 +255,7 @@ private:
     bool m_isDetached { false };
     mutable AtomString m_kind;
     mutable AtomString m_contentHint;
+    ThreadSafeWeakPtr<Keeper> m_keeper;
 };
 
 typedef Vector<Ref<MediaStreamTrack>> MediaStreamTrackVector;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaStreamTrackHandle.h"
+
+#if ENABLE(MEDIA_STREAM)
+
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/WeakPtrImpl.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaStreamTrackHandle::DataHolder);
+
+ExceptionOr<Ref<MediaStreamTrackHandle>> MediaStreamTrackHandle::create(MediaStreamTrack& track)
+{
+    RefPtr context = track.scriptExecutionContext();
+    if (!context)
+        return Exception { ExceptionCode::InvalidStateError, "Track context is gone"_s };
+
+    return create(context->identifier(), track, track.keeper());
+}
+
+Ref<MediaStreamTrackHandle> MediaStreamTrackHandle::create(DataHolder&& holder)
+{
+    return create(holder.contextIdentifier, WTF::move(holder.track), WTF::move(holder.trackKeeper));
+}
+
+Ref<MediaStreamTrackHandle> MediaStreamTrackHandle::create(ScriptExecutionContextIdentifier contextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&& track, Ref<MediaStreamTrack::Keeper>&& trackKeeper)
+{
+    return adoptRef(*new MediaStreamTrackHandle(contextIdentifier, WTF::move(track), WTF::move(trackKeeper)));
+}
+
+MediaStreamTrackHandle::MediaStreamTrackHandle(ScriptExecutionContextIdentifier contextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&& track, Ref<MediaStreamTrack::Keeper>&& trackKeeper)
+    : m_contextIdentifier(contextIdentifier)
+    , m_track(WTF::move(track))
+    , m_trackKeeper(WTF::move(trackKeeper))
+{
+}
+
+MediaStreamTrackHandle::~MediaStreamTrackHandle() = default;
+
+UniqueRef<MediaStreamTrackHandle::DataHolder> MediaStreamTrackHandle::detach()
+{
+    ASSERT(!isDetached());
+    m_isDetached = true;
+    return makeUniqueRef<DataHolder>(DataHolder { m_contextIdentifier, m_track, m_trackKeeper });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)
+

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM)
+
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/MediaStreamTrack.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class MediaStreamTrackHandle : public RefCounted<MediaStreamTrackHandle> {
+public:
+    ~MediaStreamTrackHandle();
+
+    struct DataHolder {
+        WTF_MAKE_TZONE_ALLOCATED(DataHolder);
+    public:
+        ScriptExecutionContextIdentifier contextIdentifier;
+        WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track;
+        Ref<MediaStreamTrack::Keeper> trackKeeper;
+    };
+
+    static ExceptionOr<Ref<MediaStreamTrackHandle>> create(MediaStreamTrack&);
+    static Ref<MediaStreamTrackHandle> create(DataHolder&&);
+    static Ref<MediaStreamTrackHandle> create(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&);
+
+    bool isDetached() const { return m_isDetached; }
+    UniqueRef<DataHolder> detach();
+
+private:
+    MediaStreamTrackHandle(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&);
+
+    bool m_isDetached { false };
+    ScriptExecutionContextIdentifier m_contextIdentifier;
+    WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> m_track;
+    Ref<MediaStreamTrack::Keeper> m_trackKeeper;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_STREAM,
+    PrivateIdentifier,
+    PublicIdentifier,
+    EnabledBySetting=MediaStreamTrackHandleEnabled,
+    Exposed=(Window,DedicatedWorker)
+] interface MediaStreamTrackHandle {
+    constructor(MediaStreamTrack track);
+};

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -27,6 +27,7 @@
 #if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
 #include "MediaStreamTrack.h"
+#include "MediaStreamTrackHandle.h"
 #include "ReadableStreamSource.h"
 #include "RealtimeMediaSource.h"
 #include "WebCodecsVideoFrame.h"
@@ -49,7 +50,7 @@ class MediaStreamTrackProcessor
     WTF_MAKE_TZONE_ALLOCATED(MediaStreamTrackProcessor);
 public:
     struct Init {
-        Ref<MediaStreamTrack> track;
+        Variant<RefPtr<MediaStreamTrack>, RefPtr<MediaStreamTrackHandle>> track;
         std::optional<unsigned short> maxBufferSize;
     };
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
@@ -34,11 +34,12 @@
     [CallWith=CurrentGlobalObject] readonly attribute ReadableStream readable;
 };
 
+typedef (MediaStreamTrack or MediaStreamTrackHandle) MediaStreamTrackOrHandle;
+
 // https://w3c.github.io/mediacapture-transform/#dictdef-mediastreamtrackprocessorinit
 [
     Conditional=MEDIA_STREAM&WEB_CODECS,
 ] dictionary MediaStreamTrackProcessorInit {
-    // FIXME: `track` should be of type `(MediaStreamTrack or MediaStreamTrackHandle)`.
-    required MediaStreamTrack track;
+    required MediaStreamTrackOrHandle track;
     [EnforceRange] unsigned short maxBufferSize;
 };

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -54,7 +54,6 @@
 #include "ResourceLoadObserver.h"
 #include "ScriptController.h"
 #include "ScriptExecutionContext.h"
-#include "SecurityOrigin.h"
 #include "SocketProvider.h"
 #include "ThreadableWebSocketChannel.h"
 #include "WebSocketChannelInspector.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -251,6 +251,7 @@ Modules/mediastream/MediaDevices.cpp
 Modules/mediastream/MediaStream.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackEvent.cpp
+Modules/mediastream/MediaStreamTrackHandle.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/MediaTrackCapabilities.cpp
 Modules/mediastream/MediaTrackConstraints.cpp
@@ -4507,6 +4508,7 @@ JSMediaStreamAudioSourceNode.cpp
 JSMediaStreamAudioSourceOptions.cpp
 JSMediaStreamTrack.cpp
 JSMediaStreamTrackEvent.cpp
+JSMediaStreamTrackHandle.cpp
 JSMediaStreamTrackProcessor.cpp
 JSMediaTrackCapabilities.cpp
 JSMediaTrackConstraints.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -38,6 +38,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 #include <WebCore/MediaStreamTrackDataHolder.h>
+#include <WebCore/MediaStreamTrackHandle.h>
 #endif
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
 #include <WebCore/MediaSourceHandle.h>
@@ -168,6 +169,7 @@ private:
 #endif
 #if ENABLE(MEDIA_STREAM)
         , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& = { }
 #endif
         , uint64_t exposedMessagePortCount = 0
         );
@@ -202,6 +204,7 @@ private:
 #endif
 #if ENABLE(MEDIA_STREAM)
         , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& = { }
 #endif
         , uint64_t exposedMessagePortCount = 0
         );
@@ -232,6 +235,7 @@ private:
 #endif
 #if ENABLE(MEDIA_STREAM)
         Vector<std::unique_ptr<MediaStreamTrackDataHolder>> serializedMediaStreamTracks { };
+        Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> serializedMediaStreamTrackHandles { };
 #endif
         std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { };
         Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -327,6 +327,7 @@ namespace WebCore {
     macro(MediaStreamAudioDestinationNode) \
     macro(MediaStreamAudioSourceNode) \
     macro(MediaStreamTrack) \
+    macro(MediaStreamTrackHandle) \
     macro(MediaStreamTrackProcessor) \
     macro(MerchantValidationEvent) \
     macro(MockRTCRtpTransform) \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8072,6 +8072,7 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
 #endif
 #if ENABLE(MEDIA_STREAM)
     [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackDataHolder>> serializedMediaStreamTracks;
+    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackHandle::DataHolder>> serializedMediaStreamTrackHandles;
 #endif
     [NotSerialized] std::unique_ptr<Vector<JSC::ArrayBufferContents>> sharedBufferContentsArray;
     [NotSerialized] Vector<std::optional<WebCore::DetachedImageBitmap>> detachedImageBitmaps;


### PR DESCRIPTION
#### 771a35742f286c2ac4738f3664fb8a0f43c6a0a9
<pre>
Prototype MediaStreamTrackHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=304595">https://bugs.webkit.org/show_bug.cgi?id=304595</a>
<a href="https://rdar.apple.com/problem/167026940">rdar://problem/167026940</a>

Reviewed by Eric Carlson.

We implement MediaStreamTrackHandle as defined in <a href="https://w3c.github.io/mediacapture-transform.">https://w3c.github.io/mediacapture-transform.</a>
This patch supports creating a handle from a track and post messaging the handle.
We do not yet support feeding a handle to MediaStreamTrackProcessor.
This will be done as a follow-up.

Canonical link: <a href="https://commits.webkit.org/306851@main">https://commits.webkit.org/306851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed4ea72f4188a64c83b48831896b518d89d83f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142566 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15030 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151231 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65bd830f-6e6d-40ba-bd4d-dcc8f7afeddb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109647 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b739625-4dbf-451f-a483-1293d28ddf3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12111 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90556 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27f9b1b4-4465-432b-8c93-418a5cad4539) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1235 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134550 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120981 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153549 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3370 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14662 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30085 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14704 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173855 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78406 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44955 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->