### PR TITLE
[AutoFill Debugging] Part 2/2: Deduplicate shortened URLs and report replacements to the client

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -1,6 +1,7 @@
 root
 	section
 		link,url='example.com/search','Multiple query parameters'
+		link,url='example.com/search2','Multiple query parameter 2'
 		link,url='example.com/path/to/file.html','Path components 1'
 		link,url='example.com/oiiai_cat','Path components 2'
 		link,url='javascript:','JavaScript link'
@@ -9,10 +10,15 @@ root
 		link,url='tel:+1-555-123-4567','Phone number'
 		link,url='blob:','Blob URL'
 		link,url='example.com/docs/guide.html','Path, query, and fragment'
+		link,url='example.com/docs/guide2.html','Query parameter'
+		link,url='example.com/docs/guide2.html','Query parameter (duplicate)'
 	section
 		image,src='image',alt='SVG data URL'
-		image,src='image',alt='PNG data URL'
+		image,src='image2',alt='PNG data URL'
 		image,src='vacation-2024-summer-beach.jpg',alt='Long image path'
-		image,src='thumbnail',alt='Image with query params'
+		image,src='thumbnail.png',alt='Image with path'
+		image,src='thumbnail2.png',alt='Image with query params'
 		image,src='image.gif',alt='Image with high entropy name'
+		image,src='image2.gif',alt='Image with high entropy name 2'
+		image,src='image2.gif',alt='Image with high entropy name (duplicate)'
 version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -26,6 +26,7 @@ img {
 <main>
     <section class="test-section" title="Links">
         <a href="https://example.com/search?q=webkit&lang=en&filter=recent&sort=relevance&page=1">Multiple query parameters</a>
+        <a href="https://example.com/search?q=html&lang=en&client=safari">Multiple query parameter 2</a>
         <a href="https://example.com/path/to/file.html">Path components 1</a>
         <a href="https://example.com/192a2083-6ccc-4508-9b59-6d6f59846dc5/oiiai_cat/19284789123">Path components 2</a>
         <a href="javascript:alert('Hello World')">JavaScript link</a>
@@ -34,13 +35,18 @@ img {
         <a href="tel:+1-555-123-4567">Phone number</a>
         <a href="blob:https://example.com/550e8400-e29b-41d4-a716-446655440000">Blob URL</a>
         <a href="https://example.com/docs/guide.html?version=latest#installation-steps">Path, query, and fragment</a>
+        <a href="https://example.com/docs/guide.html?version=2025">Query parameter</a>
+        <a href="https://example.com/docs/guide.html?version=2025">Query parameter (duplicate)</a>
     </section>
     <section class="test-section" title="Images">
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">
         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="PNG data URL">
         <img src="https://cdn.example.com/media/users/12039859134234/uploads/2024/photos/vacation-2024-summer-beach.jpg" alt="Long image path">
-        <img src="https://images.example.com/thumbnail?id=98765&size=large&quality=high&format=webp&cache=false" alt="Image with query params">
+        <img src="https://images.example.com/foo/thumbnail.png" alt="Image with path">
+        <img src="https://images.example.com/thumbnail.png?id=98765&size=large&quality=high&format=webp&cache=false" alt="Image with query params">
         <img src="https://assets.example.com/61d7035fa8d4.gif" alt="Image with high entropy name">
+        <img src="https://assets.example.com/70a27eafd353.gif" alt="Image with high entropy name 2">
+        <img src="https://assets.example.com/70a27eafd353.gif" alt="Image with high entropy name (duplicate)">
     </section>
 </main>
 

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "TextExtractionURLCache.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
 #include <wtf/OptionSet.h>
@@ -73,16 +74,18 @@ struct TextExtractionOptions {
         , version(other.version)
         , flags(other.flags)
         , outputFormat(other.outputFormat)
+        , urlCache(WTF::move(other.urlCache))
     {
     }
 
-    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat)
+    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr)
         : filterCallbacks(WTF::move(filters))
         , nativeMenuItems(WTF::move(items))
         , replacementStrings(WTF::move(replacementStrings))
         , version(version)
         , flags(flags)
         , outputFormat(outputFormat)
+        , urlCache(urlCache)
     {
     }
 
@@ -92,11 +95,13 @@ struct TextExtractionOptions {
     std::optional<TextExtractionVersion> version;
     TextExtractionOptionFlags flags;
     TextExtractionOutputFormat outputFormat { TextExtractionOutputFormat::TextTree };
+    RefPtr<TextExtractionURLCache> urlCache;
 };
 
 struct TextExtractionResult {
     String textContent;
     bool filteredOutAnyText { false };
+    Vector<String> shortenedURLStrings;
 };
 
 void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);

--- a/Source/WebKit/Shared/TextExtractionURLCache.cpp
+++ b/Source/WebKit/Shared/TextExtractionURLCache.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtractionURLCache.h"
+
+namespace WebKit {
+
+void TextExtractionURLCache::clear()
+{
+    m_shortenedStringToURLMap.clear();
+    m_urlToShortenedStringMap.clear();
+    m_shortenedStringCounts.clear();
+}
+
+String TextExtractionURLCache::add(const String& shortenedString, const URL& originalURL, ExtractedURLType type)
+{
+    if (shortenedString.isEmpty() || originalURL.isEmpty())
+        return shortenedString;
+
+    if (auto existingString = m_urlToShortenedStringMap.get(originalURL); !existingString.isEmpty())
+        return existingString;
+
+    auto addSuffix = [&](StringView string, unsigned suffix) {
+        auto fullStopIndex = string.reverseFind('.');
+        if (isASCIIDigit(string[string.length() - 1]))
+            return makeString(string, '-', suffix);
+
+        if (type == ExtractedURLType::Link) {
+            auto slashIndex = string.reverseFind('/');
+            if ((slashIndex == notFound) || (fullStopIndex != notFound && slashIndex > fullStopIndex))
+                return makeString(string, suffix);
+        }
+
+        if (fullStopIndex == notFound)
+            return makeString(string, suffix);
+
+        if (fullStopIndex && isASCIIDigit(string[fullStopIndex - 1]))
+            return makeString(string.left(fullStopIndex), '-', suffix, string.right(string.length() - fullStopIndex));
+
+        return makeString(string.left(fullStopIndex), suffix, string.right(string.length() - fullStopIndex));
+    };
+
+    m_shortenedStringCounts.add(shortenedString);
+
+    if (auto addResult = m_shortenedStringToURLMap.add(shortenedString, originalURL); addResult.isNewEntry) {
+        m_urlToShortenedStringMap.set(originalURL, shortenedString);
+        return shortenedString;
+    }
+
+    auto count = m_shortenedStringCounts.count(shortenedString);
+    String newShortenedString;
+    do {
+        newShortenedString = addSuffix(shortenedString, count++);
+    } while (!m_shortenedStringToURLMap.add(newShortenedString, originalURL).isNewEntry);
+    m_urlToShortenedStringMap.add(originalURL, newShortenedString);
+
+    return newShortenedString;
+}
+
+URL TextExtractionURLCache::urlForShortenedString(const String& string) const
+{
+    if (string.isEmpty())
+        return { };
+
+    return m_shortenedStringToURLMap.get(string);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/TextExtractionURLCache.h
+++ b/Source/WebKit/Shared/TextExtractionURLCache.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashCountedSet.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
+#include <wtf/URL.h>
+
+namespace WebKit {
+
+enum class ExtractedURLType : bool { Link, Image };
+class TextExtractionURLCache : public RefCounted<TextExtractionURLCache> {
+public:
+    static Ref<TextExtractionURLCache> create()
+    {
+        return adoptRef(*new TextExtractionURLCache);
+    }
+
+    String add(const String& shortenedString, const URL& originalURL, ExtractedURLType);
+    void clear();
+
+    URL urlForShortenedString(const String&) const;
+
+private:
+    TextExtractionURLCache() = default;
+
+    HashMap<String, URL> m_shortenedStringToURLMap;
+    HashMap<URL, String> m_urlToShortenedStringMap;
+    HashCountedSet<String> m_shortenedStringCounts;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -248,6 +248,7 @@ Shared/SharedStringHashStore.cpp
 Shared/SharedStringHashTableReadOnly.cpp
 Shared/SharedStringHashTable.cpp
 Shared/TextExtractionToStringConversion.cpp
+Shared/TextExtractionURLCache.cpp
 Shared/UserData.cpp
 Shared/WebBackForwardListFrameItem.cpp
 Shared/WebBackForwardListItem.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -137,6 +137,7 @@ class IconLoadingDelegate;
 class NavigationState;
 class PointerTouchCompatibilitySimulator;
 class ResourceLoadDelegate;
+class TextExtractionURLCache;
 class UIDelegate;
 class ViewSnapshot;
 class WebPageProxy;
@@ -509,6 +510,7 @@ struct PerWebProcessState {
 #if ENABLE(TEXT_EXTRACTION_FILTER)
     HashMap<unsigned /* string hash */, TextValidationMapValue> _textValidationCache;
 #endif
+    RefPtr<WebKit::TextExtractionURLCache> _textExtractionURLCache;
 }
 
 - (BOOL)_isValid;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -167,6 +167,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  */
 @property (nonatomic, readonly) BOOL filteredOutAnyText;
 
+/*!
+ A map of shortened URL strings to their original URLs; only populated when
+ `shortenURLs` is set when performing text extraction.
+ */
+@property (nonatomic, readonly) NSDictionary<NSString *, NSURL *> *shortenedURLs;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -181,13 +181,15 @@
 
 @implementation _WKTextExtractionResult {
     RetainPtr<NSString> _textContent;
+    RetainPtr<NSDictionary<NSString *, NSURL *>> _shortenedURLs;
 }
 
-- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText
+- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs
 {
     if (self = [super init]) {
         _textContent = textContent;
         _filteredOutAnyText = filteredOutAnyText;
+        _shortenedURLs = shortenedURLs;
     }
     return self;
 }
@@ -195,6 +197,11 @@
 - (NSString *)textContent
 {
     return _textContent.get();
+}
+
+- (NSDictionary<NSString *, NSURL *> *)shortenedURLs
+{
+    return _shortenedURLs.get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKTextExtractionResult ()
 
-- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText;
+- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs;
 
 @end
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2571,6 +2571,7 @@
 		F4E2A38F2EBAAA7700D7A783 /* CoreIPCDDSecureActionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E2A38B2EBA8A9500D7A783 /* CoreIPCDDSecureActionContext.h */; };
 		F4E44EB72DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E44EB62DCD33E800A304C4 /* WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
+		F4E89F5C2EFC702000E4D96E /* TextExtractionURLCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E89F5A2EFC702000E4D96E /* TextExtractionURLCache.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
 		F4EC69CC2D0D1E3A001F903E /* CursorContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EC69C92D0D001A001F903E /* CursorContext.h */; };
 		F4EC94E32356CC57000BB614 /* ApplicationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */; };
@@ -8793,6 +8794,8 @@
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
 		F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTapHighlightView.h; sourceTree = "<group>"; };
 		F4E8912F2AB7C344005AEBC3 /* WKTapHighlightView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTapHighlightView.mm; sourceTree = "<group>"; };
+		F4E89F5A2EFC702000E4D96E /* TextExtractionURLCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionURLCache.h; sourceTree = "<group>"; };
+		F4E89F5B2EFC702000E4D96E /* TextExtractionURLCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionURLCache.cpp; sourceTree = "<group>"; };
 		F4EB4AFC269CD23600D297AE /* OSStateSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSStateSPI.h; sourceTree = "<group>"; };
 		F4EC69C92D0D001A001F903E /* CursorContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CursorContext.h; path = ios/CursorContext.h; sourceTree = "<group>"; };
 		F4EC69CB2D0D001A001F903E /* CursorContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = CursorContext.serialization.in; path = ios/CursorContext.serialization.in; sourceTree = "<group>"; };
@@ -10184,6 +10187,8 @@
 				1A5E4DA312D3BD3D0099A2BB /* TextCheckerState.h */,
 				F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */,
 				F4217F1C2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.h */,
+				F4E89F5B2EFC702000E4D96E /* TextExtractionURLCache.cpp */,
+				F4E89F5A2EFC702000E4D96E /* TextExtractionURLCache.h */,
 				86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */,
 				7B7C380E2EBABD5300F71B4A /* TextManipulationParameters.h */,
 				7B7C38102EBABF1500F71B4A /* TextManipulationParameters.serialization.in */,
@@ -18317,6 +18322,7 @@
 				53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */,
 				1A5E4DA412D3BD3D0099A2BB /* TextCheckerState.h in Headers */,
 				F42CDFFF2E6E28A9005837F8 /* TextExtractionFilter.h in Headers */,
+				F4E89F5C2EFC702000E4D96E /* TextExtractionURLCache.h in Headers */,
 				CE1A0BD71A48E6C60054EF74 /* TextInputSPI.h in Headers */,
 				7B7C380F2EBABD7F00F71B4A /* TextManipulationParameters.h in Headers */,
 				E3C6727329D4A3AD00AD4452 /* TextTrackRepresentationCocoa.h in Headers */,


### PR DESCRIPTION
#### b137fef748b7711f22e63952f81b794968f6e504
<pre>
[AutoFill Debugging] Part 2/2: Deduplicate shortened URLs and report replacements to the client
<a href="https://bugs.webkit.org/show_bug.cgi?id=304680">https://bugs.webkit.org/show_bug.cgi?id=304680</a>
<a href="https://rdar.apple.com/167149825">rdar://167149825</a>

Reviewed by Richard Robinson.

Add a strategy to deduplicate different URLs that are shortened to the same string, when opting into
URL shortening for text extraction; combine that with a new property on `_WKTextExtractionResult`
that reports a mapping from shortened URLs to each original URL, back to the WebKit text extraction
client.

See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:

Augment this layout test to exercise the deduplication strategy.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::stringForURL):

Add a helper method that uses `TextExtractionURLCache` to map each shortened URL string to a
deduplicated string.

(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
(WebKit::centerEllipsize): Deleted.
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/Shared/TextExtractionURLCache.cpp: Added.

Add a new helper class that represents a cache of shortened URL strings and original URLs.

(WebKit::TextExtractionURLCache::clear):

Reset the cache (called during top level navigation, or if the web process swaps or exits).

(WebKit::TextExtractionURLCache::add):

Main entry point for updating the cache: this takes the shortened URL string and original URL as
arguments, and returns the shortened URL string saved to the cache, adjusting it by adding a
numbered suffix if necessary. For instance:

-   Suppose `<a href="https://example.com/foo?bar=baz`">https://example.com/foo?bar=baz`</a> is shortened to &quot;example.com/foo&quot;.

-   If `<a href="https://example.com/foo?bar=garply`">https://example.com/foo?bar=garply`</a> appears later on, it will also get shortened to
    &quot;example.com/foo&quot; which is then deduplicated to &quot;example.com/foo2&quot;.

-   If `<a href="https://example.com/foo.html`">https://example.com/foo.html`</a> appears, it will shorten to &quot;example.com/foo.html&quot; because the
    shortened version doesn&apos;t conflict with the other shortened strings above.

-   If `<a href="https://example.com/foo.html?bar=baz`">https://example.com/foo.html?bar=baz`</a> appears later on, it will also get shortened to
    &quot;example.com/foo.html&quot; which is then deduplicated to &quot;example.com/foo2.html&quot;.

(WebKit::TextExtractionURLCache::urlForShortenedString const):
* Source/WebKit/Shared/TextExtractionURLCache.h: Added.
(WebKit::TextExtractionURLCache::create):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(createEmptyTextExtractionResult):
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:completionHandler:]):
(-[WKWebView _clearTextExtractionFilterCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Store a `TextExtractionURLCache` on the web view, and pass it into the text conversion pipeline.
Clear the cache upon navigation.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionResult initWithTextContent:filteredOutAnyText:shortenedURLs:]):
(-[_WKTextExtractionResult shortenedURLs]):

Add support for a new property on `_WKTextExtractionResult` that contains a map of shortened
extracted URLs to their original URLs.

(-[_WKTextExtractionResult initWithTextContent:filteredOutAnyText:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/304963@main">https://commits.webkit.org/304963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3ccc1d805bb673d02040c6ad8bd34eb393385d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90009 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/421a16a0-6940-4cec-bc0b-31d6b22b7ee2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1b04cd71-6889-4f50-b823-af682f809cfc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69d51ab5-521c-4283-876b-a1d8c434dab3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4751 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5368 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147534 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6971 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63386 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9127 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37113 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9068 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->