### PR TITLE
Fix Objective-C leaks caused by missing -dealloc and missing -release

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
@@ -30,7 +30,11 @@
 
 - (void)dealloc
 {
-    SUPPRESS_UNRETAINED_ARG [_appid release];
+    self.appid = nil;
+    self.evalByCredential = nil;
+    self.eval = nil;
+    self.largeBlob = nil;
+
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -50,7 +50,7 @@ WK_EXTERN
 
 + (instancetype)menuController;
 
-@property (weak, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
+@property (weak, nullable, nonatomic) id<WKCaptionStyleMenuControllerDelegate> delegate;
 @property (readonly, nonatomic) PlatformMenu *captionStyleMenu;
 #if !TARGET_OS_OSX && !TARGET_OS_WATCH
 @property (readonly, nullable, nonatomic) UIContextMenuInteraction *contextMenuInteraction;

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h
@@ -49,9 +49,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setPreviewProfileID:(nullable NSString *)profileID;
 
 @property (nonatomic, copy, nullable) NSString *savedActiveProfileID;
-@property (nonatomic, strong) PlatformMenu *menu;
+@property (nonatomic, strong, nullable) PlatformMenu *menu;
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)
-@property (nonatomic, strong) UIContextMenuInteraction *interaction;
+@property (nonatomic, strong, nullable) UIContextMenuInteraction *interaction;
 #endif
 #if PLATFORM(IOS_FAMILY)
 - (void)notifyMenuWillOpen;

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
@@ -75,6 +75,18 @@ using namespace WTF;
     return self;
 }
 
+- (void)dealloc
+{
+    self.delegate = nil;
+    self.savedActiveProfileID = nil;
+    self.menu = nil;
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)
+    self.interaction = nil;
+#endif
+
+    [super dealloc];
+}
+
 - (void)rebuildMenu
 {
     [_menu removeAllItems];


### PR DESCRIPTION
#### fd984eb67bc80f4134925d5a5a1345c8feb9e856
<pre>
Fix Objective-C leaks caused by missing -dealloc and missing -release
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=304645">https://bugs.webkit.org/show_bug.cgi?id=304645</a>&gt;
&lt;<a href="https://rdar.apple.com/167089343">rdar://167089343</a>&gt;

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm:
(-[_WKAuthenticationExtensionsClientInputs dealloc]):
- Release remaining three instance variables to fix leaks.
* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
(_WKCaptionStyleMenuController.delegate):
- Make delegate property nullable.
* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuControllerInternal.h:
(_WKCaptionStyleMenuController.menu):
(_WKCaptionStyleMenuController.interaction):
- Make nullable so they may be released in -dealloc.
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm:
(-[WKCaptionStyleMenuController dealloc]):
- Clear _delegate and release _savedActiveProfileID, _menu and
  _interaction instance variables to match ARC behavior.

Canonical link: <a href="https://commits.webkit.org/305337@main">https://commits.webkit.org/305337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd6830c2758a7320defb291bee20d454f975e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146209 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78489133-0b64-4160-a072-ad18b9d5c4d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105648 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8051403b-598e-4969-a52b-2f11cb8b0d14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86500 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/63994742-d595-48c6-8af9-b8611881ff4e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5734 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6491 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117377 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148919 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114058 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114391 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7907 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120127 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38069 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9958 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->