### PR TITLE
[JSC] GreedyRegAlloc: support coalescing with pinned registers

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -102,7 +102,7 @@ public:
     // regsInPriorityOrder. Any registers not in this set are said to be "pinned".
     RegisterSet mutableRegs() const { return m_mutableRegs.toRegisterSet().includeWholeRegisterWidth(); }
 
-    bool isPinned(Reg reg) const { return !mutableRegs().contains(reg, IgnoreVectors); }
+    bool isPinned(Reg reg) const { return pinnedRegisters().contains(reg, IgnoreVectors); }
     JS_EXPORT_PRIVATE void pinRegister(Reg);
 
     void setOptLevel(unsigned optLevel) { m_optLevel = optLevel; }

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -40,6 +40,7 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numUnspillableTmps)                   \
     macro(numSpillTmps)                         \
     macro(numTmpsOut)                           \
+    macro(numCoalescedPinned)                   \
     macro(numSpilledTmps)                       \
     macro(numSpillStackSlots)                   \
     macro(numLoadSpill)                         \

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -44,19 +44,11 @@ bool shouldRun(const TestConfig* config, const char* testName)
     if (!filter && isARM64()) {
         for (auto& failingTest : {
             "testNegFloatWithUselessDoubleConversion",
-            "testPinRegisters",
         }) {
             if (WTF::findIgnoringASCIICaseWithoutLength(testName, failingTest) != WTF::notFound) {
                 dataLogLn("*** Warning: Skipping known-bad test: ", testName);
                 return false;
             }
-        }
-    }
-    // FIXME: rdar://145150735. But note this test is already skipped on ARM64, see above.
-    if (!filter && Options::airUseGreedyRegAlloc()) {
-        if (WTF::findIgnoringASCIICaseWithoutLength(testName, "testPinRegisters") != WTF::notFound) {
-            dataLogLn("*** Warning: Skipping known-bad test: ", testName);
-            return false;
         }
     }
 

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -522,6 +522,14 @@ public:
         return m_bits.count();
     }
 
+    template<typename Func>
+    inline constexpr void forEachReg(const Func& func) const
+    {
+        m_bits.forEachSetBit([&] (size_t index) {
+            func(Reg::fromIndex(index));
+        });
+    }
+
     void dump(PrintStream& out) const { toRegisterSet().dump(out); }
 
 private:


### PR DESCRIPTION
#### 450c32d69eed0fd2adaa5ab7484c3f2c825865a1
<pre>
[JSC] GreedyRegAlloc: support coalescing with pinned registers
<a href="https://bugs.webkit.org/show_bug.cgi?id=304605">https://bugs.webkit.org/show_bug.cgi?id=304605</a>
<a href="https://rdar.apple.com/167036366">rdar://167036366</a>

Reviewed by Yusuke Suzuki.

Wasm code pins some registers for internal runtime usage. Those pinned
registers are off limits for register allocation. However, the IR
sometimes contains moves from those pinned registers into a Tmp, and
then the Tmp is used without modification. In these cases, we should
allow the Tmp to be assigned to the pinned register to avoid the
unnecessary copy and reduce memory pressure at these points slightly.

Test: Source/JavaScriptCore/b3/testb3_1.cpp
Canonical link: <a href="https://commits.webkit.org/304889@main">https://commits.webkit.org/304889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fdee287ca4a6ba2d8d4bb345d4a35e0543aeab2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89696 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/499ca1c6-f91a-45e0-898c-218afc69550b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104556 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d1a47e62-07a0-4e71-a07e-695080240437) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85395 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b95e92e8-dfe5-481d-9ce9-80c2a93e64ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6797 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4486 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5043 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128684 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116117 "Found 1 new API test failure: TestWebKitAPI.WebKit2.RTCDataChannelPostMessage (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147209 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112909 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113239 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6718 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62918 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21089 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8814 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36851 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167989 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72380 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43830 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->