### PR TITLE
Synthesize preserveAspectRatio='none' for SVGs embedded in <img> without viewBox

### DIFF
--- a/LayoutTests/svg/as-image/svg-image-aspect-ration-par-none-expected.html
+++ b/LayoutTests/svg/as-image/svg-image-aspect-ration-par-none-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+img, svg {
+  border: 5px solid red;
+}
+</style>
+<body>
+<img style="width: 200px; height: 500px;" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='500'><rect fill='lime' width='200' height='500'/></svg>">
+<img style="width: 500px; height: 200px;" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='500' height='200'><rect fill='lime' width='500' height='200'/></svg>">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+<rect fill="lime" width="100" height="50"/>
+</svg>
+</body>

--- a/LayoutTests/svg/as-image/svg-image-aspect-ration-par-none.html
+++ b/LayoutTests/svg/as-image/svg-image-aspect-ration-par-none.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+img, svg {
+    border: 5px solid red;
+}
+</style>
+<body>
+    <img style="width: 200px; height: 500px;" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='50' preserveAspectRatio='xMidYMid meet'><rect fill='lime' width='100' height='50'/></svg>">
+    <img style="width: 500px; height: 200px;" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='50' preserveAspectRatio='xMidYMid meet'><rect fill='lime' width='100' height='50'/></svg>">
+    <svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+        <rect fill="lime" width="100" height="50"/>
+    </svg>
+</body>


### PR DESCRIPTION
#### 2f7f2a11688698603f8ef12421efd6e3ace72685
<pre>
Synthesize preserveAspectRatio=&apos;none&apos; for SVGs embedded in &lt;img&gt; without viewBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=304669">https://bugs.webkit.org/show_bug.cgi?id=304669</a>
<a href="https://rdar.apple.com/167121931">rdar://167121931</a>

Reviewed by Nikolas Zimmermann.

When an SVG is embedded through SVGImage (e.g., in an &lt;img&gt; tag) and has
fixed width/height attributes but no explicit viewBox, WebKit synthesizes
a viewBox matching the SVG&apos;s intrinsic dimensions. However, this alone
causes the SVG to preserve its aspect ratio and center within the &lt;img&gt;
container, which differs from Chrome and Firefox behavior.

Chrome and Firefox stretch the SVG to fill the container dimensions in
these cases, matching the behavior of raster images. To align with this
behavior and meet author expectations, we now also synthesize
preserveAspectRatio=&apos;none&apos; when a viewBox is synthesized for an embedded
SVG. This allows the SVG content to stretch to fill the &lt;img&gt; container,
consistent with other browsers and the expected behavior for replaced
elements.

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::isEmbeddedThroughSVGImage):
(WebCore::SVGSVGElement::currentViewBoxRect const):
(WebCore::SVGSVGElement::viewBoxToViewTransform const):
* LayoutTests/svg/as-image/svg-image-aspect-ration-par-none.html: Added.
* LayoutTests/svg/as-image/svg-image-aspect-ration-par-none-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/305043@main">https://commits.webkit.org/305043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99725c56be7952fa73b642bf37d64f02a3fc8f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4dadc043-c1ec-49ac-8c5f-0a1e2df35c5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a464d8e-142b-4a54-ad9a-40ea4371fe1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85646 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28afcbd4-eea1-41d2-b1b5-cf0b02aff839) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4780 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5396 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147563 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9107 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113165 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6999 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9155 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37138 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9096 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8948 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->