### PR TITLE
Enable downcasting of all EventTarget classes

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -188,4 +188,6 @@ private:
     bool m_waitingForDeviceLostPromise { false };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(GPUDevice)

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -175,6 +175,8 @@ private:
     unsigned m_version;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ApplePaySession)
 
 #endif

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -115,3 +116,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(Clipboard)

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -31,6 +31,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/EventTarget.h>
+#include <WebCore/EventTargetInterfaces.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -84,5 +85,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(DOMAudioSession)
 
 #endif // ENABLE(DOM_AUDIO_SESSION)

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -29,6 +29,7 @@
 #include "CookieChangeListener.h"
 #include "CookieJar.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -99,4 +100,6 @@ private:
     HashMap<uint64_t, Ref<DeferredPromise>> m_promises;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(CookieStore)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -155,4 +155,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaKeySession)
+
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -114,6 +114,8 @@ private:
     Timer m_addKeyTimer;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebKitMediaKeySession)
 
 #endif // ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -145,3 +145,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(IDBDatabase)

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.h
@@ -78,6 +78,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IDBOpenDBRequest)
-    static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.eventTargetInterface() == WebCore::EventTargetInterfaceType::IDBOpenDBRequest; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(IDBOpenDBRequest)

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -218,6 +218,4 @@ WebCoreOpaqueRoot root(IDBRequest*);
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IDBRequest)
-    static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.eventTargetInterface() == WebCore::EventTargetInterfaceType::IDBRequest; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(IDBRequest)

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -320,3 +320,5 @@ inline bool IDBTransaction::isFinishedOrFinishing() const
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(IDBTransaction)

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -152,4 +152,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaRecorder)
+
 #endif // ENABLE(MEDIA_RECORDER)

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -121,6 +121,8 @@ private:
     std::optional<PlaySessionCommand> m_currentPlaySessionCommand;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaSessionCoordinator)
 
 #endif // ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -44,13 +44,16 @@ public:
 
     static bool isTypeSupported(ScriptExecutionContext&, const String& type);
 
-    bool streaming() const override { return m_streaming; }
+    bool streaming() const final { return m_streaming; }
     bool streamingAllowed() const { return m_streamingAllowed; }
 
     bool isManaged() const final { return true; }
 
 private:
     ManagedMediaSource(ScriptExecutionContext&, MediaSourceInit&&);
+
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ManagedMediaSource; }
+
     void monitorSourceBuffers() final;
     void elementDetached() final;
     void setStreaming(bool);
@@ -66,8 +69,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ManagedMediaSource)
-    static bool isType(const WebCore::MediaSource& mediaSource) { return mediaSource.isManaged(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ManagedMediaSource)
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h
@@ -43,12 +43,12 @@ public:
 
 private:
     ManagedSourceBuffer(Ref<SourceBufferPrivate>&&, ManagedMediaSource&);
+
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ManagedSourceBuffer; }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ManagedSourceBuffer)
-    static bool isType(const WebCore::SourceBuffer& buffer) { return buffer.isManaged(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ManagedSourceBuffer)
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -34,6 +34,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaPlayer.h"
 #include "MediaPromiseTypes.h"
 #include "MediaSourceInit.h"
@@ -211,7 +212,7 @@ private:
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    enum EventTargetInterfaceType eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
 
     // URLRegistrable.
     URLRegistry& registry() const final;
@@ -285,6 +286,7 @@ struct LogArgument<WebCore::MediaSource::ReadyState> {
 } // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaSource)
+    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::EventTargetInterfaceType::MediaSource; }
     static bool isType(const WebCore::URLRegistrable& registrable) { return registrable.registrableType() == WebCore::URLRegistrable::RegistrableType::MediaSource; }
 SPECIALIZE_TYPE_TRAITS_END()
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -190,7 +190,7 @@ private:
     void videoTrackSelectedChanged(VideoTrack&) final;
 
     // EventTarget
-    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SourceBuffer; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::SourceBuffer; }
 
     bool isRemoved() const;
     void scheduleEvent(const AtomString& eventName);
@@ -280,5 +280,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(SourceBuffer)
 
 #endif

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -90,4 +90,6 @@ WebCoreOpaqueRoot root(SourceBufferList*);
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(SourceBufferList)
+
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -148,4 +148,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaDevices)
+
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -169,4 +169,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaStream)
+
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -251,4 +251,6 @@ typedef Vector<Ref<MediaStreamTrack>> MediaStreamTrackVector;
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaStreamTrack)
+
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -87,4 +87,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCDTMFSender)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -142,4 +142,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCDataChannel)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -84,4 +84,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCDtlsTransport)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -99,4 +99,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCIceTransport)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -300,4 +300,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCPeerConnection)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -108,4 +108,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCRtpSFrameTransform)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -81,4 +81,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RTCSctpTransport)
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -183,4 +183,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(Notification)
+
 #endif // ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -136,4 +136,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(PaymentResponse)
+
 #endif // ENABLE(PAYMENT_REQUEST)

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -75,3 +75,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(PermissionStatus)

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -69,4 +69,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(PictureInPictureWindow)
+
 #endif // ENABLE(PICTURE_IN_PICTURE_API)

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -121,7 +121,9 @@ private:
     bool m_available { false };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(RemotePlayback)
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
 

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -75,3 +75,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WakeLockSentinel)

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -111,3 +111,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(SpeechRecognition)

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -138,4 +138,6 @@ template<> struct EnumTraits<WebCore::SpeechSynthesis::BehaviorRestrictionFlags>
 
 } // namespace WTF
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(SpeechSynthesis)
+
 #endif // ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -30,6 +30,7 @@
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/EventTarget.h>
+#include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/PlatformSpeechSynthesisUtterance.h>
 #include <WebCore/SpeechSynthesisErrorCode.h>
 #include <WebCore/SpeechSynthesisVoice.h>
@@ -130,6 +131,10 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SpeechSynthesisUtterance)
+    static bool isType(const WebCore::EventTarget& context)
+    {
+        return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::SpeechSynthesisUtterance;
+    }
     static bool isType(const WebCore::PlatformSpeechSynthesisUtteranceClient& client)
     {
         return client.isSpeechSynthesisUtterance();

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -28,6 +28,7 @@
 #include "ChannelCountMode.h"
 #include "ChannelInterpretation.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -319,6 +320,8 @@ template<> struct LogArgument<WebCore::AudioNode::NodeType> {
 };
 
 } // namespace WTF
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(AudioNode)
 
 #define SPECIALIZE_TYPE_TRAITS_AUDIONODE(ToValueTypeName, NodeTypeName) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -31,6 +31,7 @@
 #include "AudioDestinationNode.h"
 #include "AudioIOCallback.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "NoiseInjectionPolicy.h"
 #include "OscillatorType.h"
@@ -320,13 +321,13 @@ private:
 
     class TailProcessingNode {
     public:
-        TailProcessingNode(AudioNode& node)
+        explicit TailProcessingNode(AudioNode& node)
             : m_node(&node)
         {
             ASSERT(!node.isTailProcessing());
             node.setIsTailProcessing(true);
         }
-        TailProcessingNode(TailProcessingNode&& other)
+        explicit TailProcessingNode(TailProcessingNode&& other)
             : m_node(std::exchange(other.m_node, nullptr))
         { }
         ~TailProcessingNode()
@@ -396,5 +397,7 @@ private:
 };
 
 } // WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(BaseAudioContext)
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -92,6 +92,8 @@ private:
     size_t m_decoderCount { 0 };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsAudioDecoder)
 
 #endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -95,6 +95,8 @@ private:
     size_t m_encoderCount { 0 };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsAudioEncoder)
 
 #endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -90,6 +90,8 @@ private:
     size_t m_decoderCount { 0 };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsVideoDecoder)
 
 #endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -98,6 +98,8 @@ private:
     size_t m_encoderCount { 0 };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsVideoEncoder)
 
 #endif

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -32,6 +32,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "WebSocketChannelClient.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
@@ -149,3 +150,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebSocket)

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -73,4 +73,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebXRLayer)
+
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -200,4 +200,6 @@ WebCoreOpaqueRoot root(WebXRSession*);
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebXRSession)
+
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -108,6 +108,8 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebXRSpace)
+
 #define SPECIALIZE_TYPE_TRAITS_WEBXRSPACE(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
     static bool isType(const WebCore::WebXRSpace& context) { return context.predicate; } \

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -98,7 +98,7 @@ protected:
     void stop() override;
 
 private:
-    WebXRSystem(Navigator&);
+    explicit WebXRSystem(Navigator&);
 
     using FeatureList = PlatformXR::Device::FeatureList;
     using JSFeatureList = Vector<JSC::JSValue>;
@@ -161,5 +161,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebXRSystem)
 
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,3 @@
-EventTargetFactory.cpp
 HTMLNames.cpp
 MathMLNames.cpp
 Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -277,6 +277,8 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebAnimation)
+
 #define SPECIALIZE_TYPE_TRAITS_WEB_ANIMATION(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
 static bool isType(const WebCore::WebAnimation& value) { return value.predicate; } \

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -90,7 +90,7 @@ private:
         ~PendingPromise();
 
     private:
-        PendingPromise(LoadPromise&&);
+        explicit PendingPromise(LoadPromise&&);
 
     public:
         Vector<Ref<FontFace>> faces;
@@ -123,4 +123,6 @@ private:
     bool m_isDocumentLoaded { true };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(FontFaceSet)

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -81,4 +81,6 @@ private:
     bool m_needsNotification { false };
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaQueryList)

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -84,7 +84,7 @@ public:
 
 private:
     enum class Aborted : bool { No, Yes };
-    explicit AbortSignal(ScriptExecutionContext*, Aborted = Aborted::No, JSC::JSValue reason = JSC::jsUndefined());
+    AbortSignal(ScriptExecutionContext*, Aborted = Aborted::No, JSC::JSValue reason = JSC::jsUndefined());
 
     void setHasActiveTimeoutTimer(bool hasActiveTimeoutTimer) { m_hasActiveTimeoutTimer = hasActiveTimeoutTimer; }
 
@@ -118,3 +118,5 @@ private:
 WebCoreOpaqueRoot root(AbortSignal*);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(AbortSignal)

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -93,3 +93,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(BroadcastChannel)

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -214,3 +214,8 @@ inline void EventTarget::setEventTargetFlag(EventTargetFlag flag, bool value)
 }
 
 } // namespace WebCore
+
+#define SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ClassName) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ClassName) \
+    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::EventTargetInterfaceType::ClassName; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -101,7 +101,7 @@ public:
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);
 
 private:
-    explicit MessagePort(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
+    MessagePort(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
@@ -126,3 +126,5 @@ private:
 WebCoreOpaqueRoot root(MessagePort*);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MessagePort)

--- a/Source/WebCore/dom/make_event_factory.pl
+++ b/Source/WebCore/dom/make_event_factory.pl
@@ -136,7 +136,7 @@ sub generateImplementation()
             print F "        return createWrapper<$interfaceName$suffix>(globalObject, WTF::move(impl));\n";
         } else {
             print F "    case ${namespace}InterfaceType::${interfaceName}:\n";
-            print F "        return toJS(state, globalObject, static_cast<$interfaceName&>(impl));\n";
+            print F "        return toJS(state, globalObject, downcast<$interfaceName>(impl));\n";
         }
         print F "#endif\n" if $conditional;
     }

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -117,3 +117,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(FileReader)

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -34,7 +34,6 @@
 #include <atomic>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/HashSet.h>
-#include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -195,8 +194,3 @@ inline const CSSParserContext& CanvasBase::cssParserContext() const
 }
 
 } // namespace WebCore
-
-#define SPECIALIZE_TYPE_TRAITS_CANVAS(ToValueTypeName, predicate) \
-SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
-static bool isType(const WebCore::CanvasBase& canvas) { return canvas.predicate; } \
-SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -82,5 +82,8 @@ private:
     mutable RefPtr<Image> m_copiedImage;
 };
 
-}
-SPECIALIZE_TYPE_TRAITS_CANVAS(WebCore::CustomPaintCanvas, isCustomPaintCanvas())
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CustomPaintCanvas)
+    static bool isType(const WebCore::CanvasBase& base) { return base.isCustomPaintCanvas(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -162,4 +162,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(MediaController)
+
 #endif

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -180,6 +180,9 @@ private:
 
 }
 
-SPECIALIZE_TYPE_TRAITS_CANVAS(WebCore::OffscreenCanvas, isOffscreenCanvas())
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::OffscreenCanvas)
+    static bool isType(const WebCore::CanvasBase& base) { return base.isOffscreenCanvas(); }
+    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::EventTargetInterfaceType::OffscreenCanvas; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -84,3 +84,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(CloseWatcher)

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 AudioTrackList::AudioTrackList(ScriptExecutionContext* context)
-    : TrackListBase(context, TrackListBase::VideoTrackList)
+    : TrackListBase(context)
 {
 }
 

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "EventTargetInterfaces.h"
 #include "TrackListBase.h"
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class AudioTrackList final : public TrackListBase {
 public:
     static Ref<AudioTrackList> create(ScriptExecutionContext* context)
     {
-        auto list = adoptRef(*new AudioTrackList(context));
+        Ref list = adoptRef(*new AudioTrackList(context));
         list->suspendIfNeeded();
         return list;
     }
@@ -54,17 +55,15 @@ public:
     void remove(TrackBase&, bool scheduleEvent = true) final;
 
     // EventTarget
-    enum EventTargetInterfaceType eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
 private:
-    AudioTrackList(ScriptExecutionContext*);
+    explicit AudioTrackList(ScriptExecutionContext*);
 };
 static_assert(sizeof(AudioTrackList) == sizeof(TrackListBase));
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioTrackList)
-    static bool isType(const WebCore::TrackListBase& trackList) { return trackList.type() == WebCore::TrackListBase::AudioTrackList; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(AudioTrackList)
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -255,6 +255,7 @@ template<> struct HashTraits<WebCore::TextTrack::Kind> : StrongEnumHashTraits<We
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TextTrack)
     static bool isType(const WebCore::TrackBase& track) { return track.type() == WebCore::TrackBase::TextTrack; }
+    static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::TextTrack; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -192,6 +192,8 @@ template<> struct LogArgument<WebCore::TextTrackCue> {
     static String toString(const WebCore::TextTrackCue& cue) { return cue.toJSONString(); }
 };
 
-}
+} // namespace WTF
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(TextTrackCue)
 
 #endif

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include <WebCore/Color.h>
+#include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/VTTCue.h>
 
 namespace WebCore {
@@ -89,10 +90,11 @@ namespace WTF {
 
 template<> struct LogArgument<WebCore::TextTrackCueGeneric> : LogArgument<WebCore::TextTrackCue> { };
 
-}
+} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TextTrackCueGeneric)
 static bool isType(const WebCore::TextTrackCue& cue) { return cue.cueType() == WebCore::TextTrackCue::ConvertedToWebVTT; }
+static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::TextTrackCue; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextTrackList);
 
 TextTrackList::TextTrackList(ScriptExecutionContext* context)
-    : TrackListBase(context, TrackListBase::TextTrackList)
+    : TrackListBase(context)
 {
 }
 

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "EventTargetInterfaces.h"
 #include "TrackListBase.h"
 #include <wtf/MediaTime.h>
 
@@ -39,17 +40,17 @@ class TextTrackList final : public TrackListBase {
 public:
     static Ref<TextTrackList> create(ScriptExecutionContext* context)
     {
-        auto list = adoptRef(*new TextTrackList(context));
+        Ref list = adoptRef(*new TextTrackList(context));
         list->suspendIfNeeded();
         return list;
     }
     virtual ~TextTrackList();
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
-    unsigned length() const override;
+    unsigned length() const final;
     int getTrackIndex(TextTrack&);
     int getTrackIndexRelativeToRenderedTracks(TextTrack&);
-    bool contains(TrackBase&) const override;
+    bool contains(TrackBase&) const final;
 
     TextTrack* item(unsigned index) const;
     RefPtr<TextTrack> getTrackById(const AtomString&) const;
@@ -57,16 +58,16 @@ public:
     TextTrack* lastItem() const { return item(length() - 1); }
 
     void append(Ref<TextTrack>&&);
-    void remove(TrackBase&, bool scheduleEvent = true) override;
+    void remove(TrackBase&, bool scheduleEvent = true) final;
 
     void setDuration(MediaTime duration) { m_duration = duration; }
     const MediaTime& duration() const { return m_duration; }
 
     // EventTarget
-    enum EventTargetInterfaceType eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
 private:
-    TextTrackList(ScriptExecutionContext*);
+    explicit TextTrackList(ScriptExecutionContext*);
 
     void invalidateTrackIndexesAfterTrack(TextTrack&);
 
@@ -77,8 +78,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TextTrackList)
-    static bool isType(const WebCore::TrackListBase& trackList) { return trackList.type() == WebCore::TrackListBase::TextTrackList; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(TextTrackList)
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -39,9 +39,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TrackListBase);
 
-TrackListBase::TrackListBase(ScriptExecutionContext* context, Type type)
+TrackListBase::TrackListBase(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
-    , m_type(type)
 {
 }
 

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -50,9 +50,6 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    enum Type { BaseTrackList, TextTrackList, AudioTrackList, VideoTrackList };
-    Type type() const { return m_type; }
-
     virtual unsigned length() const;
     virtual bool contains(TrackBase&) const;
     virtual bool contains(TrackID) const;
@@ -78,7 +75,7 @@ public:
     bool isAnyTrackEnabled() const;
 
 protected:
-    TrackListBase(ScriptExecutionContext*, Type);
+    explicit TrackListBase(ScriptExecutionContext*);
 
     void scheduleAddTrackEvent(Ref<TrackBase>&&);
     void scheduleRemoveTrackEvent(Ref<TrackBase>&&);
@@ -92,7 +89,6 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    Type m_type;
     WeakPtr<OpaqueRootObserver> m_opaqueRootObserver;
     bool m_isChangeEventScheduled { false };
 };

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 VideoTrackList::VideoTrackList(ScriptExecutionContext* context)
-    : TrackListBase(context, TrackListBase::VideoTrackList)
+    : TrackListBase(context)
 {
 }
 

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "EventTargetInterfaces.h"
 #include "TrackListBase.h"
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class VideoTrackList final : public TrackListBase {
 public:
     static Ref<VideoTrackList> create(ScriptExecutionContext* context)
     {
-        auto list = adoptRef(*new VideoTrackList(context));
+        Ref list = adoptRef(*new VideoTrackList(context));
         list->suspendIfNeeded();
         return list;
     }
@@ -54,17 +55,15 @@ public:
     void append(Ref<VideoTrack>&&);
 
     // EventTarget
-    enum EventTargetInterfaceType eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
 private:
-    VideoTrackList(ScriptExecutionContext*);
+    explicit VideoTrackList(ScriptExecutionContext*);
 };
 static_assert(sizeof(VideoTrackList) == sizeof(TrackListBase));
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::VideoTrackList)
-    static bool isType(const WebCore::TrackListBase& trackList) { return trackList.type() == WebCore::TrackListBase::VideoTrackList; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(VideoTrackList)
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -254,6 +254,4 @@ WebCoreOpaqueRoot root(DOMWindow*);
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DOMWindow)
-    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::EventTargetInterfaceType::DOMWindow; }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(DOMWindow)

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -151,3 +151,5 @@ inline EventSource::State EventSource::readyState() const
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(EventSource)

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindowProperty.h"
 #include "NavigateEvent.h"
@@ -291,3 +292,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(Navigation)

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "EventHandler.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "HistoryItem.h"
 #include "ReferrerPolicy.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -103,3 +104,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(NavigationHistoryEntry)

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -188,4 +188,6 @@ private:
     ListHashSet<RefPtr<PerformanceObserver>> m_observers;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(Performance)

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -88,3 +88,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ScreenOrientation)

--- a/Source/WebCore/page/VisualViewport.h
+++ b/Source/WebCore/page/VisualViewport.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "LocalDOMWindowProperty.h"
 #include <wtf/RefCounted.h>
 
@@ -72,3 +73,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(VisualViewport)

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -114,7 +114,13 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DedicatedWorkerGlobalScope)
+    static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::DedicatedWorkerGlobalScope; }
     static bool isType(const WebCore::ScriptExecutionContext& context)
+    {
+        auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
+        return global && global->type() == WebCore::WorkerGlobalScope::Type::DedicatedWorker;
+    }
+    static bool isType(const WebCore::WorkerOrWorkletGlobalScope& context)
     {
         auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
         return global && global->type() == WebCore::WorkerGlobalScope::Type::DedicatedWorker;

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -125,3 +125,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(Worker)

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ScriptExecutionContext.h"
 #include "ServiceWorkerData.h"
 #include <JavaScriptCore/Strong.h>
@@ -100,3 +101,5 @@ inline ServiceWorker* ScriptExecutionContext::serviceWorker(ServiceWorkerIdentif
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ServiceWorker)

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -183,3 +183,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ServiceWorkerContainer)

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CookieStore.h"
+#include "EventTargetInterfaces.h"
 #include "FetchIdentifier.h"
 #include "NotificationClient.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -171,7 +172,13 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ServiceWorkerGlobalScope)
+    static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::ServiceWorkerGlobalScope; }
     static bool isType(const WebCore::ScriptExecutionContext& context)
+    {
+        auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
+        return global && global->type() == WebCore::WorkerGlobalScope::Type::ServiceWorker;
+    }
+    static bool isType(const WebCore::WorkerOrWorkletGlobalScope& context)
     {
         auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
         return global && global->type() == WebCore::WorkerGlobalScope::Type::ServiceWorker;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "CookieStoreManager.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "Notification.h"
 #include "NotificationOptions.h"
@@ -144,3 +145,5 @@ private:
 WebCoreOpaqueRoot root(ServiceWorkerRegistration*);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(ServiceWorkerRegistration)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -90,3 +90,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(BackgroundFetchRegistration)

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -27,6 +27,7 @@
 
 #include "AbstractWorker.h"
 #include "ActiveDOMObject.h"
+#include "EventTargetInterfaces.h"
 #include "SharedWorkerKey.h"
 #include "SharedWorkerObjectIdentifier.h"
 #include "URLKeepingBlobAlive.h"
@@ -93,3 +94,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(SharedWorker)

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -61,7 +61,13 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SharedWorkerGlobalScope)
+static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::SharedWorkerGlobalScope; }
 static bool isType(const WebCore::ScriptExecutionContext& context)
+{
+    auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
+    return global && global->type() == WebCore::WorkerGlobalScope::Type::SharedWorker;
+}
+static bool isType(const WebCore::WorkerOrWorkletGlobalScope& context)
 {
     auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
     return global && global->type() == WebCore::WorkerGlobalScope::Type::SharedWorker;

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -130,4 +130,6 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkletGlobalScope)
 static bool isType(const WebCore::ScriptExecutionContext& context) { return context.isWorkletGlobalScope(); }
+static bool isType(const WebCore::WorkerOrWorkletGlobalScope& context) { return context.isWorkletGlobalScope(); }
+static bool isType(const WebCore::EventTarget& context) { return context.eventTargetInterface() == WebCore::EventTargetInterfaceType::WorkletGlobalScope; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -268,3 +268,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(XMLHttpRequest)

--- a/Source/WebCore/xml/XMLHttpRequestUpload.h
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.h
@@ -60,3 +60,5 @@ private:
 WebCoreOpaqueRoot root(XMLHttpRequestUpload*);
     
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENTTARGET(XMLHttpRequestUpload)


### PR DESCRIPTION
#### 68cbd8d90a9e0d62e096f607de2fd636f0dd9fb5
<pre>
Enable downcasting of all EventTarget classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304670">https://bugs.webkit.org/show_bug.cgi?id=304670</a>

Reviewed by Simon Fraser.

This is a fairly mechanical change, but there are a couple noteworthy
aspects:

- TrackListBase derived classes already supported downcasting, but this
  was not being used and it was incorrect for AudioTrackList as that
  advertised itself as a VideoTrackList. This change removes all that
  infrastructure.
- SPECIALIZE_TYPE_TRAITS_CANVAS is removed as it remained only useful
  for CustomPaintCanvas.
- ManagedMediaSource and ManagedSourceBuffer did not implement
  eventTargetInterface(), but they do appear in EventTargetFactory.in.
  So patch adds eventTargetInterface() to them.

See also <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304922@main">https://commits.webkit.org/304922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d5d15f21bc89a41cb70d2cdf34de8969e23e91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89876 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b81238b-3755-4ee7-a44e-2498f6aff16a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104686 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b57796b7-08b9-4345-b6c7-0d2fbc809fbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c59d453f-0e09-4d2e-a99d-29ccb060cbd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4629 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5227 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113370 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6856 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63149 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21101 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8994 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36997 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->