### PR TITLE
[UsedStyle] Extract transform related computation from RenderStyle

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3172,6 +3172,7 @@ style/StyleResolver.cpp
 style/StyleScope.cpp
 style/StyleScopeRuleSets.cpp
 style/StyleSheetContentsCache.cpp
+style/StyleTransformResolver.cpp
 style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp
 style/Styleable.cpp

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -77,6 +77,7 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "StyleSingleAnimationRange.h"
+#include "StyleTransformResolver.h"
 #include "StyleWillChange.h"
 #include "StyledElement.h"
 #include "TimelineRangeOffset.h"
@@ -2529,8 +2530,7 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
     auto addStyleToCumulativeBounds = [&](const RenderStyle& style) {
         auto keyframeBounds = bounds;
 
-        TransformationMatrix transform;
-        style.applyTransform(transform, transformOperationData);
+        auto transform = Style::TransformResolver::computeTransform(style, transformOperationData);
         if (!transform.isAffine())
             return false;
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -38,6 +38,7 @@
 #include "StyleOffsetDistance.h"
 #include "StyleOffsetPath.h"
 #include "StyleOffsetPosition.h"
+#include "StyleTransformResolver.h"
 #include "TransformOperationData.h"
 
 namespace WebCore {
@@ -121,7 +122,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
 
     if (!style.offsetPath().isNone() && transformOperationData) {
         if (auto path = Style::tryPath(style.offsetPath(), *transformOperationData)) {
-            transformOrigin = { .value = style.computeTransformOrigin(transformOperationData->boundingBox).xy() };
+            transformOrigin = { .value = Style::TransformResolver::computeTransformOrigin(style, transformOperationData->boundingBox).xy() };
             offsetPath = Style::toPlatform(style.offsetPath());
             offsetDistance = Style::evaluate<AcceleratedEffectOffsetDistance>(style.offsetDistance(), path->length(), Style::ZoomNeeded { });
             offsetRotate = Style::evaluate<AcceleratedEffectOffsetRotate>(style.offsetRotate());

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -180,42 +180,6 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     matrix.translate(-shiftToOrigin.width(), -shiftToOrigin.height());
 }
 
-void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const TransformOperationData& transformData, const RenderStyle& style)
-{
-    auto offsetPath = Style::tryPath(style.offsetPath(), transformData);
-    if (!offsetPath)
-        return;
-
-    auto boundingBox = transformData.boundingBox;
-
-    auto transformOrigin = style.computeTransformOrigin(boundingBox).xy();
-    auto transformBox = style.transformBox();
-
-    auto offsetDistance = Style::evaluate<float>(style.offsetDistance(), offsetPath->length(), Style::ZoomNeeded { });
-    auto offsetAnchor = WTF::switchOn(style.offsetAnchor(),
-        [&](const Style::Position& position) -> std::optional<FloatPoint> {
-            return Style::evaluate<FloatPoint>(position, boundingBox.size(), Style::ZoomNeeded { });
-        },
-        [&](const CSS::Keyword::Auto&) -> std::optional<FloatPoint> {
-            return { };
-        }
-    );
-    auto offsetRotate = style.offsetRotate().angle().value;
-    auto offsetRotateHasAuto = style.offsetRotate().hasAuto();
-
-    applyMotionPathTransform(
-        matrix,
-        transformData,
-        transformOrigin,
-        transformBox,
-        *offsetPath,
-        offsetAnchor,
-        offsetDistance,
-        offsetRotate,
-        offsetRotateHasAuto
-    );
-}
-
 bool MotionPath::needsUpdateAfterContainingBlockLayout(const Style::OffsetPath& offsetPath)
 {
     return WTF::holdsAlternative<Style::RayPath>(offsetPath)

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -50,7 +50,6 @@ public:
     static bool needsUpdateAfterContainingBlockLayout(const Style::OffsetPath&);
 
     static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, FloatPoint transformOrigin, TransformBox, const Path&, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto);
-    static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, const RenderStyle&);
 
     static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&);
     static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -99,6 +99,7 @@
 #include "StyleBoxShadow.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleTransformResolver.h"
 #include "TransformOperationData.h"
 #include "TransformState.h"
 #include <algorithm>
@@ -703,9 +704,9 @@ void RenderBox::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
     quads.append(localToAbsoluteQuad(localRect, UseTransforms, wasFixed));
 }
 
-void RenderBox::applyTransform(TransformationMatrix& t, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderBox::applyTransform(TransformationMatrix& t, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
-    style.applyTransform(t, TransformOperationData(boundingBox, this), options);
+    Style::TransformResolver::applyTransform(t, style, TransformOperationData(boundingBox, this), options);
 }
 
 void RenderBox::constrainLogicalMinMaxSizesByAspectRatio(LayoutUnit& computedMinSize, LayoutUnit& computedMaxSize, LayoutUnit computedSize, MinimumSizeIsAutomaticContentBased minimumSizeType, ConstrainDimension dimension) const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -181,7 +181,7 @@ public:
     void addOverflowFromContainedBox(const RenderBox& child, OptionSet<ComputeOverflowOptions> = { });
     void addOverflowFromFloatBox(const FloatingObject&);
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const override;
 
     inline LayoutSize contentBoxSize() const;
     inline LayoutUnit contentBoxWidth() const;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -1017,7 +1017,7 @@ void RenderBoxModelObject::collectAbsoluteQuadsForContinuation(Vector<FloatQuad>
     }
 }
 
-void RenderBoxModelObject::applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect&, OptionSet<RenderStyle::TransformOperationOption>) const
+void RenderBoxModelObject::applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect&, OptionSet<Style::TransformResolverOption>) const
 {
     // applyTransform() is only used through RenderLayer*, which only invokes this for RenderBox derived renderers, thus not for
     // RenderInline/RenderLineBreak - the other two renderers that inherit from RenderBoxModelObject.

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -211,7 +211,7 @@ public:
 
     bool hasRunningAcceleratedAnimations() const;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const override;
 
 protected:
     RenderBoxModelObject(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -69,6 +69,10 @@ void outputLayerPositionTreeRecursive(TextStream&, const WebCore::RenderLayer&, 
 
 namespace WebCore {
 
+namespace Style {
+enum class TransformResolverOption : uint8_t;
+}
+
 class ClipRects;
 class ClipRectsCache;
 class HitTestRequest;
@@ -807,11 +811,11 @@ public:
     // Note that this transform has the transform-origin baked in.
     TransformationMatrix* transform() const { return m_transform.get(); }
     // updateTransformFromStyle computes a transform according to the passed options (e.g. transform-origin baked in or excluded) and the given style.
-    void updateTransformFromStyle(TransformationMatrix&, const RenderStyle&, OptionSet<RenderStyle::TransformOperationOption>) const;
+    void updateTransformFromStyle(TransformationMatrix&, const RenderStyle&, OptionSet<Style::TransformResolverOption>) const;
     // currentTransform computes a transform which takes accelerated animations into account. The
     // resulting transform has transform-origin baked in, unless non-default options are given. If
     // the layer does not have a transform, the identity matrix is returned.
-    TransformationMatrix currentTransform(OptionSet<RenderStyle::TransformOperationOption>) const;
+    TransformationMatrix currentTransform(OptionSet<Style::TransformResolverOption>) const;
     TransformationMatrix currentTransform() const;
     TransformationMatrix renderableTransform(OptionSet<PaintBehavior>) const;
     

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -92,6 +92,7 @@
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
 #include "StyleResolver.h"
+#include "StyleTransformResolver.h"
 #include "Styleable.h"
 #include "TiledBacking.h"
 #include "ViewTransition.h"
@@ -738,7 +739,7 @@ void RenderLayerBacking::updateTransform(const RenderStyle& style)
             }
         }
     } else if (m_owningLayer.isTransformed())
-        m_owningLayer.updateTransformFromStyle(t, style, RenderStyle::individualTransformOperations());
+        m_owningLayer.updateTransformFromStyle(t, style, Style::TransformResolver::individualTransformOperations);
     
     if (m_contentsContainmentLayer) {
         m_contentsContainmentLayer->setTransform(t);
@@ -4305,7 +4306,7 @@ bool RenderLayerBacking::getCurrentTransform(const GraphicsLayer* graphicsLayer,
         return false;
 
     if (m_owningLayer.isTransformed()) {
-        transform = m_owningLayer.currentTransform(RenderStyle::individualTransformOperations());
+        transform = m_owningLayer.currentTransform(Style::TransformResolver::individualTransformOperations);
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -42,6 +42,7 @@ class SVGGraphicsElement;
 
 namespace Style {
 struct SVGMarkerResource;
+enum class TransformResolverOption : uint8_t;
 }
 
 class RenderLayerModelObject : public RenderElement {
@@ -94,7 +95,7 @@ public:
     // This lives in RenderLayerModelObject, which is the common base-class for all SVG renderers.
     void mapLocalToSVGContainer(const RenderLayerModelObject* ancestorContainer, TransformState&, OptionSet<MapCoordinatesMode>, bool* wasFixed) const;
 
-    void applySVGTransform(TransformationMatrix&, const SVGGraphicsElement&, const RenderStyle&, const FloatRect& boundingBox, const std::optional<AffineTransform>& preApplySVGTransformMatrix, const std::optional<AffineTransform>& postApplySVGTransformMatrix, OptionSet<RenderStyle::TransformOperationOption>) const;
+    void applySVGTransform(TransformationMatrix&, const SVGGraphicsElement&, const RenderStyle&, const FloatRect& boundingBox, const std::optional<AffineTransform>& preApplySVGTransformMatrix, const std::optional<AffineTransform>& postApplySVGTransformMatrix, OptionSet<Style::TransformResolverOption>) const;
     void updateHasSVGTransformFlags();
     virtual bool needsHasSVGTransformFlags() const { ASSERT_NOT_REACHED(); return false; }
 
@@ -124,7 +125,7 @@ public:
     TransformationMatrix* layerTransform() const;
 
     virtual void updateLayerTransform();
-    virtual void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const = 0;
+    virtual void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const = 0;
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
     inline bool shouldUsePositionedClipping() const;

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -33,18 +33,6 @@
 
 namespace WebCore {
 
-// MARK: Transforms
-
-constexpr auto RenderStyle::allTransformOperations() -> OptionSet<TransformOperationOption>
-{
-    return { TransformOperationOption::TransformOrigin, TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset };
-}
-
-constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption>
-{
-    return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset };
-}
-
 // MARK: - Comparisons
 
 inline bool RenderStyle::operator==(const RenderStyle& other) const

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -77,6 +77,11 @@ inline void RenderStyle::copyPseudoElementBitsFrom(const RenderStyle& other)
 
 // MARK: - Style adjustment utilities
 
+inline void RenderStyle::setPageScaleTransform(float scale)
+{
+    m_computedStyle.setPageScaleTransform(scale);
+}
+
 inline void RenderStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMode)
 {
     m_computedStyle.setColumnStylesFromPaginationMode(paginationMode);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -88,7 +88,8 @@ public:
 
     // MARK: - Style adjustment utilities
 
-    void setColumnStylesFromPaginationMode(PaginationMode);
+    inline void setPageScaleTransform(float);
+    inline void setColumnStylesFromPaginationMode(PaginationMode);
     inline void addToTextDecorationLineInEffect(Style::TextDecorationLine);
     inline void containIntrinsicWidthAddAuto();
     inline void containIntrinsicHeightAddAuto();
@@ -350,41 +351,12 @@ public:
     static constexpr bool preserveNewline(WhiteSpaceCollapse);
     static constexpr bool collapseWhiteSpace(WhiteSpaceCollapse);
 
-    // MARK: - Transforms
-
     // Return true if any transform related property (currently transform, translate, scale, rotate, transformStyle3D or perspective)
     // indicates that we are transforming. The usedTransformStyle3D is not used here because in many cases (such as for deciding
     // whether or not to establish a containing block), the computed value is what matters.
     inline bool hasTransformRelatedProperty() const;
     inline bool preserves3D() const;
     inline bool affectsTransform() const;
-
-    enum class TransformOperationOption : uint8_t {
-        TransformOrigin = 1 << 0,
-        Translate       = 1 << 1,
-        Rotate          = 1 << 2,
-        Scale           = 1 << 3,
-        Offset          = 1 << 4
-    };
-
-    static constexpr OptionSet<TransformOperationOption> allTransformOperations();
-    static constexpr OptionSet<TransformOperationOption> individualTransformOperations();
-
-    bool affectedByTransformOrigin() const;
-
-    FloatPoint computePerspectiveOrigin(const FloatRect& boundingBox) const;
-    void applyPerspective(TransformationMatrix&, const FloatPoint& originTranslate) const;
-
-    FloatPoint3D computeTransformOrigin(const FloatRect& boundingBox) const;
-    void applyTransformOrigin(TransformationMatrix&, const FloatPoint3D& originTranslate) const;
-    void unapplyTransformOrigin(TransformationMatrix&, const FloatPoint3D& originTranslate) const;
-
-    // applyTransform calls applyTransformOrigin(), then applyCSSTransform(), followed by unapplyTransformOrigin().
-    void applyTransform(TransformationMatrix&, const TransformOperationData& boundingBox) const;
-    void applyTransform(TransformationMatrix&, const TransformOperationData& boundingBox, OptionSet<TransformOperationOption>) const;
-    void applyCSSTransform(TransformationMatrix&, const TransformOperationData& boundingBox) const;
-    void applyCSSTransform(TransformationMatrix&, const TransformOperationData& boundingBox, OptionSet<TransformOperationOption>) const;
-    void setPageScaleTransform(float);
 
     // MARK: - Colors
 

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -130,7 +130,7 @@ void RenderSVGForeignObject::updateFromStyle()
         setHasNonVisibleOverflow();
 }
 
-void RenderSVGForeignObject::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGForeignObject::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     applySVGTransform(transform, protectedForeignObjectElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -65,7 +65,7 @@ private:
     // fixed position content uses the <fO> as ancestor layer (when computing offsets from the container).
     bool needsHasSVGTransformFlags() const final { return true; }
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
 
     FloatRect m_viewport;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -52,7 +52,7 @@ private:
 
 protected:
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation&, const LayoutPoint&, HitTestAction) final { return false; }
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect&, OptionSet<RenderStyle::TransformOperationOption>) const override { }
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect&, OptionSet<Style::TransformResolverOption>) const override { }
     void updateFromStyle() override { }
     bool needsHasSVGTransformFlags() const override { return false; }
 };

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -420,7 +420,7 @@ bool RenderSVGImage::needsHasSVGTransformFlags() const
     return protectedImageElement()->hasTransformRelatedAttributes();
 }
 
-void RenderSVGImage::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGImage::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     applySVGTransform(transform, protectedImageElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -76,7 +76,7 @@ private:
 
     bool needsHasSVGTransformFlags() const final;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
 
     CachedImage* cachedImage() const { return imageResource().cachedImage(); }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -47,6 +47,7 @@
 #include "SVGNames.h"
 #include "SVGPathData.h"
 #include "SVGUseElement.h"
+#include "StyleTransformResolver.h"
 #include "TransformState.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -276,11 +277,11 @@ bool RenderSVGModelObject::applyCachedClipAndScrollPosition(RepaintRects& rects,
 Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
 {
     if (layer()->isTransformed())
-        transform.multiply(layer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
+        transform.multiply(layer()->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
 
     if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protectedElement())) {
         if (CheckedPtr clipChildRenderer = useElement->rendererClipChild())
-            transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
+            transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
         if (RefPtr clipChild = useElement->clipChild())
             return pathFromGraphicsElement(*clipChild);
     }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -238,7 +238,7 @@ void RenderSVGResourceClipper::updateFromStyle()
     updateHasSVGTransformFlags();
 }
 
-void RenderSVGResourceClipper::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGResourceClipper::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
     applySVGTransform(transform, protectedClipPathElement(), style, boundingBox, std::nullopt, std::nullopt, options);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -48,7 +48,7 @@ public:
 
     inline SVGUnitTypes::SVGUnitType clipPathUnits() const;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -62,7 +62,7 @@ private:
 
     FloatRect computeViewport() const;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     LayoutRect overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const final;
     void updateLayerTransform() final;
     bool needsHasSVGTransformFlags() const final { return true; }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -422,7 +422,7 @@ bool RenderSVGShape::needsHasSVGTransformFlags() const
     return protectedGraphicsElement()->hasTransformRelatedAttributes();
 }
 
-void RenderSVGShape::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGShape::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     applySVGTransform(transform, protectedGraphicsElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -96,7 +96,7 @@ public:
 
     bool needsHasSVGTransformFlags() const final;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
 
     AffineTransform nonScalingStrokeTransform() const;
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -770,7 +770,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
     return false;
 }
 
-void RenderSVGText::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGText::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
     applySVGTransform(transform, protectedTextElement(), style, boundingBox, std::nullopt, std::nullopt, options);

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -90,7 +90,7 @@ private:
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     bool hitTestInlineChildren(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 
     bool requiresLayer() const override;

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -38,6 +38,7 @@
 #include "SVGRootInlineBox.h"
 #include "SVGTextPathElement.h"
 #include "Settings.h"
+#include "StyleTransformResolver.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -79,7 +80,7 @@ Path RenderSVGTextPath::layoutPath() const
     if (element->renderer() && document().settings().layerBasedSVGEngineEnabled()) {
         auto& renderer = downcast<RenderSVGShape>(*element->renderer());
         if (auto* layer = renderer.layer()) {
-            const auto& layerTransform = layer->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform();
+            const auto& layerTransform = layer->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform();
             if (!layerTransform.isIdentity())
                 path.transform(layerTransform);
             return path;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -95,7 +95,7 @@ void RenderSVGTransformableContainer::updateLayerTransform()
     RenderSVGContainer::updateLayerTransform();
 }
 
-void RenderSVGTransformableContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGTransformableContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     auto postTransform = m_supplementalLayerTransform.isIdentity() ? std::nullopt : std::make_optional(m_supplementalLayerTransform);
     applySVGTransform(transform, protectedGraphicsElement(), style, boundingBox, std::nullopt, postTransform, options);

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -42,7 +42,7 @@ private:
     Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
     FloatSize additionalContainerTranslation() const;
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     void updateLayerTransform() final;
     bool needsHasSVGTransformFlags() const final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -159,7 +159,7 @@ void RenderSVGViewportContainer::updateLayerTransform()
     RenderSVGContainer::updateLayerTransform();
 }
 
-void RenderSVGViewportContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+void RenderSVGViewportContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     applySVGTransform(transform, protectedSVGSVGElement(), style, boundingBox, m_supplementalLayerTransform.isIdentity() ? std::nullopt : std::make_optional(m_supplementalLayerTransform), std::nullopt, options);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -57,7 +57,7 @@ private:
     FloatPoint computeViewportLocation() const;
     FloatSize computeViewportSize() const;
 
-    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     LayoutRect overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const final;
     void updateLayerTransform() final;
     bool needsHasSVGTransformFlags() const final;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -73,6 +73,7 @@
 #include "StylePropertyShorthand.h"
 #include "StylePropertyShorthandFunctions.h"
 #include "StyleTransformFunction.h"
+#include "StyleTransformResolver.h"
 #include "WebAnimationUtilities.h"
 
 namespace WebCore {
@@ -2171,11 +2172,8 @@ inline Ref<CSSValue> ExtractorCustom::extractTransform(ExtractorState& state)
     if (!state.style.hasTransform())
         return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
-    if (state.renderer) {
-        TransformationMatrix transform;
-        state.style.applyTransform(transform, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { });
-        return CSSTransformListValue::create(createCSSValue(state.pool, state.style, transform));
-    }
+    if (state.renderer)
+        return CSSTransformListValue::create(createCSSValue(state.pool, state.style, TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { })));
 
     // https://w3c.github.io/csswg-drafts/css-transforms-1/#serialization-of-the-computed-value
     // If we don't have a renderer, then the value should be "none" if we're asking for the
@@ -2194,9 +2192,7 @@ inline void ExtractorCustom::extractTransformSerialization(ExtractorState& state
     }
 
     if (state.renderer) {
-        TransformationMatrix transform;
-        state.style.applyTransform(transform, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { });
-        serializationForCSS(builder, context, state.style, transform);
+        serializationForCSS(builder, context, state.style, TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { }));
         return;
     }
 

--- a/Source/WebCore/style/StyleTransformResolver.cpp
+++ b/Source/WebCore/style/StyleTransformResolver.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleTransformResolver.h"
+
+#include "FloatPoint.h"
+#include "FloatPoint3D.h"
+#include "FloatRect.h"
+#include "MotionPath.h"
+#include "RenderStyle.h"
+#include "StyleComputedStyle+GettersInlines.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "TransformOperationData.h"
+#include "TransformationMatrix.h"
+
+namespace WebCore {
+namespace Style {
+
+TransformResolver::TransformResolver(TransformationMatrix& transform, const ComputedStyle& style)
+    : m_transform { transform }
+    , m_style { style }
+{
+}
+
+TransformResolver::TransformResolver(TransformationMatrix& transform, const RenderStyle& style)
+    : TransformResolver { transform, style.computedStyle() }
+{
+}
+
+bool TransformResolver::affectedByTransformOrigin(const ComputedStyle& style)
+{
+    return style.rotate().affectedByTransformOrigin()
+        || style.scale().affectedByTransformOrigin()
+        || style.transform().affectedByTransformOrigin()
+        || style.offsetPath().affectedByTransformOrigin();
+}
+
+bool TransformResolver::affectedByTransformOrigin(const RenderStyle& style)
+{
+    CheckedRef computedStyle = style.computedStyle();
+    return affectedByTransformOrigin(computedStyle);
+}
+
+bool TransformResolver::affectedByTransformOrigin() const
+{
+    return affectedByTransformOrigin(m_style);
+}
+
+FloatPoint3D TransformResolver::computeTransformOrigin(const ComputedStyle& style, const FloatRect& boundingBox)
+{
+    FloatPoint3D originTranslate;
+    originTranslate.setXY(boundingBox.location() + evaluate<FloatPoint>(style.transformOrigin().xy(), boundingBox.size(), ZoomNeeded { }));
+    originTranslate.setZ(style.transformOriginZ().resolveZoom(ZoomNeeded { }));
+    return originTranslate;
+}
+
+FloatPoint3D TransformResolver::computeTransformOrigin(const RenderStyle& style, const FloatRect& boundingBox)
+{
+    CheckedRef computedStyle = style.computedStyle();
+    return computeTransformOrigin(computedStyle, boundingBox);
+}
+
+FloatPoint3D TransformResolver::computeTransformOrigin(const FloatRect& boundingBox) const
+{
+    return computeTransformOrigin(m_style, boundingBox);
+}
+
+FloatPoint TransformResolver::computePerspectiveOrigin(const ComputedStyle& style, const FloatRect& boundingBox)
+{
+    return boundingBox.location() + evaluate<FloatPoint>(style.perspectiveOrigin(), boundingBox.size(), ZoomNeeded { });
+}
+
+FloatPoint TransformResolver::computePerspectiveOrigin(const RenderStyle& style, const FloatRect& boundingBox)
+{
+    CheckedRef computedStyle = style.computedStyle();
+    return computePerspectiveOrigin(computedStyle, boundingBox);
+}
+
+FloatPoint TransformResolver::computePerspectiveOrigin(const FloatRect& boundingBox) const
+{
+    return computePerspectiveOrigin(m_style, boundingBox);
+}
+
+void TransformResolver::applyPerspective(const FloatPoint& originTranslate)
+{
+    // https://www.w3.org/TR/css-transforms-2/#perspective
+    // The perspective matrix is computed as follows:
+    // 1. Start with the identity matrix.
+
+    // 2. Translate by the computed X and Y values of perspective-origin
+    m_transform.translate(originTranslate.x(), originTranslate.y());
+
+    // 3. Multiply by the matrix that would be obtained from the perspective() transform function, where the length is provided by the value of the perspective property
+    m_transform.applyPerspective(m_style->perspective().usedPerspective());
+
+    // 4. Translate by the negated computed X and Y values of perspective-origin
+    m_transform.translate(-originTranslate.x(), -originTranslate.y());
+}
+
+void TransformResolver::applyTransformOrigin(const FloatPoint3D& originTranslate)
+{
+    if (!originTranslate.isZero())
+        m_transform.translate3d(originTranslate.x(), originTranslate.y(), originTranslate.z());
+}
+
+void TransformResolver::unapplyTransformOrigin(const FloatPoint3D& originTranslate)
+{
+    if (!originTranslate.isZero())
+        m_transform.translate3d(-originTranslate.x(), -originTranslate.y(), -originTranslate.z());
+}
+
+void TransformResolver::applyCSSTransform(const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    // https://www.w3.org/TR/css-transforms-2/#ctm
+    // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and offset properties as follows:
+    // 1. Start with the identity matrix.
+
+    // 2. Translate by the computed X, Y, and Z values of transform-origin.
+    // (implemented in applyTransformOrigin)
+    auto& boundingBox = transformData.boundingBox;
+
+    // 3. Translate by the computed X, Y, and Z values of translate.
+    if (options.contains(Option::Translate))
+        m_style->translate().apply(m_transform, boundingBox.size());
+
+    // 4. Rotate by the computed <angle> about the specified axis of rotate.
+    if (options.contains(Option::Rotate))
+        m_style->rotate().apply(m_transform, boundingBox.size());
+
+    // 5. Scale by the computed X, Y, and Z values of scale.
+    if (options.contains(Option::Scale))
+        m_style->scale().apply(m_transform, boundingBox.size());
+
+    // 6. Translate and rotate by the transform specified by offset.
+    if (options.contains(Option::Offset))
+        applyMotionPathTransform(transformData);
+
+    // 7. Multiply by each of the transform functions in transform from left to right.
+    m_style->transform().apply(m_transform, boundingBox.size());
+
+    // 8. Translate by the negated computed X, Y and Z values of transform-origin.
+    // (implemented in unapplyTransformOrigin)
+}
+
+void TransformResolver::applyTransform(const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    if (!options.contains(Option::TransformOrigin) || !affectedByTransformOrigin()) {
+        applyCSSTransform(transformData, options);
+        return;
+    }
+
+    auto originTranslate = computeTransformOrigin(transformData.boundingBox);
+    applyTransformOrigin(originTranslate);
+    applyCSSTransform(transformData, options);
+    unapplyTransformOrigin(originTranslate);
+}
+
+void TransformResolver::applyTransform(TransformationMatrix& transform, const ComputedStyle& style, const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    TransformResolver { transform, style }.applyTransform(transformData, options);
+}
+
+void TransformResolver::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    CheckedRef computedStyle = style.computedStyle();
+    applyTransform(transform, computedStyle, transformData, options);
+}
+
+TransformationMatrix TransformResolver::computeTransform(const ComputedStyle& style, const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    TransformationMatrix transform;
+    TransformResolver::applyTransform(transform, style, transformData, options);
+    return transform;
+}
+
+TransformationMatrix TransformResolver::computeTransform(const RenderStyle& style, const TransformOperationData& transformData, OptionSet<Option> options)
+{
+    CheckedRef computedStyle = style.computedStyle();
+    return computeTransform(computedStyle, transformData, options);
+}
+
+void TransformResolver::applyMotionPathTransform(const TransformOperationData& transformData)
+{
+    auto offsetPath = tryPath(m_style->offsetPath(), transformData);
+    if (!offsetPath)
+        return;
+
+    auto& boundingBox = transformData.boundingBox;
+
+    auto transformOrigin = computeTransformOrigin(boundingBox).xy();
+    auto transformBox = m_style->transformBox();
+
+    auto offsetDistance = evaluate<float>(m_style->offsetDistance(), offsetPath->length(), ZoomNeeded { });
+    auto offsetAnchor = WTF::switchOn(m_style->offsetAnchor(),
+        [&](const Position& position) -> std::optional<FloatPoint> {
+            return evaluate<FloatPoint>(position, boundingBox.size(), ZoomNeeded { });
+        },
+        [&](const CSS::Keyword::Auto&) -> std::optional<FloatPoint> {
+            return { };
+        }
+    );
+    auto offsetRotate = m_style->offsetRotate().angle().value;
+    auto offsetRotateHasAuto = m_style->offsetRotate().hasAuto();
+
+    MotionPath::applyMotionPathTransform(
+        m_transform,
+        transformData,
+        transformOrigin,
+        transformBox,
+        *offsetPath,
+        offsetAnchor,
+        offsetDistance,
+        offsetRotate,
+        offsetRotateHasAuto
+    );
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleTransformResolver.h
+++ b/Source/WebCore/style/StyleTransformResolver.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleComputedStyle.h"
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+
+class FloatPoint;
+class FloatPoint3D;
+class FloatRect;
+class TransformationMatrix;
+struct TransformOperationData;
+
+namespace Style {
+
+enum class TransformResolverOption : uint8_t {
+    TransformOrigin = 1 << 0,
+    Translate       = 1 << 1,
+    Rotate          = 1 << 2,
+    Scale           = 1 << 3,
+    Offset          = 1 << 4
+};
+
+class TransformResolver {
+public:
+    using Option = TransformResolverOption;
+
+    static constexpr OptionSet allTransformOperations { Option::TransformOrigin, Option::Translate, Option::Rotate, Option::Scale, Option::Offset };
+    static constexpr OptionSet individualTransformOperations { Option::Translate, Option::Rotate, Option::Scale, Option::Offset };
+
+    explicit TransformResolver(TransformationMatrix&, const RenderStyle&);
+    explicit TransformResolver(TransformationMatrix&, const ComputedStyle&);
+
+    static bool affectedByTransformOrigin(const RenderStyle&);
+    static bool affectedByTransformOrigin(const ComputedStyle&);
+    bool affectedByTransformOrigin() const;
+
+    static FloatPoint3D computeTransformOrigin(const RenderStyle&, const FloatRect& boundingBox);
+    static FloatPoint3D computeTransformOrigin(const ComputedStyle&, const FloatRect& boundingBox);
+    FloatPoint3D computeTransformOrigin(const FloatRect& boundingBox) const;
+
+    static FloatPoint computePerspectiveOrigin(const RenderStyle&, const FloatRect& boundingBox);
+    static FloatPoint computePerspectiveOrigin(const ComputedStyle&, const FloatRect& boundingBox);
+    FloatPoint computePerspectiveOrigin(const FloatRect& boundingBox) const;
+
+    void applyPerspective(const FloatPoint& originTranslate);
+
+    void applyTransformOrigin(const FloatPoint3D& originTranslate);
+    void unapplyTransformOrigin(const FloatPoint3D& originTranslate);
+
+    void applyCSSTransform(const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+
+    // `applyTransform`/`computedTransform` perform the following operations in order:
+    //    1. applyTransformOrigin()
+    //    2. applyCSSTransform()
+    //    3. unapplyTransformOrigin()
+
+    void applyTransform(const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+
+    static void applyTransform(TransformationMatrix&, const ComputedStyle&, const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+    static void applyTransform(TransformationMatrix&, const RenderStyle&, const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+
+    static TransformationMatrix computeTransform(const ComputedStyle&, const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+    static TransformationMatrix computeTransform(const RenderStyle&, const TransformOperationData&, OptionSet<Option> = allTransformOperations);
+
+private:
+    void applyMotionPathTransform(const TransformOperationData&);
+
+    TransformationMatrix& m_transform;
+    const CheckedRef<const ComputedStyle> m_style;
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -316,6 +316,16 @@ float ComputedStyle::computeLineHeight(const LineHeight& lineHeight) const
     );
 }
 
+void ComputedStyle::setPageScaleTransform(float scale)
+{
+    if (scale == 1)
+        return;
+
+    setTransform(Style::Transform { Style::TransformFunction { Style::ScaleTransformFunction::create(scale, scale, Style::TransformFunctionType::Scale) } });
+    setTransformOriginX(0_css_px);
+    setTransformOriginY(0_css_px);
+}
+
 void ComputedStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMode)
 {
     if (paginationMode == Pagination::Mode::Unpaginated)

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -61,6 +61,7 @@ public:
 
     // MARK: - Style adjustment utilities
 
+    void setPageScaleTransform(float);
     void setColumnStylesFromPaginationMode(PaginationMode);
     inline void addToTextDecorationLineInEffect(TextDecorationLine);
     inline void containIntrinsicWidthAddAuto();

--- a/Source/WebCore/style/values/motion/StyleOffsetPath.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPath.h
@@ -59,6 +59,8 @@ struct OffsetPath {
     std::optional<BasicShapePath> tryBasicShape() const;
     std::optional<BoxPath> tryBox() const;
 
+    bool affectedByTransformOrigin() const { return !isNone(); }
+
     template<typename> bool holdsAlternative() const;
     template<typename... F> decltype(auto) switchOn(F&&...) const;
 


### PR DESCRIPTION
#### 7fe27ed4c75e1140faf75a67d82e578fe7a77949
<pre>
[UsedStyle] Extract transform related computation from RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=304656">https://bugs.webkit.org/show_bug.cgi?id=304656</a>

Reviewed by Alan Baradlay.

Extracts the transform related functions from `RenderStyle` into
a new class, `Style::TransformResolver`.

`Style::TransformResolver` has static functions that directly
parallel the functions from RenderStyle (except they take the
style as a parameter), but can also be instantiated with a
style and TransformationMatrix reference, and then used to
apply multiple operations, simplifying some callers.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/rendering/MotionPath.cpp:
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleTransformResolver.cpp: Added.
* Source/WebCore/style/StyleTransformResolver.h: Added.
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/values/motion/StyleOffsetPath.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:

Canonical link: <a href="https://commits.webkit.org/304938@main">https://commits.webkit.org/304938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c3877c0843549547f397ccd7a521ef4f1db31f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4649 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113057 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113387 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6871 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9013 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37013 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72579 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->