### PR TITLE
[JSC] Implement `String#repeat` in C++

### DIFF
--- a/JSTests/stress/string-repeat-complex.js
+++ b/JSTests/stress/string-repeat-complex.js
@@ -1,0 +1,274 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected "${expected}", got "${actual}"`);
+}
+
+function shouldThrow(func, errorType) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (!(error instanceof errorType))
+        throw new Error(`bad error type: expected ${errorType.name}, got ${error.constructor.name}`);
+}
+
+{
+    shouldBe("".repeat(0), "");
+    shouldBe("".repeat(-0), "");
+    shouldBe("".repeat(1), "");
+    shouldBe("".repeat(10), "");
+    shouldBe("".repeat(100), "");
+    shouldBe("".repeat(1000), "");
+    shouldBe("".repeat(0xFFFFFF), "");
+    shouldBe("".repeat(0xFFFFFFFF), "");
+    shouldThrow(() => "".repeat(Infinity), RangeError);
+    shouldThrow(() => "".repeat(-Infinity), RangeError);
+    shouldThrow(() => "".repeat(-1), RangeError);
+    shouldBe("".repeat(-0.1), "");
+    shouldBe("".repeat(-0.9), "");
+}
+
+{
+    shouldBe("a".repeat(0), "");
+    shouldBe("ab".repeat(0), "");
+    shouldBe("abc".repeat(0), "");
+    shouldBe("abcdefgh".repeat(0), "");
+    shouldBe("abcdefghi".repeat(0), "");
+    shouldBe("a".repeat(-0), "");
+    shouldBe("\u{1F600}".repeat(0), "");
+    shouldBe("\u0100".repeat(0), "");
+}
+
+{
+    shouldBe("a".repeat(1), "a");
+    shouldBe("a".repeat(2), "aa");
+    shouldBe("a".repeat(3), "aaa");
+    shouldBe("a".repeat(7), "aaaaaaa");
+    shouldBe("a".repeat(8), "aaaaaaaa");
+    shouldBe("a".repeat(9), "aaaaaaaaa");
+    shouldBe("a".repeat(100), "a".repeat(100));
+    shouldBe("x".repeat(1000), "x".repeat(1000));
+    shouldBe("a".repeat(1023).length, 1023);
+    shouldBe("a".repeat(1024).length, 1024);
+    shouldBe("a".repeat(1025).length, 1025);
+    shouldBe("\x00".repeat(5), "\x00\x00\x00\x00\x00");
+    shouldBe("\xFF".repeat(3), "\xFF\xFF\xFF");
+    shouldBe(" ".repeat(10), "          ");
+    shouldBe("\n".repeat(3), "\n\n\n");
+    shouldBe("\t".repeat(4), "\t\t\t\t");
+}
+
+{
+    shouldBe("\u0100".repeat(1), "\u0100");
+    shouldBe("\u0100".repeat(3), "\u0100\u0100\u0100");
+    shouldBe("\u0100".repeat(10).length, 10);
+    shouldBe("\u4E2D".repeat(3), "\u4E2D\u4E2D\u4E2D");
+    shouldBe("\u3042".repeat(4), "\u3042\u3042\u3042\u3042");
+    shouldBe("\uFFFF".repeat(2), "\uFFFF\uFFFF");
+    shouldBe("\u0100".repeat(1024).length, 1024);
+    shouldBe("\u0100".repeat(1025).length, 1025);
+}
+
+{
+    shouldBe("\u{1F600}".repeat(1), "\u{1F600}");
+    shouldBe("\u{1F600}".repeat(2), "\u{1F600}\u{1F600}");
+    shouldBe("\u{1F600}".repeat(3).length, 6);
+    shouldBe("a\u{1F600}b".repeat(2), "a\u{1F600}ba\u{1F600}b");
+}
+
+{
+    let str8 = "abcdefgh";
+    shouldBe(str8.repeat(1), "abcdefgh");
+    shouldBe(str8.repeat(2), "abcdefghabcdefgh");
+    shouldBe(str8.repeat(128).length, 1024);
+    shouldBe(str8.repeat(129).length, 1032);
+
+    let str9 = "abcdefghi";
+    shouldBe(str9.repeat(1), "abcdefghi");
+    shouldBe(str9.repeat(2), "abcdefghiabcdefghi");
+    shouldBe(str9.repeat(100).length, 900);
+
+    let str20 = "12345678901234567890";
+    shouldBe(str20.repeat(1), "12345678901234567890");
+    shouldBe(str20.repeat(5).length, 100);
+
+    let str4 = "abcd";
+    shouldBe(str4.repeat(256).length, 1024);
+    shouldBe(str4.repeat(257).length, 1028);
+
+    let utf16_8 = "\u0100\u0101\u0102\u0103\u0104\u0105\u0106\u0107";
+    shouldBe(utf16_8.repeat(1).length, 8);
+    shouldBe(utf16_8.repeat(128).length, 1024);
+    shouldBe(utf16_8.repeat(129).length, 1032);
+
+    let utf16_2 = "\u0100\u0101";
+    shouldBe(utf16_2.repeat(512).length, 1024);
+    shouldBe(utf16_2.repeat(513).length, 1026);
+}
+
+{
+    shouldBe("ab".repeat(2.0), "abab");
+    shouldBe("ab".repeat(2.1), "abab");
+    shouldBe("ab".repeat(2.5), "abab");
+    shouldBe("ab".repeat(2.9), "abab");
+    shouldBe("ab".repeat(2.999999), "abab");
+    shouldBe("ab".repeat(0.1), "");
+    shouldBe("ab".repeat(0.5), "");
+    shouldBe("ab".repeat(0.9), "");
+    shouldBe("ab".repeat(0.999999), "");
+    shouldBe("ab".repeat(-0.0), "");
+    shouldBe("ab".repeat(-0.1), "");
+    shouldBe("ab".repeat(-0.9), "");
+    shouldThrow(() => "ab".repeat(-1.0), RangeError);
+    shouldThrow(() => "ab".repeat(-1.5), RangeError);
+}
+
+{
+    shouldBe("x".repeat({ valueOf() { return 3; } }), "xxx");
+    shouldBe("x".repeat({ valueOf() { return 2.7; } }), "xx");
+    shouldBe("x".repeat({ valueOf() { return 0; } }), "");
+    shouldBe("x".repeat({ valueOf() { return "4"; } }), "xxxx");
+    shouldBe("x".repeat({ toString() { return "2"; } }), "xx");
+    shouldBe("x".repeat({
+        valueOf() { return 3; },
+        toString() { return 5; }
+    }), "xxx");
+    shouldThrow(() => {
+        "x".repeat({ valueOf() { throw new TypeError("custom"); } });
+    }, TypeError);
+    shouldBe("ab".repeat(null), "");
+    shouldBe("ab".repeat(undefined), "");
+    shouldBe("ab".repeat(false), "");
+    shouldBe("ab".repeat(true), "ab");
+    shouldBe("ab".repeat(NaN), "");
+}
+
+{
+    shouldThrow(() => String.prototype.repeat.call(null, 1), TypeError);
+    shouldThrow(() => String.prototype.repeat.call(undefined, 1), TypeError);
+    shouldThrow(() => String.prototype.repeat.call(Symbol("test"), 1), TypeError);
+}
+
+{
+    let obj = { toString() { return "abc"; } };
+    shouldBe(String.prototype.repeat.call(obj, 2), "abcabc");
+    shouldBe(String.prototype.repeat.call(obj, 0), "");
+
+    let obj2 = {
+        toString() { return "XY"; },
+        valueOf() { return "ZZ"; }
+    };
+    shouldBe(String.prototype.repeat.call(obj2, 3), "XYXYXY");
+
+    shouldBe(String.prototype.repeat.call(123, 2), "123123");
+    shouldBe(String.prototype.repeat.call(3.14, 2), "3.143.14");
+    shouldBe(String.prototype.repeat.call(true, 2), "truetrue");
+    shouldBe(String.prototype.repeat.call(false, 3), "falsefalsefalse");
+    shouldBe(String.prototype.repeat.call([1, 2, 3], 2), "1,2,31,2,3");
+    shouldBe(String.prototype.repeat.call([], 5), "");
+
+    shouldThrow(() => {
+        String.prototype.repeat.call({ toString() { throw new RangeError("custom"); } }, 1);
+    }, RangeError);
+}
+
+{
+    shouldThrow(() => "ab".repeat(0x7FFFFFFF), Error);
+    shouldThrow(() => "ab".repeat(0xFFFFFFFF), Error);
+
+    let longStr = "x".repeat(10000);
+    shouldThrow(() => longStr.repeat(0x7FFFFFFF), Error);
+}
+
+{
+    shouldThrow(() => "a".repeat(-1), RangeError);
+    shouldBe("a".repeat(-0.0001), "a".repeat(0));
+    shouldThrow(() => "a".repeat(-1e10), RangeError);
+    shouldThrow(() => "a".repeat(-Infinity), RangeError);
+    shouldThrow(() => "a".repeat(Infinity), RangeError);
+    shouldThrow(() => "abc".repeat(Infinity), RangeError);
+    shouldThrow(() => "a".repeat(1e100), Error);
+}
+
+{
+    let result = "ABC".repeat(100);
+    shouldBe(result.length, 300);
+    for (let i = 0; i < 100; i++) {
+        shouldBe(result.substring(i * 3, i * 3 + 3), "ABC");
+    }
+
+    let result2 = "XY".repeat(7);
+    shouldBe(result2, "XYXYXYXYXYXYXY");
+
+    let result3 = "123".repeat(11);
+    shouldBe(result3.length, 33);
+    shouldBe(result3, "123123123123123123123123123123123");
+
+    let result4 = "\u0100\u0101".repeat(5);
+    shouldBe(result4, "\u0100\u0101\u0100\u0101\u0100\u0101\u0100\u0101\u0100\u0101");
+}
+
+{
+    let ropeStr = "abcdefghi";
+    shouldBe(ropeStr.repeat(2).length, 18);
+    shouldBe(ropeStr.repeat(3).length, 27);
+    shouldBe(ropeStr.repeat(4).length, 36);
+    shouldBe(ropeStr.repeat(5).length, 45);
+    shouldBe(ropeStr.repeat(7).length, 63);
+    shouldBe(ropeStr.repeat(8).length, 72);
+    shouldBe(ropeStr.repeat(15).length, 135);
+    shouldBe(ropeStr.repeat(16).length, 144);
+    shouldBe(ropeStr.repeat(31).length, 279);
+    shouldBe(ropeStr.repeat(32).length, 288);
+    shouldBe(ropeStr.repeat(63).length, 567);
+    shouldBe(ropeStr.repeat(64).length, 576);
+
+    for (let i = 2; i <= 100; i++) {
+        let result = ropeStr.repeat(i);
+        shouldBe(result.length, 9 * i);
+        for (let j = 0; j < i; j++) {
+            shouldBe(result.substring(j * 9, j * 9 + 9), ropeStr);
+        }
+    }
+}
+
+{
+    function test(str, count) {
+        return str.repeat(count);
+    }
+    noInline(test);
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldBe(test("a", 5), "aaaaa");
+    }
+
+    shouldBe(test("", 100), "");
+    shouldBe(test("xyz", 0), "");
+    shouldBe(test("ab", 1), "ab");
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldBe(test("x", i % 20), "x".repeat(i % 20));
+        shouldBe(test("abcdefgh", i % 10), "abcdefgh".repeat(i % 10));
+        shouldBe(test("abcdefghi", i % 10), "abcdefghi".repeat(i % 10));
+    }
+}
+
+{
+    let mixed = "abc\u0100def";
+    shouldBe(mixed.repeat(2), "abc\u0100defabc\u0100def");
+    shouldBe(mixed.repeat(3).length, 21);
+
+    let latin1 = "abc";
+    let utf16 = "abc\u0100";
+
+    for (let i = 1; i <= testLoopCount; i++) {
+        shouldBe(latin1.repeat(i).length, 3 * i);
+        shouldBe(utf16.repeat(i).length, 4 * i);
+    }
+}

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -65,36 +65,6 @@ function matchAll(arg)
 }
 
 @linkTimeConstant
-function repeatSlowPath(string, count)
-{
-    "use strict";
-
-    // Return an empty string.
-    if (count === 0 || string.length === 0)
-        return "";
-
-    // Return the original string.
-    if (count === 1)
-        return string;
-
-    if (string.length * count > @MAX_STRING_LENGTH)
-        @throwOutOfMemoryError();
-
-    // Bit operation onto |count| is safe because |count| should be within Int32 range,
-    // Repeat log N times to generate the repeated string rope.
-    var result = "";
-    var operand = string;
-    while (true) {
-        if (count & 1)
-            result += operand;
-        count >>= 1;
-        if (!count)
-            return result;
-        operand += operand;
-    }
-}
-
-@linkTimeConstant
 function repeatCharactersSlowPath(string, count)
 {
     "use strict";
@@ -115,26 +85,6 @@ function repeatCharactersSlowPath(string, count)
     if (remainingCharacters)
         result += @stringSubstring.@call(string, 0, remainingCharacters);
     return result;
-}
-
-
-function repeat(count)
-{
-    "use strict";
-
-    if (@isUndefinedOrNull(this))
-        @throwTypeError("String.prototype.repeat requires that |this| not be null or undefined");
-
-    var string = @toString(this);
-    count = @toIntegerOrInfinity(count);
-
-    if (count < 0 || count === @Infinity)
-        @throwRangeError("String.prototype.repeat argument must be greater than or equal to 0 and not be Infinity");
-
-    if (string.length === 1)
-        return @repeatCharacter(string, count);
-
-    return @repeatSlowPath(string, count);
 }
 
 function padStart(maxLength/*, fillString*/)


### PR DESCRIPTION
#### 2526a45e199d29c41a19e2726f7b1fe672197529
<pre>
[JSC] Implement `String#repeat` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=304631">https://bugs.webkit.org/show_bug.cgi?id=304631</a>

Reviewed by Yusuke Suzuki.

This patch changes to implement `String#repeat` in C++.

Previously, `String#repeat` only allocated a sequential buffer without building a rope string
when the original string length was 1. This patch changes the behavior to allocate a sequential
buffer even when the length is not 1, as long as the resulting string is short enough.

                                               TipOfTree                  Patched

string-repeat-not-resolving-fixed            0.8174+-0.0664     ?      0.8587+-0.0355        ? might be 1.0505x slower
string-repeat-single-resolving               1.7876+-0.1402            1.6992+-0.0705          might be 1.0520x faster
string-repeat-small-resolving                1.1884+-0.0411     ^      0.7413+-0.0943        ^ definitely 1.6031x faster
string-repeat-resolving-no-inline            1.5253+-0.2846     ^      1.0961+-0.0468        ^ definitely 1.3916x faster
string-repeat-single-not-resolving           1.7091+-0.1271            1.5642+-0.0656          might be 1.0926x faster
string-repeat-small-not-resolving            1.1239+-0.0927     ?      1.1445+-0.0643        ? might be 1.0184x slower
string-repeat-not-resolving                  1.3078+-0.1511     ?      1.3150+-0.0577        ?
string-repeat-arith                          5.5090+-0.2520     !      6.5450+-0.0464        ! definitely 1.1881x slower
string-repeat-not-resolving-no-inline        1.3218+-0.0293     ?      1.3260+-0.0629        ?
string-repeat-resolving-fixed                1.9260+-0.3135     ^      0.9126+-0.0318        ^ definitely 2.1104x faster
string-repeat-resolving                      1.5575+-0.1956     ^      1.1582+-0.0874        ^ definitely 1.3448x faster
string-repeat-single-japanese                3.8928+-0.1288            3.8227+-0.0975          might be 1.0183x faster
string-repeat-single-emoji                   1.1680+-0.0333            1.1477+-0.0139          might be 1.0177x faster
string-repeat-single-ascii                   1.8143+-0.2555            1.7250+-0.1485          might be 1.0517x faster

Test: JSTests/stress/string-repeat-complex.js

* JSTests/stress/string-repeat-complex.js: Added.
(shouldBe):
(throw.new.Error):
(shouldThrow):
(shouldThrow.longStr.repeat):
(shouldBe.test):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.repeatSlowPath): Deleted.
(repeat): Deleted.
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::repeatString):
(JSC::repeatRope):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/304955@main">https://commits.webkit.org/304955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49c18e90263656ceb72c9571463f833b550f6b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9502 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85613 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4736 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5347 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128976 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147513 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135501 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41518 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9076 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6959 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37102 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168282 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72672 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->