### PR TITLE
Add a way to prepend event listeners in autofill content worlds

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -697,6 +697,7 @@ namespace WebCore {
     macro(parent) \
     macro(pendingPullIntos) \
     macro(postMessage) \
+    macro(prependEventListener) \
     macro(privateGetStats) \
     macro(pull) \
     macro(pullAgain) \

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -3149,6 +3149,7 @@ sub GenerateHeader
     }
 
     $headerIncludes{"JSWindowProxy.h"} = 1 if $interfaceName eq "DOMWindow";
+    $headerIncludes{"AddEventListenerOptionsInlines.h"} = 1 if $interfaceName eq "DOMWindow";
     $headerIncludes{"EventTarget.h"} = 1 if $parentClassName eq "JSEventTarget";
 
     my $exportMacro = GetExportMacroForJSClass($interface);

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/JSDOMWrapper.h>
 #include <WebCore/JSEventTarget.h>

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -116,6 +116,23 @@ void EventListenerMap::replace(const AtomString& eventType, EventListener& oldLi
     registeredListener = RegisteredEventListener::create(WTF::move(newListener), options);
 }
 
+void EventListenerMap::moveLastListenerToFirst(const AtomString& eventType)
+{
+    // This is only used for autofill worlds and is never used repeatedly, so it isn't worth the overhead
+    // of using a Deque to prevent O(n^2) algorithms from using this repeatedly.
+    auto* vectorPointer = find(eventType);
+    if (!vectorPointer || vectorPointer->isEmpty()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    auto& vector = *vectorPointer;
+    RefPtr last = vector.last();
+    for (size_t i = vector.size(); i >= 2; --i)
+        vector[i - 1] = WTF::move(vector[i - 2]);
+    ASSERT(!vector[0]);
+    vector[0] = WTF::move(last);
+}
+
 bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& listener, const RegisteredEventListener::Options& options)
 {
     releaseAssertOrSetThreadUID();

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -75,6 +75,7 @@ public:
 
     void replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options&);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
+    void moveLastListenerToFirst(const AtomString& eventType);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
     WEBCORE_EXPORT EventListenerVector* find(const AtomString& eventType);
     const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
@@ -116,6 +117,7 @@ private:
             m_threadUID = Thread::currentSingleton().uid();
     }
 
+    // FIXME: m_entries should probably have WTF_GUARDED_BY_LOCK(m_lock);
     Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;
     Lock m_lock;
     uint32_t m_threadUID { 0 };

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -88,6 +88,12 @@ bool EventTarget::isPaymentRequest() const
     return false;
 }
 
+void EventTarget::prependEventListener(const AtomString& eventType, RefPtr<EventListener>&& listener, AddEventListenerOptionsOrBoolean&& variant)
+{
+    addEventListenerForBindings(eventType, WTF::move(listener), WTF::move(variant));
+    ensureEventTargetData().eventListenerMap.moveLastListenerToFirst(eventType);
+}
+
 bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
 {
 #if ASSERT_ENABLED

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -103,6 +103,7 @@ public:
     void addEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, AddEventListenerOptionsOrBoolean&&);
     using EventListenerOptionsOrBoolean = Variant<EventListenerOptions, bool>;
     void removeEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, EventListenerOptionsOrBoolean&&);
+    void prependEventListener(const AtomString& eventType, RefPtr<EventListener>&&, AddEventListenerOptionsOrBoolean&&);
     ExceptionOr<bool> dispatchEventForBindings(Event&);
 
     virtual bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&);

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -98,6 +98,7 @@
 
 
     // Non-standard
+    [EnabledForWorld=allowAutofill] undefined prependEventListener([AtomString] DOMString type, EventListener? listener, optional (AddEventListenerOptions or boolean) options = false);
     [Replaceable, CustomGetter] readonly attribute Event event;
     boolean find(optional DOMString string, optional boolean caseSensitive = false, optional boolean backwards = false, optional boolean wrap = false, optional boolean wholeWord = false, optional boolean searchInFrames = false, optional boolean showDialog = false);
     [Replaceable] readonly attribute  boolean offscreenBuffering;

--- a/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
@@ -183,6 +183,33 @@ TEST(KeyboardEventTests, UserTextInputEvent)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "input without webkitusertextinput textarea");
 }
 
+TEST(KeyboardEventTests, PrependEventListener)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+
+    __block Vector<RetainPtr<NSString>> alerts;
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
+    delegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
+        alerts.append(message);
+        completionHandler();
+    };
+    webView.get().UIDelegate = delegate.get();
+
+    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
+    configuration.get().allowAutofill = YES;
+    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    NSString *js = @""
+        "window.addEventListener('keydown', (e) => { alert('regular ' + e.key + ' ' + e.customProperty); e.customProperty = 'foo' });"
+        "window.prependEventListener('keydown', (e) => { alert('prepended ' + e.key + ' ' + e.customProperty); e.customProperty = 'bar' });";
+    [webView objectByEvaluatingJavaScript:js inFrame:nil inContentWorld:autofillWorld.get()];
+
+    [webView typeCharacter:'a'];
+    while (alerts.size() < 2u)
+        Util::spinRunLoop();
+    EXPECT_WK_STREQ(alerts[0].get(), "prepended a undefined");
+    EXPECT_WK_STREQ(alerts[1].get(), "regular a bar");
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 826e8cdd9172b1276dacffa02cb01a2307894e8e
<pre>
Add a way to prepend event listeners in autofill content worlds
<a href="https://bugs.webkit.org/show_bug.cgi?id=304652">https://bugs.webkit.org/show_bug.cgi?id=304652</a>
<a href="https://rdar.apple.com/167101754">rdar://167101754</a>

Reviewed by NOBODY (OOPS!).

Safari&apos;s autofill implementation runs some JS that adds event listeners before anything else can.
This adds a way to add an event listener and bump it to the front of the line to be called before
other event listeners.  This should remove the need to run JS as early as we do.
This is limited to autofill content worlds because everyone wants to cut in line, but the normal
worlds&apos; JS needs to play fair like it has.
I initially put the function prependEventListener on DOMWindow because that&apos;s the only place we
currently use it and it seemed less expensive than putting it on EventTarget, which is instantiated
many times per global object.  We may be able to revisit that if needed.

Test: Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm

* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):
* Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h:
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::EventListenerMap::moveLastListenerToFirst):
* Source/WebCore/dom/EventListenerMap.h:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::prependEventListener):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/page/DOMWindow.idl:
* Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm:
(TestWebKitAPI::TEST(KeyboardEventTests, PrependEventListener)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/826e8cdd9172b1276dacffa02cb01a2307894e8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89852 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0aee01f6-7302-47f6-addd-c91e8ef7466b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104668 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76388 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1af1ed77-bac5-4bc3-b7aa-189a6314e18d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b2531c0d-3efc-4ede-8b94-e8b2c411d2e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6911 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4608 "Found 3 new API test failures: TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedAndUntrustedContexts, TestWebKitAPI.PermissionsAPI.GeolocationPermissionGrantedFromPromptAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5203 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147372 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113026 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113355 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6837 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63112 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8970 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36976 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->