### PR TITLE
[Site Isolation] [intersection-observer] Synchronize layoutViewportRect and visibleRectOfChild to RemoteFrameView

### DIFF
--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -30,3 +30,10 @@ FrameCanCreatePaymentSession : bool
 FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/SecurityOrigin.h>]
 FrameURLProtocol : String [Headers=<wtf/text/WTFString.h>]
 FrameRect : WebCore::IntRect [Headers=<WebCore/IntRect.h>]
+
+## Layout information for Intersection Observer
+
+FrameLayoutViewportRect : WebCore::LayoutRect [Headers=<WebCore/LayoutRect.h>]
+
+# Rectangle of the visible portion of the frame in its parent frame, in the coordinate space of the document of the parent frame
+ChildrenFrameVisibleRectMap : HashMap<WebCore::FrameIdentifier, std::optional<WebCore::LayoutRect>> [Headers=<WebCore/LayoutRect.h>,<WebCore/FrameIdentifier.h>]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2039,6 +2039,11 @@ LayoutRect LocalFrameView::layoutViewportRect() const
     return LayoutRect(m_layoutViewportOrigin, baseLayoutViewportSize());
 }
 
+void LocalFrameView::updateLayoutViewportRect()
+{
+    m_frame->loader().client().broadcastFrameLayoutViewportRectToOtherProcesses(layoutViewportRect());
+}
+
 // visibleContentRect is in the bounds of the scroll view content. That consists of an
 // optional header, the document, and an optional footer. Only the document is scaled,
 // so we have to compute the visible part of the document in unscaled document coordinates.

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -322,6 +322,7 @@ public:
 
     // These are in document coordinates, unaffected by page scale (but affected by zooming).
     WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
+    void updateLayoutViewportRect();
     WEBCORE_EXPORT LayoutRect visualViewportRect() const;
 
     LayoutRect layoutViewportRectIncludingObscuredInsets() const;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1404,6 +1404,8 @@ public:
     AcceleratedTimelinesUpdater& ensureAcceleratedTimelinesUpdater();
 #endif
 
+    void syncLocalFrameInfoToRemote();
+
 private:
     explicit Page(PageConfiguration&&);
 

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -55,14 +55,12 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
 
 LayoutRect RemoteFrameView::layoutViewportRect() const
 {
-    ASSERT_NOT_REACHED();
-    return { };
+    return m_frame->frameTreeSyncData().frameLayoutViewportRect;
 }
 
-std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame&) const
+std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child) const
 {
-    ASSERT_NOT_REACHED();
-    return { };
+    return m_frame->frameTreeSyncData().childrenFrameVisibleRectMap.get(child.frameID());
 }
 
 // FIXME: Implement all the stubs below.

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -665,7 +665,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), url().protocol().toString(), IntRect { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, std::optional<LayoutRect>> { });
 }
 
 Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7855,8 +7855,12 @@ void WebPageProxy::broadcastFrameTreeSyncData(IPC::Connection& connection, Frame
 
     // FIXME: This could instead be an option in FrameTreeSyncData.in to allow
     // certain properties to be mutable from non-frame-owning processes.
-    if (frameTreePropertyIsRestrictedToFrameOwningProcess(data.type))
-        MESSAGE_CHECK(process, &webFrameProxy->process() == &process.get());
+    if (frameTreePropertyIsRestrictedToFrameOwningProcess(data.type)) {
+        if (&webFrameProxy->process() != &process.get()) {
+            // FIXME: make this a MESSAGE_CHECK.
+            return;
+        }
+    }
 
     if (data.type == WebCore::FrameTreeSyncDataType::FrameRect)
         webFrameProxy->setRemoteFrameRect(std::get<IntRect>(data.value));


### PR DESCRIPTION
#### 48950a6b5f62f770bd1c0f66e070addc5ce8320b
<pre>
[Site Isolation] [intersection-observer] Synchronize layoutViewportRect and visibleRectOfChild to RemoteFrameView
<a href="https://rdar.apple.com/166915894">rdar://166915894</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304534">https://bugs.webkit.org/show_bug.cgi?id=304534</a>

Reviewed by Simon Fraser.

Following 304640@main, this patch made LocalFrameView::{layoutViewportRect, visibleRectOfChild}
available in the corresponding RemoteFrameView. After page rendering update, the properties are
synchroinzed to RemoteFrameView using FrameTreeSyncData. layoutViewportRect is synchronized as
the rect, while for visibleRectOfChild, we synchronize a pre-computed HashMap of visible rects
for each child. RemoteFrameView then simply look up the HashMap to return the visible rect.

* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateLayoutViewportRect):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
(WebCore::Page::doAfterUpdateRendering):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::layoutViewportRect const):
(WebCore::RemoteFrameView::visibleRectOfChild const):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastFrameTreeSyncData):
  - Because of how layoutViewportRect/visibleRectOfChild is synchronized, during navigation,
    it&apos;s possible for the sync message to arrive at UI process after process swapping. The UI
    process will then MESSAGE_CHECK, because the process owns the frame when the message is
    sent, but then process swapping occurs and it no longer owns the frame. For now, don&apos;t
    MESSAGE_CHECK in this situation, and just silently ignore the message instead.

Canonical link: <a href="https://commits.webkit.org/305560@main">https://commits.webkit.org/305560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/466b5dc25cefdcf4b109e0dd1d03b8bf38039917

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91725 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/620f5308-a2f4-4357-b22c-b0e1af88c98c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106171 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fceb1485-714f-4a95-a966-75b84cd90a61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8911 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87042 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f350ee30-9c47-41ac-ba9c-b91dca2fb6a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6244 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7164 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114556 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8765 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10846 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/193 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74487 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10785 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->