### PR TITLE
[JSC] Promise.any should create AggregateError directly

### DIFF
--- a/JSTests/stress/promise-any-creates-aggregateerror-directly.js
+++ b/JSTests/stress/promise-any-creates-aggregateerror-directly.js
@@ -1,0 +1,10 @@
+let count = 0;
+Array.prototype[Symbol.iterator] = function* () {
+  if (count++ >= 2)
+    throw "done";
+  Promise.any([]);
+};
+Array.from([]);
+
+if (count !== 3)
+  throw new Error("Array.prototype[Symbol.iterator] invoked incorrect number of times");

--- a/Source/JavaScriptCore/runtime/AggregateError.cpp
+++ b/Source/JavaScriptCore/runtime/AggregateError.cpp
@@ -26,40 +26,15 @@
 #include "config.h"
 #include "AggregateError.h"
 
-#include "ExceptionScope.h"
-#include "IteratorOperations.h"
-#include "JSCJSValueInlines.h"
-#include "JSGlobalObjectInlines.h"
+#include "CommonIdentifiers.h"
+#include "JSArray.h"
 
 namespace JSC {
 
-ErrorInstance* createAggregateError(JSGlobalObject* globalObject, VM& vm, Structure* structure, JSValue errors, JSValue message, JSValue options, ErrorInstance::SourceAppender appender, RuntimeType type, bool useCurrentFrame)
+ErrorInstance* createAggregateError(VM& vm, Structure* structure, JSArray* errors, const String& message, JSValue cause, ErrorInstance::SourceAppender appender, RuntimeType type, bool useCurrentFrame)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    JSValue cause;
-    if (options.isObject()) {
-        // Since `throw undefined;` is valid, we need to distinguish the case where `cause` is an explicit undefined.
-        cause = asObject(options)->getIfPropertyExists(globalObject, vm.propertyNames->cause);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-    }
-
-    MarkedArgumentBuffer errorsList;
-    forEachInIterable(globalObject, errors, [&] (VM&, JSGlobalObject*, JSValue nextValue) {
-        errorsList.append(nextValue);
-        if (errorsList.hasOverflowed()) [[unlikely]]
-            throwOutOfMemoryError(globalObject, scope);
-    });
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    auto* array = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), errorsList);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    auto* error = ErrorInstance::create(vm, structure, messageString, cause, appender, type, ErrorType::AggregateError, useCurrentFrame);
-    error->putDirect(vm, vm.propertyNames->errors, array, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    auto* error = ErrorInstance::create(vm, structure, message, cause, appender, type, ErrorType::AggregateError, useCurrentFrame);
+    error->putDirect(vm, vm.propertyNames->errors, errors, static_cast<unsigned>(PropertyAttribute::DontEnum));
     return error;
 }
 

--- a/Source/JavaScriptCore/runtime/AggregateError.h
+++ b/Source/JavaScriptCore/runtime/AggregateError.h
@@ -29,6 +29,6 @@
 
 namespace JSC {
 
-ErrorInstance* createAggregateError(JSGlobalObject*, VM&, Structure*, JSValue errors, JSValue message, JSValue options, ErrorInstance::SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
+ErrorInstance* createAggregateError(VM&, Structure*, JSArray* errors, const String& message, JSValue cause, ErrorInstance::SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -296,7 +296,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         --count;
         globalContext->setRemainingElementsCount(vm, jsNumber(count));
         if (!count) {
-            auto* aggregateError = createAggregateError(globalObject, vm, globalObject->errorStructure(ErrorType::AggregateError), errors, jsUndefined(), jsUndefined());
+            auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
             scope.release();
             promise->reject(vm, globalObject, aggregateError);
         }

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -1226,7 +1226,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
     --count;
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
-        auto* aggregateError = createAggregateError(globalObject, vm, globalObject->errorStructure(ErrorType::AggregateError), errors, jsUndefined(), jsUndefined());
+        auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         callReject(aggregateError);
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
@@ -1339,7 +1339,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
     --count;
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
-        auto* aggregateError = createAggregateError(globalObject, vm, globalObject->errorStructure(ErrorType::AggregateError), errors, jsUndefined(), jsUndefined());
+        auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
         promise->reject(vm, globalObject, aggregateError);
         if (scope.exception()) [[unlikely]] {
@@ -1379,7 +1379,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnyRejectFunction, (JSGlobalObject* globalObject
     --count;
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
-        auto* aggregateError = createAggregateError(globalObject, vm, globalObject->errorStructure(ErrorType::AggregateError), errors, jsUndefined(), jsUndefined());
+        auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
         promise->reject(vm, globalObject, aggregateError);
     }
@@ -1417,7 +1417,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     --count;
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
-        auto* aggregateError = createAggregateError(globalObject, vm, globalObject->errorStructure(ErrorType::AggregateError), errors, jsUndefined(), jsUndefined());
+        auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         MarkedArgumentBuffer rejectArguments;
         rejectArguments.append(aggregateError);
         ASSERT(!rejectArguments.hasOverflowed());


### PR DESCRIPTION
#### 74119f1b889edd14f8d72ea1dd3a92a7f7e63ad6
<pre>
[JSC] Promise.any should create AggregateError directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=304611">https://bugs.webkit.org/show_bug.cgi?id=304611</a>
<a href="https://rdar.apple.com/167013937">rdar://167013937</a>

Reviewed by Dan Hecht and Yusuke Suzuki.

Per spec, Promise.any creates AggregateErrors directly [1] without going
through the user-exposed constructor. In particular this means there&apos;s no user
code called for argument coercion. The current implementation goes through the
user-exposed constructor which incorrectly calls user code, like going through
Array.prototype[Symbol.iterator].

This PR fixes it and splits the existing createAggregateError function into a
constructAggregateError, which handles argument coercion, and refactors the
existing createAggregateError to not call into user code.

Test: JSTests/stress/promise-any-creates-aggregateerror-directly.js

[1] <a href="https://tc39.es/ecma262/#sec-performpromiseany">https://tc39.es/ecma262/#sec-performpromiseany</a> 5.b.ii

Canonical link: <a href="https://commits.webkit.org/304884@main">https://commits.webkit.org/304884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd2adc4e27cbda2d77e79e5768af37fc587d0e6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144494 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2aeeb32-36c8-4088-b67c-6b5d3e01a2b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8969 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139708 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/7179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85420 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f68e8a0d-d5a9-45af-b299-33ea8425095b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5083 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128724 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/116144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/40721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147251 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135249 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41293 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8824 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6741 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118823 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/62960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8854 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72420 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/8794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->