### PR TITLE
Allow constructing MediaStreamTrackProcessor from MediaStreamTrackHandle

### DIFF
--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Use MediaStreamTrackHandle for MediaStreamTrackProcessor
+PASS Stopped track with MediaStreamTrackHandle should close MediaStreamTrackProcessor stream
+PASS MediaStreamTrack.enabled should be respected
+

--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle.html
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
+    const worker = await createWorker(`
+        let processor;
+        let reader;
+        self.onmessage = async (event) => {
+            if (!processor) {
+                processor = new MediaStreamTrackProcessor({ track:event.data });
+                reader = processor.readable.getReader();
+            }
+
+            let data = await reader.read();
+            data.value.close();
+
+            data = await reader.read();
+            self.postMessage(data.value);
+            data.value.close();
+        }
+    `);
+
+    const handle = new MediaStreamTrackHandle(stream.getVideoTracks()[0]);
+
+    worker.postMessage(handle, [handle]);
+
+    const videoFrame1 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    test.add_cleanup(() => videoFrame1.close());
+    assert_equals(videoFrame1.codedWidth, 640);
+    assert_equals(videoFrame1.codedHeight, 480);
+
+    await stream.getVideoTracks()[0].applyConstraints({ width: 320, height: 240 });
+    worker.postMessage({});
+    
+    const videoFrame2 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    test.add_cleanup(() => videoFrame2.close());
+    assert_equals(videoFrame2.codedWidth, 320);
+    assert_equals(videoFrame2.codedHeight, 240);
+}, "Use MediaStreamTrackHandle for MediaStreamTrackProcessor");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getVideoTracks()[0];
+    test.add_cleanup(() => track.stop());
+
+    const worker = await createWorker(`
+        let processor;
+        let reader;
+        self.onmessage = async (event) => {
+            const processor = new MediaStreamTrackProcessor({ track:event.data });
+            const reader = processor.readable.getReader();
+            reader.closed.then(() => self.postMessage("closed"), error => self.postMessage("errored"));
+        }
+    `);
+
+    const clone = track.clone();
+    const handle1 = new MediaStreamTrackHandle(clone);
+    clone.stop();
+    worker.postMessage(handle1, [handle1]);
+    const result1 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_equals(result1, "closed", "result1");
+}, "Stopped track with MediaStreamTrackHandle should close MediaStreamTrackProcessor stream");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    const track = stream.getVideoTracks()[0];
+    test.add_cleanup(() => track.stop());
+
+    const worker = await createWorker(`
+        let processor;
+        let reader;
+        self.onmessage = async (event) => {
+            if (!processor) {
+                processor = new MediaStreamTrackProcessor({ track:event.data });
+                reader = processor.readable.getReader();
+            }
+
+            const data = await reader.read();
+            self.postMessage(data.value);
+            data.value.close();
+        }
+    `);
+
+    const handle = new MediaStreamTrackHandle(track);
+
+    worker.postMessage(handle, [handle]);
+
+    const videoFrame1 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    test.add_cleanup(() => videoFrame1.close());
+    assert_equals(videoFrame1.codedWidth, 640);
+    assert_equals(videoFrame1.codedHeight, 480);
+
+    track.enabled = false;
+    await stream.getVideoTracks()[0].applyConstraints({ width: 320, height: 240 });
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+
+    worker.postMessage({});
+    const videoFrame2Promise = new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+
+    await stream.getVideoTracks()[0].applyConstraints({ width: 640, height: 480 });
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+    track.enabled = true;
+
+    const videoFrame2 = await videoFrame2Promise;
+    test.add_cleanup(() => videoFrame2.close());
+    assert_equals(videoFrame2.codedWidth, 640);
+    assert_equals(videoFrame2.codedHeight, 480);
+}, "MediaStreamTrack.enabled should be respected");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -209,6 +209,8 @@ bool MediaStreamTrack::enabled() const
 
 void MediaStreamTrack::setEnabled(bool enabled)
 {
+    if (RefPtr keeper = m_keeper.get())
+        keeper->setEnabled(enabled);
     m_private->setEnabled(enabled);
 }
 
@@ -685,7 +687,7 @@ Ref<MediaStreamTrack::Keeper> MediaStreamTrack::keeper()
 {
     RefPtr keeper = m_keeper.get();
     if (!keeper) {
-        keeper = Keeper::create();
+        keeper = Keeper::create(enabled());
         m_keeper = *keeper;
     }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -194,9 +194,17 @@ public:
 
     class Keeper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Keeper> {
     public:
-        static Ref<Keeper> create() { return adoptRef(*new Keeper);}
+        static Ref<Keeper> create(bool isEnabled) { return adoptRef(*new Keeper(isEnabled)); }
+        bool isTrackEnabled() const { return m_isEnabled; }
+        void setEnabled(bool isEnabled) { m_isEnabled = isEnabled; }
+
     private:
-        Keeper() = default;
+        explicit Keeper(bool isEnabled)
+            : m_isEnabled(isEnabled)
+        {
+        }
+
+        std::atomic<bool> m_isEnabled;
     };
 
     Ref<Keeper> keeper();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
@@ -42,22 +42,30 @@ public:
         ScriptExecutionContextIdentifier contextIdentifier;
         WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track;
         Ref<MediaStreamTrack::Keeper> trackKeeper;
+        Ref<MediaStreamTrackPrivateSourceObserver> trackSourceObserver;
     };
 
     static ExceptionOr<Ref<MediaStreamTrackHandle>> create(MediaStreamTrack&);
     static Ref<MediaStreamTrackHandle> create(DataHolder&&);
-    static Ref<MediaStreamTrackHandle> create(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&);
+    static Ref<MediaStreamTrackHandle> create(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&, Ref<MediaStreamTrackPrivateSourceObserver>&&);
 
     bool isDetached() const { return m_isDetached; }
     UniqueRef<DataHolder> detach();
 
+    ScriptExecutionContextIdentifier trackContextIdentifier() const { return m_contextIdentifier; }
+    WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track() const { return m_track; }
+    Ref<MediaStreamTrackPrivateSourceObserver> protectedTrackSourceObserver() const { return m_trackSourceObserver; }
+
+    const MediaStreamTrack::Keeper& trackKeeper() const { return m_trackKeeper.get(); }
+
 private:
-    MediaStreamTrackHandle(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&);
+    MediaStreamTrackHandle(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData>&&, Ref<MediaStreamTrack::Keeper>&&, Ref<MediaStreamTrackPrivateSourceObserver>&&);
 
     bool m_isDetached { false };
-    ScriptExecutionContextIdentifier m_contextIdentifier;
-    WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> m_track;
-    Ref<MediaStreamTrack::Keeper> m_trackKeeper;
+    const ScriptExecutionContextIdentifier m_contextIdentifier;
+    const WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> m_track;
+    const Ref<MediaStreamTrack::Keeper> m_trackKeeper;
+    const Ref<MediaStreamTrackPrivateSourceObserver> m_trackSourceObserver;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f03c4748b44a49eb535c200a030e3b199889d503
<pre>
Allow constructing MediaStreamTrackProcessor from MediaStreamTrackHandle
<a href="https://rdar.apple.com/167029476">rdar://167029476</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304596">https://bugs.webkit.org/show_bug.cgi?id=304596</a>

Reviewed by Eric Carlson.

Test: http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle.html
* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-mediastreamtrackhandle.html: Added.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::keeper):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::Keeper::create):
(WebCore::MediaStreamTrack::Keeper::isTrackEnabled const):
(WebCore::MediaStreamTrack::Keeper::setEnabled):
(WebCore::MediaStreamTrack::Keeper::Keeper):
* Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.cpp:
(WebCore::MediaStreamTrackHandle::create):
(WebCore::MediaStreamTrackHandle::MediaStreamTrackHandle):
(WebCore::MediaStreamTrackHandle::detach):
* Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h:
(WebCore::MediaStreamTrackHandle::trackContextIdentifier const):
(WebCore::MediaStreamTrackHandle::track const):
(WebCore::MediaStreamTrackHandle::protectedTrackSourceObserver const):
(WebCore::MediaStreamTrackHandle::trackKeeper const):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::create):
(WebCore::MediaStreamTrackProcessor::MediaStreamTrackProcessor):
(WebCore::m_trackObserver):
(WebCore::MediaStreamTrackProcessor::~MediaStreamTrackProcessor):
(WebCore::MediaStreamTrackProcessor::readable):
(WebCore::MediaStreamTrackProcessor::contextDestroyed):
(WebCore::MediaStreamTrackProcessor::stopObserving):
(WebCore::MediaStreamTrackProcessor::trackEnded):
(WebCore::MediaStreamTrackProcessor::Source::Source):
(WebCore::MediaStreamTrackProcessor::Source::trackEnded):
(WebCore::MediaStreamTrackProcessor::Source::doPull):
(WebCore::MediaStreamTrackProcessor::Source::doCancel):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::create):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::TrackObserverWrapper):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::start):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::stop):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::trackEnded):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::removeObserver):
(WebCore::m_track): Deleted.
(WebCore::MediaStreamTrackProcessor::stopVideoFrameObserver): Deleted.
(WebCore::MediaStreamTrackProcessor::Source::~Source): Deleted.
(WebCore::MediaStreamTrackProcessor::Source::close): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
(WebCore::MediaStreamTrackProcessor::isEnabled const):
(WebCore::MediaStreamTrackProcessor::TrackObserverWrapper::~TrackObserverWrapper):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readMediaStreamTrackHandle):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivateSourceObserver::MediaStreamTrackPrivateSourceObserver):
(WebCore::MediaStreamTrackPrivateSourceObserver::initialize):
(WebCore::MediaStreamTrackPrivateSourceObserver::start):
(WebCore::MediaStreamTrackPrivateSourceObserver::stop):
(WebCore::MediaStreamTrackPrivateSourceObserver::requestToEnd):
(WebCore::MediaStreamTrackPrivateSourceObserver::setMuted):
(WebCore::MediaStreamTrackPrivateSourceObserver::close):
(WebCore::MediaStreamTrackPrivateSourceObserver::applyConstraints):
(WebCore::MediaStreamTrackPrivateSourceObserver::create): Deleted.
(WebCore::MediaStreamTrackPrivateSourceObserver::std::function&lt;void): Deleted.
(WebCore::MediaStreamTrackPrivateSourceObserver::source): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
(WebCore::MediaStreamTrackPrivateSourceObserver::create):
(WebCore::MediaStreamTrackPrivateSourceObserver::std::function&lt;void):
(WebCore::MediaStreamTrackPrivateSourceObserver::source):

Canonical link: <a href="https://commits.webkit.org/307071@main">https://commits.webkit.org/307071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdb06b096f121d0cce65b7151f2fc864bf22b800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143306 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151982 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f03d5e7f-676e-4c6f-a50f-5855bbdfaa4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110215 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb2dbb07-a8df-48f5-9c30-bf644113de6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12657 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91124 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bd79302-d388-4cc0-8102-fa44e6924ecf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9859 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1980 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121569 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/5098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154293 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15825 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118234 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14512 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71220 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15450 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/4928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->