### PR TITLE
Reduce unsafeness in MathMLRowElement

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -48,7 +48,6 @@ inspector/agents/InspectorCSSAgent.cpp
 layout/layouttree/LayoutIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
-mathml/MathMLRowElement.cpp
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -88,7 +88,8 @@ private:
 
 inline bool Node::hasTagName(const MathMLQualifiedName& name) const
 {
-    return isMathMLElement() && downcast<MathMLElement>(*this).hasTagName(name);
+    auto* element = dynamicDowncast<MathMLElement>(*this);
+    return element && element->hasTagName(name);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -46,6 +46,7 @@ using namespace MathMLOperatorDictionary;
 MathMLOperatorElement::MathMLOperatorElement(const QualifiedName& tagName, Document& document)
     : MathMLTokenElement(tagName, document)
 {
+    ASSERT(hasTagName(MathMLNames::moTag));
 }
 
 Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& tagName, Document& document)
@@ -270,10 +271,9 @@ void MathMLOperatorElement::attributeChanged(const QualifiedName& name, const At
 
 RenderPtr<RenderElement> MathMLOperatorElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    ASSERT(hasTagName(MathMLNames::moTag));
     return createRenderer<RenderMathMLOperator>(RenderObject::Type::MathMLOperator, *this, WTF::move(style));
 }
 
-}
+} // namespace WebCore
 
 #endif // ENABLE(MATHML)

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -36,7 +36,7 @@ class MathMLOperatorElement final : public MathMLTokenElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLOperatorElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLOperatorElement);
 public:
-    static Ref<MathMLOperatorElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLOperatorElement> create(const QualifiedName&, Document&);
     struct OperatorChar {
         char32_t character { 0 };
         bool isVertical { true };
@@ -54,7 +54,7 @@ public:
     const Length& maxSize();
 
 private:
-    MathMLOperatorElement(const QualifiedName& tagName, Document&);
+    MathMLOperatorElement(const QualifiedName&, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void childrenChanged(const ChildChange&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
@@ -78,6 +78,6 @@ private:
     std::optional<Length> m_maxSize;
 };
 
-}
+} // namespace WebCore
 
 #endif // ENABLE(MATHML)

--- a/Source/WebCore/mathml/MathMLRowElement.cpp
+++ b/Source/WebCore/mathml/MathMLRowElement.cpp
@@ -59,8 +59,8 @@ void MathMLRowElement::childrenChanged(const ChildChange& change)
     // FIXME: Avoid this invalidation for valid MathMLFractionElement/MathMLScriptsElement.
     // See https://bugs.webkit.org/show_bug.cgi?id=276828.
     for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
-        if (child->hasTagName(moTag))
-            static_cast<MathMLOperatorElement*>(child.get())->setOperatorFormDirty();
+        if (auto* mo = dynamicDowncast<MathMLOperatorElement>(child.get()))
+            mo->setOperatorFormDirty();
     }
 
     MathMLPresentationElement::childrenChanged(change);


### PR DESCRIPTION
#### b43f2f0c38c341a46456becfddb8f616717e4446
<pre>
Reduce unsafeness in MathMLRowElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=304672">https://bugs.webkit.org/show_bug.cgi?id=304672</a>

Reviewed by Rob Buis.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> and
address a couple of minor nits in surrounding code.

Canonical link: <a href="https://commits.webkit.org/304933@main">https://commits.webkit.org/304933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f393730f3babb0c72daada48ccbd7806e468e432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89877 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b18dcdb-1617-419f-88e4-8012b04c9de7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b66df10d-87ec-47e8-ab3e-6acccf78f540) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8738cbe-bae4-4c8d-b40f-f88d8d073423) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4631 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113371 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6854 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63150 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21105 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8995 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36998 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->