### PR TITLE
Enable downcasting of WaveShaperDSPKernel

### DIFF
--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -51,6 +51,8 @@ public:
     void lazyInitializeOversampling();
 
 private:
+    bool isWaveShaperDSPKernel() const final { return true; }
+
     // Apply the shaping curve.
     void processCurve(std::span<const float> source, std::span<float> destination);
 
@@ -73,3 +75,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WaveShaperDSPKernel)
+    static bool isType(const WebCore::AudioDSPKernel& kernel) { return kernel.isWaveShaperDSPKernel(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -73,7 +73,7 @@ void WaveShaperProcessor::setOversampleForBindings(OverSampleType oversample)
         return;
 
     for (auto& audioDSPKernel : m_kernels)
-        static_cast<WaveShaperDSPKernel&>(*audioDSPKernel).lazyInitializeOversampling();
+        downcast<WaveShaperDSPKernel>(*audioDSPKernel).lazyInitializeOversampling();
 }
 
 void WaveShaperProcessor::process(const AudioBus& source, AudioBus& destination, size_t framesToProcess)
@@ -98,7 +98,7 @@ void WaveShaperProcessor::process(const AudioBus& source, AudioBus& destination,
 
     // For each channel of our input, process using the corresponding WaveShaperDSPKernel into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
+        downcast<WaveShaperDSPKernel>(*m_kernels[i]).process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -8,7 +8,6 @@ Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
-Modules/webaudio/WaveShaperProcessor.cpp
 SVGNames.cpp
 TagName.cpp
 bindings/js/DOMGCOutputConstraint.cpp

--- a/Source/WebCore/platform/audio/AudioDSPKernel.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernel.h
@@ -43,13 +43,13 @@ class AudioDSPKernel {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioDSPKernel);
     WTF_MAKE_NONCOPYABLE(AudioDSPKernel);
 public:
-    AudioDSPKernel(AudioDSPKernelProcessor* kernelProcessor)
+    explicit AudioDSPKernel(AudioDSPKernelProcessor* kernelProcessor)
         : m_kernelProcessor(kernelProcessor)
         , m_sampleRate(kernelProcessor->sampleRate())
     {
     }
 
-    AudioDSPKernel(float sampleRate)
+    explicit AudioDSPKernel(float sampleRate)
         : m_sampleRate(sampleRate)
     {
     }
@@ -73,6 +73,8 @@ public:
     virtual double tailTime() const = 0;
     virtual double latencyTime() const = 0;
     virtual bool requiresTailProcessing() const = 0;
+
+    virtual bool isWaveShaperDSPKernel() const { return false; }
 
 protected:
     CheckedPtr<AudioDSPKernelProcessor> m_kernelProcessor;


### PR DESCRIPTION
#### 511e5834a602a28e21bd54f2d0b5e158aba123b1
<pre>
Enable downcasting of WaveShaperDSPKernel
<a href="https://bugs.webkit.org/show_bug.cgi?id=304673">https://bugs.webkit.org/show_bug.cgi?id=304673</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304973@main">https://commits.webkit.org/304973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7717a20cff3f01b32aea65d38a03ed9942161132

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80417d0d-8c57-479a-9b43-ab0371be560b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f30f0f6-da53-4e0d-a078-3ae791b7cb5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/42104609-0130-4806-9318-163345d63c5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6929 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4628 "Found 1 new API test failure: TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5224 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147393 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6853 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63140 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8991 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36994 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->