### PR TITLE
[CI Filters] Implement FEComposite in CoreImage

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -503,6 +503,7 @@ platform/graphics/cv/VideoFrameCV.mm @nonARC
 platform/graphics/coreimage/FEBlendCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FECompositeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FilterImageCoreImage.mm @nonARC
 platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEComposite;
+
+class FECompositeCoreImageApplier final : public FilterEffectConcreteApplier<FEComposite> {
+    WTF_MAKE_TZONE_ALLOCATED(FECompositeCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEComposite>;
+
+public:
+    FECompositeCoreImageApplier(const FEComposite&);
+
+    static bool supportsCoreImageRendering(const FEComposite&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FECompositeCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FEComposite.h"
+#import "FilterImage.h"
+#import <CoreImage/CoreImage.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FECompositeCoreImageApplier);
+
+FECompositeCoreImageApplier::FECompositeCoreImageApplier(const FEComposite& effect)
+    : Base(effect)
+{
+}
+
+bool FECompositeCoreImageApplier::supportsCoreImageRendering(const FEComposite& effect)
+{
+    return effect.operation() != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC;
+}
+
+bool FECompositeCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 2);
+    auto& input1 = inputs[0].get();
+    auto& input2 = inputs[1].get();
+
+    auto inputImage1 = input1.ciImage();
+    if (!inputImage1)
+        return false;
+
+    auto inputImage2 = input2.ciImage();
+    if (!inputImage2)
+        return false;
+
+    RetainPtr<CIBlendKernel> kernel;
+    switch (m_effect->operation()) {
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
+        return false;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OVER:
+        kernel = [CIBlendKernel sourceOver];
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_IN:
+        kernel = [CIBlendKernel sourceIn];
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OUT:
+        kernel = [CIBlendKernel destinationOut];
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP:
+        kernel = [CIBlendKernel sourceAtop];
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_XOR:
+        kernel = [CIBlendKernel exclusiveOr];
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC:
+        ASSERT_NOT_REACHED();
+        break;
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER:
+        kernel = [CIBlendKernel componentAdd];
+        break;
+    }
+
+    RetainPtr resultImage = [kernel applyWithForeground:inputImage1.get() background:inputImage2.get()];
+    result.setCIImage(resultImage.get());
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -72,6 +72,8 @@ private:
 
     bool resultIsValidPremultiplied() const override { return m_type != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC; }
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;

--- a/Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm
@@ -28,6 +28,7 @@
 #if !PLATFORM(IOS_FAMILY)
 
 #import "WebCoreFullScreenWindow.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 // FIXME: This isn't really an NSWindowController method - it's a method that
 // the NSWindowController subclass that's using WebCoreFullScreenWindow needs to implement.

--- a/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
-        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
+        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
-        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
+        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...


### PR DESCRIPTION
#### 2e1751db3617cfd1eaec2235988d643cf47f12f9
<pre>
[CI Filters] Implement FEComposite in CoreImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=304626">https://bugs.webkit.org/show_bug.cgi?id=304626</a>
<a href="https://rdar.apple.com/167057225">rdar://167057225</a>

Reviewed by Mike Wyrzykowski.

Add FECompositeCoreImageApplier. This uses a CIKernel, which supports all the operators we need.
This doesn&apos;t support the `arithmetic` operator yet.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm: Added.
(WebCore::FECompositeCoreImageApplier::FECompositeCoreImageApplier):
(WebCore::FECompositeCoreImageApplier::supportsCoreImageRendering):
(WebCore::FECompositeCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FEComposite.cpp:
(WebCore::FEComposite::supportedFilterRenderingModes const):
(WebCore::FEComposite::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEComposite.h:
* Source/WebCore/platform/mac/WebCoreFullScreenWindow.mm: Unified build fix.
* WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd: Add CIBlendKernel for watchOS.
* WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd: Ditto.

Canonical link: <a href="https://commits.webkit.org/304901@main">https://commits.webkit.org/304901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8401d7e8e5ec8dd99d21e2d7011f2d8b499db5e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6cd5d219-1245-4b37-a17e-a363f63425a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/041b58bb-bca6-4b6c-93f6-349e3e496938) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85472 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/96dacc4e-c9dc-4b8c-a0d3-ccba2a81ee12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4570 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5159 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8879 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41353 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6797 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63057 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36937 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8648 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72493 "Found 2 new failures in platform/graphics/coreimage/FECompositeCoreImageApplier.mm") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->