### PR TITLE
[CI Filters] Implement FEBlend in CoreImage

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -500,6 +500,7 @@ platform/graphics/cv/CVUtilities.mm @nonARC
 platform/graphics/cv/ImageTransferSessionVT.mm @nonARC
 platform/graphics/cv/PixelBufferConformerCV.cpp
 platform/graphics/cv/VideoFrameCV.mm @nonARC
+platform/graphics/coreimage/FEBlendCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEBlend;
+
+class FEBlendCoreImageApplier final : public FilterEffectConcreteApplier<FEBlend> {
+    WTF_MAKE_TZONE_ALLOCATED(FEBlendCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEBlend>;
+
+public:
+    FEBlendCoreImageApplier(const FEBlend&);
+
+    static bool supportsCoreImageRendering(const FEBlend&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEBlendCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "ColorSpaceCG.h"
+#import "FEBlend.h"
+#import "Logging.h"
+#import <CoreImage/CIFilterBuiltins.h>
+#import <CoreImage/CoreImage.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEBlendCoreImageApplier);
+
+FEBlendCoreImageApplier::FEBlendCoreImageApplier(const FEBlend& effect)
+    : Base(effect)
+{
+}
+
+bool FEBlendCoreImageApplier::supportsCoreImageRendering(const FEBlend&)
+{
+    return true;
+}
+
+bool FEBlendCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 2);
+    auto& input1 = inputs[0].get();
+    auto& input2 = inputs[1].get();
+
+    auto inputImage1 = input1.ciImage();
+    if (!inputImage1)
+        return false;
+
+    auto inputImage2 = input2.ciImage();
+    if (!inputImage2)
+        return false;
+
+    RetainPtr<CIFilter> filter;
+    switch (m_effect->blendMode()) {
+    case BlendMode::Normal:
+        result.setCIImage(inputImage1.get());
+        return true;
+    case BlendMode::Multiply:
+        filter = [CIFilter multiplyBlendModeFilter];
+        break;
+    case BlendMode::Screen:
+        filter = [CIFilter screenBlendModeFilter];
+        break;
+    case BlendMode::Darken:
+        filter = [CIFilter darkenBlendModeFilter];
+        break;
+    case BlendMode::Lighten:
+        filter = [CIFilter lightenBlendModeFilter];
+        break;
+    case BlendMode::Overlay:
+        filter = [CIFilter overlayBlendModeFilter];
+        break;
+    case BlendMode::ColorDodge:
+        filter = [CIFilter colorDodgeBlendModeFilter];
+        break;
+    case BlendMode::ColorBurn:
+        filter = [CIFilter colorBurnBlendModeFilter];
+        break;
+    case BlendMode::HardLight:
+        filter = [CIFilter hardLightBlendModeFilter];
+        break;
+    case BlendMode::SoftLight:
+        filter = [CIFilter softLightBlendModeFilter];
+        break;
+    case BlendMode::Difference:
+        filter = [CIFilter differenceBlendModeFilter];
+        break;
+    case BlendMode::Exclusion:
+        filter = [CIFilter exclusionBlendModeFilter];
+        break;
+    case BlendMode::Hue:
+        filter = [CIFilter hueBlendModeFilter];
+        break;
+    case BlendMode::Saturation:
+        filter = [CIFilter saturationBlendModeFilter];
+        break;
+    case BlendMode::Color:
+        filter = [CIFilter colorBlendModeFilter];
+        break;
+    case BlendMode::Luminosity:
+        filter = [CIFilter luminosityBlendModeFilter];
+        break;
+    case BlendMode::PlusDarker:
+    case BlendMode::PlusLighter:
+        // These are not supported by SVG.
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    [filter setValue:inputImage1.get() forKey:kCIInputImageKey];
+    [filter setValue:inputImage2.get() forKey:kCIInputBackgroundImageKey];
+
+    result.setCIImage([filter outputImage]);
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
@@ -79,7 +79,7 @@ ImageBuffer* FilterImage::imageBufferFromCIImage()
     RetainPtr context = colorSpace() == DestinationColorSpace::LinearSRGB() ? sharedLinearSRGBCIContext() : sharedSRGBCIContext();
     [context.get() render:m_ciImage.get() toIOSurface:imageBuffer->surface()->surface() bounds:destRect colorSpace:m_colorSpace.platformColorSpace()];
 
-    LOG_WITH_STREAM(Filters, stream << "FilterImage::imageBufferFromCIImage - result " << ValueOrNull(m_imageBuffer.get()));
+    LOG_WITH_STREAM(Filters, stream << "FilterImage::imageBufferFromCIImage - output rect " << m_absoluteImageRect << " result " << ValueOrNull(m_imageBuffer.get()));
 
     return m_imageBuffer.get();
 }

--- a/Source/WebCore/platform/graphics/filters/FEBlend.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.cpp
@@ -31,6 +31,10 @@
 #include "ImageBuffer.h"
 #include <wtf/text/TextStream.h>
 
+#if USE(CORE_IMAGE)
+#include "FEBlendCoreImageApplier.h"
+#endif
+
 namespace WebCore {
 
 Ref<FEBlend> FEBlend::create(BlendMode mode, DestinationColorSpace colorSpace)
@@ -55,6 +59,24 @@ bool FEBlend::setBlendMode(BlendMode mode)
         return false;
     m_mode = mode;
     return true;
+}
+
+OptionSet<FilterRenderingMode> FEBlend::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
+{
+    OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
+#if USE(CORE_IMAGE)
+    modes.add(FilterRenderingMode::Accelerated);
+#endif
+    return modes & preferredFilterRenderingModes;
+}
+
+std::unique_ptr<FilterEffectApplier> FEBlend::createAcceleratedApplier() const
+{
+#if USE(CORE_IMAGE)
+    return FilterEffectApplier::create<FEBlendCoreImageApplier>(*this);
+#else
+    return nullptr;
+#endif
 }
 
 std::unique_ptr<FilterEffectApplier> FEBlend::createSoftwareApplier() const

--- a/Source/WebCore/platform/graphics/filters/FEBlend.h
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.h
@@ -46,6 +46,8 @@ private:
 
     unsigned numberOfEffectInputs() const override { return 2; }
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -57,15 +57,11 @@ bool LegacyRenderSVGResourceFilter::isIdentity() const
 
 void LegacyRenderSVGResourceFilter::removeAllClientsFromCache()
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p removeAllClientsFromCache", this);
-
     m_rendererFilterDataMap.clear();
 }
 
 void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& client)
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p removing client %p", this, &client);
-    
     auto findResult = m_rendererFilterDataMap.find(client);
     if (findResult != m_rendererFilterDataMap.end()) {
         FilterData& filterData = *findResult->value;


### PR DESCRIPTION
#### 7eb44b915a43686f4d37ea23db5417d5b4c6f4d8
<pre>
[CI Filters] Implement FEBlend in CoreImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=304603">https://bugs.webkit.org/show_bug.cgi?id=304603</a>
<a href="https://rdar.apple.com/167034446">rdar://167034446</a>

Reviewed by Mike Wyrzykowski.

Add FEBlendCoreImageApplier. For `normal` it just returns the first input image. For other
blend modes, it uses the appropriate CIFilter with two inputs.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm: Added.
(WebCore::FEBlendCoreImageApplier::FEBlendCoreImageApplier):
(WebCore::FEBlendCoreImageApplier::supportsCoreImageRendering):
(WebCore::FEBlendCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm: Use a RetainPtr.
(WebCore::FEColorMatrixCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FEBlend.cpp:
(WebCore::FEBlend::supportedFilterRenderingModes const):
(WebCore::FEBlend::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEBlend.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::removeAllClientsFromCache): Remove some noisy logging.
(WebCore::LegacyRenderSVGResourceFilter::removeClientFromCache):

Canonical link: <a href="https://commits.webkit.org/304886@main">https://commits.webkit.org/304886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a12ebdf4d25ece562c1e0ce451d76743e4bb0d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f32ea65b-3d2a-4dd0-a52d-dcb356594af7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7989665-b6be-45af-9283-d222d0d3a223) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1abbdade-5013-4a70-b4d2-8b749c191dc8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6821 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5084 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/116142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147252 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112938 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6743 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62961 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8855 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36878 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8576 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72421 "Found 2 new failures in platform/graphics/coreimage/FEBlendCoreImageApplier.mm") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->