### PR TITLE
[GCC] Fix build for Debian 12 after 304713@main

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1574,6 +1574,39 @@ template<typename T, typename U> constexpr auto forward_like(U&& value) -> detai
 template<typename T, typename U> constexpr auto forward_like_preserving_const(U&& value) -> detail::forward_like_preserving_const_impl<T, U> { return static_cast<detail::forward_like_preserving_const_impl<T, U>>(value); }
 } // namespace WTF
 
+#if defined(__GLIBCXX__) && !defined(__cpp_lib_ranges_zip)
+#include <wtf/ZippedRange.h>
+
+namespace std::ranges {
+
+struct _Zip {
+    template<typename... _Ts>
+    requires (sizeof...(_Ts) <= 2)
+    constexpr auto
+    operator() [[nodiscard]] (_Ts&&... __ts) const {
+        if constexpr (!sizeof...(_Ts)) {
+            return views::empty<tuple<>>;
+        } else if constexpr (sizeof...(_Ts) == 1) {
+            return [](auto&& arg1, auto&&...) {
+                return std::forward<decltype(arg1)>(arg1);
+            }(std::forward<_Ts>(__ts)...);
+        } else {
+            return [](auto&& arg1, auto&& arg2, auto&&...) {
+                return zippedRange(std::forward<decltype(arg1)>(arg1), std::forward<decltype(arg2)>(arg2));
+            }(std::forward<_Ts>(__ts)...);
+        }
+    }
+};
+
+namespace views {
+    inline constexpr _Zip zip;
+}
+
+using WTF::zippedRange;
+
+} // namespace std::ranges
+#endif // defined(__GLIBCXX__) && !defined(__cpp_lib_ranges_zip)
+
 using WTF::GB;
 using WTF::KB;
 using WTF::MB;


### PR DESCRIPTION
#### 2a29e8b8f084321c841319c28b11a7adc91206a7
<pre>
[GCC] Fix build for Debian 12 after <a href="https://commits.webkit.org/304713@main">304713@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304348">https://bugs.webkit.org/show_bug.cgi?id=304348</a>

Reviewed by NOBODY (OOPS!).

Changeset <a href="https://commits.webkit.org/304713@main">304713@main</a> made use of function std::views:zip. However,
GCC12 uses a version of libstdc++ which doesn&apos;t implement that function.

Add custom implementation of &apos;std::views::zip&apos; to StdLibExtras.h in case
it&apos;s not defined. This implementation relies on WTF::zippedRange and it
only works with two arguments.

* Source/WTF/wtf/StdLibExtras.h:
(std::ranges::_Zip::nodiscard const):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a29e8b8f084321c841319c28b11a7adc91206a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76394 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85523 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4630 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5226 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128863 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147395 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135388 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113373 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6855 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63148 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36996 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168169 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72559 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43877 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->