### PR TITLE
[Lockdown] Update list of trusted fonts for Facebook.com

### DIFF
--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -854,7 +854,18 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& trustedFontHas
         "tboC32G7FHmioWbF0ScsnhgR4SnPevGgAcN9oyBxyV4="_s /* NT9VJlUQ2j5.woff */,
         "toGCSrhxtzDo2US+GzyShOuyCBJSqfpLCfpuyuo3+Ig="_s /* F7ZcL-Lm2Os.woff */,
         "ugyD8SdndqzkOiSODDKB0PXx5gR72goGjJ8HtpLzoBc="_s /* FqiK19_SYWS.woff */,
-        "wkSmw8cD+LK683467qvTuPjr847yjaPsRdrfsajfIgc="_s /* tL12ldcgP15.woff2 */ });
+        "wkSmw8cD+LK683467qvTuPjr847yjaPsRdrfsajfIgc="_s /* tL12ldcgP15.woff2 */,
+        // Additional Facebook fonts (rdar://161923840)
+        "d7qRCdV5/RE4G2gD8lTw0lMBBgZoYbnZVaMdp6iV6pU="_s,
+        "OZi5uEsAf6Spp4aQ2syyt5RUkd9fT5ORRKYZwa119oA="_s,
+        "zYrzt0vfPKuP9hUDcU30SY3bbC+0LK6mILZVPKifsEU="_s,
+        "GmXuTu6TDvuSVHEjpr6eoEnG3s70BAmemj5bNPqPONs="_s,
+        "fiZ7T0ZTzGDKRTLwgOJG6x2/stxnqupP2KD8gRs7oC0="_s,
+        "f2uqA9Hhf6CfDS4QKA6URp31yuMrP0cwWOD4JZGmLRE="_s,
+        "4lwRbTGm3tahH1/N4+/Y2X4K+yngJLAUyDzhf4q8kOQ="_s,
+        "WY/G2MZa1/vsJr+lZc0AAsVBwuxuLxJEE0zdu5z5jSk="_s,
+        "OKhOTmvrlR2wFVV65RzWwZrDm01wTM76amx7a8yybyM="_s,
+        "mXkRKROZST2m7meFkdxZmUGDQ5Q5IxgaInsfPAAoAbY="_s });
 
     return trustedFontHashes;
 }


### PR DESCRIPTION
#### 0cd843152f93498d6b35765dba84fa2771b30478
<pre>
[Lockdown] Update list of trusted fonts for Facebook.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=304598">https://bugs.webkit.org/show_bug.cgi?id=304598</a>
<a href="https://rdar.apple.com/161923840">rdar://161923840</a>

Reviewed by Matthieu Dubet.

Safe font parser is not available on down levels so we need
to update the list of trusted fonts for Facebook.com

* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::trustedFontHashesInLockdownMode):

Canonical link: <a href="https://commits.webkit.org/304866@main">https://commits.webkit.org/304866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f124a16fd389a1af8e0de898fa58ca02a5a4225

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136711 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/9087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89684 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a2f319a7-2a6f-4b53-b4a3-f42c6b941d9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104543 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b78280d-0473-40c6-b05a-9bf934296c3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/22bb5e4f-5f9b-49f8-9b15-cb44cfd86687) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4476 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5031 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/116107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147196 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112896 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8772 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6705 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8802 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8742 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->