### PR TITLE
Fix `typo` of incorrect lengths compared to `SVGRadialGradientElement.h`

### DIFF
--- a/LayoutTests/platform/glib/svg/custom/gradient-deep-referencing-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/gradient-deep-referencing-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1f"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,100)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1e"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1d"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
-      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,400)] [focal=(400,400)] [radius=400.00] [focalRadius=0.00]
+      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,300)] [focal=(400,300)] [radius=353.55] [focalRadius=0.00]
         RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
         RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1b"] [gradientUnits=userSpaceOnUse] [start=(0,0)] [end=(100,0)]

--- a/LayoutTests/platform/ios/svg/custom/gradient-deep-referencing-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/gradient-deep-referencing-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1f"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,100)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1e"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1d"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
-      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,400)] [focal=(400,400)] [radius=400.00] [focalRadius=0.00]
+      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,300)] [focal=(400,300)] [radius=353.55] [focalRadius=0.00]
         RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
         RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1b"] [gradientUnits=userSpaceOnUse] [start=(0,0)] [end=(100,0)]

--- a/LayoutTests/platform/mac/svg/custom/gradient-deep-referencing-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/gradient-deep-referencing-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1f"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,100)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1e"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1d"] [gradientUnits=userSpaceOnUse] [start=(0,100)] [end=(100,0)]
-      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,400)] [focal=(400,400)] [radius=400.00] [focalRadius=0.00]
+      RenderSVGResourceRadialGradient {radialGradient} [id="gradient1c"] [gradientUnits=userSpaceOnUse] [center=(400,300)] [focal=(400,300)] [radius=353.55] [focalRadius=0.00]
         RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
         RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
       RenderSVGResourceLinearGradient {linearGradient} [id="gradient1b"] [gradientUnits=userSpaceOnUse] [start=(0,0)] [end=(100,0)]

--- a/Source/WebCore/svg/RadialGradientAttributes.h
+++ b/Source/WebCore/svg/RadialGradientAttributes.h
@@ -26,8 +26,8 @@ namespace WebCore {
 struct RadialGradientAttributes : GradientAttributes {
     RadialGradientAttributes()
         : m_cx(SVGLengthMode::Width, "50%"_s)
-        , m_cy(SVGLengthMode::Width, "50%"_s)
-        , m_r(SVGLengthMode::Width, "50%"_s)
+        , m_cy(SVGLengthMode::Height, "50%"_s)
+        , m_r(SVGLengthMode::Other, "50%"_s)
         , m_cxSet(false)
         , m_cySet(false)
         , m_rSet(false)


### PR DESCRIPTION
#### 8615f506db9162ea73173834af9e4b997d92dd93
<pre>
Fix `typo` of incorrect lengths compared to `SVGRadialGradientElement.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=304686">https://bugs.webkit.org/show_bug.cgi?id=304686</a>
<a href="https://rdar.apple.com/167162675">rdar://167162675</a>

Reviewed by Said Abou-Hallawa.

This just aligns `RadialGradientAttributes.h` with `SVGRadialGradientElement.h`,
where these values have appropriate lengths, it must be copy paste error
from the past, so this just fixes this typo issue and align both files.

* LayoutTests/platform/glib/svg/custom/gradient-deep-referencing-expected.txt:
* LayoutTests/platform/ios/svg/custom/gradient-deep-referencing-expected.txt:
* LayoutTests/platform/mac/svg/custom/gradient-deep-referencing-expected.txt:
* Source/WebCore/svg/RadialGradientAttributes.h:
(WebCore::RadialGradientAttributes::RadialGradientAttributes):

Canonical link: <a href="https://commits.webkit.org/304966@main">https://commits.webkit.org/304966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d22b69be0032c972acd872f57816ef6aaebe257

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89905 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fbe3b2f-12b3-4f70-b8b7-98fbba7b941a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104708 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fc3599aa-df17-489d-821c-170acb7cfbe4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2ee90803-ee23-47e9-a84e-1db26ee25101) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4660 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5262 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147427 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8975 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113066 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6879 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63203 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37023 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->