### PR TITLE
Ensure third party cookie blocking mode stays unchanged when last page is gone

### DIFF
--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -190,7 +190,7 @@ bool HTTPCookieStore::isOptInCookiePartitioningEnabled() const
 {
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     if (RefPtr dataStore = m_owningDataStore.get())
-        return dataStore->isOptInCookiePartitioningEnabled();
+        return dataStore->computeIsOptInCookiePartitioningEnabled();
 #endif
     return false;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1609,6 +1609,28 @@ struct WKWebsiteData {
     });
 }
 
+- (NSString *)_thirdPartyCookieBlockingModeForTesting
+{
+    switch (protectedWebsiteDataStore(self)->thirdPartyCookieBlockingMode()) {
+    case WebCore::ThirdPartyCookieBlockingMode::All:
+        return @"All";
+    case WebCore::ThirdPartyCookieBlockingMode::AllExceptBetweenAppBoundDomains:
+        return @"AllExceptBetweenAppBoundDomains";
+    case WebCore::ThirdPartyCookieBlockingMode::AllExceptManagedDomains:
+        return @"AllExceptManagedDomains";
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+    case WebCore::ThirdPartyCookieBlockingMode::AllExceptPartitioned:
+        return @"AllExceptPartitioned";
+#endif
+    case WebCore::ThirdPartyCookieBlockingMode::AllOnSitesWithoutUserInteraction:
+        return @"AllOnSitesWithoutUserInteraction";
+    case WebCore::ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy:
+        return @"OnlyAccordingToPerDomainPolicy";
+    }
+
+    return @"Invalid";
+}
+
 @end
 
 #if PLATFORM(IOS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -109,6 +109,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 
 @property (nullable, nonatomic, weak) id <_WKWebsiteDataStoreDelegate> _delegate WK_API_AVAILABLE(macos(10.15), ios(13.0));
 @property (nonatomic, readonly, copy) _WKWebsiteDataStoreConfiguration *_configuration;
+@property (readonly) NSString *_thirdPartyCookieBlockingModeForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 + (WKNotificationManagerRef)_sharedServiceWorkerNotificationManager WK_API_AVAILABLE(macos(13.0), ios(16.0));
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -979,7 +979,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
 #endif
         websiteDataStore.trackingPreventionEnabled()
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
-        , websiteDataStore.isOptInCookiePartitioningEnabled()
+        , websiteDataStore.computeIsOptInCookiePartitioningEnabled()
 #endif
     };
 }

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -269,21 +269,6 @@ std::optional<bool> WebsiteDataStore::useNetworkLoader()
 #endif // NETWORK_LOADER
 }
 
-#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
-bool WebsiteDataStore::isOptInCookiePartitioningEnabled() const
-{
-#if defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
-    return std::ranges::any_of(m_processes, [](auto& process) {
-        return std::ranges::any_of(process.pages(), [](auto& page) {
-            return page->preferences().optInPartitionedCookiesEnabled();
-        });
-    });
-#else
-    return false;
-#endif
-}
-#endif
-
 void WebsiteDataStore::platformInitialize()
 {
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -194,7 +194,9 @@ public:
     void didAllowPrivateTokenUsageByThirdPartyForTesting(bool wasAllowed, URL&& resourceURL);
 
     bool isBlobRegistryPartitioningEnabled() const;
-    bool isOptInCookiePartitioningEnabled() const;
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+    bool computeIsOptInCookiePartitioningEnabled() const;
+#endif
     void propagateSettingUpdates();
 
 #if PLATFORM(IOS_FAMILY)
@@ -684,7 +686,7 @@ private:
     bool m_inspectionForServiceWorkersAllowed { true };
     bool m_isBlobRegistryPartitioningEnabled { false };
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
-    bool m_isOptInCookiePartitioningEnabled { false };
+    std::optional<bool> m_cachedIsOptInCookiePartitioningEnabled;
 #endif
 
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypesForTesting;


### PR DESCRIPTION
#### cf54cd7ce1f0251c089ef4c68d2ec14e05c04058
<pre>
Ensure third party cookie blocking mode stays unchanged when last page is gone
<a href="https://bugs.webkit.org/show_bug.cgi?id=304622">https://bugs.webkit.org/show_bug.cgi?id=304622</a>
<a href="https://rdar.apple.com/167053937">rdar://167053937</a>

Reviewed by Matthew Finkel.

In current implementation, WebsiteDataStore::isOptInCookiePartitioningEnabled() returns true if any of its pages has
the flag enabled. It means when the last page is gone, the value becomes false (as no page has the flag). When a new
page is created with default preferences (where the flag is enabled), isOptInCookiePartitioningEnabled() will become
true again. This causes unnecessary IPC messages to update third party cookie blocking mode. To fix it, avoid changing
the flag value when there is no active page.

Test: WKWebsiteDataStorePrivate.ThirdPartyCookieBlockingModeUnchangedBetweenViews

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::isOptInCookiePartitioningEnabled const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _thirdPartyCookieBlockingModeForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::isOptInCookiePartitioningEnabled const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setThirdPartyCookieBlockingMode):
(WebKit::WebsiteDataStore::computeIsOptInCookiePartitioningEnabled const):
(WebKit::WebsiteDataStore::propagateSettingUpdates):
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::isOptInCookiePartitioningEnabled const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::(WKWebsiteDataStorePrivate, ThirdPartyCookieBlockingModeUnchangedBetweenViews)):

Canonical link: <a href="https://commits.webkit.org/305654@main">https://commits.webkit.org/305654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17406e680b6023598dc220ab5062ab276ec99d74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebd8f0cf-dd9d-4977-af2c-3a6bbb0ff87f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a14ff9f-9b60-4b07-a309-ecb70816b251) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87246 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01d3b040-6319-41fc-bef5-66643b8370c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6419 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149884 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8974 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65933 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11077 "Hash 17406e68 for PR 55810 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11017 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->