### PR TITLE
[Back-deployment] Crash in STP: "Library not loaded: @rpath/libswiftCompatibilitySpan.dylib"

### DIFF
--- a/Source/WebKit/Configurations/BaseXPCService.xcconfig
+++ b/Source/WebKit/Configurations/BaseXPCService.xcconfig
@@ -80,6 +80,11 @@ WK_PATH_FROM_SERVICE_EXECUTABLE_TO_FRAMEWORK_SHALLOW_BUNDLE_YES_DEPLOYMENT_YES =
 WK_PATH_FROM_SERVICE_EXECUTABLE_TO_FRAMEWORK_SHALLOW_BUNDLE_NO_DEPLOYMENT_NO = ../../..;
 WK_PATH_FROM_SERVICE_EXECUTABLE_TO_FRAMEWORK_SHALLOW_BUNDLE_YES_DEPLOYMENT_NO = ..;
 
+// In relocatable builds, dyld needs to find any Swift compatibility libraries
+// that were copied into the application bundle.
+LD_RUNPATH_SEARCH_PATHS = $(LD_RUNPATH_SEARCH_PATHS_$(WK_RELOCATABLE_FRAMEWORKS));
+LD_RUNPATH_SEARCH_PATHS_YES = @loader_path/../../../;
+
 // We want this to always be NO for non-simulator builds. If set to YES, Xcode will invoke codesign with an --entitlements parameter that points to the platform's BaseEntitlements.plist. This parameter would override any --entitlements parameter that we establish in WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS, causing our entitlements to be ignored.
 CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 CODE_SIGN_INJECT_BASE_ENTITLEMENTS[sdk=*simulator] = YES;


### PR DESCRIPTION
#### c5cd363ad5f2b7b0ca310fa9705d318e3d879f77
<pre>
[Back-deployment] Crash in STP: &quot;Library not loaded: @rpath/libswiftCompatibilitySpan.dylib&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=304649">https://bugs.webkit.org/show_bug.cgi?id=304649</a>
<a href="https://rdar.apple.com/166804178">rdar://166804178</a>

Reviewed by Richard Robinson and Alexey Proskuryakov.

In relocatable builds, we rely on the DYLD_LIBRARY_PATH baked into
WebKit&apos;s XPC services to load dylibs. In STP, this load command is set
up so that the install paths for ANGLE (@loader_path/../../../libANGLE-shared.dylib)
and webrtc (@loader_path/../../../libwebrtc.dylib) can be resolved.

The Swift runtime compatibility libraries that our build copies from the
toolchain are linked against with an rpath-based install path
(@rpath/libswiftCompatibilitySpan.dylib). So, the DYLD_LIBRARY_PATH we
have doesn&apos;t work. It needs to be combined with the relative path
from the service bundle to the shallow bundle (../../..).

Adding new search paths to DYLD_LIBRARY_PATH is risky, since we would
need to carefully consider every path WebKit.framework can be installed
at, to ensure it is never possible to load untrusted code from outside
the bundle. Instead, add `@loader_path/../../../` to the XPC service&apos;s
rpath list, so that rpath resolution uses the same semantics as our own
two dylibs.

* Source/WebKit/Configurations/BaseXPCService.xcconfig:

Canonical link: <a href="https://commits.webkit.org/305178@main">https://commits.webkit.org/305178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74e3a201bc6a5e2f90dee4923bff255673e58a8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89832 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4576754b-0537-462a-8894-7006adca65d8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104651 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76379 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0eb82ca-3438-42eb-abc4-d4ca46c13ae5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6ca94159-894f-426d-bbbe-99c48b568dfd) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6899 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/worker-performance.worker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4589 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5183 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116223 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113338 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/28919 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6816 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63087 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21204 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8950 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72516 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->