### PR TITLE
[CI Filters] Implement filter regions

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -416,8 +416,8 @@ void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const Fl
     auto result = filter.apply(sourceImage, sourceImageRect, results);
     if (!result)
         return;
-    
-    RefPtr imageBuffer = result->imageBuffer();
+
+    RefPtr imageBuffer = filter.filterResultBuffer(*result);
     if (!imageBuffer)
         return;
 

--- a/Source/WebCore/platform/graphics/coreimage/FEFloodCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEFloodCoreImageApplier.mm
@@ -50,7 +50,7 @@ bool FEFloodCoreImageApplier::supportsCoreImageRendering(const FEFlood&)
     return true;
 }
 
-bool FEFloodCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage& result) const
+bool FEFloodCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
 {
     auto color = m_effect->floodColor().colorWithAlphaMultipliedBy(m_effect->floodOpacity());
     auto [r, g, b, a] = color.toResolvedColorComponentsInColorSpace(m_effect->operatingColorSpace());
@@ -62,7 +62,11 @@ bool FEFloodCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterIma
     if (!image)
         return false;
 
-    // FIXME: We need to set extent to get correct geometry.
+    auto absoluteFilterRegion = filter.scaledByFilterScale(filter.filterRegion());
+    auto absoluteImageRect = FloatRect { result.absoluteImageRect() };
+
+    auto cropRect = FloatRect(absoluteImageRect.x() - absoluteFilterRegion.x(), absoluteFilterRegion.maxY() - absoluteImageRect.maxY(), absoluteImageRect.width(), absoluteImageRect.height());
+    image = [image imageByCroppingToRect:cropRect];
     result.setCIImage(WTF::move(image));
     return true;
 }

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -132,4 +132,14 @@ FilterStyleVector Filter::createFilterStyles(GraphicsContext& context, const Flo
     return result;
 }
 
+ImageBuffer* Filter::filterResultBuffer(FilterImage& filterImage) const
+{
+#if USE(CORE_IMAGE)
+    auto absoluteFilterRegion = scaledByFilterScale(filterRegion());
+    return filterImage.filterResultImageBuffer(absoluteFilterRegion);
+#endif
+
+    return filterImage.imageBuffer();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -78,6 +78,8 @@ public:
     WEBCORE_EXPORT RefPtr<FilterImage> apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults&);
     WEBCORE_EXPORT FilterStyleVector createFilterStyles(GraphicsContext&, const FloatRect& sourceImageRect) const;
 
+    ImageBuffer* filterResultBuffer(FilterImage&) const;
+
 protected:
     Filter(Filter::Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
     Filter(Filter::Type, const FilterGeometry&, std::optional<RenderingResourceIdentifier> = std::nullopt);

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -112,8 +112,11 @@ size_t FilterImage::memoryCost() const
 ImageBuffer* FilterImage::imageBuffer()
 {
 #if USE(CORE_IMAGE)
-    if (m_ciImage)
-        return imageBufferFromCIImage();
+    if (m_ciImage) {
+        // We'll never request an imageBuffer() in the middle of the filter chain. The final image buffer is produced via filterResultImageBuffer().
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
 #endif
     return imageBufferFromPixelBuffer();
 }

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -81,6 +81,8 @@ public:
     void transformToColorSpace(const DestinationColorSpace&);
 
 #if USE(CORE_IMAGE)
+    ImageBuffer* filterResultImageBuffer(FloatRect absoluteFilterRegion);
+
     RetainPtr<CIImage> ciImage() const { return m_ciImage; }
     void setCIImage(RetainPtr<CIImage>&&);
     size_t memoryCostOfCIImage() const;
@@ -93,10 +95,6 @@ private:
     RefPtr<PixelBuffer>& pixelBufferSlot(AlphaPremultiplication);
 
     ImageBuffer* imageBufferFromPixelBuffer();
-
-#if USE(CORE_IMAGE)
-    ImageBuffer* imageBufferFromCIImage();
-#endif
 
     bool requiresPixelBufferColorSpaceConversion(std::optional<DestinationColorSpace>) const;
 

--- a/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
-        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIVector]
+        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
-        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIVector]
+        objc-classes: [CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...


### PR DESCRIPTION
#### 6b45e20e451f2610bac08657b24de4439e40f2c0
<pre>
[CI Filters] Implement filter regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=304629">https://bugs.webkit.org/show_bug.cgi?id=304629</a>
<a href="https://rdar.apple.com/167058188">rdar://167058188</a>

Reviewed by Mike Wyrzykowski.

At each step in the filter chain, we potentially have to set geometry based on the filter
primitive subregion.

Core Image uses flipped coordinates, and only resolves those coordinates once we do the
final render to an IOSurface. The existing code, using `[CIContext
render:toIOSurface:bounds:colorSpace]`, uses the IOSurface size to resolve coordinates,
but that&apos;s just the size of the last filter output, not necessarily the `filterRegion`
size of the `&lt;filter&gt;`. The `bounds` parameter is not used to resolve these coordinates
either.

To fix this shortcoming, use `[CIContext startTaskToRender:fromRect:...]` instead, where
the `fromRect` does what we need: we supply the size of the `filterRegion`. That allows us
to specify the extents of intermediate CIImages by using the filterRegion as input to
flipping math.

The `Filter` was not accessible to `FilterImage::imageBuffer()`, which is where the Core
Image implementation needs to get `filterRegion`, so wrap the fetching of the final
ImageBuffer in `Filter::filterResultBuffer()` which can pass in the filterRegion, scaled
to absolute coordinates.

`FEFloodCoreImageApplier::apply` is fixed to do this filter primitive subregion
computation, setting the extent of the CIImage. There will be other sites that need to do
this in future.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/coreimage/FEFloodCoreImageApplier.mm:
(WebCore::FEFloodCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::filterResultImageBuffer):
(WebCore::FilterImage::imageBufferFromCIImage): Deleted.
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::filterResultBuffer const):
* Source/WebCore/platform/graphics/filters/Filter.h:
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::imageBuffer):
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd: Make watchOS build.
* WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:

Canonical link: <a href="https://commits.webkit.org/304893@main">https://commits.webkit.org/304893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8158d1a1a8c45161590ec371871ffefb389f7028

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136799 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144530 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/89772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/743513f7-b17c-459c-9433-357427e2b7b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/89772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1aad6bde-1c8e-44c3-87b9-6494622c3942) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/91b7cb94-9497-4ba8-9b5f-17eb7468db7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4538 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147288 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8842 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113298 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28779 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6770 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63004 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8890 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36906 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->