### PR TITLE
REGRESSION(288788@main): SVG doesn't render gradient fill when using paint-order

### DIFF
--- a/LayoutTests/svg/text/text-paint-order-stroke-fill-gradient-expected.svg
+++ b/LayoutTests/svg/text/text-paint-order-stroke-fill-gradient-expected.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+    <meta name="fuzzy" content="maxDifference=0-15; totalPixels=0-1599" />
+    <style>
+        svg {
+            border: 1px solid black;
+        }
+        text {
+            stroke: black;
+            stroke-width: 2;
+            stroke-linejoin: round;
+            font-weight: bold;
+            font-family: serif;
+            fill: green;
+        }
+    </style>
+    <defs>
+        <linearGradient id="g">
+            <stop offset="0%" stop-color="green"/>
+            <stop offset="100%" stop-color="green"/>
+        </linearGradient>
+        <clipPath id="textClip">
+            <text x="50%" y="20%" text-anchor="middle" font-size="25">
+                With Solid Fill
+            </text>
+            <text x="50%" y="80%" text-anchor="middle" font-size="25">
+                With Gradient Fill, And Paint Order
+            </text>
+        </clipPath>
+    </defs>
+    <text x="50%" y="20%" text-anchor="middle" font-size="25">
+        With Solid Fill
+    </text>
+    <text x="50%" y="50%" text-anchor="middle" font-size="25">
+        With Gradient Fill, No Paint Order
+    </text>
+    <text x="50%" y="80%" text-anchor="middle" font-size="25">
+        With Gradient Fill, And Paint Order
+    </text>
+    <rect width="100%" height="100%" fill="green" clip-path="url(#textClip)" />
+</svg>

--- a/LayoutTests/svg/text/text-paint-order-stroke-fill-gradient.svg
+++ b/LayoutTests/svg/text/text-paint-order-stroke-fill-gradient.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+    <meta name="fuzzy" content="maxDifference=0-22; totalPixels=0-2801" />
+    <style>
+        svg {
+            border: 1px solid black;
+        }
+        text {
+            stroke: black;
+            stroke-width: 2;
+            stroke-linejoin: round;
+            font-weight: bold;
+            font-family: serif;
+            
+        }
+        .solid-order {
+            fill: green;
+            paint-order: stroke fill;
+        }
+        .gradient-no-order {
+            fill: url(#g);
+        }
+        .gradient-order {
+            fill: url(#g);
+            paint-order: stroke fill;
+        }
+    </style>
+    <defs>
+        <linearGradient id="g">
+            <stop offset="0%" stop-color="green"/>
+            <stop offset="100%" stop-color="green"/>
+        </linearGradient>
+    </defs>
+    <text x="50%" y="20%" text-anchor="middle" font-size="25" class="solid-order">
+        With Solid Fill
+    </text>
+    <text x="50%" y="50%" text-anchor="middle" font-size="25" class="gradient-no-order">
+        With Gradient Fill, No Paint Order
+    </text>
+    <text x="50%" y="80%" text-anchor="middle" font-size="25" class="gradient-order">
+        With Gradient Fill, And Paint Order
+    </text>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -320,10 +320,10 @@ auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, con
 #if USE(CG)
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToText)) {
         // PDF does not support some CompositeOperation
-        if (context->renderingMode() == RenderingMode::PDFDocument)
-            m_gradientApplier = makeUnique<TextGradientClipper>();
-        else
+        if (context->renderingMode() != RenderingMode::PDFDocument && style.paintOrder() == Style::SVGPaintOrder::Type::FillStrokeMarkers)
             m_gradientApplier = makeUnique<TextGradientCompositor>();
+        else
+            m_gradientApplier = makeUnique<TextGradientClipper>();
     }
 #endif
 


### PR DESCRIPTION
#### 0a662721c2e04557824adff2324915aa0b5c8341
<pre>
REGRESSION(288788@main): SVG doesn&apos;t render gradient fill when using paint-order
<a href="https://bugs.webkit.org/show_bug.cgi?id=304582">https://bugs.webkit.org/show_bug.cgi?id=304582</a>
<a href="https://rdar.apple.com/166997630">rdar://166997630</a>

Reviewed by Nikolas Zimmermann.

If the paint-order is &quot;stroke fill&quot; and the transparency layer compositing is
used the gradient will fill the stroke itself not inside it.

The fix is to use the transparency layer compositing only if the paint-order is
&quot;fill stroke&quot;. Otherwise clip the context to the stroke then fill the whole
rectangle with the gradient.

* LayoutTests/svg/text/text-paint-order-stroke-fill-gradient-expected.svg: Added.
* LayoutTests/svg/text/text-paint-order-stroke-fill-gradient.svg: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::applyResource):

Canonical link: <a href="https://commits.webkit.org/304903@main">https://commits.webkit.org/304903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0dad44f3afa261a01fc7861876fff66d68e0164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89753 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7cb77e8-b5e8-421b-aee8-1d113c2de741) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d4707d2e-a0e2-4677-b0ca-e6fa8a3bcee3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85433 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4524 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5100 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147268 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112950 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6754 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62977 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8871 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36888 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->