### PR TITLE
[AutoFill Debugging] Part 1/2: Add an option to heuristically shorten/redact high-entropy URLs in extracted text

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -1,0 +1,18 @@
+root
+	section
+		link,url='example.com/search','Multiple query parameters'
+		link,url='example.com/path/to/file.html','Path components 1'
+		link,url='example.com/oiiai_cat','Path components 2'
+		link,url='javascript:','JavaScript link'
+		link,url='data:','HTML data URL'
+		link,url='mailto:test@example.com','Email with params'
+		link,url='tel:+1-555-123-4567','Phone number'
+		link,url='blob:','Blob URL'
+		link,url='example.com/docs/guide.html','Path, query, and fragment'
+	section
+		image,src='image',alt='SVG data URL'
+		image,src='image',alt='PNG data URL'
+		image,src='vacation-2024-summer-beach.jpg',alt='Long image path'
+		image,src='thumbnail',alt='Image with query params'
+		image,src='image.gif',alt='Image with high entropy name'
+version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -1,0 +1,64 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.test-section {
+    margin: 20px 0;
+    padding: 10px;
+    border: 1px solid #ccc;
+}
+
+img {
+    width: 50px;
+    height: 50px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<main>
+    <section class="test-section" title="Links">
+        <a href="https://example.com/search?q=webkit&lang=en&filter=recent&sort=relevance&page=1">Multiple query parameters</a>
+        <a href="https://example.com/path/to/file.html">Path components 1</a>
+        <a href="https://example.com/192a2083-6ccc-4508-9b59-6d6f59846dc5/oiiai_cat/19284789123">Path components 2</a>
+        <a href="javascript:alert('Hello World')">JavaScript link</a>
+        <a href="data:text/html;charset=utf-8,%3Ch1%3EHello%3C%2Fh1%3E">HTML data URL</a>
+        <a href="mailto:test@example.com">Email with params</a>
+        <a href="tel:+1-555-123-4567">Phone number</a>
+        <a href="blob:https://example.com/550e8400-e29b-41d4-a716-446655440000">Blob URL</a>
+        <a href="https://example.com/docs/guide.html?version=latest#installation-steps">Path, query, and fragment</a>
+    </section>
+    <section class="test-section" title="Images">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="PNG data URL">
+        <img src="https://cdn.example.com/media/users/12039859134234/uploads/2024/photos/vacation-2024-summer-beach.jpg" alt="Long image path">
+        <img src="https://images.example.com/thumbnail?id=98765&size=large&quality=high&format=webp&cache=false" alt="Image with query params">
+        <img src="https://assets.example.com/61d7035fa8d4.gif" alt="Image with high entropy name">
+    </section>
+</main>
+
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        includeURLs: true,
+        shortenURLs: true,
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2424,6 +2424,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SleepDisablerClient.h
     platform/SleepDisablerIdentifier.h
     platform/StaticPasteboard.h
+    platform/StringEntropyHelpers.h
     platform/StyleAppearance.h
     platform/SuddenTermination.h
     platform/Supplementable.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2317,6 +2317,7 @@ platform/FileMonitor.cpp
 platform/FileStream.cpp
 platform/FixedContainerEdges.cpp
 platform/FrameRateMonitor.cpp
+platform/StringEntropyHelpers.cpp
 platform/KeyboardScroll.cpp
 platform/KeyboardScrollingAnimator.cpp
 platform/LLVMProfiling.cpp

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -114,12 +114,14 @@ struct ScrollableItemData {
 
 struct ImageItemData {
     URL completedSource;
+    String shortenedName;
     String altText;
 };
 
 struct LinkItemData {
     String target;
     URL completedURL;
+    String shortenedURLString;
 };
 
 struct ContentEditableData {

--- a/Source/WebCore/platform/StringEntropyHelpers.cpp
+++ b/Source/WebCore/platform/StringEntropyHelpers.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StringEntropyHelpers.h"
+
+#include <array>
+#include <wtf/text/MakeString.h>
+
+namespace WebCore::StringEntropyHelpers {
+
+enum class Symbol : uint8_t {
+    HexLower = 0,
+    NonHexLower,
+    HexUpper,
+    NonHexUpper,
+    Digit,
+    Dash,
+    Underscore,
+    FullStop,
+    OtherPunctuation,
+    OtherCharacter,
+    NumberOfSymbols // Must stay at the end.
+};
+
+static constexpr size_t numberOfSymbols = static_cast<size_t>(Symbol::NumberOfSymbols);
+
+static Symbol symbol(UChar32 character)
+{
+    if (character >= 'a' && character <= 'f')
+        return Symbol::HexLower;
+
+    if (character >= 'g' && character <= 'z')
+        return Symbol::NonHexLower;
+
+    if (character >= 'A' && character <= 'F')
+        return Symbol::HexUpper;
+
+    if (character >= 'G' && character <= 'Z')
+        return Symbol::NonHexUpper;
+
+    if (character >= '0' && character <= '9')
+        return Symbol::Digit;
+
+    switch (character) {
+    case '-':
+        return Symbol::Dash;
+    case '_':
+        return Symbol::Underscore;
+    case '.':
+        return Symbol::FullStop;
+    case '+':
+    case '=':
+    case '/':
+    case '\\':
+        return Symbol::OtherPunctuation;
+    default:
+        break;
+    }
+
+    return Symbol::OtherCharacter;
+}
+
+static constexpr std::array<uint8_t, numberOfSymbols * numberOfSymbols> quantizedBigramWeights { {
+    153, 214, 100,  97, 116, 180, 199, 179, 119, 121, // HexLower
+    209, 194,  86,  78, 106, 236, 203, 212, 123, 183, // NonHexLower
+    135, 125,  75,  93,  92, 124, 122, 121,  17, 173, // HexUpper
+    138, 100,  89,  80,  53, 145, 122, 117,  75, 114, // NonHexUpper
+    111,  99, 114,  53, 126, 139, 155, 152,  86, 157, // Digit
+    179, 235, 186, 185, 147, 144, 154, 164,  77, 156, // Dash
+    199, 194, 160, 154, 167, 162, 174, 112, 127, 112, // Underscore
+    173, 174, 210, 141, 162, 221, 104, 147, 167, 255, // FullStop
+    134, 153,  66,  72, 128,  88,  50, 127,   0, 114, // OtherPunctuation
+    158, 160, 112,  53, 167, 187, 131, 174, 182, 163, // OtherCharacter
+} };
+
+static double dequantize(uint8_t quantizedWeight)
+{
+    static constexpr double weightScale = 0.0273696267;
+    static constexpr double weightZeroPoint = -4.0833584258;
+    return quantizedWeight * weightScale + weightZeroPoint;
+}
+
+static double bigramWeight(Symbol first, Symbol second)
+{
+    auto tableOffset = numberOfSymbols * static_cast<uint8_t>(first) + static_cast<uint8_t>(second);
+    return dequantize(quantizedBigramWeights[tableOffset]);
+}
+
+static double entropyScore(StringView text)
+{
+    auto textLength = text.length();
+    if (textLength <= 1)
+        return 0;
+
+    double totalWeight = 0;
+    std::optional<Symbol> previousSymbol;
+    for (size_t i = 0; i < textLength; ++i) {
+        auto character = text[i];
+        auto currentSymbol = symbol(character);
+        if (previousSymbol)
+            totalWeight += bigramWeight(*previousSymbol, currentSymbol);
+        previousSymbol = currentSymbol;
+    }
+
+    return totalWeight / textLength;
+}
+
+static bool isProbablyHumanReadable(StringView text, double entropyThreshold = 0)
+{
+    static constexpr auto highEntropyThreshold = 40;
+    static constexpr auto lowEntropyThreshold = 5;
+
+    if (text.length() >= highEntropyThreshold)
+        return false;
+
+    if (text.length() <= lowEntropyThreshold)
+        return true;
+
+    return entropyScore(text) >= entropyThreshold;
+}
+
+String lowEntropyLastPathComponent(const URL& url, const String& fallbackName)
+{
+    if (url.protocolIsData() || url.protocolIsBlob() || url.protocolIsJavaScript())
+        return fallbackName;
+
+    auto component = url.lastPathComponent();
+    if (isProbablyHumanReadable(component))
+        return component.toString();
+
+    auto fullStopIndex = component.reverseFind('.');
+    if (fullStopIndex == notFound)
+        return fallbackName;
+
+    return makeString(fallbackName, component.right(component.length() - fullStopIndex));
+}
+
+URL removeHighEntropyComponents(const URL& url)
+{
+    if (url.protocolIs("mailto"_s) || url.protocolIs("tel"_s))
+        return url;
+
+    if (url.protocolIsData() || url.protocolIsBlob() || url.protocolIsJavaScript()) {
+        URL urlPreservingProtocolOnly;
+        urlPreservingProtocolOnly.setProtocol(url.protocol());
+        return urlPreservingProtocolOnly;
+    }
+
+    auto newURL = url;
+
+    StringBuilder newPath;
+    bool removedAnyPathComponent = false;
+    for (auto component : url.path().split('/')) {
+        if (!isProbablyHumanReadable(component)) {
+            removedAnyPathComponent = true;
+            continue;
+        }
+
+        if (!newPath.isEmpty())
+            newPath.append('/');
+
+        newPath.append(component);
+    }
+
+    if (removedAnyPathComponent)
+        newURL.setPath(newPath.toString());
+
+    newURL.removeQueryAndFragmentIdentifier();
+    return newURL;
+}
+
+} // namespace WebCore::StringEntropyHelpers

--- a/Source/WebCore/platform/StringEntropyHelpers.h
+++ b/Source/WebCore/platform/StringEntropyHelpers.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/URL.h>
+
+namespace WebCore::StringEntropyHelpers {
+
+String lowEntropyLastPathComponent(const URL&, const String& fallbackName);
+URL removeHighEntropyComponents(const URL&);
+
+} // namespace WebCore::StringEntropyHelpers

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -52,6 +52,7 @@ enum class TextExtractionOptionFlag : uint8_t {
     IncludeURLs     = 1 << 0,
     IncludeRects    = 1 << 1,
     OnlyIncludeText = 1 << 2,
+    ShortenURLs     = 1 << 3,
 };
 
 enum class TextExtractionOutputFormat : uint8_t {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6848,6 +6848,7 @@ header: <WebCore/TextExtractionTypes.h>
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::ImageItemData {
     URL completedSource;
+    String shortenedName;
     String altText;
 };
 
@@ -6855,6 +6856,7 @@ header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::LinkItemData {
     String target;
     URL completedURL;
+    String shortenedURLString;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6792,6 +6792,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         includeURLs = configuration.includeURLs,
         includeRects = configuration.includeRects,
         onlyIncludeText = configuration.onlyIncludeVisibleText,
+        shortenURLs = configuration.shortenURLs,
         maxWordsPerParagraph = WTF::move(maxWordsPerParagraph),
         version,
         replacementStrings = extractReplacementStrings(configuration),
@@ -6915,6 +6916,8 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             optionFlags.add(IncludeRects);
         if (onlyIncludeText)
             optionFlags.add(OnlyIncludeText);
+        if (shortenURLs)
+            optionFlags.add(ShortenURLs);
         WebKit::TextExtractionOptions options {
             WTF::move(filterCallbacks),
             [strongSelf _activeNativeMenuItemTitles],

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -148,6 +148,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  */
 @property (nonatomic) _WKTextExtractionFilterOptions filterOptions;
 
+/*!
+ Automatically shorten extracted URLs by removing or replacing parts of each URL.
+ The default value is `NO`.
+ */
+@property (nonatomic) BOOL shortenURLs;
+
 @end
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -168,6 +168,13 @@
     _outputFormat = outputFormat;
 }
 
+- (void)setShortenURLs:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _shortenURLs = value;
+}
+
 #undef ENSURE_VALID_TEXT_ONLY_CONFIGURATION
 
 @end

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -47,6 +47,7 @@ dictionary TextExtractionTestOptions {
     boolean clipToBounds = false;
     boolean includeRects = false;
     boolean includeURLs = false;
+    boolean shortenURLs = false;
     DOMString nodeIdentifierInclusion = "none";
     boolean includeEventListeners = false;
     boolean includeAccessibilityAttributes = false;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -62,6 +62,7 @@ struct TextExtractionTestOptions {
     bool clipToBounds { false };
     bool includeRects { false };
     bool includeURLs { false };
+    bool shortenURLs { false };
     JSRetainPtr<JSStringRef> nodeIdentifierInclusion;
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -74,6 +74,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
     options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
+    options.shortenURLs = booleanProperty(context, (JSObjectRef)argument, "shortenURLs", false);
     options.includeEventListeners = booleanProperty(context, (JSObjectRef)argument, "includeEventListeners", false);
     options.includeAccessibilityAttributes = booleanProperty(context, (JSObjectRef)argument, "includeAccessibilityAttributes", false);
     options.includeTextInAutoFilledControls = booleanProperty(context, (JSObjectRef)argument, "includeTextInAutoFilledControls", false);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -350,6 +350,7 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
     [configuration setIncludeRects:options && options->includeRects];
     [configuration setIncludeURLs:options && options->includeURLs];
+    [configuration setShortenURLs:options && options->shortenURLs];
     [configuration setNodeIdentifierInclusion:^{
         if (!options)
             return _WKTextExtractionNodeIdentifierInclusionNone;


### PR DESCRIPTION
#### a551f89f60b6372833ff3c139223bb6341b6f256
<pre>
[AutoFill Debugging] Part 1/2: Add an option to heuristically shorten/redact high-entropy URLs in extracted text
<a href="https://bugs.webkit.org/show_bug.cgi?id=304653">https://bugs.webkit.org/show_bug.cgi?id=304653</a>
<a href="https://rdar.apple.com/165847831">rdar://165847831</a>

Reviewed by Richard Robinson.

Add support for a flag, `-shortenURLs`, that clients can use to opt into aggressive policy around
shortening link `href` and image `src` when performing text extraction. For links, we discard all
query parameters and fragments, and any path components that are not &quot;low-entropy&quot; (based on the
results of a fast, very lightweight binary classifier — see below). For images, we use the last path
component only if it&apos;s &quot;low-entropy&quot;, and otherwise fall back to &quot;image&quot; (preserving any existing
file extension).

Test: fast/text-extraction/debug-text-extraction-shorten-urls.html

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html: Added.

Add a layout test to exercise this new option.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Use the helpers below to strip out high-entropy path components from extracted URLs, along with any
query parameters and fragment.

* Source/WebCore/platform/StringEntropyHelpers.cpp: Added.
(WebCore::StringEntropyHelpers::symbol):
(WebCore::StringEntropyHelpers::dequantize):
(WebCore::StringEntropyHelpers::bigramWeight):
(WebCore::StringEntropyHelpers::entropyScore):
(WebCore::StringEntropyHelpers::isProbablyHumanReadable):
(WebCore::StringEntropyHelpers::lowEntropyLastPathComponent):
(WebCore::StringEntropyHelpers::removeHighEntropyComponents):

Add the fast path component classifier; see above for more details. Each character is mapped to one
of 10 character symbol types (e.g. uppercase hex, lowercase hex, uppercase non-hex, lowercase non-
hex, digits, etc.); the classifier is a very simple single-layer perceptron that takes (as inputs)
bigrams where each bigram consists of two adjacent symbol types. The 100 weights corresponding to
each bigram are encoded in a tiny lookup table, where each weight is quantized to a single byte
(`uint8_t`).

* Source/WebCore/platform/StringEntropyHelpers.h: Added.
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::centerEllipsize):
(WebKit::TextExtractionAggregator::shortenURLs const):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
(WebKit::normalizedURLString): Deleted.

Honor the `shortenURLs` flag by using the shortened versions of link hrefs and image sources.

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration setShortenURLs:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):

Add plumbing from `UIHelper` -&gt; `WebKitTestRunner`, for the new `shortenURLs` flag.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/304927@main">https://commits.webkit.org/304927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287cd56346b594592bf2a007bfa26547531d35fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89890 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c107181-5095-4455-8ef2-82f013ac7376) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85533 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/52f6c7f3-2925-46d8-ab98-92df89eae9e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4644 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147411 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8960 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41425 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/worker-performance.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113053 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6867 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63177 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37009 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8729 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->