### PR TITLE
[WebRTC] Remove obsolete emulateRTCPeerConnectionPlatformEvent

### DIFF
--- a/LayoutTests/fast/mediastream/RTCPeerConnection-icecandidate-event.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-icecandidate-event.html
@@ -58,8 +58,6 @@
             }).then(function () {
                 testPassed("Local description set");
                 testPassed("End of test promise chain");
-                if (window.internals)
-                    window.internals.emulateRTCPeerConnectionPlatformEvent(pc, "dispatch-fake-ice-candidates");
                 shouldDoChecking = true;
                 checkCandidates();
                 stream.getTracks().forEach(track => track.stop());

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html
@@ -62,7 +62,6 @@
                 shouldBe("pc.getTransceivers().length", "3");
                 shouldBe("pc.iceConnectionState", "'new'");
 
-                window.internals.emulateRTCPeerConnectionPlatformEvent(pc, "step-ice-transport-states");
                 testPassed("End of test promise chain");
                 debug("");
                 stream1.getTracks().forEach(track => track.stop());

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html
@@ -82,8 +82,6 @@
             })
             .then(function () {
                 testPassed("Offer/answer dialog completed")
-
-                window.internals.emulateRTCPeerConnectionPlatformEvent(pcB, "unmute-remote-sources-by-mid");
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -139,8 +139,6 @@ public:
     void markAsNeedingNegotiation(uint32_t);
     virtual bool isNegotiationNeeded(uint32_t) const = 0;
 
-    virtual void emulatePlatformEvent(const String& action) = 0;
-
     struct DescriptionStates {
         std::optional<RTCSignalingState> signalingState;
         std::optional<RTCSdpType> currentLocalDescriptionSdpType;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -740,11 +740,6 @@ ScriptExecutionContext* RTCPeerConnection::scriptExecutionContext() const
     return ActiveDOMObject::scriptExecutionContext();
 }
 
-void RTCPeerConnection::emulatePlatformEvent(const String& action)
-{
-    protectedBackend()->emulatePlatformEvent(action);
-}
-
 void RTCPeerConnection::stop()
 {
     doClose();

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -173,9 +173,6 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final;
     using ActiveDOMObject::protectedScriptExecutionContext;
 
-    // Used for testing with a mock
-    WEBCORE_EXPORT void emulatePlatformEvent(const String& action);
-
     // API used by PeerConnectionBackend and relatives
     void updateIceGatheringState(RTCIceGatheringState);
     void updateIceConnectionState(RTCIceConnectionState);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -76,7 +76,6 @@ private:
     void getStats(RTCRtpSender&, Ref<DeferredPromise>&&) final;
     void getStats(RTCRtpReceiver&, Ref<DeferredPromise>&&) final;
 
-    void emulatePlatformEvent(const String&) final { }
     void applyRotationForOutgoingVideoSources() final;
 
     void gatherDecoderImplementationName(Function<void(String&&)>&&) final;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -75,7 +75,6 @@ private:
 
     std::optional<bool> canTrickleIceCandidates() const final;
 
-    void emulatePlatformEvent(const String&) final { }
     void applyRotationForOutgoingVideoSources() final;
 
     friend class LibWebRTCMediaEndpoint;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1861,14 +1861,6 @@ unsigned Internals::minimumExpectedVoiceCount()
 
 #if ENABLE(WEB_RTC)
 
-void Internals::emulateRTCPeerConnectionPlatformEvent(RTCPeerConnection& connection, const String& action)
-{
-    if (!WebRTCProvider::webRTCAvailable())
-        return;
-
-    connection.emulatePlatformEvent(action);
-}
-
 void Internals::useMockRTCPeerConnectionFactory(const String& testCase)
 {
     if (!WebRTCProvider::webRTCAvailable())

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1083,7 +1083,6 @@ enum ContentsFormat {
 
     [Conditional=WEB_AUDIO] undefined useMockAudioDestinationCocoa();
 
-    [Conditional=WEB_RTC] undefined emulateRTCPeerConnectionPlatformEvent(RTCPeerConnection connection, DOMString action);
     [Conditional=WEB_RTC] undefined useMockRTCPeerConnectionFactory(DOMString testCase);
     [Conditional=WEB_RTC] undefined setICECandidateFiltering(boolean enabled);
     [Conditional=WEB_RTC] undefined setEnumeratingAllNetworkInterfacesEnabled(boolean enabled);


### PR DESCRIPTION
#### 8e56989ed07b95908ddfb01a903e87388dc46777
<pre>
[WebRTC] Remove obsolete emulateRTCPeerConnectionPlatformEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=304638">https://bugs.webkit.org/show_bug.cgi?id=304638</a>

Reviewed by Adrian Perez de Castro.

That was needed in OpenWebRTC times and was left un-implemented when libwebrtc was added.

* LayoutTests/fast/mediastream/RTCPeerConnection-icecandidate-event.html:
* LayoutTests/fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html:
* LayoutTests/fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::emulatePlatformEvent): Deleted.
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::emulateRTCPeerConnectionPlatformEvent): Deleted.
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/304896@main">https://commits.webkit.org/304896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a82af4f07da6aeeec1518a5f6005c57f57025d43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4557 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5142 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112980 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6787 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63034 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8911 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36922 "Found 1 new test failure: imported/w3c/web-platform-tests/reporting/reporting-isolated-across-navigations.https.sub.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72477 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->